### PR TITLE
fix: show cursor when suspending to interactive shell-outs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,7 @@ fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String]) {
         return;
     }
     ratatui::restore();
+    let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
     let _ = std::process::Command::new(&argv[0])
         .args(&argv[1..])
         .status();


### PR DESCRIPTION
## Summary
- Explicitly show the cursor (`?25h`) after `ratatui::restore()` when suspending the TUI for an interactive shell-out (`s` exec, `e` edit, `a` attach, plugins)
- ratatui hides the cursor on every `draw()` (`?25l`), but `restore()` only disables raw mode and leaves the alt-screen — it never un-hides the cursor, so the child shell/vim ran with an invisible cursor

## Test plan
- [x] PTY harness A/B: unfixed binary hands off with cursor hidden, fixed binary emits `?25h` before the child prompt
- [x] Verified interactively in ghostty: `s` into a pod shows a cursor, vim renders normally
- [x] `cargo test` (80 passed), clippy, fmt via pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)