### PR TITLE
feat: Flux status columns, ready-aware pod colors, alias-first palette

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2671,10 +2671,21 @@ impl App {
             }
         }
 
+        // An exact alias/kind/plural hit (e.g. `hr` → helmreleases) outranks
+        // every fuzzy match, so a shorthand lands on its target instead of an
+        // alphabetically-earlier lookalike (hr → horizontalpodautoscalers).
+        let alias_target = if q.is_empty() {
+            None
+        } else {
+            self.cluster.resolve(q).map(|k| k.ar.plural.to_lowercase())
+        };
+
         // Resource catalog (RBAC-filtered).
         for c in self.cluster.catalog.iter().filter(|c| self.rbac_visible(c)) {
             let score = if q.is_empty() {
                 Some(0)
+            } else if alias_target.as_deref() == Some(c.as_str()) {
+                Some(i64::MAX)
             } else {
                 self.matcher.fuzzy_match(c, q)
             };
@@ -3795,6 +3806,23 @@ mod tests {
             key: row_key(&o),
             obj: Box::new(o),
         });
+    }
+
+    #[tokio::test]
+    async fn exact_alias_outranks_fuzzy_suggestions() {
+        let (mut app, _rx) = test_app();
+        // `hr` fuzzy-matches horizontalpodautoscalers too; the alias target
+        // must still be the first suggestion.
+        app.command = "hr".into();
+        app.update_suggestions();
+        let first = app.cmd_suggestions.first().expect("has suggestions");
+        assert_eq!(first.label, "helmreleases");
+        assert!(first.kind == SuggestKind::Resource);
+
+        // A full plural typed exactly stays on top as well.
+        app.command = "pods".into();
+        app.update_suggestions();
+        assert_eq!(app.cmd_suggestions[0].label, "pods");
     }
 
     #[test]

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -29,6 +29,9 @@ pub fn headers(plural: &str) -> Vec<&'static str> {
         "ingresses" => vec!["NAME", "CLASS", "HOSTS", "AGE"],
         "endpoints" => vec!["NAME", "ENDPOINTS", "AGE"],
         "customresourcedefinitions" => vec!["NAME", "GROUP", "KIND", "VERSIONS", "SCOPE", "AGE"],
+        "kustomizations" | "helmreleases" => {
+            vec!["NAME", "READY", "MESSAGE", "REVISION", "SUSPENDED", "AGE"]
+        }
         _ => vec!["NAME", "AGE"],
     }
 }
@@ -150,6 +153,12 @@ pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) 
             let scope = sget(d, &["spec", "scope"]).unwrap_or_default();
             (vec![name, group, ckind, versions, scope, age], None)
         }
+        "kustomizations" | "helmreleases" => {
+            let (ready, msg) = ready_condition(d);
+            let revision = flux_revision(d);
+            let suspended = bget(d, &["spec", "suspend"]).to_string();
+            (vec![name, ready, msg, revision, suspended, age], Some(1))
+        }
         _ => (vec![name, age], None),
     }
 }
@@ -172,6 +181,46 @@ fn crd_versions(d: &Value) -> String {
     } else {
         names.join(",")
     }
+}
+
+/// (status, message) of the `Ready` condition, the health summary Flux (and
+/// most condition-based CRDs) maintain. Missing condition reads as Unknown —
+/// e.g. a Kustomization the controller hasn't reconciled yet.
+fn ready_condition(d: &Value) -> (String, String) {
+    d.pointer("/status/conditions")
+        .and_then(Value::as_array)
+        .and_then(|conds| {
+            conds
+                .iter()
+                .find(|c| c.get("type").and_then(Value::as_str) == Some("Ready"))
+        })
+        .map(|c| {
+            (
+                c.get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Unknown")
+                    .to_string(),
+                c.get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            )
+        })
+        .unwrap_or_else(|| ("Unknown".into(), String::new()))
+}
+
+/// Last applied revision of a Flux object: Kustomizations (and HelmRelease
+/// v2beta*) expose `lastAppliedRevision`; HelmRelease v2 GA moved it into
+/// `history`, with `lastAttemptedRevision` as the pre-first-success fallback.
+fn flux_revision(d: &Value) -> String {
+    sget(d, &["status", "lastAppliedRevision"])
+        .or_else(|| {
+            d.pointer("/status/history/0/chartVersion")
+                .and_then(Value::as_str)
+                .map(String::from)
+        })
+        .or_else(|| sget(d, &["status", "lastAttemptedRevision"]))
+        .unwrap_or_default()
 }
 
 fn sget(v: &Value, path: &[&str]) -> Option<String> {
@@ -590,6 +639,67 @@ mod tests {
         assert_eq!(cells[2], "Widget");
         assert_eq!(cells[3], "v1beta1,v1");
         assert_eq!(cells[4], "Namespaced");
+    }
+
+    #[test]
+    fn kustomization_cells_show_ready_condition_and_revision() {
+        let ks = obj(json!({
+            "apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+            "kind": "Kustomization",
+            "metadata": {"name": "apps", "namespace": "flux-system"},
+            "spec": {"suspend": false},
+            "status": {
+                "lastAppliedRevision": "main@sha1:abc123",
+                "conditions": [
+                    {"type": "Reconciling", "status": "False"},
+                    {"type": "Ready", "status": "True",
+                     "message": "Applied revision: main@sha1:abc123"}
+                ]
+            }
+        }));
+        let (cells, status_idx) = cells(&ks, "kustomizations");
+        assert_eq!(cells[0], "apps");
+        assert_eq!(cells[1], "True");
+        assert_eq!(cells[2], "Applied revision: main@sha1:abc123");
+        assert_eq!(cells[3], "main@sha1:abc123");
+        assert_eq!(cells[4], "false");
+        assert_eq!(status_idx, Some(1));
+    }
+
+    #[test]
+    fn helmrelease_cells_fall_back_to_history_revision() {
+        let hr = obj(json!({
+            "apiVersion": "helm.toolkit.fluxcd.io/v2",
+            "kind": "HelmRelease",
+            "metadata": {"name": "podinfo", "namespace": "default"},
+            "spec": {"suspend": true},
+            "status": {
+                "history": [{"chartVersion": "6.5.4"}],
+                "conditions": [
+                    {"type": "Ready", "status": "False",
+                     "message": "install retries exhausted"}
+                ]
+            }
+        }));
+        let (cells, status_idx) = cells(&hr, "helmreleases");
+        assert_eq!(cells[1], "False");
+        assert_eq!(cells[2], "install retries exhausted");
+        assert_eq!(cells[3], "6.5.4");
+        assert_eq!(cells[4], "true");
+        assert_eq!(status_idx, Some(1));
+    }
+
+    #[test]
+    fn flux_object_without_status_reads_unknown() {
+        let ks = obj(json!({
+            "apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+            "kind": "Kustomization",
+            "metadata": {"name": "new"}
+        }));
+        let (cells, _) = cells(&ks, "kustomizations");
+        assert_eq!(cells[1], "Unknown");
+        assert_eq!(cells[2], "");
+        assert_eq!(cells[3], "");
     }
 
     #[test]

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -358,6 +358,26 @@ impl Cluster {
                 true,
             ),
         );
+        // An alias/plural pair that collide on fuzzy matching (`hr` is a
+        // subsequence of horizontalpodautoscalers), for suggestion-priority
+        // tests.
+        let hr = mk(
+            "helm.toolkit.fluxcd.io",
+            "HelmRelease",
+            "helmreleases",
+            true,
+        );
+        registry.insert("helmreleases".to_string(), hr.clone());
+        registry.insert("hr".to_string(), hr);
+        registry.insert(
+            "horizontalpodautoscalers".to_string(),
+            mk(
+                "autoscaling",
+                "HorizontalPodAutoscaler",
+                "horizontalpodautoscalers",
+                true,
+            ),
+        );
         Self {
             client,
             context: "test".into(),
@@ -367,6 +387,8 @@ impl Cluster {
             registry,
             catalog: vec![
                 "deployments".to_string(),
+                "helmreleases".to_string(),
+                "horizontalpodautoscalers".to_string(),
                 "kustomizations".to_string(),
                 "namespaces".to_string(),
                 "nodes".to_string(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -175,6 +175,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // string-compared per cell.
     let name_col = if show_ns { 1 } else { 0 };
     let age_idx = headers.iter().position(|h| *h == "AGE");
+    let ready_idx = headers.iter().position(|h| *h == "READY");
     let restarts_idx = headers.iter().position(|h| *h == "RESTARTS");
     let cpu_idx = headers.iter().position(|h| *h == "CPU");
     let mem_idx = headers.iter().position(|h| *h == "MEM");
@@ -218,7 +219,20 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 .and_then(|i| cells.get(i))
                 .map(String::as_str)
                 .unwrap_or("");
-            let row_color = theme::row_color(status_val);
+            // A pod is phase=Running the moment its sandbox starts, long before
+            // every container passes its readiness probe — until READY is n/n,
+            // paint it as transitional, not healthy.
+            let running_not_ready = status_val == "Running"
+                && ready_idx
+                    .and_then(|i| cells.get(i))
+                    .is_some_and(|r| !all_ready(r));
+            let status_key = if running_not_ready {
+                "PodInitializing"
+            } else {
+                status_val
+            };
+            let row_color = theme::row_color(status_key);
+            let status_badge = theme::status_color(status_key);
             let render_cells: Vec<Cell> = cells
                 .into_iter()
                 .enumerate()
@@ -232,8 +246,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                                 .add_modifier(Modifier::BOLD),
                         )
                     } else if Some(i) == style_idx {
-                        let sc = theme::status_color(&c);
-                        Cell::from(c).style(Style::default().fg(sc))
+                        Cell::from(c).style(Style::default().fg(status_badge))
                     } else if i == name_col {
                         render_name_cell(app, &c, row_color)
                     } else if Some(i) == age_idx {
@@ -284,6 +297,11 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             "KIND" => Constraint::Length(20),
             "VERSIONS" => Constraint::Length(20),
             "SCOPE" => Constraint::Length(12),
+            // Flux views: the Ready condition message and git/chart revision
+            // are the columns you read — split the leftover space with NAME.
+            "MESSAGE" => Constraint::Fill(4),
+            "REVISION" => Constraint::Fill(2),
+            "SUSPENDED" => Constraint::Length(9),
             _ => Constraint::Fill(1),
         })
         .collect();
@@ -326,6 +344,16 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         );
 
     frame.render_stateful_widget(table, area, &mut app.table_state);
+}
+
+/// `true` when a `n/m` READY cell has every container ready. Cells that
+/// aren't in that shape (statuses without a ready fraction) count as ready so
+/// they never trigger the not-ready tint.
+fn all_ready(ready: &str) -> bool {
+    match ready.split_once('/') {
+        Some((r, t)) => r == t,
+        None => true,
+    }
 }
 
 /// Render the NAME cell, highlighting characters that matched the active
@@ -1753,6 +1781,16 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn all_ready_requires_full_fraction() {
+        assert!(all_ready("2/2"));
+        assert!(all_ready("0/0"));
+        assert!(!all_ready("1/2"));
+        assert!(!all_ready("0/1"));
+        // Non-fraction cells (other kinds' status columns) never trigger it.
+        assert!(all_ready("Ready"));
+    }
 
     /// The scroll math (`wrapped_height`) and the renderer (`wrap_line`) must
     /// produce the same row count for any input, or follow/clamping drifts.


### PR DESCRIPTION
## Summary
- **Flux status columns**: `kustomizations` and `helmreleases` no longer fall back to bare NAME/AGE — they get `READY / MESSAGE / REVISION / SUSPENDED` columns driven by the `Ready` condition, with `status.lastAppliedRevision` → `status.history[0].chartVersion` → `lastAttemptedRevision` fallbacks for HelmRelease v2 GA. READY is the colored status column (green/blue when `True`, red when `False`).
- **Ready-aware pod coloring**: a pod with STATUS=Running but containers not all ready (READY `1/2`) is tinted with the transitional color (yellow badge, peach row) instead of the healthy one; it flips to healthy only once READY is `n/n`. Displayed text stays `Running`, matching kubectl.
- **Shorthands win in the `:` palette**: an exact alias/kind/plural hit (resolved through the same registry as `switch_kind`, including user aliases) outranks every fuzzy match, so `:hr` suggests `helmreleases` first instead of the alphabetically-earlier `horizontalpodautoscalers`.

## Test plan
- [x] `cargo test` — 83 tests pass, including new coverage for Flux cells (ready condition, revision fallbacks, missing status), `all_ready` fraction parsing, and alias-first suggestion ordering
- [x] `cargo clippy --all-targets` clean
- [ ] Manual: `:ks` / `:hr` against a Flux cluster show READY/MESSAGE/REVISION/SUSPENDED
- [ ] Manual: a pod stuck at READY 0/1 with STATUS Running renders peach, not blue
- [ ] Manual: `:hr`⏎ lands on helmreleases