### PR TITLE
repo improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,6 +2400,7 @@ name = "sofka"
 version = "0.1.4"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "crossterm",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,21 +179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,33 +324,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
 
 [[package]]
 name = "colorchoice"
@@ -739,16 +682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,7 +761,6 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -850,17 +782,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -962,12 +883,6 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gloo-timers"
@@ -1150,12 +1065,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -1526,15 +1435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,15 +1476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,15 +1508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1663,12 +1545,6 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "palette"
@@ -2160,12 +2036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,15 +2322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,9 +2401,7 @@ version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
- "color-eyre",
  "crossterm",
- "futures",
  "futures-util",
  "fuzzy-matcher",
  "k8s-openapi",
@@ -2555,8 +2414,6 @@ dependencies = [
  "terminal-colorsaurus",
  "tokio",
  "toml",
- "tracing",
- "tracing-subscriber",
  "unicode-width",
 ]
 
@@ -2980,42 +2837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3110,12 +2931,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/nklmilojevic/sofka"
 
 [dependencies]
 anyhow = "1.0.102"
+base64 = "0.22.1"
 clap = { version = "4.6.1", features = ["derive"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 futures-util = "0.3.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,7 @@ repository = "https://github.com/nklmilojevic/sofka"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
-color-eyre = "0.6.5"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
-futures = "0.3.32"
 futures-util = "0.3.32"
 fuzzy-matcher = "0.3.7"
 k8s-openapi = { version = "0.28", features = ["latest"] }
@@ -24,6 +22,4 @@ similar = "3.1.1"
 terminal-colorsaurus = "1.0.3"
 tokio = { version = "1.52.3", features = ["full"] }
 toml = "1.1.2"
-tracing = "0.1.44"
-tracing-subscriber = "0.3.23"
 unicode-width = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ terminal-colorsaurus = "1.0.3"
 tokio = { version = "1.52.3", features = ["full"] }
 toml = "1.1.2"
 unicode-width = "0.2.2"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true

--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ sofka [RESOURCE] [-n NAMESPACE] [-A]
 | `r`                       | rollout restart (workloads) / refresh (elsewhere)                                                       |
 | `f` / `shift-f`           | port-forward (pods/services) - runs in the background                                                   |
 | `t`                       | Flux: suspend/resume/reconcile menu                                                                     |
-| `ctrl-d` / `ctrl-k`       | delete / kill (marked rows, or current)                                                                 |
+| `C` / `U` / `D`           | nodes: cordon / uncordon / drain                                                                        |
+| `ctrl-d` / `ctrl-k`       | delete / force-delete (marked rows, or current); `f` toggles force in confirm                           |
 | `:q`, `ctrl-c`            | quit                                                                                                    |
 | `?`                       | help                                                                                                    |
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ sofka [RESOURCE] [-n NAMESPACE] [-A]
 | `o`                       | show the node hosting the selected pod                                                                  |
 | `ctrl-r`                  | refresh the watch                                                                                       |
 | `y` / `d` / `E`           | view YAML / describe (`kubectl`) / live events                                                          |
+| `:skin`                   | switch the color skin live (`:skin gruvbox-dark` applies directly)                                      |
 | `l` / `p`                 | logs (workload = all matching pods) / previous-container logs                                           |
 | `c`                       | copy resource name to clipboard                                                                         |
 | `e`                       | edit in `$EDITOR` (`kubectl edit`)                                                                      |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Not a marketing number - these are specific, checkable design choices:
   pods, node → its pods, pod → containers, namespace → re-scope, CRD → its
   custom resources. `esc` pops back.
 - **Command palette** (`:`) - fuzzy over the full resource catalog _and_
-  built-in commands (`ctx`, `pulse`, `xray`, `diff`, `pf`) together, plus
+  built-in commands (`ctx`, `pulse`, `xray`, `diff`, `events`, `pf`) together, plus
   fuzzy row **filtering** (`/`) with matched-character highlighting.
 - **Multiselect** (`space`) for bulk delete/kill/suspend/resume/reconcile.
 - **Pulse dashboard** (`:pulse`) - cluster-health tiles, refreshed every 5s.
@@ -114,6 +114,8 @@ Not a marketing number - these are specific, checkable design choices:
   resource.
 - **Diff** (`:diff`) - unified diff of the live object vs its
   `last-applied-configuration`.
+- **Events** (`:events` / `E`) - live Kubernetes Events for the selected
+  object, filtered by UID when available.
 - **RBAC-aware palette** - hides resource kinds you can't `list`.
 - **Namespace switcher** (`n`) and **context switcher** (`:ctx`).
 - **YAML view** (`y`) and **describe** (`d`, via `kubectl`).
@@ -216,7 +218,7 @@ sofka [RESOURCE] [-n NAMESPACE] [-A]
 | `shift-j`                 | jump to owner/controller                                                                                |
 | `o`                       | show the node hosting the selected pod                                                                  |
 | `ctrl-r`                  | refresh the watch                                                                                       |
-| `y` / `d`                 | view YAML / describe (`kubectl`)                                                                        |
+| `y` / `d` / `E`           | view YAML / describe (`kubectl`) / live events                                                          |
 | `l` / `p`                 | logs (workload = all matching pods) / previous-container logs                                           |
 | `c`                       | copy resource name to clipboard                                                                         |
 | `e`                       | edit in `$EDITOR` (`kubectl edit`)                                                                      |

--- a/src/app.rs
+++ b/src/app.rs
@@ -2017,6 +2017,37 @@ impl App {
         self.mode = Mode::Confirm;
     }
 
+    fn spawn_patch_action<F>(
+        &self,
+        kind: Kind,
+        targets: Vec<(String, String)>,
+        patch: Patch<Value>,
+        error_message: F,
+    ) where
+        F: Fn(&str, kube::Error) -> String + Send + 'static,
+    {
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            for (name, ns) in targets {
+                let api: Api<DynamicObject> = if kind.namespaced && !ns.is_empty() {
+                    Api::namespaced_with(client.clone(), &ns, &kind.ar)
+                } else {
+                    Api::all_with(client.clone(), &kind.ar)
+                };
+                if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: error_message(&name, e),
+                        })
+                        .await;
+                }
+            }
+        });
+    }
+
     fn do_delete(&mut self, targets: Vec<(String, String)>, force: bool) {
         let Some(kind) = self.kind.clone() else {
             return;
@@ -2069,10 +2100,6 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
-        let client = self.cluster.client.clone();
-        let tx = self.tx.clone();
-        let genr = self.generation;
-        let patch_doc = node_unschedulable_patch(unschedulable);
         let verb = if unschedulable {
             "cordoning"
         } else {
@@ -2084,20 +2111,16 @@ impl App {
             format!("{verb} {} nodes…", targets.len())
         };
         self.flash_err = false;
-        tokio::spawn(async move {
-            let api: Api<DynamicObject> = Api::all_with(client, &kind.ar);
-            let patch = Patch::Merge(patch_doc);
-            for name in targets {
-                if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    let _ = tx
-                        .send(Msg::Error {
-                            generation: genr,
-                            error: format!("{verb} {name} failed: {e}"),
-                        })
-                        .await;
-                }
-            }
-        });
+        let targets = targets
+            .into_iter()
+            .map(|name| (name, String::new()))
+            .collect();
+        self.spawn_patch_action(
+            kind,
+            targets,
+            Patch::Merge(node_unschedulable_patch(unschedulable)),
+            move |name, e| format!("{verb} {name} failed: {e}"),
+        );
     }
 
     fn request_drain(&mut self) {
@@ -2415,23 +2438,14 @@ impl App {
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
-        let client = self.cluster.client.clone();
-        let tx = self.tx.clone();
-        let genr = self.generation;
         self.flash = format!("restarting {name}…");
         self.flash_err = false;
-        tokio::spawn(async move {
-            let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
-            let patch = Patch::Strategic(restart_patch(&now));
-            if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                let _ = tx
-                    .send(Msg::Error {
-                        generation: genr,
-                        error: format!("restart failed: {e}"),
-                    })
-                    .await;
-            }
-        });
+        self.spawn_patch_action(
+            kind,
+            vec![(name, ns)],
+            Patch::Strategic(restart_patch(&now)),
+            |_, e| format!("restart failed: {e}"),
+        );
     }
 
     /// Open the Set-Image picker for the selected workload/pod (k9s `i`).
@@ -2530,24 +2544,14 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
-        let client = self.cluster.client.clone();
-        let tx = self.tx.clone();
-        let genr = self.generation;
-        let patch_doc = set_image_patch(&plural, &container, &image);
         self.flash = format!("setting image: {container} → {image}");
         self.flash_err = false;
-        tokio::spawn(async move {
-            let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
-            let patch = Patch::Strategic(patch_doc);
-            if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                let _ = tx
-                    .send(Msg::Error {
-                        generation: genr,
-                        error: format!("set image failed: {e}"),
-                    })
-                    .await;
-            }
-        });
+        self.spawn_patch_action(
+            kind,
+            vec![(name, ns)],
+            Patch::Strategic(set_image_patch(&plural, &container, &image)),
+            |_, e| format!("set image failed: {e}"),
+        );
     }
 
     fn request_edit(&mut self) {
@@ -2765,23 +2769,14 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
-        let client = self.cluster.client.clone();
-        let tx = self.tx.clone();
-        let genr = self.generation;
         self.flash = format!("scaling {name} → {replicas}");
         self.flash_err = false;
-        tokio::spawn(async move {
-            let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
-            let patch = Patch::Merge(scale_patch(replicas));
-            if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                let _ = tx
-                    .send(Msg::Error {
-                        generation: genr,
-                        error: format!("scale failed: {e}"),
-                    })
-                    .await;
-            }
-        });
+        self.spawn_patch_action(
+            kind,
+            vec![(name, ns)],
+            Patch::Merge(scale_patch(replicas)),
+            |_, e| format!("scale failed: {e}"),
+        );
     }
 
     /// Open the Flux suspend/resume menu (`t`) for the marked rows, or the
@@ -2837,9 +2832,6 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
-        let client = self.cluster.client.clone();
-        let tx = self.tx.clone();
-        let genr = self.generation;
         let verb = if suspend { "suspending" } else { "resuming" };
         self.flash = if targets.len() == 1 {
             format!("{verb} {}…", targets[0].0)
@@ -2848,20 +2840,12 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
-        tokio::spawn(async move {
-            let patch = Patch::Merge(suspend_patch(suspend));
-            for (name, ns) in targets {
-                let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
-                if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    let _ = tx
-                        .send(Msg::Error {
-                            generation: genr,
-                            error: format!("{verb} {name} failed: {e}"),
-                        })
-                        .await;
-                }
-            }
-        });
+        self.spawn_patch_action(
+            kind,
+            targets,
+            Patch::Merge(suspend_patch(suspend)),
+            move |name, e| format!("{verb} {name} failed: {e}"),
+        );
     }
 
     /// Force an immediate Flux reconciliation, bypassing the normal interval —
@@ -2871,9 +2855,6 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
-        let client = self.cluster.client.clone();
-        let tx = self.tx.clone();
-        let genr = self.generation;
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
         self.flash = if targets.len() == 1 {
             format!("reconciling {}…", targets[0].0)
@@ -2882,20 +2863,12 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
-        tokio::spawn(async move {
-            let patch = Patch::Merge(reconcile_patch(&now));
-            for (name, ns) in targets {
-                let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
-                if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    let _ = tx
-                        .send(Msg::Error {
-                            generation: genr,
-                            error: format!("reconcile {name} failed: {e}"),
-                        })
-                        .await;
-                }
-            }
-        });
+        self.spawn_patch_action(
+            kind,
+            targets,
+            Patch::Merge(reconcile_patch(&now)),
+            |name, e| format!("reconcile {name} failed: {e}"),
+        );
     }
 
     /// Force an immediate External Secrets Operator refresh on the marked rows
@@ -2921,9 +2894,6 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
-        let client = self.cluster.client.clone();
-        let tx = self.tx.clone();
-        let genr = self.generation;
         let now = k8s_openapi::jiff::Timestamp::now().as_second().to_string();
         self.flash = if targets.len() == 1 {
             format!("refreshing {}…", targets[0].0)
@@ -2932,20 +2902,12 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
-        tokio::spawn(async move {
-            let patch = Patch::Merge(external_secret_refresh_patch(&now));
-            for (name, ns) in targets {
-                let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
-                if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    let _ = tx
-                        .send(Msg::Error {
-                            generation: genr,
-                            error: format!("refresh {name} failed: {e}"),
-                        })
-                        .await;
-                }
-            }
-        });
+        self.spawn_patch_action(
+            kind,
+            targets,
+            Patch::Merge(external_secret_refresh_patch(&now)),
+            |name, e| format!("refresh {name} failed: {e}"),
+        );
     }
 
     fn flash_warn(&mut self, msg: &str) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@
 //! drills into a child (workload -> pods, pod -> containers, namespace ->
 //! re-scope the previous view), and `esc` pops back.
 
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -331,6 +331,27 @@ impl SortKey {
 struct RowsCache {
     dirty: bool,
     keys: Vec<String>,
+    cells: HashMap<String, CellCacheEntry>,
+}
+
+struct CellCacheEntry {
+    plural: String,
+    resource_version: Option<String>,
+    cells: Vec<String>,
+    status_idx: Option<usize>,
+}
+
+pub(crate) struct TableCellCache<'a> {
+    cache: Ref<'a, RowsCache>,
+}
+
+impl TableCellCache<'_> {
+    pub(crate) fn get(&self, key: &str) -> Option<(&[String], Option<usize>)> {
+        self.cache
+            .cells
+            .get(key)
+            .map(|entry| (entry.cells.as_slice(), entry.status_idx))
+    }
 }
 
 /// A saved view, pushed onto the stack when drilling down.
@@ -523,6 +544,7 @@ impl App {
             rows_cache: RefCell::new(RowsCache {
                 dirty: true,
                 keys: Vec::new(),
+                cells: HashMap::new(),
             }),
         }
     }
@@ -779,19 +801,19 @@ impl App {
         match msg {
             Msg::Reset { generation } if generation == self.generation => {
                 self.store.clear();
-                self.invalidate_rows();
+                self.clear_rows_cache();
             }
             Msg::Applied {
                 generation,
                 key,
                 obj,
             } if generation == self.generation => {
-                self.store.apply(key, *obj);
-                self.invalidate_rows();
+                self.store.apply(key.clone(), *obj);
+                self.invalidate_row(&key);
             }
             Msg::Deleted { generation, key } if generation == self.generation => {
                 self.store.remove(&key);
-                self.invalidate_rows();
+                self.invalidate_row(&key);
             }
             Msg::Synced { generation } if generation == self.generation => self.store.synced = true,
             Msg::Error { generation, error } if generation == self.generation => {
@@ -960,6 +982,19 @@ impl App {
         self.rows_cache.borrow_mut().dirty = true;
     }
 
+    fn clear_rows_cache(&self) {
+        let mut cache = self.rows_cache.borrow_mut();
+        cache.dirty = true;
+        cache.keys.clear();
+        cache.cells.clear();
+    }
+
+    fn invalidate_row(&self, key: &str) {
+        let mut cache = self.rows_cache.borrow_mut();
+        cache.dirty = true;
+        cache.cells.remove(key);
+    }
+
     /// Does this object pass the current fuzzy filter?
     fn matches_filter(&self, o: &DynamicObject) -> bool {
         if self.filter.is_empty() {
@@ -1042,6 +1077,35 @@ impl App {
             .iter()
             .filter_map(|k| self.store.get(k))
             .collect()
+    }
+
+    pub(crate) fn ensure_table_cell_cache(&self, rows: &[&DynamicObject]) {
+        let mut cache = self.rows_cache.borrow_mut();
+        for obj in rows {
+            let key = row_key(obj);
+            let resource_version = obj.metadata.resource_version.clone();
+            let stale = cache.cells.get(&key).is_none_or(|entry| {
+                entry.plural != self.kind_plural || entry.resource_version != resource_version
+            });
+            if stale {
+                let (cells, status_idx) = crate::columns::cells(obj, &self.kind_plural);
+                cache.cells.insert(
+                    key,
+                    CellCacheEntry {
+                        plural: self.kind_plural.clone(),
+                        resource_version,
+                        cells,
+                        status_idx,
+                    },
+                );
+            }
+        }
+    }
+
+    pub(crate) fn table_cell_cache(&self) -> TableCellCache<'_> {
+        TableCellCache {
+            cache: self.rows_cache.borrow(),
+        }
     }
 
     /// The headers as displayed: kind columns, with NAMESPACE prepended when
@@ -4515,6 +4579,53 @@ mod tests {
 
         app.filter = "zzz".into();
         assert_eq!(app.filter_match_indices("kube-httpcache-0"), None); // no match
+    }
+
+    #[tokio::test]
+    async fn table_cell_cache_invalidates_on_apply() {
+        let (mut app, _rx) = test_app();
+        app.kind_plural = "pods".into();
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": "web",
+                    "namespace": "default",
+                    "resourceVersion": "1"
+                },
+                "status": {"phase": "Pending"}
+            }),
+        );
+        {
+            let rows = app.rows();
+            app.ensure_table_cell_cache(&rows);
+            let key = row_key(rows[0]);
+            let cache = app.table_cell_cache();
+            let (cells, _) = cache.get(&key).unwrap();
+            assert_eq!(cells[2], "Pending");
+        }
+
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": "web",
+                    "namespace": "default",
+                    "resourceVersion": "2"
+                },
+                "status": {"phase": "Running"}
+            }),
+        );
+        let rows = app.rows();
+        app.ensure_table_cell_cache(&rows);
+        let key = row_key(rows[0]);
+        let cache = app.table_cell_cache();
+        let (cells, _) = cache.get(&key).unwrap();
+        assert_eq!(cells[2], "Running");
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2177,11 +2177,7 @@ impl App {
         self.flash_err = false;
         tokio::spawn(async move {
             let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
-            let patch = Patch::Strategic(json!({
-                "spec": { "template": { "metadata": { "annotations": {
-                    "kubectl.kubernetes.io/restartedAt": now
-                }}}}
-            }));
+            let patch = Patch::Strategic(restart_patch(&now));
             if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
                 let _ = tx
                     .send(Msg::Error {
@@ -2292,12 +2288,7 @@ impl App {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
-        let containers = json!([{ "name": container, "image": image }]);
-        let patch_doc = if plural == "pods" {
-            json!({ "spec": { "containers": containers } })
-        } else {
-            json!({ "spec": { "template": { "spec": { "containers": containers } } } })
-        };
+        let patch_doc = set_image_patch(&plural, &container, &image);
         self.flash = format!("setting image: {container} → {image}");
         self.flash_err = false;
         tokio::spawn(async move {
@@ -2491,7 +2482,7 @@ impl App {
         self.flash_err = false;
         tokio::spawn(async move {
             let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
-            let patch = Patch::Merge(json!({ "spec": { "replicas": replicas } }));
+            let patch = Patch::Merge(scale_patch(replicas));
             if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
                 let _ = tx
                     .send(Msg::Error {
@@ -2568,7 +2559,7 @@ impl App {
         self.flash_err = false;
         self.marked.clear();
         tokio::spawn(async move {
-            let patch = Patch::Merge(json!({ "spec": { "suspend": suspend } }));
+            let patch = Patch::Merge(suspend_patch(suspend));
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
@@ -2602,9 +2593,7 @@ impl App {
         self.flash_err = false;
         self.marked.clear();
         tokio::spawn(async move {
-            let patch = Patch::Merge(json!({
-                "metadata": { "annotations": { "reconcile.fluxcd.io/requestedAt": now } }
-            }));
+            let patch = Patch::Merge(reconcile_patch(&now));
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
@@ -2654,9 +2643,7 @@ impl App {
         self.flash_err = false;
         self.marked.clear();
         tokio::spawn(async move {
-            let patch = Patch::Merge(json!({
-                "metadata": { "annotations": { "force-sync": now } }
-            }));
+            let patch = Patch::Merge(external_secret_refresh_patch(&now));
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
@@ -3807,6 +3794,43 @@ impl App {
 }
 
 // ----- free helpers ------------------------------------------------------
+
+fn restart_patch(restarted_at: &str) -> Value {
+    json!({
+        "spec": { "template": { "metadata": { "annotations": {
+            "kubectl.kubernetes.io/restartedAt": restarted_at
+        }}}}
+    })
+}
+
+fn set_image_patch(plural: &str, container: &str, image: &str) -> Value {
+    let containers = json!([{ "name": container, "image": image }]);
+    if plural == "pods" {
+        json!({ "spec": { "containers": containers } })
+    } else {
+        json!({ "spec": { "template": { "spec": { "containers": containers } } } })
+    }
+}
+
+fn scale_patch(replicas: i32) -> Value {
+    json!({ "spec": { "replicas": replicas } })
+}
+
+fn suspend_patch(suspend: bool) -> Value {
+    json!({ "spec": { "suspend": suspend } })
+}
+
+fn reconcile_patch(requested_at: &str) -> Value {
+    json!({
+        "metadata": { "annotations": { "reconcile.fluxcd.io/requestedAt": requested_at } }
+    })
+}
+
+fn external_secret_refresh_patch(force_sync: &str) -> Value {
+    json!({
+        "metadata": { "annotations": { "force-sync": force_sync } }
+    })
+}
 
 /// Pick a version name to query a CRD's custom resources: the storage version
 /// if flagged, else the first served version, else the first listed.
@@ -5003,6 +5027,44 @@ mod tests {
             {"name": "v1", "served": true}
         ]}});
         assert_eq!(crd_served_version(&d2).as_deref(), Some("v1"));
+    }
+
+    #[test]
+    fn mutating_action_patch_payloads_are_stable() {
+        assert_eq!(
+            restart_patch("2026-07-04T12:00:00Z"),
+            json!({
+                "spec": { "template": { "metadata": { "annotations": {
+                    "kubectl.kubernetes.io/restartedAt": "2026-07-04T12:00:00Z"
+                }}}}
+            })
+        );
+        assert_eq!(
+            set_image_patch("pods", "app", "nginx:1.27"),
+            json!({ "spec": { "containers": [{ "name": "app", "image": "nginx:1.27" }] } })
+        );
+        assert_eq!(
+            set_image_patch("deployments", "app", "nginx:1.27"),
+            json!({
+                "spec": { "template": { "spec": {
+                    "containers": [{ "name": "app", "image": "nginx:1.27" }]
+                }}}
+            })
+        );
+        assert_eq!(scale_patch(3), json!({ "spec": { "replicas": 3 } }));
+        assert_eq!(suspend_patch(true), json!({ "spec": { "suspend": true } }));
+        assert_eq!(
+            reconcile_patch("2026-07-04T12:00:00Z"),
+            json!({
+                "metadata": { "annotations": {
+                    "reconcile.fluxcd.io/requestedAt": "2026-07-04T12:00:00Z"
+                }}
+            })
+        );
+        assert_eq!(
+            external_secret_refresh_patch("1783166400"),
+            json!({ "metadata": { "annotations": { "force-sync": "1783166400" } } })
+        );
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -648,6 +648,7 @@ impl App {
         };
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
+        let genr = self.generation;
         // Namespace this review is computed for (echoed back so a stale result
         // from a previous namespace/context is dropped). SelfSubjectRulesReview
         // needs a concrete namespace, so "" falls back to "default".
@@ -697,6 +698,7 @@ impl App {
             }
             let _ = tx
                 .send(Msg::Rbac {
+                    generation: genr,
                     ns: current_ns,
                     allowed,
                 })
@@ -812,7 +814,11 @@ impl App {
             Msg::PulseData { generation, data } if generation == self.generation => {
                 self.pulse = data;
             }
-            Msg::Rbac { ns, allowed } if ns == self.namespace => {
+            Msg::Rbac {
+                generation,
+                ns,
+                allowed,
+            } if generation == self.generation && ns == self.namespace => {
                 self.rbac_allowed = Some(allowed);
             }
             Msg::XrayData { generation, items } if generation == self.generation => {
@@ -849,14 +855,18 @@ impl App {
                     .scroll
                     .min(self.detail.lines.len().saturating_sub(1));
             }
-            Msg::Namespaces { list } => {
+            Msg::Namespaces { generation, list } if generation == self.generation => {
                 // Keep the picker open and preserve the selection if possible.
                 let keep = self.ns_state.selected().unwrap_or(0);
                 self.ns_list = list;
                 self.ns_state
                     .select(Some(keep.min(self.ns_list.len().saturating_sub(1))));
             }
-            Msg::ContextSwitched { name, result } => match result {
+            Msg::ContextSwitched {
+                generation,
+                name,
+                result,
+            } if generation == self.generation => match result {
                 Ok(cluster) => self.apply_context_switch(name, cluster),
                 Err(e) => self.flash_warn(&format!("context switch failed: {e}")),
             },
@@ -3085,6 +3095,7 @@ impl App {
         let client = self.cluster.client.clone();
         let kind = self.cluster.resolve("namespaces").map(|k| k.ar);
         let tx = self.tx.clone();
+        let genr = self.generation;
         tokio::spawn(async move {
             let Some(ar) = kind else { return };
             let api: Api<DynamicObject> = Api::all_with(client, &ar);
@@ -3096,7 +3107,12 @@ impl App {
                     .collect();
                 names.sort();
                 names.insert(0, "<all>".into());
-                let _ = tx.send(Msg::Namespaces { list: names }).await;
+                let _ = tx
+                    .send(Msg::Namespaces {
+                        generation: genr,
+                        list: names,
+                    })
+                    .await;
             }
         });
     }
@@ -3279,12 +3295,19 @@ impl App {
         self.store.clear();
         self.invalidate_rows();
         let tx = self.tx.clone();
+        let genr = self.generation;
         tokio::spawn(async move {
             let result = Cluster::connect_context(&name)
                 .await
                 .map(Box::new)
                 .map_err(|e| e.to_string());
-            let _ = tx.send(Msg::ContextSwitched { name, result }).await;
+            let _ = tx
+                .send(Msg::ContextSwitched {
+                    generation: genr,
+                    name,
+                    result,
+                })
+                .await;
         });
     }
 
@@ -5141,6 +5164,7 @@ mod tests {
         let mut other = HashSet::new();
         other.insert("secrets".to_string());
         app.handle_msg(Msg::Rbac {
+            generation: app.generation,
             ns: "kube-system".into(),
             allowed: other,
         });
@@ -5149,12 +5173,51 @@ mod tests {
         let mut here = HashSet::new();
         here.insert("pods".to_string());
         app.handle_msg(Msg::Rbac {
+            generation: app.generation,
             ns: "default".into(),
             allowed: here,
         });
         assert!(app.rbac_allowed.is_some());
         assert!(app.rbac_visible("pods"));
         assert!(!app.rbac_visible("secrets"));
+    }
+
+    #[tokio::test]
+    async fn stale_async_picker_results_are_dropped() {
+        let (mut app, _rx) = test_app();
+        let stale = app.generation;
+        app.bump_generation();
+
+        app.ns_list = vec!["<all>".into()];
+        app.handle_msg(Msg::Namespaces {
+            generation: stale,
+            list: vec!["<all>".into(), "stale".into()],
+        });
+        assert_eq!(app.ns_list, vec!["<all>".to_string()]);
+
+        let flash = app.flash.clone();
+        app.handle_msg(Msg::ContextSwitched {
+            generation: stale,
+            name: "old-context".into(),
+            result: Err("old failure".into()),
+        });
+        assert_eq!(app.flash, flash);
+    }
+
+    #[tokio::test]
+    async fn rbac_for_old_generation_is_dropped() {
+        let (mut app, _rx) = test_app();
+        let stale = app.generation;
+        app.bump_generation();
+
+        let mut allowed = HashSet::new();
+        allowed.insert("secrets".to_string());
+        app.handle_msg(Msg::Rbac {
+            generation: stale,
+            ns: "default".into(),
+            allowed,
+        });
+        assert!(app.rbac_allowed.is_none());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,7 @@ use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;
 use ratatui::widgets::{ListState, TableState};
 use serde_json::{Value, json};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
 use crate::k8s::{Cluster, Kind};
@@ -37,6 +37,12 @@ const MAX_LOG_LINES: usize = 5_000;
 /// resume scrolling). Only a runaway firehose during a very long pause hits
 /// this; resuming follow trims back to [`MAX_LOG_LINES`].
 const MAX_LOG_LINES_PAUSED: usize = 100_000;
+
+/// Log streams batch lines before sending them through the UI channel. This
+/// avoids one wake-up/message per line under high-volume workloads while still
+/// flushing quickly for low-volume logs.
+const LOG_BATCH_LINES: usize = 64;
+const LOG_BATCH_MS: u64 = 50;
 
 /// Flux CD resource kinds whose spec has a `suspend: bool` field — every kind
 /// with a corresponding `flux suspend/resume` subcommand: kustomize- and
@@ -346,7 +352,7 @@ pub struct App {
     pub generation: u64,
     gen_flag: Arc<AtomicU64>,
     pub tasks: Vec<JoinHandle<()>>,
-    pub tx: UnboundedSender<Msg>,
+    pub tx: Sender<Msg>,
     stack: Vec<Frame>,
 
     pub mode: Mode,
@@ -437,7 +443,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(cluster: Cluster, tx: UnboundedSender<Msg>) -> Self {
+    pub fn new(cluster: Cluster, tx: Sender<Msg>) -> Self {
         let namespace = cluster.default_namespace.clone();
         Self {
             cluster,
@@ -677,10 +683,12 @@ impl App {
             if allowed.is_empty() {
                 return;
             }
-            let _ = tx.send(Msg::Rbac {
-                ns: current_ns,
-                allowed,
-            });
+            let _ = tx
+                .send(Msg::Rbac {
+                    ns: current_ns,
+                    allowed,
+                })
+                .await;
         });
     }
 
@@ -732,6 +740,7 @@ impl App {
                             generation: genr,
                             data,
                         })
+                        .await
                         .is_err()
                     {
                         break;
@@ -774,44 +783,8 @@ impl App {
                 self.flash = format!("error: {error}");
                 self.flash_err = true;
             }
-            Msg::LogLine { generation, line } if generation == self.log_gen => {
-                // Strip carriage returns so progress output doesn't overwrite a
-                // row, and expand tabs to spaces — many loggers (e.g. Caddy's
-                // console encoder) separate `timestamp<tab>LEVEL<tab>message`
-                // with tabs, which the terminal renders as zero width, gluing
-                // the fields together. Spaces also make in-log search match.
-                self.logs
-                    .view
-                    .lines
-                    .push(line.replace('\r', "").replace('\t', " "));
-                // While following, keep a tight tail buffer. While paused, avoid
-                // trimming so indices don't shift under the frozen view (only a
-                // huge backlog hits the larger paused cap).
-                let cap = if self.logs.follow {
-                    MAX_LOG_LINES
-                } else {
-                    MAX_LOG_LINES_PAUSED
-                };
-                let overflow = self.logs.view.lines.len().saturating_sub(cap);
-                if overflow > 0 {
-                    // If we trim while paused, shift the anchored scroll by the
-                    // display rows the dropped lines occupied on screen —
-                    // filtered lines take none, wrapped lines take several —
-                    // so the frozen view stays put.
-                    if !self.logs.follow {
-                        let filter = self.logs.filter.to_lowercase();
-                        let rows: usize = self.logs.view.lines[..overflow]
-                            .iter()
-                            .filter(|l| filter.is_empty() || l.to_lowercase().contains(&filter))
-                            .map(|l| match self.logs.last_wrap_width {
-                                0 => 1,
-                                w => crate::ui::wrapped_height(l, w),
-                            })
-                            .sum();
-                        self.logs.view.scroll = self.logs.view.scroll.saturating_sub(rows);
-                    }
-                    self.logs.view.lines.drain(0..overflow);
-                }
+            Msg::LogLines { generation, lines } if generation == self.log_gen => {
+                self.push_log_lines(lines);
             }
             Msg::Metrics { generation, data } if generation == self.generation => {
                 let sort_uses_metrics = self
@@ -867,6 +840,50 @@ impl App {
     }
 
     // ----- selection -----------------------------------------------------
+
+    fn push_log_lines<I>(&mut self, lines: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        // Strip carriage returns so progress output doesn't overwrite a row,
+        // and expand tabs to spaces — many loggers separate timestamp/level/body
+        // with tabs, which some terminals render awkwardly in a TUI cell.
+        self.logs.view.lines.extend(
+            lines
+                .into_iter()
+                .map(|line| line.replace('\r', "").replace('\t', " ")),
+        );
+
+        // While following, keep a tight tail buffer. While paused, avoid
+        // trimming so indices don't shift under the frozen view (only a huge
+        // backlog hits the larger paused cap).
+        let cap = if self.logs.follow {
+            MAX_LOG_LINES
+        } else {
+            MAX_LOG_LINES_PAUSED
+        };
+        let overflow = self.logs.view.lines.len().saturating_sub(cap);
+        if overflow == 0 {
+            return;
+        }
+
+        // If we trim while paused, shift the anchored scroll by the display
+        // rows the dropped lines occupied on screen — filtered lines take none,
+        // wrapped lines take several — so the frozen view stays put.
+        if !self.logs.follow {
+            let filter = self.logs.filter.to_lowercase();
+            let rows: usize = self.logs.view.lines[..overflow]
+                .iter()
+                .filter(|l| filter.is_empty() || l.to_lowercase().contains(&filter))
+                .map(|l| match self.logs.last_wrap_width {
+                    0 => 1,
+                    w => crate::ui::wrapped_height(l, w),
+                })
+                .sum();
+            self.logs.view.scroll = self.logs.view.scroll.saturating_sub(rows);
+        }
+        self.logs.view.lines.drain(0..overflow);
+    }
 
     /// Mark the cached row order/filter stale. Cheap; safe to over-call.
     fn invalidate_rows(&self) {
@@ -1382,7 +1399,7 @@ impl App {
                     warn: Some("kubectl not found; showing YAML".into()),
                 },
             };
-            let _ = tx.send(msg);
+            let _ = tx.send(msg).await;
         });
     }
 
@@ -1610,7 +1627,6 @@ impl App {
         let genr = self.log_gen;
         let flag = self.log_flag.clone();
         let handle = tokio::spawn(async move {
-            use futures_util::{AsyncBufReadExt, TryStreamExt};
             let api: Api<Pod> = Api::namespaced(client, &ns);
             let lp = LogParams {
                 follow: !previous,
@@ -1620,32 +1636,7 @@ impl App {
                 tail_lines: if previous { None } else { Some(300) },
                 ..Default::default()
             };
-            match api.log_stream(&pod, &lp).await {
-                Ok(stream) => {
-                    let mut lines = stream.lines();
-                    while let Ok(Some(line)) = lines.try_next().await {
-                        if flag.load(Ordering::SeqCst) != genr {
-                            break;
-                        }
-                        if tx
-                            .send(Msg::LogLine {
-                                generation: genr,
-                                line: format!("{prefix}{line}"),
-                            })
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                }
-                Err(e) => {
-                    // Surface stream errors in the log view itself.
-                    let _ = tx.send(Msg::LogLine {
-                        generation: genr,
-                        line: format!("[error] {e}"),
-                    });
-                }
-            }
+            forward_log_stream(api, pod, lp, prefix, tx, genr, flag).await;
         });
         self.log_tasks.push(handle);
     }
@@ -1656,7 +1647,6 @@ impl App {
         let genr = self.log_gen;
         let flag = self.log_flag.clone();
         let handle = tokio::spawn(async move {
-            use futures_util::{AsyncBufReadExt, TryStreamExt};
             let list_api: Api<Pod> = if ns.is_empty() {
                 Api::all(client.clone())
             } else {
@@ -1665,19 +1655,24 @@ impl App {
             let pods = match list_api.list(&ListParams::default().labels(&labels)).await {
                 Ok(p) => p,
                 Err(e) => {
-                    let _ = tx.send(Msg::LogLine {
-                        generation: genr,
-                        line: format!("[error] {e}"),
-                    });
+                    let _ = tx
+                        .send(Msg::LogLines {
+                            generation: genr,
+                            lines: vec![format!("[error] {e}")],
+                        })
+                        .await;
                     return;
                 }
             };
             if pods.items.is_empty() {
-                let _ = tx.send(Msg::LogLine {
-                    generation: genr,
-                    line: "(no matching pods)".into(),
-                });
+                let _ = tx
+                    .send(Msg::LogLines {
+                        generation: genr,
+                        lines: vec!["(no matching pods)".into()],
+                    })
+                    .await;
             }
+            let mut streams = tokio::task::JoinSet::new();
             for p in pods {
                 let pod_ns = p.metadata.namespace.clone().unwrap_or_default();
                 let pod_name = p.metadata.name.clone().unwrap_or_default();
@@ -1695,7 +1690,7 @@ impl App {
                     };
                     let (client, tx, flag) = (client.clone(), tx.clone(), flag.clone());
                     let (pn, pns) = (pod_name.clone(), pod_ns.clone());
-                    tokio::spawn(async move {
+                    streams.spawn(async move {
                         let api: Api<Pod> = Api::namespaced(client, &pns);
                         let lp = LogParams {
                             follow: true,
@@ -1704,24 +1699,13 @@ impl App {
                             tail_lines: Some(100),
                             ..Default::default()
                         };
-                        if let Ok(stream) = api.log_stream(&pn, &lp).await {
-                            let mut lines = stream.lines();
-                            while let Ok(Some(line)) = lines.try_next().await {
-                                if flag.load(Ordering::SeqCst) != genr {
-                                    break;
-                                }
-                                if tx
-                                    .send(Msg::LogLine {
-                                        generation: genr,
-                                        line: format!("{prefix}{line}"),
-                                    })
-                                    .is_err()
-                                {
-                                    break;
-                                }
-                            }
-                        }
+                        forward_log_stream(api, pn, lp, prefix, tx, genr, flag).await;
                     });
+                }
+            }
+            while streams.join_next().await.is_some() {
+                if flag.load(Ordering::SeqCst) != genr {
+                    break;
                 }
             }
         });
@@ -1780,10 +1764,12 @@ impl App {
                     Api::all_with(client.clone(), &kind.ar)
                 };
                 if let Err(e) = api.delete(&name, &dp).await {
-                    let _ = tx.send(Msg::Error {
-                        generation: genr,
-                        error: format!("delete {name} failed: {e}"),
-                    });
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("delete {name} failed: {e}"),
+                        })
+                        .await;
                 }
             }
         });
@@ -1967,10 +1953,12 @@ impl App {
                 }}}}
             }));
             if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                let _ = tx.send(Msg::Error {
-                    generation: genr,
-                    error: format!("restart failed: {e}"),
-                });
+                let _ = tx
+                    .send(Msg::Error {
+                        generation: genr,
+                        error: format!("restart failed: {e}"),
+                    })
+                    .await;
             }
         });
     }
@@ -2083,10 +2071,12 @@ impl App {
             let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
             let patch = Patch::Strategic(patch_doc);
             if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                let _ = tx.send(Msg::Error {
-                    generation: genr,
-                    error: format!("set image failed: {e}"),
-                });
+                let _ = tx
+                    .send(Msg::Error {
+                        generation: genr,
+                        error: format!("set image failed: {e}"),
+                    })
+                    .await;
             }
         });
     }
@@ -2262,10 +2252,12 @@ impl App {
             let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
             let patch = Patch::Merge(json!({ "spec": { "replicas": replicas } }));
             if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                let _ = tx.send(Msg::Error {
-                    generation: genr,
-                    error: format!("scale failed: {e}"),
-                });
+                let _ = tx
+                    .send(Msg::Error {
+                        generation: genr,
+                        error: format!("scale failed: {e}"),
+                    })
+                    .await;
             }
         });
     }
@@ -2339,10 +2331,12 @@ impl App {
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    let _ = tx.send(Msg::Error {
-                        generation: genr,
-                        error: format!("{verb} {name} failed: {e}"),
-                    });
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("{verb} {name} failed: {e}"),
+                        })
+                        .await;
                 }
             }
         });
@@ -2373,10 +2367,12 @@ impl App {
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    let _ = tx.send(Msg::Error {
-                        generation: genr,
-                        error: format!("reconcile {name} failed: {e}"),
-                    });
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("reconcile {name} failed: {e}"),
+                        })
+                        .await;
                 }
             }
         });
@@ -2423,10 +2419,12 @@ impl App {
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &kind.ar);
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    let _ = tx.send(Msg::Error {
-                        generation: genr,
-                        error: format!("refresh {name} failed: {e}"),
-                    });
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("refresh {name} failed: {e}"),
+                        })
+                        .await;
                 }
             }
         });
@@ -2969,7 +2967,7 @@ impl App {
                     .collect();
                 names.sort();
                 names.insert(0, "<all>".into());
-                let _ = tx.send(Msg::Namespaces { list: names });
+                let _ = tx.send(Msg::Namespaces { list: names }).await;
             }
         });
     }
@@ -3157,7 +3155,7 @@ impl App {
                 .await
                 .map(Box::new)
                 .map_err(|e| e.to_string());
-            let _ = tx.send(Msg::ContextSwitched { name, result });
+            let _ = tx.send(Msg::ContextSwitched { name, result }).await;
         });
     }
 
@@ -3275,6 +3273,7 @@ impl App {
                         generation: genr,
                         data: p,
                     })
+                    .await
                     .is_err()
                 {
                     break;
@@ -3372,6 +3371,7 @@ impl App {
                         generation: genr,
                         items,
                     })
+                    .await
                     .is_err()
                 {
                     break;
@@ -3685,6 +3685,80 @@ fn copy_to_clipboard(text: &str) -> bool {
     false
 }
 
+async fn forward_log_stream(
+    api: Api<Pod>,
+    pod: String,
+    lp: LogParams,
+    prefix: String,
+    tx: Sender<Msg>,
+    generation: u64,
+    flag: Arc<AtomicU64>,
+) {
+    use futures_util::{AsyncBufReadExt, TryStreamExt};
+    use tokio::time::MissedTickBehavior;
+
+    let stream = match api.log_stream(&pod, &lp).await {
+        Ok(stream) => stream,
+        Err(e) => {
+            let _ = tx
+                .send(Msg::LogLines {
+                    generation,
+                    lines: vec![format!("[error] {e}")],
+                })
+                .await;
+            return;
+        }
+    };
+
+    let mut lines = stream.lines();
+    let mut batch = Vec::with_capacity(LOG_BATCH_LINES);
+    let mut flush = tokio::time::interval(Duration::from_millis(LOG_BATCH_MS));
+    flush.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        if flag.load(Ordering::SeqCst) != generation {
+            break;
+        }
+
+        tokio::select! {
+            next = lines.try_next() => {
+                match next {
+                    Ok(Some(line)) => {
+                        batch.push(format!("{prefix}{line}"));
+                        if batch.len() >= LOG_BATCH_LINES
+                            && !send_log_batch(&tx, generation, &mut batch).await
+                        {
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        batch.push(format!("[error] {e}"));
+                        break;
+                    }
+                }
+            }
+            _ = flush.tick(), if !batch.is_empty() => {
+                if !send_log_batch(&tx, generation, &mut batch).await {
+                    break;
+                }
+            }
+        }
+    }
+
+    if flag.load(Ordering::SeqCst) == generation {
+        let _ = send_log_batch(&tx, generation, &mut batch).await;
+    }
+}
+
+async fn send_log_batch(tx: &Sender<Msg>, generation: u64, batch: &mut Vec<String>) -> bool {
+    if batch.is_empty() {
+        return true;
+    }
+    let lines = std::mem::take(batch);
+    tx.send(Msg::LogLines { generation, lines }).await.is_ok()
+}
+
 /// Recursively flatten an object and its owned children into xray rows.
 fn emit_xray(
     kind: &str,
@@ -3849,14 +3923,14 @@ mod tests {
     use super::*;
     use crate::store::row_key;
     use serde_json::json;
-    use tokio::sync::mpsc::{self, UnboundedReceiver};
+    use tokio::sync::mpsc::{self, Receiver};
 
     fn obj(v: serde_json::Value) -> DynamicObject {
         serde_json::from_value(v).unwrap()
     }
 
-    fn test_app() -> (App, UnboundedReceiver<Msg>) {
-        let (tx, rx) = mpsc::unbounded_channel();
+    fn test_app() -> (App, Receiver<Msg>) {
+        let (tx, rx) = mpsc::channel(1024);
         (App::new(Cluster::fake(), tx), rx)
     }
 
@@ -4068,9 +4142,9 @@ mod tests {
 
         // Lines keep streaming while paused; the frozen offset must not drift.
         for i in 0..500 {
-            app.handle_msg(Msg::LogLine {
+            app.handle_msg(Msg::LogLines {
                 generation: app.log_gen,
-                line: format!("line {i}"),
+                lines: vec![format!("line {i}")],
             });
         }
         assert!(!app.logs.follow);
@@ -4530,9 +4604,9 @@ mod tests {
     async fn log_lines_expand_tabs_and_strip_cr() {
         let (mut app, _rx) = test_app();
         // Caddy-style tab-separated line (level would be color-wrapped too).
-        app.handle_msg(Msg::LogLine {
+        app.handle_msg(Msg::LogLines {
             generation: app.log_gen,
-            line: "2026/07/01 09:21:14.062\tINFO\tProvisioning WAF\r".into(),
+            lines: vec!["2026/07/01 09:21:14.062\tINFO\tProvisioning WAF\r".into()],
         });
         assert_eq!(
             app.logs.view.lines.last().unwrap(),
@@ -4544,9 +4618,9 @@ mod tests {
     async fn log_buffer_is_capped() {
         let (mut app, _rx) = test_app();
         for i in 0..(MAX_LOG_LINES + 50) {
-            app.handle_msg(Msg::LogLine {
+            app.handle_msg(Msg::LogLines {
                 generation: app.log_gen,
-                line: format!("line {i}"),
+                lines: vec![format!("line {i}")],
             });
         }
         assert_eq!(app.logs.view.lines.len(), MAX_LOG_LINES);
@@ -4731,9 +4805,9 @@ mod tests {
         let (mut app, _rx) = test_app();
         app.logs.follow = false; // autoscroll OFF
         let lg = app.log_gen;
-        let line = |i: usize| Msg::LogLine {
+        let line = |i: usize| Msg::LogLines {
             generation: lg,
-            line: format!("line {i}"),
+            lines: vec![format!("line {i}")],
         };
         // Well past the *following* cap, but under the paused cap: nothing is
         // dropped, so a frozen view never appears to resume scrolling.
@@ -4757,23 +4831,23 @@ mod tests {
         app.logs.view.scroll = 500;
         let lg = app.log_gen;
         // The first line is the one trimmed later: 25 chars → 3 rows at width 10.
-        app.handle_msg(Msg::LogLine {
+        app.handle_msg(Msg::LogLines {
             generation: lg,
-            line: "a".repeat(25),
+            lines: vec!["a".repeat(25)],
         });
         for i in 1..MAX_LOG_LINES_PAUSED {
-            app.handle_msg(Msg::LogLine {
+            app.handle_msg(Msg::LogLines {
                 generation: lg,
-                line: format!("l{i}"),
+                lines: vec![format!("l{i}")],
             });
         }
         assert_eq!(app.logs.view.lines.len(), MAX_LOG_LINES_PAUSED);
         assert_eq!(app.logs.view.scroll, 500); // nothing trimmed yet
         // One more line overflows the paused cap: the wrapped first line drains
         // and the frozen anchor shifts by its 3 display rows, not by 1 line.
-        app.handle_msg(Msg::LogLine {
+        app.handle_msg(Msg::LogLines {
             generation: lg,
-            line: "x".into(),
+            lines: vec!["x".into()],
         });
         assert_eq!(app.logs.view.lines.len(), MAX_LOG_LINES_PAUSED);
         assert_eq!(app.logs.view.scroll, 497);

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@
 //! re-scope the previous view), and `esc` pops back.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -177,7 +177,7 @@ enum PromptKind {
 
 pub struct Scrollable {
     pub title: String,
-    pub lines: Vec<String>,
+    pub lines: VecDeque<String>,
     /// Scroll offset in display rows. `usize` on purpose: a paused log buffer
     /// (100k lines, wrapped) far exceeds `u16`; views that hand this to a
     /// ratatui `Paragraph` clamp at the edge instead.
@@ -253,7 +253,7 @@ impl Scrollable {
     fn empty() -> Self {
         Self {
             title: String::new(),
-            lines: Vec::new(),
+            lines: VecDeque::new(),
             scroll: 0,
         }
     }
@@ -835,7 +835,7 @@ impl App {
             } if generation == self.generation => {
                 self.detail = Scrollable {
                     title,
-                    lines,
+                    lines: lines.into(),
                     scroll: 0,
                 };
                 self.mode = Mode::Detail;
@@ -849,7 +849,7 @@ impl App {
                 lines,
             } if generation == self.event_gen => {
                 self.detail.title = title;
-                self.detail.lines = lines;
+                self.detail.lines = lines.into();
                 self.detail.scroll = self
                     .detail
                     .scroll
@@ -938,8 +938,12 @@ impl App {
         // wrapped lines take several — so the frozen view stays put.
         if !self.logs.follow {
             let filter = self.logs.filter.to_lowercase();
-            let rows: usize = self.logs.view.lines[..overflow]
+            let rows: usize = self
+                .logs
+                .view
+                .lines
                 .iter()
+                .take(overflow)
                 .filter(|l| filter.is_empty() || l.to_lowercase().contains(&filter))
                 .map(|l| match self.logs.last_wrap_width {
                     0 => 1,
@@ -1418,7 +1422,7 @@ impl App {
         let title = obj.metadata.name.clone().unwrap_or_else(|| "object".into());
         self.detail = Scrollable {
             title: format!("{title} — YAML"),
-            lines: self.object_yaml(obj),
+            lines: self.object_yaml(obj).into(),
             scroll: 0,
         };
         self.mode = Mode::Detail;
@@ -1555,7 +1559,7 @@ impl App {
         }
         self.detail = Scrollable {
             title: format!("{name} — diff (last-applied → live)"),
-            lines,
+            lines: lines.into(),
             scroll: 0,
         };
         self.mode = Mode::Diff;
@@ -1601,7 +1605,7 @@ impl App {
         let genr = self.event_gen;
         self.detail = Scrollable {
             title: title.clone(),
-            lines: vec!["loading events…".into()],
+            lines: vec!["loading events…".into()].into(),
             scroll: 0,
         };
         self.flash = format!("events: {name}");
@@ -1728,7 +1732,7 @@ impl App {
         // the selection is preserved. Log streams have their own lifecycle.
         self.logs.view = Scrollable {
             title,
-            lines: Vec::new(),
+            lines: VecDeque::new(),
             scroll: 0,
         };
         self.logs.follow = true;
@@ -4423,7 +4427,7 @@ mod tests {
     fn scrollable_scroll_clamps() {
         let mut s = Scrollable {
             title: String::new(),
-            lines: vec!["a".into(), "b".into(), "c".into()],
+            lines: vec!["a".into(), "b".into(), "c".into()].into(),
             scroll: 0,
         };
         s.scroll_by(100);
@@ -5111,7 +5115,7 @@ mod tests {
             lines: vec!["2026/07/01 09:21:14.062\tINFO\tProvisioning WAF\r".into()],
         });
         assert_eq!(
-            app.logs.view.lines.last().unwrap(),
+            app.logs.view.lines.back().unwrap(),
             "2026/07/01 09:21:14.062 INFO Provisioning WAF"
         );
     }
@@ -5128,7 +5132,7 @@ mod tests {
         assert_eq!(app.logs.view.lines.len(), MAX_LOG_LINES);
         // Oldest lines dropped; newest retained.
         assert_eq!(
-            app.logs.view.lines.last().unwrap(),
+            app.logs.view.lines.back().unwrap(),
             &format!("line {}", MAX_LOG_LINES + 49)
         );
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -814,7 +814,14 @@ impl App {
                 }
             }
             Msg::Metrics { generation, data } if generation == self.generation => {
+                let sort_uses_metrics = self
+                    .sort_column
+                    .and_then(|i| self.display_headers().get(i).copied())
+                    .is_some_and(|h| matches!(h, "CPU" | "MEM"));
                 self.metrics = data;
+                if sort_uses_metrics {
+                    self.invalidate_rows();
+                }
             }
             Msg::PulseData { generation, data } if generation == self.generation => {
                 self.pulse = data;
@@ -4595,6 +4602,48 @@ mod tests {
         app.switch_kind("services");
         assert_eq!(app.sort_column, None);
         assert!(!app.sort_desc);
+    }
+
+    #[tokio::test]
+    async fn metrics_update_invalidates_metric_sorted_rows() {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        for name in ["a", "b"] {
+            apply(
+                &mut app,
+                json!({"apiVersion": "v1", "kind": "Pod",
+                       "metadata": {"name": name, "namespace": "default"}}),
+            );
+        }
+
+        let cpu_idx = app
+            .display_headers()
+            .iter()
+            .position(|h| *h == "CPU")
+            .unwrap();
+        app.sort_column = Some(cpu_idx);
+        app.sort_desc = true;
+        app.invalidate_rows();
+        let names: Vec<String> = app
+            .rows()
+            .iter()
+            .map(|o| o.metadata.name.clone().unwrap())
+            .collect();
+        assert_eq!(names, ["a", "b"]); // cached before metrics arrive
+
+        app.handle_msg(Msg::Metrics {
+            generation: app.generation,
+            data: HashMap::from([
+                ("default/a".to_string(), (10, 0)),
+                ("default/b".to_string(), (100, 0)),
+            ]),
+        });
+        let names: Vec<String> = app
+            .rows()
+            .iter()
+            .map(|o| o.metadata.name.clone().unwrap())
+            .collect();
+        assert_eq!(names, ["b", "a"]);
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1153,16 +1153,22 @@ impl App {
         self.flash_err = false;
     }
 
-    pub fn selected(&self) -> Option<DynamicObject> {
+    pub fn selected_ref(&self) -> Option<&DynamicObject> {
         let rows = self.rows();
         let idx = self.table_state.selected()?;
-        rows.get(idx).map(|o| (*o).clone())
+        rows.get(idx).copied()
+    }
+
+    pub fn selected(&self) -> Option<DynamicObject> {
+        self.selected_ref().cloned()
     }
 
     /// Toggle the mark on the current row (SPACE).
     fn toggle_mark(&mut self) {
-        let Some(obj) = self.selected() else { return };
-        let key = row_key(&obj);
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
+        let key = row_key(obj);
         if !self.marked.remove(&key) {
             self.marked.insert(key);
         }
@@ -1179,7 +1185,7 @@ impl App {
             )
         };
         if self.marked.is_empty() {
-            return self.selected().as_ref().map(to_pair).into_iter().collect();
+            return self.selected_ref().map(to_pair).into_iter().collect();
         }
         self.rows()
             .iter()
@@ -1378,7 +1384,7 @@ impl App {
             Mode::Table
         };
         // Remember the selected row so we can land back on it.
-        self.return_selection = self.selected().map(|o| row_key(&o));
+        self.return_selection = self.selected_ref().map(row_key);
     }
 
     /// Re-select the row remembered by [`set_return_mode`], by identity, so the
@@ -1394,13 +1400,13 @@ impl App {
 
     fn open_detail(&mut self) {
         self.set_return_mode();
-        let Some(obj) = self.selected() else {
+        let Some(obj) = self.selected_ref() else {
             return;
         };
         let title = obj.metadata.name.clone().unwrap_or_else(|| "object".into());
         self.detail = Scrollable {
             title: format!("{title} — YAML"),
-            lines: self.object_yaml(&obj),
+            lines: self.object_yaml(obj),
             scroll: 0,
         };
         self.mode = Mode::Detail;
@@ -1411,14 +1417,16 @@ impl App {
     /// or fails. The result arrives as `Msg::Detail`.
     fn describe(&mut self) {
         self.set_return_mode();
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let plural = self.kind_plural.clone();
         let ns = obj.metadata.namespace.clone();
 
         // Compute the YAML fallback up front while we hold the object; the
         // selection may change before the describe completes.
-        let yaml = self.object_yaml(&obj);
+        let yaml = self.object_yaml(obj);
         let yaml_title = format!("{name} — YAML");
 
         let tx = self.tx.clone();
@@ -1546,7 +1554,7 @@ impl App {
     /// preferred but events.k8s.io clusters still work.
     fn open_events(&mut self) {
         self.set_return_mode();
-        let Some(obj) = self.selected() else {
+        let Some(obj) = self.selected_ref() else {
             self.flash_warn("no selection for events");
             return;
         };
@@ -1661,13 +1669,15 @@ impl App {
     /// Logs for the current selection. For pods: stream every container. For
     /// workloads/services: list matching pods and aggregate all their logs.
     fn open_logs(&mut self) {
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
 
         match self.kind_plural.as_str() {
             "pods" => {
-                let containers = container_names(&obj);
+                let containers = container_names(obj);
                 self.launch_logs(
                     LogSource::Pod {
                         ns,
@@ -1678,7 +1688,7 @@ impl App {
                 );
             }
             "deployments" | "statefulsets" | "daemonsets" | "replicasets" | "jobs" => {
-                match label_selector(&obj, "matchLabels") {
+                match label_selector(obj, "matchLabels") {
                     Some(labels) => self.launch_logs(
                         LogSource::Selector { ns, labels },
                         format!("{}/{name} — logs (all pods)", trim_s(&self.kind_plural)),
@@ -1686,7 +1696,7 @@ impl App {
                     None => self.flash_warn("no pod selector for logs"),
                 }
             }
-            "services" => match label_selector(&obj, "selector") {
+            "services" => match label_selector(obj, "selector") {
                 Some(labels) => self.launch_logs(
                     LogSource::Selector { ns, labels },
                     format!("svc/{name} — logs (all pods)"),
@@ -1946,7 +1956,9 @@ impl App {
             self.flash_warn("attach is only available for pods");
             return;
         }
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let mut argv = self.kubectl_base();
@@ -1960,12 +1972,15 @@ impl App {
             self.flash_warn("'o' shows the node for a pod");
             return;
         }
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let Some(node) = obj.data.pointer("/spec/nodeName").and_then(Value::as_str) else {
             self.flash_warn("pod has no node assigned");
             return;
         };
         let node = node.to_string();
+        let pod_name = obj.metadata.name.clone().unwrap_or_default();
         let Some(nodes) = self.cluster.resolve("nodes") else {
             self.flash_warn("nodes kind unavailable");
             return;
@@ -1976,7 +1991,7 @@ impl App {
         self.namespace = String::new();
         self.labels = None;
         self.fields = Some(format!("metadata.name={node}"));
-        self.scope_label = Some(format!("host of {}", obj.metadata.name.unwrap_or_default()));
+        self.scope_label = Some(format!("host of {pod_name}"));
         self.filter.clear();
         self.reset_sort();
         self.table_state.select(Some(0));
@@ -1985,7 +2000,9 @@ impl App {
 
     /// Jump to the selected object's controller/owner (k9s Shift-J).
     fn jump_owner(&mut self) {
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let owners = obj
             .metadata
             .owner_references
@@ -2001,16 +2018,14 @@ impl App {
         };
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let owner_name = owner.name.clone();
+        let child_name = obj.metadata.name.clone().unwrap_or_default();
         self.push_frame();
         self.kind_plural = kind.ar.plural.to_lowercase();
         self.kind = Some(kind);
         self.namespace = ns;
         self.labels = None;
         self.fields = Some(format!("metadata.name={owner_name}"));
-        self.scope_label = Some(format!(
-            "owner of {}",
-            obj.metadata.name.unwrap_or_default()
-        ));
+        self.scope_label = Some(format!("owner of {child_name}"));
         self.filter.clear();
         self.reset_sort();
         self.table_state.select(Some(0));
@@ -2078,7 +2093,9 @@ impl App {
 
     /// Copy the selected resource's name to the system clipboard (k9s `c`).
     fn copy_name(&mut self) {
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         self.copy_to_clipboard_async(
             name.clone(),
@@ -2112,10 +2129,12 @@ impl App {
             self.flash_warn("previous logs are for pods (use the container picker elsewhere)");
             return;
         }
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
-        let containers = container_names(&obj);
+        let containers = container_names(obj);
         let container = containers.into_iter().next();
         self.launch_logs(
             LogSource::Single {
@@ -2130,7 +2149,9 @@ impl App {
 
     /// Rollout-restart a workload by stamping the template annotation (k9s `r`).
     fn request_restart(&mut self) {
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let Some(kind) = self.kind.clone() else {
             return;
         };
@@ -2175,7 +2196,9 @@ impl App {
             self.flash_warn("set image applies to pods and workload controllers");
             return;
         }
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let ptr = if is_pod {
             "/spec/containers"
         } else {
@@ -2205,13 +2228,14 @@ impl App {
             self.flash_warn("no containers found");
             return;
         }
-        self.container_list = names;
-        self.image_values = images;
-        self.image_target = Some((
+        let target = (
             obj.metadata.namespace.clone().unwrap_or_default(),
             obj.metadata.name.clone().unwrap_or_default(),
             self.kind_plural.clone(),
-        ));
+        );
+        self.container_list = names;
+        self.image_values = images;
+        self.image_target = Some(target);
         self.container_state.select(Some(0));
         self.mode = Mode::SetImage;
     }
@@ -2279,7 +2303,9 @@ impl App {
     }
 
     fn request_edit(&mut self) {
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let mut argv = self.kubectl_base();
         argv.extend(["edit".into(), self.kind_plural.clone(), name]);
@@ -2295,7 +2321,9 @@ impl App {
             self.flash_warn("shell is only available for pods");
             return;
         }
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let mut argv = self.kubectl_base();
@@ -2321,7 +2349,9 @@ impl App {
             self.flash_warn("scale applies to deployments/statefulsets/replicasets");
             return;
         }
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let cur = obj
@@ -2336,7 +2366,9 @@ impl App {
     }
 
     fn request_port_forward(&mut self) {
-        let Some(obj) = self.selected() else { return };
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
         if !matches!(self.kind_plural.as_str(), "pods" | "services") {
             self.flash_warn("port-forward applies to pods/services");
             return;
@@ -2803,7 +2835,7 @@ impl App {
         else {
             return;
         };
-        let Some(obj) = self.selected() else {
+        let Some(obj) = self.selected_ref() else {
             self.flash_warn("no selection for plugin");
             return;
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use futures_util::StreamExt;
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use k8s_openapi::api::core::v1::Pod;
@@ -19,6 +20,7 @@ use kube::Client;
 use kube::api::{Api, DeleteParams, ListParams, LogParams, Patch, PatchParams};
 use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;
+use kube::runtime::watcher;
 use ratatui::widgets::{ListState, TableState};
 use serde_json::{Value, json};
 use tokio::sync::mpsc::Sender;
@@ -92,6 +94,7 @@ pub enum Mode {
     Pulse,
     Xray,
     Diff,
+    Events,
     FluxMenu,
     PortForwards,
 }
@@ -211,6 +214,7 @@ enum PaletteAction {
     Pulse,
     Xray,
     Diff,
+    Events,
     PortForwards,
 }
 
@@ -230,6 +234,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Diff,
         names: &["diff"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Events,
+        names: &["events", "event"],
     },
     PaletteCommand {
         action: PaletteAction::PortForwards,
@@ -430,6 +438,8 @@ pub struct App {
     log_gen: u64,
     log_flag: Arc<AtomicU64>,
     log_tasks: Vec<JoinHandle<()>>,
+    event_gen: u64,
+    event_task: Option<JoinHandle<()>>,
 
     pub pending: Option<Suspend>,
     /// Mode to return to when leaving a transient view (logs/detail/diff).
@@ -503,6 +513,8 @@ impl App {
             log_gen: 0,
             log_flag: Arc::new(AtomicU64::new(0)),
             log_tasks: Vec::new(),
+            event_gen: 0,
+            event_task: None,
             pending: None,
             return_mode: Mode::Table,
             return_selection: None,
@@ -753,6 +765,7 @@ impl App {
     }
 
     fn bump_generation(&mut self) {
+        self.stop_event_stream();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -823,6 +836,18 @@ impl App {
                 if let Some(w) = warn {
                     self.flash_warn(&w);
                 }
+            }
+            Msg::Events {
+                generation,
+                title,
+                lines,
+            } if generation == self.event_gen => {
+                self.detail.title = title;
+                self.detail.lines = lines;
+                self.detail.scroll = self
+                    .detail
+                    .scroll
+                    .min(self.detail.lines.len().saturating_sub(1));
             }
             Msg::Namespaces { list } => {
                 // Keep the picker open and preserve the selection if possible.
@@ -1473,6 +1498,106 @@ impl App {
             scroll: 0,
         };
         self.mode = Mode::Diff;
+    }
+
+    /// Live Events for the selected object, filtered by object UID when
+    /// available. Uses the discovered `events` resource, so core/v1 Events are
+    /// preferred but events.k8s.io clusters still work.
+    fn open_events(&mut self) {
+        self.set_return_mode();
+        let Some(obj) = self.selected() else {
+            self.flash_warn("no selection for events");
+            return;
+        };
+        let Some(kind) = self.cluster.resolve("events") else {
+            self.flash_warn("events kind unavailable");
+            return;
+        };
+
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        let title = format!("{name} — events");
+        let field = if kind.ar.group == "events.k8s.io" {
+            "regarding"
+        } else {
+            "involvedObject"
+        };
+        let selector = obj
+            .metadata
+            .uid
+            .as_ref()
+            .filter(|uid| !uid.is_empty())
+            .map(|uid| format!("{field}.uid={uid}"))
+            .unwrap_or_else(|| {
+                let mut parts = vec![format!("{field}.name={name}")];
+                if !ns.is_empty() {
+                    parts.push(format!("{field}.namespace={ns}"));
+                }
+                parts.join(",")
+            });
+
+        self.stop_event_stream();
+        let genr = self.event_gen;
+        self.detail = Scrollable {
+            title: title.clone(),
+            lines: vec!["loading events…".into()],
+            scroll: 0,
+        };
+        self.flash = format!("events: {name}");
+        self.flash_err = false;
+        self.mode = Mode::Events;
+
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let ar = kind.ar.clone();
+        let namespaced = kind.namespaced;
+        let watch_ns = ns;
+        let is_events_v1 = ar.group == "events.k8s.io";
+        let handle = tokio::spawn(async move {
+            let api: Api<DynamicObject> = if namespaced && !watch_ns.is_empty() {
+                Api::namespaced_with(client, &watch_ns, &ar)
+            } else {
+                Api::all_with(client, &ar)
+            };
+            let cfg = watcher::Config::default().any_semantic().fields(&selector);
+            let mut stream = watcher(api, cfg).boxed();
+            let mut items: HashMap<String, DynamicObject> = HashMap::new();
+
+            while let Some(event) = stream.next().await {
+                match event {
+                    Ok(watcher::Event::Init) => items.clear(),
+                    Ok(watcher::Event::Apply(obj)) | Ok(watcher::Event::InitApply(obj)) => {
+                        items.insert(row_key(&obj), obj);
+                    }
+                    Ok(watcher::Event::Delete(obj)) => {
+                        items.remove(&row_key(&obj));
+                    }
+                    Ok(watcher::Event::InitDone) => {}
+                    Err(e) => {
+                        let _ = tx
+                            .send(Msg::Events {
+                                generation: genr,
+                                title: title.clone(),
+                                lines: vec![format!("error: {e}")],
+                            })
+                            .await;
+                        continue;
+                    }
+                }
+
+                if !send_event_snapshot(&tx, genr, &title, &items, is_events_v1).await {
+                    break;
+                }
+            }
+        });
+        self.event_task = Some(handle);
+    }
+
+    fn stop_event_stream(&mut self) {
+        self.event_gen += 1;
+        if let Some(task) = self.event_task.take() {
+            task.abort();
+        }
     }
 
     // ----- containers / logs --------------------------------------------
@@ -2475,7 +2600,7 @@ impl App {
             Mode::Table => self.key_table(key),
             Mode::Command => self.key_command(key),
             Mode::Filter => self.key_filter(key),
-            Mode::Detail | Mode::Diff => self.key_scroll(key, true),
+            Mode::Detail | Mode::Diff | Mode::Events => self.key_scroll(key, true),
             Mode::Logs => self.key_logs(key),
             Mode::LogFilter => self.key_log_filter(key),
             Mode::Help => {
@@ -2539,6 +2664,7 @@ impl App {
             KeyCode::Enter => self.drill(),
             KeyCode::Char('y') => self.open_detail(),
             KeyCode::Char('d') => self.describe(),
+            KeyCode::Char('E') => self.open_events(),
             KeyCode::Char('l') => self.open_logs(),
             KeyCode::Char('p') => self.open_previous_logs(),
             KeyCode::Char('e') => self.request_edit(),
@@ -2683,6 +2809,7 @@ impl App {
             PaletteAction::Pulse => self.open_pulse(),
             PaletteAction::Xray => self.open_xray(),
             PaletteAction::Diff => self.open_diff(),
+            PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),
         }
     }
@@ -2799,6 +2926,8 @@ impl App {
                 // landing back on the same row.
                 if !detail {
                     self.stop_log_stream();
+                } else if self.mode == Mode::Events {
+                    self.stop_event_stream();
                 }
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
@@ -3759,6 +3888,129 @@ async fn send_log_batch(tx: &Sender<Msg>, generation: u64, batch: &mut Vec<Strin
     tx.send(Msg::LogLines { generation, lines }).await.is_ok()
 }
 
+async fn send_event_snapshot(
+    tx: &Sender<Msg>,
+    generation: u64,
+    title: &str,
+    items: &HashMap<String, DynamicObject>,
+    events_v1: bool,
+) -> bool {
+    tx.send(Msg::Events {
+        generation,
+        title: title.to_string(),
+        lines: format_event_lines(items.values(), events_v1),
+    })
+    .await
+    .is_ok()
+}
+
+fn format_event_lines<'a, I>(events: I, events_v1: bool) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a DynamicObject>,
+{
+    let mut rows: Vec<(String, String)> = events
+        .into_iter()
+        .map(|event| {
+            let seen = event_time(event, events_v1);
+            (seen.clone(), event_line(event, events_v1, &seen))
+        })
+        .collect();
+    rows.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut lines = vec![format!(
+        "{:<20} {:<8} {:<24} {:>5} {}",
+        "LAST SEEN", "TYPE", "REASON", "COUNT", "MESSAGE"
+    )];
+    if rows.is_empty() {
+        lines.push("(no events)".into());
+    } else {
+        lines.extend(rows.into_iter().map(|(_, line)| line));
+    }
+    lines
+}
+
+fn event_line(event: &DynamicObject, events_v1: bool, seen: &str) -> String {
+    let typ = svalue(&event.data, &["type"]).unwrap_or_default();
+    let reason = svalue(&event.data, &["reason"]).unwrap_or_default();
+    let count = event_count(event, events_v1);
+    let message = if events_v1 {
+        svalue(&event.data, &["note"])
+            .or_else(|| svalue(&event.data, &["message"]))
+            .unwrap_or_default()
+    } else {
+        svalue(&event.data, &["message"])
+            .or_else(|| svalue(&event.data, &["note"]))
+            .unwrap_or_default()
+    };
+    format!(
+        "{:<20} {:<8} {:<24} {:>5} {}",
+        compact_event_time(seen),
+        typ,
+        reason,
+        count,
+        message.replace('\n', " ")
+    )
+}
+
+fn event_count(event: &DynamicObject, events_v1: bool) -> i64 {
+    if events_v1 {
+        ivalue(&event.data, &["series", "count"])
+            .or_else(|| ivalue(&event.data, &["deprecatedCount"]))
+            .unwrap_or(1)
+    } else {
+        ivalue(&event.data, &["count"]).unwrap_or(1)
+    }
+}
+
+fn event_time(event: &DynamicObject, events_v1: bool) -> String {
+    let data = &event.data;
+    let value = if events_v1 {
+        svalue(data, &["series", "lastObservedTime"])
+            .or_else(|| svalue(data, &["eventTime"]))
+            .or_else(|| svalue(data, &["deprecatedLastTimestamp"]))
+            .or_else(|| svalue(data, &["deprecatedFirstTimestamp"]))
+    } else {
+        svalue(data, &["lastTimestamp"])
+            .or_else(|| svalue(data, &["eventTime"]))
+            .or_else(|| svalue(data, &["firstTimestamp"]))
+    };
+    value
+        .or_else(|| {
+            event
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|ts| ts.0.to_string())
+        })
+        .unwrap_or_default()
+}
+
+fn compact_event_time(raw: &str) -> String {
+    let trimmed = raw.trim_end_matches('Z');
+    if let Some((date, time)) = trimmed.split_once('T') {
+        let time = time.split('.').next().unwrap_or(time);
+        format!("{date} {time}")
+    } else {
+        raw.to_string()
+    }
+}
+
+fn svalue(v: &Value, path: &[&str]) -> Option<String> {
+    let mut cur = v;
+    for p in path {
+        cur = cur.get(p)?;
+    }
+    cur.as_str().map(String::from)
+}
+
+fn ivalue(v: &Value, path: &[&str]) -> Option<i64> {
+    let mut cur = v;
+    for p in path {
+        cur = cur.get(p)?;
+    }
+    cur.as_i64()
+}
+
 /// Recursively flatten an object and its owned children into xray rows.
 fn emit_xray(
     kind: &str,
@@ -4493,6 +4745,35 @@ mod tests {
         let (mut app, _rx) = test_app();
         assert!(app.run_palette_command("pf"));
         assert_eq!(app.mode, Mode::PortForwards);
+    }
+
+    #[tokio::test]
+    async fn events_palette_command_dispatches() {
+        let (mut app, _rx) = test_app();
+        assert!(app.run_palette_command("events"));
+        assert_eq!(app.mode, Mode::Table);
+        assert!(app.flash_err);
+        assert!(app.flash.contains("events"), "{}", app.flash);
+    }
+
+    #[test]
+    fn event_lines_show_core_event_fields() {
+        let event = obj(json!({
+            "apiVersion": "v1",
+            "kind": "Event",
+            "metadata": {"name": "web.123", "namespace": "default"},
+            "type": "Warning",
+            "reason": "FailedScheduling",
+            "message": "0/3 nodes are available",
+            "count": 4,
+            "lastTimestamp": "2026-07-04T12:34:56Z"
+        }));
+        let lines = format_event_lines([&event], false);
+        assert!(lines[0].contains("LAST SEEN"));
+        assert!(lines[1].contains("Warning"));
+        assert!(lines[1].contains("FailedScheduling"));
+        assert!(lines[1].contains("0/3 nodes are available"));
+        assert!(lines[1].contains("4"));
     }
 
     fn spawn_test_child(argv0: &str, arg: &str) -> tokio::process::Child {

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use k8s_openapi::api::core::v1::Pod;
 use kube::Client;
-use kube::api::{Api, DeleteParams, ListParams, LogParams, Patch, PatchParams};
+use kube::api::{Api, DeleteParams, EvictParams, ListParams, LogParams, Patch, PatchParams};
 use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;
 use kube::runtime::watcher;
@@ -135,6 +135,8 @@ enum ConfirmAction {
         targets: Vec<(String, String)>,
         force: bool,
     },
+    /// One or more node names to cordon and drain.
+    Drain { targets: Vec<String> },
 }
 
 /// What the logs view is currently streaming, so it can be re-streamed when
@@ -1243,6 +1245,16 @@ impl App {
         self.selected_ref().cloned()
     }
 
+    pub fn confirm_allows_force_toggle(&self) -> bool {
+        matches!(
+            self.confirm_action,
+            Some(ConfirmAction::Delete {
+                targets: _,
+                force: _
+            })
+        )
+    }
+
     /// Toggle the mark on the current row (SPACE).
     fn toggle_mark(&mut self) {
         let Some(obj) = self.selected_ref() else {
@@ -1271,6 +1283,14 @@ impl App {
             .iter()
             .filter(|o| self.marked.contains(&row_key(o)))
             .map(|o| to_pair(o))
+            .collect()
+    }
+
+    fn node_action_targets(&self) -> Vec<String> {
+        self.action_targets()
+            .into_iter()
+            .map(|(name, _)| name)
+            .filter(|name| !name.is_empty())
             .collect()
     }
 
@@ -1975,22 +1995,7 @@ impl App {
         if targets.is_empty() {
             return;
         }
-        let verb = if force {
-            "Kill (force-delete)"
-        } else {
-            "Delete"
-        };
-        self.confirm_label = if targets.len() == 1 {
-            let (name, ns) = &targets[0];
-            let where_ns = if ns.is_empty() {
-                String::new()
-            } else {
-                format!(" in {ns}")
-            };
-            format!("{verb} {} {name}{where_ns}?", trim_s(&self.kind_plural))
-        } else {
-            format!("{verb} {} {}?", targets.len(), self.kind_plural)
-        };
+        self.confirm_label = delete_confirm_label(&self.kind_plural, &targets, force);
         self.confirm_action = Some(ConfirmAction::Delete { targets, force });
         self.mode = Mode::Confirm;
     }
@@ -2026,6 +2031,161 @@ impl App {
                             error: format!("delete {name} failed: {e}"),
                         })
                         .await;
+                }
+            }
+        });
+    }
+
+    fn request_cordon(&mut self, unschedulable: bool) {
+        if self.kind_plural != "nodes" {
+            self.flash_warn("cordon/uncordon applies to nodes");
+            return;
+        }
+        let targets = self.node_action_targets();
+        if targets.is_empty() {
+            return;
+        }
+        self.do_cordon_nodes(targets, unschedulable);
+    }
+
+    fn do_cordon_nodes(&mut self, targets: Vec<String>, unschedulable: bool) {
+        let Some(kind) = self.kind.clone() else {
+            return;
+        };
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        let patch_doc = node_unschedulable_patch(unschedulable);
+        let verb = if unschedulable {
+            "cordoning"
+        } else {
+            "uncordoning"
+        };
+        self.flash = if targets.len() == 1 {
+            format!("{verb} {}…", targets[0])
+        } else {
+            format!("{verb} {} nodes…", targets.len())
+        };
+        self.flash_err = false;
+        tokio::spawn(async move {
+            let api: Api<DynamicObject> = Api::all_with(client, &kind.ar);
+            let patch = Patch::Merge(patch_doc);
+            for name in targets {
+                if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("{verb} {name} failed: {e}"),
+                        })
+                        .await;
+                }
+            }
+        });
+    }
+
+    fn request_drain(&mut self) {
+        if self.kind_plural != "nodes" {
+            self.flash_warn("drain applies to nodes");
+            return;
+        }
+        let targets = self.node_action_targets();
+        if targets.is_empty() {
+            return;
+        }
+        self.confirm_label = if targets.len() == 1 {
+            format!("Drain node {}? Cordon and evict eligible pods.", targets[0])
+        } else {
+            format!(
+                "Drain {} nodes? Cordon and evict eligible pods.",
+                targets.len()
+            )
+        };
+        self.confirm_action = Some(ConfirmAction::Drain { targets });
+        self.mode = Mode::Confirm;
+    }
+
+    fn do_drain_nodes(&mut self, targets: Vec<String>) {
+        let Some(kind) = self.kind.clone() else {
+            return;
+        };
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        self.flash = if targets.len() == 1 {
+            format!("draining {}…", targets[0])
+        } else {
+            format!("draining {} nodes…", targets.len())
+        };
+        self.flash_err = false;
+        tokio::spawn(async move {
+            let nodes: Api<DynamicObject> = Api::all_with(client.clone(), &kind.ar);
+            let node_patch = Patch::Merge(node_unschedulable_patch(true));
+            let pods: Api<Pod> = Api::all(client.clone());
+            for node in targets {
+                if let Err(e) = nodes
+                    .patch(&node, &PatchParams::default(), &node_patch)
+                    .await
+                {
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("drain {node}: cordon failed: {e}"),
+                        })
+                        .await;
+                    continue;
+                }
+
+                let listed = pods
+                    .list(&ListParams::default().fields(&format!("spec.nodeName={node}")))
+                    .await;
+                let pod_list = match listed {
+                    Ok(list) => list,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Msg::Error {
+                                generation: genr,
+                                error: format!("drain {node}: list pods failed: {e}"),
+                            })
+                            .await;
+                        continue;
+                    }
+                };
+
+                for pod in pod_list.items.iter().filter(|pod| drainable_pod(pod)) {
+                    let Some(name) = pod.metadata.name.as_deref() else {
+                        continue;
+                    };
+                    let ns = pod.metadata.namespace.as_deref().unwrap_or("default");
+                    let pod_api: Api<Pod> = Api::namespaced(client.clone(), ns);
+                    let evict = EvictParams {
+                        delete_options: Some(DeleteParams::default()),
+                        ..Default::default()
+                    };
+                    match pod_api.evict(name, &evict).await {
+                        Ok(_) => {}
+                        Err(e) if eviction_unsupported(&e) => {
+                            if let Err(delete_err) =
+                                pod_api.delete(name, &DeleteParams::default()).await
+                            {
+                                let _ = tx
+                                    .send(Msg::Error {
+                                        generation: genr,
+                                        error: format!(
+                                            "drain {node}: delete {ns}/{name} failed after eviction fallback: {delete_err}"
+                                        ),
+                                    })
+                                    .await;
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx
+                                .send(Msg::Error {
+                                    generation: genr,
+                                    error: format!("drain {node}: evict {ns}/{name} failed: {e}"),
+                                })
+                                .await;
+                        }
+                    }
                 }
             }
         });
@@ -2852,6 +3012,9 @@ impl App {
             KeyCode::Char('o') => self.show_node(),
             KeyCode::Char('c') => self.copy_name(),
             KeyCode::Char('J') => self.jump_owner(),
+            KeyCode::Char('C') => self.request_cordon(true),
+            KeyCode::Char('U') => self.request_cordon(false),
+            KeyCode::Char('D') => self.request_drain(),
             // Sorting: S cycles the column, I inverts the direction.
             KeyCode::Char('S') => self.cycle_sort(),
             KeyCode::Char('I') => self.toggle_sort_dir(),
@@ -3797,11 +3960,31 @@ impl App {
     fn key_confirm(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
-                if let Some(ConfirmAction::Delete { targets, force }) = self.confirm_action.take() {
-                    self.do_delete(targets, force);
-                    self.marked.clear();
+                if let Some(action) = self.confirm_action.take() {
+                    match action {
+                        ConfirmAction::Delete { targets, force } => {
+                            self.do_delete(targets, force);
+                            self.marked.clear();
+                        }
+                        ConfirmAction::Drain { targets } => {
+                            self.do_drain_nodes(targets);
+                            self.marked.clear();
+                        }
+                    }
                 }
                 self.mode = Mode::Table;
+            }
+            KeyCode::Char('f') | KeyCode::Char('F') => {
+                let update = match self.confirm_action.as_mut() {
+                    Some(ConfirmAction::Delete { targets, force }) => {
+                        *force = !*force;
+                        Some((targets.clone(), *force))
+                    }
+                    _ => None,
+                };
+                if let Some((targets, force)) = update {
+                    self.confirm_label = delete_confirm_label(&self.kind_plural, &targets, force);
+                }
             }
             _ => {
                 self.confirm_action = None;
@@ -3897,6 +4080,61 @@ fn external_secret_refresh_patch(force_sync: &str) -> Value {
     json!({
         "metadata": { "annotations": { "force-sync": force_sync } }
     })
+}
+
+fn node_unschedulable_patch(unschedulable: bool) -> Value {
+    json!({ "spec": { "unschedulable": unschedulable } })
+}
+
+fn delete_confirm_label(kind_plural: &str, targets: &[(String, String)], force: bool) -> String {
+    let verb = if force { "Force delete" } else { "Delete" };
+    if targets.len() == 1 {
+        let (name, ns) = &targets[0];
+        let where_ns = if ns.is_empty() {
+            String::new()
+        } else {
+            format!(" in {ns}")
+        };
+        format!("{verb} {} {name}{where_ns}?", trim_s(kind_plural))
+    } else {
+        format!("{verb} {} {}?", targets.len(), kind_plural)
+    }
+}
+
+fn drainable_pod(pod: &Pod) -> bool {
+    if pod.metadata.deletion_timestamp.is_some() {
+        return false;
+    }
+    if pod
+        .metadata
+        .annotations
+        .as_ref()
+        .is_some_and(|a| a.contains_key("kubernetes.io/config.mirror"))
+    {
+        return false;
+    }
+    if pod
+        .metadata
+        .owner_references
+        .as_ref()
+        .is_some_and(|owners| {
+            owners
+                .iter()
+                .any(|owner| owner.kind.eq_ignore_ascii_case("DaemonSet"))
+        })
+    {
+        return false;
+    }
+    !matches!(
+        pod.status
+            .as_ref()
+            .and_then(|status| status.phase.as_deref()),
+        Some("Succeeded" | "Failed")
+    )
+}
+
+fn eviction_unsupported(err: &kube::Error) -> bool {
+    matches!(err, kube::Error::Api(api_err) if matches!(api_err.code, 404 | 405))
 }
 
 /// Pick a version name to query a CRD's custom resources: the storage version
@@ -4892,6 +5130,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_confirm_force_can_toggle() {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": "web", "namespace": "default"}}),
+        );
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+            .unwrap();
+        assert_eq!(app.mode, Mode::Confirm);
+        assert!(app.confirm_allows_force_toggle());
+        assert!(app.confirm_label.starts_with("Delete pod web"));
+        assert!(matches!(
+            app.confirm_action,
+            Some(ConfirmAction::Delete { force: false, .. })
+        ));
+
+        app.handle_key(press(KeyCode::Char('f'))).unwrap();
+        assert!(app.confirm_label.starts_with("Force delete pod web"));
+        assert!(matches!(
+            app.confirm_action,
+            Some(ConfirmAction::Delete { force: true, .. })
+        ));
+
+        app.handle_key(press(KeyCode::Char('f'))).unwrap();
+        assert!(app.confirm_label.starts_with("Delete pod web"));
+        assert!(matches!(
+            app.confirm_action,
+            Some(ConfirmAction::Delete { force: false, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn node_drain_key_opens_confirm_for_marked_nodes() {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("nodes");
+        for n in ["node-a", "node-b"] {
+            apply(
+                &mut app,
+                json!({"apiVersion": "v1", "kind": "Node",
+                       "metadata": {"name": n}}),
+            );
+        }
+        app.handle_key(press(KeyCode::Char(' '))).unwrap();
+        app.handle_key(press(KeyCode::Char(' '))).unwrap();
+
+        app.handle_key(press(KeyCode::Char('D'))).unwrap();
+        assert_eq!(app.mode, Mode::Confirm);
+        assert_eq!(
+            app.confirm_label,
+            "Drain 2 nodes? Cordon and evict eligible pods."
+        );
+        assert!(!app.confirm_allows_force_toggle());
+        let Some(ConfirmAction::Drain { mut targets }) = app.confirm_action.take() else {
+            panic!("expected drain confirm action");
+        };
+        targets.sort();
+        assert_eq!(targets, vec!["node-a".to_string(), "node-b".to_string()]);
+    }
+
+    #[tokio::test]
     async fn esc_clears_marks_before_popping() {
         let (mut app, _rx) = test_app();
         app.switch_kind("pods");
@@ -5207,6 +5508,14 @@ mod tests {
         assert_eq!(
             external_secret_refresh_patch("1783166400"),
             json!({ "metadata": { "annotations": { "force-sync": "1783166400" } } })
+        );
+        assert_eq!(
+            node_unschedulable_patch(true),
+            json!({ "spec": { "unschedulable": true } })
+        );
+        assert_eq!(
+            node_unschedulable_patch(false),
+            json!({ "spec": { "unschedulable": false } })
         );
     }
 
@@ -5697,6 +6006,33 @@ mod tests {
         assert!(names.contains(&"app".to_string()));
         assert!(names.contains(&"sidecar".to_string()));
         assert!(names.contains(&"init".to_string()));
+    }
+
+    #[test]
+    fn drainable_pod_skips_daemonset_mirror_and_completed_pods() {
+        let pod = |v| serde_json::from_value::<Pod>(v).unwrap();
+        assert!(drainable_pod(&pod(json!({
+            "metadata": {"name": "web", "namespace": "default"},
+            "status": {"phase": "Running"}
+        }))));
+        assert!(!drainable_pod(&pod(json!({
+            "metadata": {
+                "name": "ds",
+                "ownerReferences": [{"kind": "DaemonSet", "name": "agent", "uid": "ds"}]
+            },
+            "status": {"phase": "Running"}
+        }))));
+        assert!(!drainable_pod(&pod(json!({
+            "metadata": {
+                "name": "static",
+                "annotations": {"kubernetes.io/config.mirror": "mirror"}
+            },
+            "status": {"phase": "Running"}
+        }))));
+        assert!(!drainable_pod(&pod(json!({
+            "metadata": {"name": "done"},
+            "status": {"phase": "Succeeded"}
+        }))));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -869,6 +869,17 @@ impl App {
                 self.ns_state
                     .select(Some(keep.min(self.ns_list.len().saturating_sub(1))));
             }
+            Msg::Contexts { generation, list } if generation == self.generation => {
+                if list.is_empty() {
+                    self.mode = Mode::Table;
+                    self.flash_warn("no contexts found in kubeconfig");
+                } else {
+                    let cur = self.cluster.context.clone();
+                    let idx = list.iter().position(|c| *c == cur).unwrap_or(0);
+                    self.ctx_list = list;
+                    self.ctx_state.select(Some(idx));
+                }
+            }
             Msg::ContextSwitched {
                 generation,
                 name,
@@ -3232,18 +3243,22 @@ impl App {
     }
 
     fn open_contexts(&mut self) {
-        let mut list = Cluster::list_contexts();
-        list.sort();
-        if list.is_empty() {
-            self.flash_warn("no contexts found in kubeconfig");
-            return;
-        }
-        let cur = self.cluster.context.clone();
-        let idx = list.iter().position(|c| *c == cur).unwrap_or(0);
-        self.ctx_list = list;
         self.ctx_filter.clear();
-        self.ctx_state.select(Some(idx));
+        self.ctx_list.clear();
+        self.ctx_state.select(None);
         self.mode = Mode::Contexts;
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let mut list = Cluster::list_contexts();
+            list.sort();
+            let _ = tx
+                .send(Msg::Contexts {
+                    generation: genr,
+                    list,
+                })
+                .await;
+        });
     }
 
     /// Contexts for the switcher, fuzzy-matched against the type-to-filter
@@ -5259,6 +5274,13 @@ mod tests {
         });
         assert_eq!(app.ns_list, vec!["<all>".to_string()]);
 
+        app.ctx_list = vec!["test".into()];
+        app.handle_msg(Msg::Contexts {
+            generation: stale,
+            list: vec!["stale-context".into()],
+        });
+        assert_eq!(app.ctx_list, vec!["test".to_string()]);
+
         let flash = app.flash.clone();
         app.handle_msg(Msg::ContextSwitched {
             generation: stale,
@@ -5266,6 +5288,17 @@ mod tests {
             result: Err("old failure".into()),
         });
         assert_eq!(app.flash, flash);
+    }
+
+    #[tokio::test]
+    async fn context_list_result_selects_current_context() {
+        let (mut app, _rx) = test_app();
+        app.handle_msg(Msg::Contexts {
+            generation: app.generation,
+            list: vec!["prod".into(), "test".into()],
+        });
+        assert_eq!(app.ctx_list, vec!["prod".to_string(), "test".to_string()]);
+        assert_eq!(app.ctx_state.selected(), Some(1));
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -862,6 +862,19 @@ impl App {
                 }
                 Err(e) => self.flash_warn(&format!("save failed: {e}")),
             },
+            Msg::ClipboardCopied {
+                generation,
+                copied,
+                success,
+                failure,
+            } if generation == self.generation => {
+                if copied {
+                    self.flash = success;
+                    self.flash_err = false;
+                } else {
+                    self.flash_warn(&failure);
+                }
+            }
             Msg::Namespaces { generation, list } if generation == self.generation => {
                 // Keep the picker open and preserve the selection if possible.
                 let keep = self.ns_state.selected().unwrap_or(0);
@@ -2012,12 +2025,11 @@ impl App {
             return;
         }
         let n = text.lines().count();
-        if copy_to_clipboard(&text) {
-            self.flash = format!("copied {n} log lines");
-            self.flash_err = false;
-        } else {
-            self.flash_warn("no clipboard tool found (pbcopy/xclip/wl-copy)");
-        }
+        self.copy_to_clipboard_async(
+            text,
+            format!("copied {n} log lines"),
+            "no clipboard target found (pbcopy/xclip/wl-copy/OSC 52)",
+        );
     }
 
     /// Save the filtered log buffer to a temp file (k9s Ctrl-S).
@@ -2068,12 +2080,30 @@ impl App {
     fn copy_name(&mut self) {
         let Some(obj) = self.selected() else { return };
         let name = obj.metadata.name.clone().unwrap_or_default();
-        if copy_to_clipboard(&name) {
-            self.flash = format!("copied: {name}");
-            self.flash_err = false;
-        } else {
-            self.flash_warn("no clipboard tool found (pbcopy/xclip/wl-copy)");
-        }
+        self.copy_to_clipboard_async(
+            name.clone(),
+            format!("copied: {name}"),
+            "no clipboard target found (pbcopy/xclip/wl-copy/OSC 52)",
+        );
+    }
+
+    fn copy_to_clipboard_async(&self, text: String, success: String, failure: &str) {
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        let failure = failure.to_string();
+        tokio::spawn(async move {
+            let copied = tokio::task::spawn_blocking(move || copy_to_clipboard(&text))
+                .await
+                .unwrap_or(false);
+            let _ = tx
+                .send(Msg::ClipboardCopied {
+                    generation: genr,
+                    copied,
+                    success,
+                    failure,
+                })
+                .await;
+        });
     }
 
     /// Previous-container logs for the selected pod (k9s `p` on a pod row).
@@ -3838,7 +3868,8 @@ fn list_step(state: &mut ListState, len: usize, down: bool) {
     state.select(Some(next));
 }
 
-/// Copy text to the system clipboard via the first available OS tool.
+/// Copy text to the system clipboard via the first available OS tool, falling
+/// back to OSC 52 for remote terminals where local clipboard tools are absent.
 fn copy_to_clipboard(text: &str) -> bool {
     use std::io::Write;
     use std::process::{Command, Stdio};
@@ -3870,7 +3901,32 @@ fn copy_to_clipboard(text: &str) -> bool {
             return true;
         }
     }
-    false
+    copy_to_clipboard_osc52(text)
+}
+
+fn copy_to_clipboard_osc52(text: &str) -> bool {
+    use std::fs::OpenOptions;
+    use std::io::{Write, stdout};
+
+    let sequence = osc52_sequence(text);
+    if let Ok(mut tty) = OpenOptions::new().write(true).open("/dev/tty") {
+        return tty
+            .write_all(sequence.as_bytes())
+            .and_then(|_| tty.flush())
+            .is_ok();
+    }
+
+    let mut out = stdout();
+    out.write_all(sequence.as_bytes())
+        .and_then(|_| out.flush())
+        .is_ok()
+}
+
+fn osc52_sequence(text: &str) -> String {
+    use base64::Engine;
+
+    let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    format!("\x1b]52;c;{encoded}\x07")
 }
 
 async fn forward_log_stream(
@@ -5012,6 +5068,35 @@ mod tests {
         });
         assert!(app.flash.contains("sofka-test.log"));
         assert!(!app.flash_err);
+    }
+
+    #[tokio::test]
+    async fn stale_clipboard_result_is_dropped() {
+        let (mut app, _rx) = test_app();
+        let stale = app.generation;
+        app.bump_generation();
+
+        app.handle_msg(Msg::ClipboardCopied {
+            generation: stale,
+            copied: false,
+            success: "copied stale".into(),
+            failure: "stale failed".into(),
+        });
+        assert!(!app.flash.contains("stale failed"));
+
+        app.handle_msg(Msg::ClipboardCopied {
+            generation: app.generation,
+            copied: true,
+            success: "copied current".into(),
+            failure: "current failed".into(),
+        });
+        assert_eq!(app.flash, "copied current");
+        assert!(!app.flash_err);
+    }
+
+    #[test]
+    fn osc52_sequence_base64_encodes_clipboard_text() {
+        assert_eq!(osc52_sequence("sofka"), "\x1b]52;c;c29ma2E=\x07");
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3636,8 +3636,14 @@ impl App {
             return;
         };
         let root_kind = trim_s(&self.kind_plural).to_string();
-        let rs = self.cluster.resolve("replicasets").map(|k| k.ar);
-        let pods = self.cluster.resolve("pods").map(|k| k.ar);
+        let pool_kinds: Vec<(String, ApiResource, bool)> = xray_pool_plurals(&root_kind)
+            .iter()
+            .filter_map(|plural| {
+                self.cluster
+                    .resolve(plural)
+                    .map(|k| (trim_s(plural).to_string(), k.ar, k.namespaced))
+            })
+            .collect();
 
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
@@ -3652,16 +3658,9 @@ impl App {
                 }
                 let roots = list_kind(&client, &root_ar, root_nsd, &ns).await;
                 let mut pool: Vec<(String, DynamicObject)> = Vec::new();
-                if root_kind != "pod" {
-                    if let Some(ar) = &rs {
-                        for o in list_kind(&client, ar, true, &ns).await {
-                            pool.push(("replicaset".into(), o));
-                        }
-                    }
-                    if let Some(ar) = &pods {
-                        for o in list_kind(&client, ar, true, &ns).await {
-                            pool.push(("pod".into(), o));
-                        }
+                for (label, ar, namespaced) in &pool_kinds {
+                    for o in list_kind(&client, ar, *namespaced, &ns).await {
+                        pool.push((label.clone(), o));
                     }
                 }
 
@@ -3961,6 +3960,16 @@ fn container_names(obj: &DynamicObject) -> Vec<String> {
 /// Trim a trailing plural "s" for breadcrumb labels (deployments -> deployment).
 fn trim_s(plural: &str) -> &str {
     plural.strip_suffix('s').unwrap_or(plural)
+}
+
+fn xray_pool_plurals(root_kind: &str) -> &'static [&'static str] {
+    match root_kind {
+        "pod" => &[],
+        "cronjob" => &["jobs", "pods"],
+        "job" | "daemonset" | "replicaset" | "statefulset" => &["pods"],
+        "deployment" => &["replicasets", "pods"],
+        _ => &["replicasets", "pods"],
+    }
 }
 
 /// Columns whose cell is a count/number and should sort numerically.
@@ -4307,6 +4316,25 @@ fn emit_xray(
 fn xray_status(kind: &str, o: &DynamicObject) -> String {
     match kind {
         "pod" => phase(o),
+        "job" => format!(
+            "{}/{}",
+            o.data
+                .pointer("/status/succeeded")
+                .and_then(Value::as_i64)
+                .unwrap_or(0),
+            o.data
+                .pointer("/spec/completions")
+                .and_then(Value::as_i64)
+                .unwrap_or(1)
+                .max(1),
+        ),
+        "cronjob" => format!(
+            "active {}",
+            o.data
+                .pointer("/status/active")
+                .and_then(Value::as_array)
+                .map_or(0, |items| items.len()),
+        ),
         "deployment" | "replicaset" | "statefulset" => format!(
             "{}/{}",
             o.data
@@ -5669,6 +5697,82 @@ mod tests {
         assert!(names.contains(&"app".to_string()));
         assert!(names.contains(&"sidecar".to_string()));
         assert!(names.contains(&"init".to_string()));
+    }
+
+    #[test]
+    fn xray_pool_plurals_include_cronjob_chain() {
+        assert_eq!(xray_pool_plurals("cronjob"), &["jobs", "pods"]);
+        assert_eq!(xray_pool_plurals("job"), &["pods"]);
+        assert_eq!(xray_pool_plurals("pod"), &[] as &[&str]);
+        assert_eq!(xray_pool_plurals("deployment"), &["replicasets", "pods"]);
+    }
+
+    #[test]
+    fn xray_emits_cronjob_job_pod_container_chain() {
+        let cron = obj(json!({
+            "apiVersion": "batch/v1",
+            "kind": "CronJob",
+            "metadata": {"name": "backup", "namespace": "default", "uid": "cron-uid"},
+            "status": {"active": [{"name": "backup-1"}]}
+        }));
+        let job = obj(json!({
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": "backup-1",
+                "namespace": "default",
+                "uid": "job-uid",
+                "ownerReferences": [{
+                    "apiVersion": "batch/v1",
+                    "kind": "CronJob",
+                    "name": "backup",
+                    "uid": "cron-uid"
+                }]
+            },
+            "spec": {"completions": 1},
+            "status": {"succeeded": 1}
+        }));
+        let pod = obj(json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "backup-1-pod",
+                "namespace": "default",
+                "uid": "pod-uid",
+                "ownerReferences": [{
+                    "apiVersion": "batch/v1",
+                    "kind": "Job",
+                    "name": "backup-1",
+                    "uid": "job-uid"
+                }]
+            },
+            "spec": {"containers": [{"name": "worker"}]},
+            "status": {"phase": "Running"}
+        }));
+        let mut children = std::collections::HashMap::new();
+        children.insert("cron-uid".to_string(), vec![("job".to_string(), job)]);
+        children.insert("job-uid".to_string(), vec![("pod".to_string(), pod)]);
+
+        let mut items = Vec::new();
+        emit_xray("cronjob", &cron, 0, &children, &mut items);
+
+        assert_eq!(items.len(), 4);
+        assert_eq!(items[0].kind, "cronjob");
+        assert_eq!(items[0].name, "backup");
+        assert_eq!(items[0].depth, 0);
+        assert_eq!(items[0].status, "active 1");
+        assert_eq!(items[1].kind, "job");
+        assert_eq!(items[1].name, "backup-1");
+        assert_eq!(items[1].depth, 1);
+        assert_eq!(items[1].status, "1/1");
+        assert_eq!(items[2].kind, "pod");
+        assert_eq!(items[2].name, "backup-1-pod");
+        assert_eq!(items[2].depth, 2);
+        assert_eq!(items[2].status, "Running");
+        assert_eq!(items[3].kind, "container");
+        assert_eq!(items[3].name, "backup-1-pod");
+        assert_eq!(items[3].depth, 3);
+        assert_eq!(items[3].container.as_deref(), Some("worker"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -97,6 +97,7 @@ pub enum Mode {
     Events,
     FluxMenu,
     PortForwards,
+    Skins,
 }
 
 /// A request for the run loop to suspend the TUI and run an interactive
@@ -218,6 +219,7 @@ enum PaletteAction {
     Diff,
     Events,
     PortForwards,
+    Skin,
 }
 
 const PALETTE_COMMANDS: &[PaletteCommand] = &[
@@ -244,6 +246,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::PortForwards,
         names: &["pf", "portforwards", "forwards"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Skin,
+        names: &["skin", "skins"],
     },
     PaletteCommand {
         action: PaletteAction::Quit,
@@ -437,6 +443,11 @@ pub struct App {
     pub port_forwards: Vec<PortForward>,
     pub pf_state: ListState,
 
+    pub skin_list: Vec<String>,
+    pub skin_state: ListState,
+    /// Per-swatch color overrides from config, re-applied when switching skins.
+    pub skin_colors: HashMap<String, String>,
+
     /// Current images aligned with `container_list`, for the Set-Image picker.
     pub image_values: Vec<String>,
     /// (namespace, name, plural) of the object being re-imaged.
@@ -522,6 +533,12 @@ impl App {
             flux_menu_state: ListState::default(),
             port_forwards: Vec::new(),
             pf_state: ListState::default(),
+            skin_list: crate::theme::BUILTIN_NAMES
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+            skin_state: ListState::default(),
+            skin_colors: HashMap::new(),
             image_values: Vec::new(),
             image_target: None,
             metrics: HashMap::new(),
@@ -2681,6 +2698,51 @@ impl App {
         }
     }
 
+    fn open_skins(&mut self) {
+        self.skin_state.select(if self.skin_list.is_empty() {
+            None
+        } else {
+            Some(0)
+        });
+        self.mode = Mode::Skins;
+    }
+
+    fn key_skins(&mut self, key: KeyEvent) {
+        let len = self.skin_list.len();
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
+            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.skin_state, len, true),
+            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.skin_state, len, false),
+            KeyCode::Enter => {
+                if let Some(name) = self
+                    .skin_state
+                    .selected()
+                    .and_then(|i| self.skin_list.get(i).cloned())
+                {
+                    self.apply_skin(&name);
+                }
+                self.mode = Mode::Table;
+            }
+            _ => {}
+        }
+    }
+
+    fn apply_skin(&mut self, name: &str) {
+        let name = name.trim();
+        if name.is_empty() {
+            self.open_skins();
+            return;
+        }
+        if crate::theme::builtin(&name.to_ascii_lowercase()).is_none() {
+            self.flash_warn(&format!("unknown skin: {name}"));
+            return;
+        }
+        let palette = crate::theme::resolve_skin(Some(name), &self.skin_colors);
+        crate::theme::set(palette);
+        self.flash = format!("skin: {name}");
+        self.flash_err = false;
+    }
+
     /// Stop (kill) the selected forward. Others keep running.
     fn stop_selected_port_forward(&mut self) {
         let Some(i) = self.pf_state.selected() else {
@@ -2952,6 +3014,7 @@ impl App {
             Mode::Xray => self.key_xray(key),
             Mode::FluxMenu => self.key_flux_menu(key),
             Mode::PortForwards => self.key_port_forwards(key),
+            Mode::Skins => self.key_skins(key),
         }
         Ok(())
     }
@@ -3145,6 +3208,7 @@ impl App {
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),
+            PaletteAction::Skin => self.open_skins(),
         }
     }
 
@@ -3154,6 +3218,18 @@ impl App {
         let cmd = cmd.trim();
         if cmd.is_empty() {
             return false;
+        }
+        let mut parts = cmd.split_whitespace();
+        if let Some(first) = parts.next()
+            && first.eq_ignore_ascii_case("skin")
+        {
+            let rest = parts.collect::<Vec<_>>().join(" ");
+            if rest.is_empty() {
+                self.open_skins();
+            } else {
+                self.apply_skin(&rest);
+            }
+            return true;
         }
         let action = PALETTE_COMMANDS
             .iter()
@@ -4937,6 +5013,23 @@ mod tests {
         assert!(app.run_palette_command("contexts")); // alias resolves
         assert!(!app.run_palette_command("pods")); // resource kind, not a command
         assert!(!app.run_palette_command("")); // empty is never a command
+    }
+
+    #[tokio::test]
+    async fn skin_palette_command_opens_picker() {
+        let (mut app, _rx) = test_app();
+        assert!(app.run_palette_command("skin"));
+        assert_eq!(app.mode, Mode::Skins);
+        assert_eq!(
+            app.skin_list.first().map(String::as_str),
+            Some("catppuccin-mocha")
+        );
+
+        app.mode = Mode::Table;
+        assert!(app.run_palette_command("skin no-such-skin"));
+        assert_eq!(app.mode, Mode::Table);
+        assert!(app.flash_err);
+        assert!(app.flash.contains("unknown skin"), "{}", app.flash);
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1988,16 +1988,7 @@ impl App {
 
     /// Copy the (filtered) log buffer to the clipboard (k9s `c` in logs).
     fn copy_logs(&mut self) {
-        let f = self.logs.filter.to_lowercase();
-        let text = self
-            .logs
-            .view
-            .lines
-            .iter()
-            .filter(|l| f.is_empty() || l.to_lowercase().contains(&f))
-            .cloned()
-            .collect::<Vec<_>>()
-            .join("\n");
+        let text = self.filtered_log_text();
         if text.is_empty() {
             self.flash_warn("no log lines to copy");
             return;
@@ -2011,9 +2002,13 @@ impl App {
         }
     }
 
-    /// Save the log buffer to a temp file (k9s Ctrl-S).
+    /// Save the filtered log buffer to a temp file (k9s Ctrl-S).
     fn save_logs(&mut self) {
-        let text = self.logs.view.lines.join("\n");
+        let text = self.filtered_log_text();
+        if text.is_empty() {
+            self.flash_warn("no log lines to save");
+            return;
+        }
         let ts = k8s_openapi::jiff::Timestamp::now().as_second();
         let safe: String = self
             .logs
@@ -2030,6 +2025,18 @@ impl App {
             }
             Err(e) => self.flash_warn(&format!("save failed: {e}")),
         }
+    }
+
+    fn filtered_log_text(&self) -> String {
+        let f = self.logs.filter.to_lowercase();
+        self.logs
+            .view
+            .lines
+            .iter()
+            .filter(|l| f.is_empty() || l.to_lowercase().contains(&f))
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Copy the selected resource's name to the system clipboard (k9s `c`).
@@ -4932,6 +4939,29 @@ mod tests {
         assert_eq!(
             app.logs.view.lines.last().unwrap(),
             &format!("line {}", MAX_LOG_LINES + 49)
+        );
+    }
+
+    #[tokio::test]
+    async fn filtered_log_text_respects_active_filter() {
+        let (mut app, _rx) = test_app();
+        app.handle_msg(Msg::LogLines {
+            generation: app.log_gen,
+            lines: vec![
+                "api request started".into(),
+                "worker finished".into(),
+                "api request finished".into(),
+            ],
+        });
+
+        assert_eq!(
+            app.filtered_log_text(),
+            "api request started\nworker finished\napi request finished"
+        );
+        app.logs.filter = "api".into();
+        assert_eq!(
+            app.filtered_log_text(),
+            "api request started\napi request finished"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -982,44 +982,56 @@ impl App {
             .map(|(_, idx)| idx)
     }
 
+    fn ensure_rows_cache(&self) {
+        let mut cache = self.rows_cache.borrow_mut();
+        if !cache.dirty {
+            return;
+        }
+
+        let headers = self.display_headers();
+        let sort_header = self.sort_column.and_then(|i| headers.get(i).copied());
+        // (primary sort key, (ns, name) tiebreak, store key)
+        let mut entries: Vec<(SortKey, (String, String), String)> = self
+            .store
+            .iter()
+            .filter(|(_, o)| self.matches_filter(o))
+            .map(|(k, o)| {
+                let primary = match sort_header {
+                    Some(h) => self.column_sort_key(o, h),
+                    None => SortKey::Text(String::new()),
+                };
+                let tie = (
+                    o.metadata.namespace.clone().unwrap_or_default(),
+                    o.metadata.name.clone().unwrap_or_default(),
+                );
+                (primary, tie, k.clone())
+            })
+            .collect();
+        let desc = self.sort_desc && sort_header.is_some();
+        entries.sort_by(|a, b| {
+            let mut ord = a.0.cmp_to(&b.0);
+            if desc {
+                ord = ord.reverse();
+            }
+            // Ties always fall back to namespace/name ascending.
+            ord.then_with(|| a.1.cmp(&b.1))
+        });
+        cache.keys = entries.into_iter().map(|(_, _, k)| k).collect();
+        cache.dirty = false;
+    }
+
+    /// Display-ordered, filtered row count, backed by the same cache as
+    /// [`rows`]. Use this when only the count is needed so a frame doesn't
+    /// rebuild a temporary `Vec<&DynamicObject>` just to call `len()`.
+    pub fn row_count(&self) -> usize {
+        self.ensure_rows_cache();
+        self.rows_cache.borrow().keys.len()
+    }
+
     /// Display-ordered, filtered rows. Backed by a cache that only recomputes
     /// the sort + fuzzy filter when the store, filter, or sort changes.
     pub fn rows(&self) -> Vec<&DynamicObject> {
-        {
-            let mut cache = self.rows_cache.borrow_mut();
-            if cache.dirty {
-                let headers = self.display_headers();
-                let sort_header = self.sort_column.and_then(|i| headers.get(i).copied());
-                // (primary sort key, (ns, name) tiebreak, store key)
-                let mut entries: Vec<(SortKey, (String, String), String)> = self
-                    .store
-                    .iter()
-                    .filter(|(_, o)| self.matches_filter(o))
-                    .map(|(k, o)| {
-                        let primary = match sort_header {
-                            Some(h) => self.column_sort_key(o, h),
-                            None => SortKey::Text(String::new()),
-                        };
-                        let tie = (
-                            o.metadata.namespace.clone().unwrap_or_default(),
-                            o.metadata.name.clone().unwrap_or_default(),
-                        );
-                        (primary, tie, k.clone())
-                    })
-                    .collect();
-                let desc = self.sort_desc && sort_header.is_some();
-                entries.sort_by(|a, b| {
-                    let mut ord = a.0.cmp_to(&b.0);
-                    if desc {
-                        ord = ord.reverse();
-                    }
-                    // Ties always fall back to namespace/name ascending.
-                    ord.then_with(|| a.1.cmp(&b.1))
-                });
-                cache.keys = entries.into_iter().map(|(_, _, k)| k).collect();
-                cache.dirty = false;
-            }
-        }
+        self.ensure_rows_cache();
         self.rows_cache
             .borrow()
             .keys

--- a/src/app.rs
+++ b/src/app.rs
@@ -855,6 +855,13 @@ impl App {
                     .scroll
                     .min(self.detail.lines.len().saturating_sub(1));
             }
+            Msg::LogsSaved { generation, result } if generation == self.log_gen => match result {
+                Ok(path) => {
+                    self.flash = format!("saved logs → {}", path.display());
+                    self.flash_err = false;
+                }
+                Err(e) => self.flash_warn(&format!("save failed: {e}")),
+            },
             Msg::Namespaces { generation, list } if generation == self.generation => {
                 // Keep the picker open and preserve the selection if possible.
                 let keep = self.ns_state.selected().unwrap_or(0);
@@ -2009,6 +2016,8 @@ impl App {
             self.flash_warn("no log lines to save");
             return;
         }
+        let genr = self.log_gen;
+        let tx = self.tx.clone();
         let ts = k8s_openapi::jiff::Timestamp::now().as_second();
         let safe: String = self
             .logs
@@ -2018,13 +2027,18 @@ impl App {
             .map(|c| if c.is_alphanumeric() { c } else { '-' })
             .collect();
         let path = std::env::temp_dir().join(format!("sofka-{safe}-{ts}.log"));
-        match std::fs::write(&path, text) {
-            Ok(_) => {
-                self.flash = format!("saved logs → {}", path.display());
-                self.flash_err = false;
-            }
-            Err(e) => self.flash_warn(&format!("save failed: {e}")),
-        }
+        tokio::spawn(async move {
+            let result = tokio::fs::write(&path, text)
+                .await
+                .map(|_| path)
+                .map_err(|e| e.to_string());
+            let _ = tx
+                .send(Msg::LogsSaved {
+                    generation: genr,
+                    result,
+                })
+                .await;
+        });
     }
 
     fn filtered_log_text(&self) -> String {
@@ -4963,6 +4977,26 @@ mod tests {
             app.filtered_log_text(),
             "api request started\napi request finished"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_log_save_result_is_dropped() {
+        let (mut app, _rx) = test_app();
+        let stale = app.log_gen;
+        app.log_gen += 1;
+
+        app.handle_msg(Msg::LogsSaved {
+            generation: stale,
+            result: Err("old write failed".into()),
+        });
+        assert!(!app.flash.contains("old write failed"));
+
+        app.handle_msg(Msg::LogsSaved {
+            generation: app.log_gen,
+            result: Ok(std::env::temp_dir().join("sofka-test.log")),
+        });
+        assert!(app.flash.contains("sofka-test.log"));
+        assert!(!app.flash_err);
     }
 
     #[tokio::test]

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -22,8 +22,29 @@ pub fn headers(plural: &str) -> Vec<&'static str> {
         "namespaces" => vec!["NAME", "STATUS", "AGE"],
         "configmaps" => vec!["NAME", "DATA", "AGE"],
         "secrets" => vec!["NAME", "TYPE", "DATA", "AGE"],
-        "jobs" => vec!["NAME", "COMPLETIONS", "AGE"],
-        "cronjobs" => vec!["NAME", "SCHEDULE", "SUSPEND", "ACTIVE", "AGE"],
+        "jobs" => vec!["NAME", "COMPLETIONS", "DURATION", "AGE"],
+        "cronjobs" => vec![
+            "NAME",
+            "SCHEDULE",
+            "SUSPEND",
+            "ACTIVE",
+            "LAST-SCHEDULE",
+            "AGE",
+        ],
+        "events" => vec![
+            "NAME", "TYPE", "REASON", "OBJECT", "MESSAGE", "COUNT", "AGE",
+        ],
+        "horizontalpodautoscalers" => {
+            vec![
+                "NAME",
+                "REFERENCE",
+                "TARGETS",
+                "MINPODS",
+                "MAXPODS",
+                "REPLICAS",
+                "AGE",
+            ]
+        }
         "persistentvolumeclaims" => vec!["NAME", "STATUS", "VOLUME", "CAPACITY", "AGE"],
         "persistentvolumes" => vec!["NAME", "CAPACITY", "STATUS", "CLAIM", "AGE"],
         "ingresses" => vec!["NAME", "CLASS", "HOSTS", "AGE"],
@@ -31,6 +52,17 @@ pub fn headers(plural: &str) -> Vec<&'static str> {
         "customresourcedefinitions" => vec!["NAME", "GROUP", "KIND", "VERSIONS", "SCOPE", "AGE"],
         "kustomizations" | "helmreleases" => {
             vec!["NAME", "READY", "MESSAGE", "REVISION", "SUSPENDED", "AGE"]
+        }
+        "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
+            vec![
+                "NAME",
+                "READY",
+                "MESSAGE",
+                "REVISION",
+                "URL",
+                "SUSPENDED",
+                "AGE",
+            ]
         }
         _ => vec!["NAME", "AGE"],
     }
@@ -117,13 +149,38 @@ pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) 
                 iget(d, &["status", "succeeded"]),
                 iget(d, &["spec", "completions"]).max(1)
             );
-            (vec![name, comp, age], None)
+            let duration = job_duration(d);
+            (vec![name, comp, duration, age], None)
         }
         "cronjobs" => {
             let sched = sget(d, &["spec", "schedule"]).unwrap_or_default();
             let suspend = bget(d, &["spec", "suspend"]).to_string();
             let active = count_arr(d, &["status", "active"]).to_string();
-            (vec![name, sched, suspend, active, age], None)
+            let last_schedule = time_since(d, &["status", "lastScheduleTime"]);
+            (vec![name, sched, suspend, active, last_schedule, age], None)
+        }
+        "events" => {
+            let typ = sget(d, &["type"]).unwrap_or_default();
+            let reason = sget(d, &["reason"]).unwrap_or_default();
+            let involved = event_object(d);
+            let message = event_message(d);
+            let count = event_count(d).to_string();
+            (vec![name, typ, reason, involved, message, count, age], None)
+        }
+        "horizontalpodautoscalers" => {
+            let reference = hpa_reference(d);
+            let targets = hpa_targets(d);
+            let min = iopt(d, &["spec", "minReplicas"]).unwrap_or(1).to_string();
+            let max = iopt(d, &["spec", "maxReplicas"])
+                .map(|n| n.to_string())
+                .unwrap_or_default();
+            let replicas = iopt(d, &["status", "currentReplicas"])
+                .unwrap_or(0)
+                .to_string();
+            (
+                vec![name, reference, targets, min, max, replicas, age],
+                None,
+            )
         }
         "persistentvolumeclaims" => {
             let status = sget(d, &["status", "phase"]).unwrap_or_default();
@@ -158,6 +215,16 @@ pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) 
             let revision = flux_revision(d);
             let suspended = bget(d, &["spec", "suspend"]).to_string();
             (vec![name, ready, msg, revision, suspended, age], Some(1))
+        }
+        "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
+            let (ready, msg) = ready_condition(d);
+            let revision = flux_source_revision(d);
+            let url = flux_source_url(d);
+            let suspended = bget(d, &["spec", "suspend"]).to_string();
+            (
+                vec![name, ready, msg, revision, url, suspended, age],
+                Some(1),
+            )
         }
         _ => (vec![name, age], None),
     }
@@ -223,12 +290,44 @@ fn flux_revision(d: &Value) -> String {
         .unwrap_or_default()
 }
 
+fn flux_source_revision(d: &Value) -> String {
+    sget(d, &["status", "artifact", "revision"])
+        .or_else(|| sget(d, &["status", "lastAppliedRevision"]))
+        .or_else(|| sget(d, &["status", "lastAttemptedRevision"]))
+        .unwrap_or_default()
+}
+
+fn flux_source_url(d: &Value) -> String {
+    sget(d, &["spec", "url"])
+        .or_else(|| {
+            let endpoint = sget(d, &["spec", "endpoint"]);
+            let bucket = sget(d, &["spec", "bucketName"]);
+            match (endpoint, bucket) {
+                (Some(endpoint), Some(bucket)) => {
+                    Some(format!("{}/{}", endpoint.trim_end_matches('/'), bucket))
+                }
+                (Some(endpoint), None) => Some(endpoint),
+                (None, Some(bucket)) => Some(bucket),
+                (None, None) => None,
+            }
+        })
+        .unwrap_or_default()
+}
+
 fn sget(v: &Value, path: &[&str]) -> Option<String> {
     let mut cur = v;
     for p in path {
         cur = cur.get(p)?;
     }
     cur.as_str().map(|s| s.to_string())
+}
+
+fn iopt(v: &Value, path: &[&str]) -> Option<i64> {
+    let mut cur = v;
+    for p in path {
+        cur = cur.get(p)?;
+    }
+    cur.as_i64()
 }
 
 fn iget(v: &Value, path: &[&str]) -> i64 {
@@ -288,6 +387,27 @@ pub fn age(obj: &DynamicObject) -> String {
 pub fn age_secs(obj: &DynamicObject) -> Option<i64> {
     let ts = obj.metadata.creation_timestamp.as_ref()?;
     Some((Timestamp::now().as_second() - ts.0.as_second()).max(0))
+}
+
+fn timestamp_secs(d: &Value, path: &[&str]) -> Option<i64> {
+    sget(d, path)
+        .and_then(|s| s.parse::<Timestamp>().ok())
+        .map(|ts| ts.as_second())
+}
+
+fn time_since(d: &Value, path: &[&str]) -> String {
+    timestamp_secs(d, path)
+        .map(|secs| humanize((Timestamp::now().as_second() - secs).max(0)))
+        .unwrap_or_else(|| "<none>".into())
+}
+
+fn job_duration(d: &Value) -> String {
+    let Some(start) = timestamp_secs(d, &["status", "startTime"]) else {
+        return "<none>".into();
+    };
+    let end = timestamp_secs(d, &["status", "completionTime"])
+        .unwrap_or_else(|| Timestamp::now().as_second());
+    humanize((end - start).max(0))
 }
 
 fn humanize(secs: i64) -> String {
@@ -479,6 +599,133 @@ fn count_endpoints(d: &Value) -> String {
         "<none>".into()
     } else {
         n.to_string()
+    }
+}
+
+fn event_object(d: &Value) -> String {
+    let Some(obj) = d.get("regarding").or_else(|| d.get("involvedObject")) else {
+        return "<none>".into();
+    };
+    let kind = obj.get("kind").and_then(Value::as_str).unwrap_or_default();
+    let name = obj.get("name").and_then(Value::as_str).unwrap_or_default();
+    match (kind.is_empty(), name.is_empty()) {
+        (false, false) => format!("{kind}/{name}"),
+        (false, true) => kind.to_string(),
+        (true, false) => name.to_string(),
+        (true, true) => "<none>".into(),
+    }
+}
+
+fn event_message(d: &Value) -> String {
+    sget(d, &["message"])
+        .or_else(|| sget(d, &["note"]))
+        .unwrap_or_default()
+        .replace(['\n', '\r'], " ")
+}
+
+fn event_count(d: &Value) -> i64 {
+    iopt(d, &["series", "count"])
+        .or_else(|| iopt(d, &["deprecatedCount"]))
+        .or_else(|| iopt(d, &["count"]))
+        .unwrap_or(1)
+}
+
+fn hpa_reference(d: &Value) -> String {
+    let kind = sget(d, &["spec", "scaleTargetRef", "kind"]).unwrap_or_default();
+    let name = sget(d, &["spec", "scaleTargetRef", "name"]).unwrap_or_default();
+    match (kind.is_empty(), name.is_empty()) {
+        (false, false) => format!("{kind}/{name}"),
+        (false, true) => kind,
+        (true, false) => name,
+        (true, true) => "<none>".into(),
+    }
+}
+
+fn hpa_targets(d: &Value) -> String {
+    if let Some(target) = iopt(d, &["spec", "targetCPUUtilizationPercentage"]) {
+        let current = iopt(d, &["status", "currentCPUUtilizationPercentage"])
+            .map(|n| format!("{n}%"))
+            .unwrap_or_else(|| "<unknown>".into());
+        return format!("{current}/{target}%");
+    }
+
+    let Some(metrics) = d.pointer("/spec/metrics").and_then(Value::as_array) else {
+        return "<none>".into();
+    };
+    if metrics.is_empty() {
+        return "<none>".into();
+    }
+
+    let current = d
+        .pointer("/status/currentMetrics")
+        .and_then(Value::as_array);
+    let mut targets: Vec<String> = metrics
+        .iter()
+        .zip(
+            current
+                .into_iter()
+                .flatten()
+                .map(Some)
+                .chain(std::iter::repeat(None)),
+        )
+        .take(3)
+        .map(|(metric, current)| hpa_metric(metric, current))
+        .collect();
+    if metrics.len() > 3 {
+        targets.push(format!("+{}", metrics.len() - 3));
+    }
+    targets.join(",")
+}
+
+fn hpa_metric(metric: &Value, current: Option<&Value>) -> String {
+    let typ = metric
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("Metric");
+    let (path, default_name) = match typ {
+        "ContainerResource" => ("containerResource", "container"),
+        "External" => ("external", "external"),
+        "Object" => ("object", "object"),
+        "Pods" => ("pods", "pods"),
+        "Resource" => ("resource", "resource"),
+        _ => ("", typ),
+    };
+    let name = if path.is_empty() {
+        default_name.to_string()
+    } else {
+        metric
+            .pointer(&format!("/{path}/name"))
+            .or_else(|| metric.pointer(&format!("/{path}/metric/name")))
+            .and_then(Value::as_str)
+            .unwrap_or(default_name)
+            .to_string()
+    };
+    let target = if path.is_empty() {
+        None
+    } else {
+        metric.pointer(&format!("/{path}/target"))
+    }
+    .map(hpa_metric_value)
+    .unwrap_or_else(|| "<target>".into());
+    let current = if path.is_empty() {
+        None
+    } else {
+        current.and_then(|m| m.pointer(&format!("/{path}/current")))
+    }
+    .map(hpa_metric_value)
+    .unwrap_or_else(|| "?".into());
+    format!("{name}: {current}/{target}")
+}
+
+fn hpa_metric_value(metric: &Value) -> String {
+    if let Some(n) = metric.get("averageUtilization").and_then(Value::as_i64) {
+        format!("{n}%")
+    } else if let Some(s) = metric.get("averageValue").and_then(Value::as_str) {
+        s.to_string()
+    } else if let Some(s) = metric.get("value").and_then(Value::as_str) {
+        s.to_string()
+    } else {
+        "?".into()
     }
 }
 
@@ -690,6 +937,188 @@ mod tests {
     }
 
     #[test]
+    fn flux_source_cells_show_ready_revision_url() {
+        let git = obj(json!({
+            "apiVersion": "source.toolkit.fluxcd.io/v1",
+            "kind": "GitRepository",
+            "metadata": {"name": "apps", "namespace": "flux-system"},
+            "spec": {"url": "https://github.com/example/apps", "suspend": true},
+            "status": {
+                "artifact": {"revision": "main@sha1:abc123"},
+                "conditions": [
+                    {"type": "Ready", "status": "True", "message": "stored artifact"}
+                ]
+            }
+        }));
+        let (cells, status_idx) = cells(&git, "gitrepositories");
+        assert_eq!(
+            headers("gitrepositories"),
+            vec![
+                "NAME",
+                "READY",
+                "MESSAGE",
+                "REVISION",
+                "URL",
+                "SUSPENDED",
+                "AGE"
+            ]
+        );
+        assert_eq!(cells[0], "apps");
+        assert_eq!(cells[1], "True");
+        assert_eq!(cells[2], "stored artifact");
+        assert_eq!(cells[3], "main@sha1:abc123");
+        assert_eq!(cells[4], "https://github.com/example/apps");
+        assert_eq!(cells[5], "true");
+        assert_eq!(status_idx, Some(1));
+    }
+
+    #[test]
+    fn bucket_cells_build_url_from_endpoint_and_bucket_name() {
+        let bucket = obj(json!({
+            "apiVersion": "source.toolkit.fluxcd.io/v1beta2",
+            "kind": "Bucket",
+            "metadata": {"name": "charts"},
+            "spec": {"endpoint": "https://s3.example.com/", "bucketName": "charts"},
+            "status": {
+                "artifact": {"revision": "sha256:abc123"},
+                "conditions": [{"type": "Ready", "status": "False", "message": "denied"}]
+            }
+        }));
+        let (cells, status_idx) = cells(&bucket, "buckets");
+        assert_eq!(cells[1], "False");
+        assert_eq!(cells[2], "denied");
+        assert_eq!(cells[3], "sha256:abc123");
+        assert_eq!(cells[4], "https://s3.example.com/charts");
+        assert_eq!(cells[5], "false");
+        assert_eq!(status_idx, Some(1));
+    }
+
+    #[test]
+    fn job_cells_include_duration() {
+        let job = obj(json!({
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {"name": "migrate"},
+            "spec": {"completions": 3},
+            "status": {
+                "succeeded": 2,
+                "startTime": "2024-01-01T00:00:00Z",
+                "completionTime": "2024-01-01T01:05:00Z"
+            }
+        }));
+        let (cells, _) = cells(&job, "jobs");
+        assert_eq!(
+            headers("jobs"),
+            vec!["NAME", "COMPLETIONS", "DURATION", "AGE"]
+        );
+        assert_eq!(cells[1], "2/3");
+        assert_eq!(cells[2], "1h5m");
+    }
+
+    #[test]
+    fn cronjob_cells_include_last_schedule() {
+        let cron = obj(json!({
+            "apiVersion": "batch/v1",
+            "kind": "CronJob",
+            "metadata": {"name": "backup"},
+            "spec": {"schedule": "*/15 * * * *", "suspend": false},
+            "status": {"active": [{"name": "backup-1"}]}
+        }));
+        let (cells, _) = cells(&cron, "cronjobs");
+        assert_eq!(
+            headers("cronjobs"),
+            vec![
+                "NAME",
+                "SCHEDULE",
+                "SUSPEND",
+                "ACTIVE",
+                "LAST-SCHEDULE",
+                "AGE"
+            ]
+        );
+        assert_eq!(cells[1], "*/15 * * * *");
+        assert_eq!(cells[2], "false");
+        assert_eq!(cells[3], "1");
+        assert_eq!(cells[4], "<none>");
+    }
+
+    #[test]
+    fn event_cells_show_object_message_and_count() {
+        let event = obj(json!({
+            "apiVersion": "events.k8s.io/v1",
+            "kind": "Event",
+            "metadata": {"name": "nginx.abc"},
+            "type": "Warning",
+            "reason": "BackOff",
+            "regarding": {"kind": "Pod", "name": "nginx"},
+            "note": "Back-off restarting\nfailed container",
+            "series": {"count": 7}
+        }));
+        let (cells, status_idx) = cells(&event, "events");
+        assert_eq!(
+            headers("events"),
+            vec![
+                "NAME", "TYPE", "REASON", "OBJECT", "MESSAGE", "COUNT", "AGE"
+            ]
+        );
+        assert_eq!(cells[1], "Warning");
+        assert_eq!(cells[2], "BackOff");
+        assert_eq!(cells[3], "Pod/nginx");
+        assert_eq!(cells[4], "Back-off restarting failed container");
+        assert_eq!(cells[5], "7");
+        assert_eq!(status_idx, None);
+    }
+
+    #[test]
+    fn hpa_cells_show_reference_targets_and_replicas() {
+        let hpa = obj(json!({
+            "apiVersion": "autoscaling/v2",
+            "kind": "HorizontalPodAutoscaler",
+            "metadata": {"name": "web"},
+            "spec": {
+                "scaleTargetRef": {"kind": "Deployment", "name": "web"},
+                "minReplicas": 2,
+                "maxReplicas": 10,
+                "metrics": [{
+                    "type": "Resource",
+                    "resource": {
+                        "name": "cpu",
+                        "target": {"type": "Utilization", "averageUtilization": 80}
+                    }
+                }]
+            },
+            "status": {
+                "currentReplicas": 4,
+                "currentMetrics": [{
+                    "type": "Resource",
+                    "resource": {
+                        "name": "cpu",
+                        "current": {"averageUtilization": 42}
+                    }
+                }]
+            }
+        }));
+        let (cells, _) = cells(&hpa, "horizontalpodautoscalers");
+        assert_eq!(
+            headers("horizontalpodautoscalers"),
+            vec![
+                "NAME",
+                "REFERENCE",
+                "TARGETS",
+                "MINPODS",
+                "MAXPODS",
+                "REPLICAS",
+                "AGE"
+            ]
+        );
+        assert_eq!(cells[1], "Deployment/web");
+        assert_eq!(cells[2], "cpu: 42%/80%");
+        assert_eq!(cells[3], "2");
+        assert_eq!(cells[4], "10");
+        assert_eq!(cells[5], "4");
+    }
+
+    #[test]
     fn flux_object_without_status_reads_unknown() {
         let ks = obj(json!({
             "apiVersion": "kustomize.toolkit.fluxcd.io/v1",
@@ -734,6 +1163,8 @@ mod tests {
             "secrets",
             "jobs",
             "cronjobs",
+            "events",
+            "horizontalpodautoscalers",
             "persistentvolumeclaims",
             "persistentvolumes",
             "ingresses",
@@ -741,6 +1172,10 @@ mod tests {
             "customresourcedefinitions",
             "kustomizations",
             "helmreleases",
+            "gitrepositories",
+            "helmrepositories",
+            "ocirepositories",
+            "buckets",
             "widgets",
         ];
 

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -8,64 +8,242 @@ use k8s_openapi::jiff::Timestamp;
 use kube::core::DynamicObject;
 use serde_json::Value;
 
+type CellFn = for<'a> fn(&CellContext<'a>) -> String;
+
+struct Column {
+    header: &'static str,
+    extract: CellFn,
+    is_status: bool,
+}
+
+struct CellContext<'a> {
+    obj: &'a DynamicObject,
+    data: &'a Value,
+    name: &'a str,
+    age: &'a str,
+}
+
+const fn column(header: &'static str, extract: CellFn) -> Column {
+    Column {
+        header,
+        extract,
+        is_status: false,
+    }
+}
+
+const fn status_column(header: &'static str, extract: CellFn) -> Column {
+    Column {
+        header,
+        extract,
+        is_status: true,
+    }
+}
+
+const POD_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("READY", col_pod_ready),
+    status_column("STATUS", col_pod_status),
+    column("RESTARTS", col_pod_restarts),
+    column("IP", col_pod_ip),
+    column("NODE", col_pod_node),
+    column("AGE", col_age),
+];
+
+const DEPLOYMENT_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("READY", col_deploy_ready),
+    column("UP-TO-DATE", col_deploy_updated),
+    column("AVAILABLE", col_deploy_available),
+    column("AGE", col_age),
+];
+
+const REPLICASET_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("DESIRED", col_rs_desired),
+    column("CURRENT", col_rs_current),
+    column("READY", col_rs_ready),
+    column("AGE", col_age),
+];
+
+const STATEFULSET_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("READY", col_sts_ready),
+    column("AGE", col_age),
+];
+
+const DAEMONSET_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("DESIRED", col_ds_desired),
+    column("CURRENT", col_ds_current),
+    column("READY", col_ds_ready),
+    column("AVAILABLE", col_ds_available),
+    column("AGE", col_age),
+];
+
+const SERVICE_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("TYPE", col_service_type),
+    column("CLUSTER-IP", col_service_cluster_ip),
+    column("EXTERNAL-IP", col_service_external_ip),
+    column("PORTS", col_service_ports),
+    column("AGE", col_age),
+];
+
+const NODE_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    status_column("STATUS", col_node_status),
+    column("ROLES", col_node_roles),
+    column("VERSION", col_node_version),
+    column("AGE", col_age),
+];
+
+const NAMESPACE_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    status_column("STATUS", col_namespace_status),
+    column("AGE", col_age),
+];
+
+const CONFIGMAP_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("DATA", col_configmap_data),
+    column("AGE", col_age),
+];
+
+const SECRET_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("TYPE", col_secret_type),
+    column("DATA", col_secret_data),
+    column("AGE", col_age),
+];
+
+const JOB_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("COMPLETIONS", col_job_completions),
+    column("DURATION", col_job_duration),
+    column("AGE", col_age),
+];
+
+const CRONJOB_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("SCHEDULE", col_cronjob_schedule),
+    column("SUSPEND", col_cronjob_suspend),
+    column("ACTIVE", col_cronjob_active),
+    column("LAST-SCHEDULE", col_cronjob_last_schedule),
+    column("AGE", col_age),
+];
+
+const EVENT_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("TYPE", col_event_type),
+    column("REASON", col_event_reason),
+    column("OBJECT", col_event_object),
+    column("MESSAGE", col_event_message),
+    column("COUNT", col_event_count),
+    column("AGE", col_age),
+];
+
+const HPA_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("REFERENCE", col_hpa_reference),
+    column("TARGETS", col_hpa_targets),
+    column("MINPODS", col_hpa_minpods),
+    column("MAXPODS", col_hpa_maxpods),
+    column("REPLICAS", col_hpa_replicas),
+    column("AGE", col_age),
+];
+
+const PVC_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    status_column("STATUS", col_pvc_status),
+    column("VOLUME", col_pvc_volume),
+    column("CAPACITY", col_pvc_capacity),
+    column("AGE", col_age),
+];
+
+const PV_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("CAPACITY", col_pv_capacity),
+    status_column("STATUS", col_pv_status),
+    column("CLAIM", col_pv_claim),
+    column("AGE", col_age),
+];
+
+const INGRESS_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("CLASS", col_ingress_class),
+    column("HOSTS", col_ingress_hosts),
+    column("AGE", col_age),
+];
+
+const ENDPOINT_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("ENDPOINTS", col_endpoint_count),
+    column("AGE", col_age),
+];
+
+const CRD_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("GROUP", col_crd_group),
+    column("KIND", col_crd_kind),
+    column("VERSIONS", col_crd_versions),
+    column("SCOPE", col_crd_scope),
+    column("AGE", col_age),
+];
+
+const FLUX_OBJECT_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    status_column("READY", col_flux_ready),
+    column("MESSAGE", col_flux_message),
+    column("REVISION", col_flux_revision),
+    column("SUSPENDED", col_flux_suspended),
+    column("AGE", col_age),
+];
+
+const FLUX_SOURCE_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    status_column("READY", col_flux_ready),
+    column("MESSAGE", col_flux_message),
+    column("REVISION", col_flux_source_revision),
+    column("URL", col_flux_source_url),
+    column("SUSPENDED", col_flux_suspended),
+    column("AGE", col_age),
+];
+
+const DEFAULT_COLUMNS: &[Column] = &[column("NAME", col_name), column("AGE", col_age)];
+
+fn columns_for(plural: &str) -> &'static [Column] {
+    match plural {
+        "pods" => POD_COLUMNS,
+        "deployments" => DEPLOYMENT_COLUMNS,
+        "replicasets" => REPLICASET_COLUMNS,
+        "statefulsets" => STATEFULSET_COLUMNS,
+        "daemonsets" => DAEMONSET_COLUMNS,
+        "services" => SERVICE_COLUMNS,
+        "nodes" => NODE_COLUMNS,
+        "namespaces" => NAMESPACE_COLUMNS,
+        "configmaps" => CONFIGMAP_COLUMNS,
+        "secrets" => SECRET_COLUMNS,
+        "jobs" => JOB_COLUMNS,
+        "cronjobs" => CRONJOB_COLUMNS,
+        "events" => EVENT_COLUMNS,
+        "horizontalpodautoscalers" => HPA_COLUMNS,
+        "persistentvolumeclaims" => PVC_COLUMNS,
+        "persistentvolumes" => PV_COLUMNS,
+        "ingresses" => INGRESS_COLUMNS,
+        "endpoints" => ENDPOINT_COLUMNS,
+        "customresourcedefinitions" => CRD_COLUMNS,
+        "kustomizations" | "helmreleases" => FLUX_OBJECT_COLUMNS,
+        "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
+            FLUX_SOURCE_COLUMNS
+        }
+        _ => DEFAULT_COLUMNS,
+    }
+}
+
 /// Headers for a kind, excluding the leading NAMESPACE column (the table view
 /// prepends that when listing across namespaces).
 pub fn headers(plural: &str) -> Vec<&'static str> {
-    match plural {
-        "pods" => vec!["NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE"],
-        "deployments" => vec!["NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"],
-        "replicasets" => vec!["NAME", "DESIRED", "CURRENT", "READY", "AGE"],
-        "statefulsets" => vec!["NAME", "READY", "AGE"],
-        "daemonsets" => vec!["NAME", "DESIRED", "CURRENT", "READY", "AVAILABLE", "AGE"],
-        "services" => vec!["NAME", "TYPE", "CLUSTER-IP", "EXTERNAL-IP", "PORTS", "AGE"],
-        "nodes" => vec!["NAME", "STATUS", "ROLES", "VERSION", "AGE"],
-        "namespaces" => vec!["NAME", "STATUS", "AGE"],
-        "configmaps" => vec!["NAME", "DATA", "AGE"],
-        "secrets" => vec!["NAME", "TYPE", "DATA", "AGE"],
-        "jobs" => vec!["NAME", "COMPLETIONS", "DURATION", "AGE"],
-        "cronjobs" => vec![
-            "NAME",
-            "SCHEDULE",
-            "SUSPEND",
-            "ACTIVE",
-            "LAST-SCHEDULE",
-            "AGE",
-        ],
-        "events" => vec![
-            "NAME", "TYPE", "REASON", "OBJECT", "MESSAGE", "COUNT", "AGE",
-        ],
-        "horizontalpodautoscalers" => {
-            vec![
-                "NAME",
-                "REFERENCE",
-                "TARGETS",
-                "MINPODS",
-                "MAXPODS",
-                "REPLICAS",
-                "AGE",
-            ]
-        }
-        "persistentvolumeclaims" => vec!["NAME", "STATUS", "VOLUME", "CAPACITY", "AGE"],
-        "persistentvolumes" => vec!["NAME", "CAPACITY", "STATUS", "CLAIM", "AGE"],
-        "ingresses" => vec!["NAME", "CLASS", "HOSTS", "AGE"],
-        "endpoints" => vec!["NAME", "ENDPOINTS", "AGE"],
-        "customresourcedefinitions" => vec!["NAME", "GROUP", "KIND", "VERSIONS", "SCOPE", "AGE"],
-        "kustomizations" | "helmreleases" => {
-            vec!["NAME", "READY", "MESSAGE", "REVISION", "SUSPENDED", "AGE"]
-        }
-        "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
-            vec![
-                "NAME",
-                "READY",
-                "MESSAGE",
-                "REVISION",
-                "URL",
-                "SUSPENDED",
-                "AGE",
-            ]
-        }
-        _ => vec!["NAME", "AGE"],
-    }
+    columns_for(plural).iter().map(|c| c.header).collect()
 }
 
 /// Cells for one object, aligned with [`headers`]. The 2nd return value is the
@@ -73,161 +251,16 @@ pub fn headers(plural: &str) -> Vec<&'static str> {
 pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) {
     let name = obj.metadata.name.clone().unwrap_or_default();
     let age = age(obj);
-    let d = &obj.data;
-
-    match plural {
-        "pods" => {
-            let (ready, status, restarts) = pod_summary(obj);
-            let ip = sget(d, &["status", "podIP"]).unwrap_or_else(|| "<none>".into());
-            let node = sget(d, &["spec", "nodeName"]).unwrap_or_else(|| "<none>".into());
-            (vec![name, ready, status, restarts, ip, node, age], Some(2))
-        }
-        "deployments" => {
-            let ready = format!(
-                "{}/{}",
-                iget(d, &["status", "readyReplicas"]),
-                iget(d, &["status", "replicas"])
-            );
-            let utd = iget(d, &["status", "updatedReplicas"]).to_string();
-            let avail = iget(d, &["status", "availableReplicas"]).to_string();
-            (vec![name, ready, utd, avail, age], None)
-        }
-        "replicasets" => {
-            let desired = iget(d, &["spec", "replicas"]).to_string();
-            let current = iget(d, &["status", "replicas"]).to_string();
-            let ready = iget(d, &["status", "readyReplicas"]).to_string();
-            (vec![name, desired, current, ready, age], None)
-        }
-        "statefulsets" => {
-            let ready = format!(
-                "{}/{}",
-                iget(d, &["status", "readyReplicas"]),
-                iget(d, &["spec", "replicas"])
-            );
-            (vec![name, ready, age], None)
-        }
-        "daemonsets" => (
-            vec![
-                name,
-                iget(d, &["status", "desiredNumberScheduled"]).to_string(),
-                iget(d, &["status", "currentNumberScheduled"]).to_string(),
-                iget(d, &["status", "numberReady"]).to_string(),
-                iget(d, &["status", "numberAvailable"]).to_string(),
-                age,
-            ],
-            None,
-        ),
-        "services" => {
-            let typ = sget(d, &["spec", "type"]).unwrap_or_else(|| "ClusterIP".into());
-            let cip = sget(d, &["spec", "clusterIP"]).unwrap_or_else(|| "<none>".into());
-            let eip = external_ip(d, &typ);
-            let ports = svc_ports(d);
-            (vec![name, typ, cip, eip, ports, age], None)
-        }
-        "nodes" => {
-            let status = node_ready(d);
-            let roles = node_roles(obj);
-            let ver = sget(d, &["status", "nodeInfo", "kubeletVersion"]).unwrap_or_default();
-            (vec![name, status, roles, ver, age], Some(1))
-        }
-        "namespaces" => {
-            let status = sget(d, &["status", "phase"]).unwrap_or_else(|| "Active".into());
-            (vec![name, status, age], Some(1))
-        }
-        "configmaps" => {
-            let n = count_obj(d, &["data"]) + count_obj(d, &["binaryData"]);
-            (vec![name, n.to_string(), age], None)
-        }
-        "secrets" => {
-            let typ = sget(d, &["type"]).unwrap_or_else(|| "Opaque".into());
-            let n = count_obj(d, &["data"]);
-            (vec![name, typ, n.to_string(), age], None)
-        }
-        "jobs" => {
-            let comp = format!(
-                "{}/{}",
-                iget(d, &["status", "succeeded"]),
-                iget(d, &["spec", "completions"]).max(1)
-            );
-            let duration = job_duration(d);
-            (vec![name, comp, duration, age], None)
-        }
-        "cronjobs" => {
-            let sched = sget(d, &["spec", "schedule"]).unwrap_or_default();
-            let suspend = bget(d, &["spec", "suspend"]).to_string();
-            let active = count_arr(d, &["status", "active"]).to_string();
-            let last_schedule = time_since(d, &["status", "lastScheduleTime"]);
-            (vec![name, sched, suspend, active, last_schedule, age], None)
-        }
-        "events" => {
-            let typ = sget(d, &["type"]).unwrap_or_default();
-            let reason = sget(d, &["reason"]).unwrap_or_default();
-            let involved = event_object(d);
-            let message = event_message(d);
-            let count = event_count(d).to_string();
-            (vec![name, typ, reason, involved, message, count, age], None)
-        }
-        "horizontalpodautoscalers" => {
-            let reference = hpa_reference(d);
-            let targets = hpa_targets(d);
-            let min = iopt(d, &["spec", "minReplicas"]).unwrap_or(1).to_string();
-            let max = iopt(d, &["spec", "maxReplicas"])
-                .map(|n| n.to_string())
-                .unwrap_or_default();
-            let replicas = iopt(d, &["status", "currentReplicas"])
-                .unwrap_or(0)
-                .to_string();
-            (
-                vec![name, reference, targets, min, max, replicas, age],
-                None,
-            )
-        }
-        "persistentvolumeclaims" => {
-            let status = sget(d, &["status", "phase"]).unwrap_or_default();
-            let vol = sget(d, &["spec", "volumeName"]).unwrap_or_default();
-            let cap = sget(d, &["status", "capacity", "storage"]).unwrap_or_default();
-            (vec![name, status, vol, cap, age], Some(1))
-        }
-        "persistentvolumes" => {
-            let cap = sget(d, &["spec", "capacity", "storage"]).unwrap_or_default();
-            let status = sget(d, &["status", "phase"]).unwrap_or_default();
-            let claim = sget(d, &["spec", "claimRef", "name"]).unwrap_or_default();
-            (vec![name, cap, status, claim, age], Some(2))
-        }
-        "ingresses" => {
-            let class = sget(d, &["spec", "ingressClassName"]).unwrap_or_else(|| "<none>".into());
-            let hosts = ingress_hosts(d);
-            (vec![name, class, hosts, age], None)
-        }
-        "endpoints" => {
-            let eps = count_endpoints(d);
-            (vec![name, eps, age], None)
-        }
-        "customresourcedefinitions" => {
-            let group = sget(d, &["spec", "group"]).unwrap_or_default();
-            let ckind = sget(d, &["spec", "names", "kind"]).unwrap_or_default();
-            let versions = crd_versions(d);
-            let scope = sget(d, &["spec", "scope"]).unwrap_or_default();
-            (vec![name, group, ckind, versions, scope, age], None)
-        }
-        "kustomizations" | "helmreleases" => {
-            let (ready, msg) = ready_condition(d);
-            let revision = flux_revision(d);
-            let suspended = bget(d, &["spec", "suspend"]).to_string();
-            (vec![name, ready, msg, revision, suspended, age], Some(1))
-        }
-        "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
-            let (ready, msg) = ready_condition(d);
-            let revision = flux_source_revision(d);
-            let url = flux_source_url(d);
-            let suspended = bget(d, &["spec", "suspend"]).to_string();
-            (
-                vec![name, ready, msg, revision, url, suspended, age],
-                Some(1),
-            )
-        }
-        _ => (vec![name, age], None),
-    }
+    let ctx = CellContext {
+        obj,
+        data: &obj.data,
+        name: &name,
+        age: &age,
+    };
+    let columns = columns_for(plural);
+    let values = columns.iter().map(|c| (c.extract)(&ctx)).collect();
+    let status_idx = columns.iter().position(|c| c.is_status);
+    (values, status_idx)
 }
 
 /// Cells whose display value changes with wall time even when the Kubernetes
@@ -246,7 +279,285 @@ pub fn volatile_cell(obj: &DynamicObject, plural: &str, header: &str) -> Option<
     }
 }
 
+fn col_name(ctx: &CellContext<'_>) -> String {
+    ctx.name.to_string()
+}
+
+fn col_age(ctx: &CellContext<'_>) -> String {
+    ctx.age.to_string()
+}
+
+fn col_pod_ready(ctx: &CellContext<'_>) -> String {
+    pod_summary(ctx.obj).0
+}
+
+fn col_pod_status(ctx: &CellContext<'_>) -> String {
+    pod_summary(ctx.obj).1
+}
+
+fn col_pod_restarts(ctx: &CellContext<'_>) -> String {
+    pod_summary(ctx.obj).2
+}
+
+fn col_pod_ip(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["status", "podIP"]).unwrap_or_else(|| "<none>".into())
+}
+
+fn col_pod_node(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "nodeName"]).unwrap_or_else(|| "<none>".into())
+}
+
+fn col_deploy_ready(ctx: &CellContext<'_>) -> String {
+    format!(
+        "{}/{}",
+        iget(ctx.data, &["status", "readyReplicas"]),
+        iget(ctx.data, &["status", "replicas"])
+    )
+}
+
+fn col_deploy_updated(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "updatedReplicas"]).to_string()
+}
+
+fn col_deploy_available(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "availableReplicas"]).to_string()
+}
+
+fn col_rs_desired(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["spec", "replicas"]).to_string()
+}
+
+fn col_rs_current(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "replicas"]).to_string()
+}
+
+fn col_rs_ready(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "readyReplicas"]).to_string()
+}
+
+fn col_sts_ready(ctx: &CellContext<'_>) -> String {
+    format!(
+        "{}/{}",
+        iget(ctx.data, &["status", "readyReplicas"]),
+        iget(ctx.data, &["spec", "replicas"])
+    )
+}
+
+fn col_ds_desired(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "desiredNumberScheduled"]).to_string()
+}
+
+fn col_ds_current(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "currentNumberScheduled"]).to_string()
+}
+
+fn col_ds_ready(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "numberReady"]).to_string()
+}
+
+fn col_ds_available(ctx: &CellContext<'_>) -> String {
+    iget(ctx.data, &["status", "numberAvailable"]).to_string()
+}
+
+fn col_service_type(ctx: &CellContext<'_>) -> String {
+    service_type(ctx.data)
+}
+
+fn col_service_cluster_ip(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "clusterIP"]).unwrap_or_else(|| "<none>".into())
+}
+
+fn col_service_external_ip(ctx: &CellContext<'_>) -> String {
+    external_ip(ctx.data, &service_type(ctx.data))
+}
+
+fn col_service_ports(ctx: &CellContext<'_>) -> String {
+    svc_ports(ctx.data)
+}
+
+fn col_node_status(ctx: &CellContext<'_>) -> String {
+    node_ready(ctx.data)
+}
+
+fn col_node_roles(ctx: &CellContext<'_>) -> String {
+    node_roles(ctx.obj)
+}
+
+fn col_node_version(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["status", "nodeInfo", "kubeletVersion"]).unwrap_or_default()
+}
+
+fn col_namespace_status(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["status", "phase"]).unwrap_or_else(|| "Active".into())
+}
+
+fn col_configmap_data(ctx: &CellContext<'_>) -> String {
+    (count_obj(ctx.data, &["data"]) + count_obj(ctx.data, &["binaryData"])).to_string()
+}
+
+fn col_secret_type(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["type"]).unwrap_or_else(|| "Opaque".into())
+}
+
+fn col_secret_data(ctx: &CellContext<'_>) -> String {
+    count_obj(ctx.data, &["data"]).to_string()
+}
+
+fn col_job_completions(ctx: &CellContext<'_>) -> String {
+    format!(
+        "{}/{}",
+        iget(ctx.data, &["status", "succeeded"]),
+        iget(ctx.data, &["spec", "completions"]).max(1)
+    )
+}
+
+fn col_job_duration(ctx: &CellContext<'_>) -> String {
+    job_duration(ctx.data)
+}
+
+fn col_cronjob_schedule(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "schedule"]).unwrap_or_default()
+}
+
+fn col_cronjob_suspend(ctx: &CellContext<'_>) -> String {
+    bget(ctx.data, &["spec", "suspend"]).to_string()
+}
+
+fn col_cronjob_active(ctx: &CellContext<'_>) -> String {
+    count_arr(ctx.data, &["status", "active"]).to_string()
+}
+
+fn col_cronjob_last_schedule(ctx: &CellContext<'_>) -> String {
+    time_since(ctx.data, &["status", "lastScheduleTime"])
+}
+
+fn col_event_type(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["type"]).unwrap_or_default()
+}
+
+fn col_event_reason(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["reason"]).unwrap_or_default()
+}
+
+fn col_event_object(ctx: &CellContext<'_>) -> String {
+    event_object(ctx.data)
+}
+
+fn col_event_message(ctx: &CellContext<'_>) -> String {
+    event_message(ctx.data)
+}
+
+fn col_event_count(ctx: &CellContext<'_>) -> String {
+    event_count(ctx.data).to_string()
+}
+
+fn col_hpa_reference(ctx: &CellContext<'_>) -> String {
+    hpa_reference(ctx.data)
+}
+
+fn col_hpa_targets(ctx: &CellContext<'_>) -> String {
+    hpa_targets(ctx.data)
+}
+
+fn col_hpa_minpods(ctx: &CellContext<'_>) -> String {
+    iopt(ctx.data, &["spec", "minReplicas"])
+        .unwrap_or(1)
+        .to_string()
+}
+
+fn col_hpa_maxpods(ctx: &CellContext<'_>) -> String {
+    iopt(ctx.data, &["spec", "maxReplicas"])
+        .map(|n| n.to_string())
+        .unwrap_or_default()
+}
+
+fn col_hpa_replicas(ctx: &CellContext<'_>) -> String {
+    iopt(ctx.data, &["status", "currentReplicas"])
+        .unwrap_or(0)
+        .to_string()
+}
+
+fn col_pvc_status(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["status", "phase"]).unwrap_or_default()
+}
+
+fn col_pvc_volume(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "volumeName"]).unwrap_or_default()
+}
+
+fn col_pvc_capacity(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["status", "capacity", "storage"]).unwrap_or_default()
+}
+
+fn col_pv_capacity(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "capacity", "storage"]).unwrap_or_default()
+}
+
+fn col_pv_status(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["status", "phase"]).unwrap_or_default()
+}
+
+fn col_pv_claim(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "claimRef", "name"]).unwrap_or_default()
+}
+
+fn col_ingress_class(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "ingressClassName"]).unwrap_or_else(|| "<none>".into())
+}
+
+fn col_ingress_hosts(ctx: &CellContext<'_>) -> String {
+    ingress_hosts(ctx.data)
+}
+
+fn col_endpoint_count(ctx: &CellContext<'_>) -> String {
+    count_endpoints(ctx.data)
+}
+
+fn col_crd_group(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "group"]).unwrap_or_default()
+}
+
+fn col_crd_kind(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "names", "kind"]).unwrap_or_default()
+}
+
+fn col_crd_versions(ctx: &CellContext<'_>) -> String {
+    crd_versions(ctx.data)
+}
+
+fn col_crd_scope(ctx: &CellContext<'_>) -> String {
+    sget(ctx.data, &["spec", "scope"]).unwrap_or_default()
+}
+
+fn col_flux_ready(ctx: &CellContext<'_>) -> String {
+    ready_condition(ctx.data).0
+}
+
+fn col_flux_message(ctx: &CellContext<'_>) -> String {
+    ready_condition(ctx.data).1
+}
+
+fn col_flux_revision(ctx: &CellContext<'_>) -> String {
+    flux_revision(ctx.data)
+}
+
+fn col_flux_source_revision(ctx: &CellContext<'_>) -> String {
+    flux_source_revision(ctx.data)
+}
+
+fn col_flux_source_url(ctx: &CellContext<'_>) -> String {
+    flux_source_url(ctx.data)
+}
+
+fn col_flux_suspended(ctx: &CellContext<'_>) -> String {
+    bget(ctx.data, &["spec", "suspend"]).to_string()
+}
+
 // ----- helpers ------------------------------------------------------------
+
+fn service_type(d: &Value) -> String {
+    sget(d, &["spec", "type"]).unwrap_or_else(|| "ClusterIP".into())
+}
 
 /// Comma-joined CRD version names (`spec.versions[].name`), e.g. `v1,v1beta1`.
 fn crd_versions(d: &Value) -> String {

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -713,4 +713,44 @@ mod tests {
         assert_eq!(cells.len(), 2);
         assert_eq!(idx, None);
     }
+
+    #[test]
+    fn curated_headers_and_cells_stay_aligned() {
+        let o = obj(json!({
+            "apiVersion": "v1",
+            "kind": "Object",
+            "metadata": {"name": "sample"}
+        }));
+        let kinds = [
+            "pods",
+            "deployments",
+            "replicasets",
+            "statefulsets",
+            "daemonsets",
+            "services",
+            "nodes",
+            "namespaces",
+            "configmaps",
+            "secrets",
+            "jobs",
+            "cronjobs",
+            "persistentvolumeclaims",
+            "persistentvolumes",
+            "ingresses",
+            "endpoints",
+            "customresourcedefinitions",
+            "kustomizations",
+            "helmreleases",
+            "widgets",
+        ];
+
+        for kind in kinds {
+            let headers = headers(kind);
+            let (cells, status_idx) = cells(&o, kind);
+            assert_eq!(headers.len(), cells.len(), "{kind} column count");
+            if let Some(idx) = status_idx {
+                assert!(idx < cells.len(), "{kind} status index");
+            }
+        }
+    }
 }

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -230,6 +230,22 @@ pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) 
     }
 }
 
+/// Cells whose display value changes with wall time even when the Kubernetes
+/// resourceVersion is unchanged. Table rendering can override cached values
+/// with these without recomputing every curated column.
+pub fn volatile_cell(obj: &DynamicObject, plural: &str, header: &str) -> Option<String> {
+    match (plural, header) {
+        (_, "AGE") => Some(age(obj)),
+        ("jobs", "DURATION") if sget(&obj.data, &["status", "completionTime"]).is_none() => {
+            Some(job_duration(&obj.data))
+        }
+        ("cronjobs", "LAST-SCHEDULE") => {
+            Some(time_since(&obj.data, &["status", "lastScheduleTime"]))
+        }
+        _ => None,
+    }
+}
+
 // ----- helpers ------------------------------------------------------------
 
 /// Comma-joined CRD version names (`spec.versions[].name`), e.g. `v1,v1beta1`.

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -11,7 +11,7 @@ use kube::core::DynamicObject;
 use kube::discovery::{ApiResource, Discovery, Scope};
 use kube::runtime::watcher;
 use kube::{Client, Config};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
 use crate::store::{Msg, row_key};
@@ -186,7 +186,7 @@ impl Cluster {
         labels: Option<String>,
         fields: Option<String>,
         generation: u64,
-        tx: UnboundedSender<Msg>,
+        tx: Sender<Msg>,
     ) -> JoinHandle<()> {
         let client = self.client.clone();
         let ar = kind.ar.clone();
@@ -208,7 +208,9 @@ impl Cluster {
                 cfg = cfg.fields(&f);
             }
             let mut stream = watcher(api, cfg).boxed();
-            let _ = tx.send(Msg::Reset { generation });
+            if tx.send(Msg::Reset { generation }).await.is_err() {
+                return;
+            }
 
             while let Some(event) = stream.next().await {
                 let msg = match event {
@@ -230,7 +232,7 @@ impl Cluster {
                         error: e.to_string(),
                     },
                 };
-                if tx.send(msg).is_err() {
+                if tx.send(msg).await.is_err() {
                     break; // UI gone
                 }
             }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -9,8 +9,8 @@ use kube::api::{Api, ListParams};
 use kube::config::{KubeConfigOptions, Kubeconfig};
 use kube::core::DynamicObject;
 use kube::discovery::{ApiResource, Discovery, Scope};
-use kube::runtime::watcher;
-use kube::{Client, Config};
+use kube::runtime::{WatchStreamExt, watcher};
+use kube::{Client, Config, ResourceExt};
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
@@ -207,7 +207,9 @@ impl Cluster {
             if let Some(f) = fields {
                 cfg = cfg.fields(&f);
             }
-            let mut stream = watcher(api, cfg).boxed();
+            let mut stream = watcher(api, cfg)
+                .modify(|obj| obj.managed_fields_mut().clear())
+                .boxed();
             if tx.send(Msg::Reset { generation }).await.is_err() {
                 return;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,9 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let cfg = config::Config::load();
 
-    // Install the color skin before anything renders. Startup-only: changing
-    // the skin requires a restart. Must run before ratatui::init() below —
-    // resolve_skin's dark/light auto-detection queries the terminal directly
-    // and expects a plain (non-alternate-screen, non-raw-mode) terminal.
+    // Install the initial color skin before anything renders. Auto-detecting
+    // dark/light mode queries the terminal directly, so it belongs before
+    // ratatui switches to the alternate screen.
     theme::init(theme::resolve_skin(
         cfg.skin.name.as_deref(),
         &cfg.skin.colors,
@@ -105,6 +104,7 @@ async fn main() -> Result<()> {
     let mut app = App::new(cluster, tx);
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
+    app.skin_colors = cfg.skin.colors.clone();
     if args.all_namespaces {
         app.namespace = String::new();
     } else if let Some(ns) = args.namespace {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ use tokio::sync::mpsc;
 use crate::app::App;
 use crate::k8s::Cluster;
 
+const EVENT_CHANNEL_CAP: usize = 4096;
+
 /// sofka: navigate, observe, and inspect your Kubernetes clusters.
 #[derive(Parser, Debug)]
 #[command(name = "sofka", version, about)]
@@ -99,7 +101,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (tx, mut rx) = mpsc::channel(EVENT_CHANNEL_CAP);
     let mut app = App::new(cluster, tx);
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
@@ -128,7 +130,7 @@ async fn main() -> Result<()> {
 
 /// Populate the store from the watch for a short window, then render one frame
 /// to an in-memory backend and print it. Headless UI smoke test.
-async fn snapshot(app: &mut App, rx: &mut mpsc::UnboundedReceiver<store::Msg>) -> Result<()> {
+async fn snapshot(app: &mut App, rx: &mut mpsc::Receiver<store::Msg>) -> Result<()> {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
@@ -260,7 +262,7 @@ fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String]) {
 async fn run(
     terminal: &mut ratatui::DefaultTerminal,
     app: &mut App,
-    rx: &mut mpsc::UnboundedReceiver<store::Msg>,
+    rx: &mut mpsc::Receiver<store::Msg>,
 ) -> Result<()> {
     let mut reader = crossterm::event::EventStream::new();
     let mut tick = tokio::time::interval(Duration::from_secs(1));

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,8 @@ async fn snapshot(app: &mut App, rx: &mut mpsc::Receiver<store::Msg>) -> Result<
                         "   ports:".into(),
                         "-  - containerPort: 8080".into(),
                         "+  - containerPort: 9090".into(),
-                    ],
+                    ]
+                    .into(),
                     scroll: 0,
                 };
                 app.mode = app::Mode::Diff;

--- a/src/store.rs
+++ b/src/store.rs
@@ -54,6 +54,11 @@ pub enum Msg {
         title: String,
         lines: Vec<String>,
     },
+    /// Result of an off-thread log save.
+    LogsSaved {
+        generation: u64,
+        result: Result<std::path::PathBuf, String>,
+    },
     /// Namespace list for the switcher, fetched off-thread.
     Namespaces {
         generation: u64,

--- a/src/store.rs
+++ b/src/store.rs
@@ -22,9 +22,9 @@ pub enum Msg {
     Synced {
         generation: u64,
     },
-    LogLine {
+    LogLines {
         generation: u64,
-        line: String,
+        lines: Vec<String>,
     },
     /// Point-in-time usage snapshot from the metrics API, keyed by "ns/name"
     /// (pods) or "name" (nodes) -> (cpu millicores, memory bytes).

--- a/src/store.rs
+++ b/src/store.rs
@@ -48,6 +48,12 @@ pub enum Msg {
         /// Set when describe failed and we fell back to YAML.
         warn: Option<String>,
     },
+    /// Live Event rows for the selected object.
+    Events {
+        generation: u64,
+        title: String,
+        lines: Vec<String>,
+    },
     /// Namespace list for the switcher, fetched off-thread.
     Namespaces {
         list: Vec<String>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -56,10 +56,12 @@ pub enum Msg {
     },
     /// Namespace list for the switcher, fetched off-thread.
     Namespaces {
+        generation: u64,
         list: Vec<String>,
     },
     /// Result of an off-thread context switch (rebuilds client + discovery).
     ContextSwitched {
+        generation: u64,
         name: String,
         result: Result<Box<crate::k8s::Cluster>, String>,
     },
@@ -67,6 +69,7 @@ pub enum Msg {
     /// (empty = cluster default). Dropped if the active namespace has since
     /// changed. "*" = all.
     Rbac {
+        generation: u64,
         ns: String,
         allowed: std::collections::HashSet<String>,
     },

--- a/src/store.rs
+++ b/src/store.rs
@@ -59,6 +59,13 @@ pub enum Msg {
         generation: u64,
         result: Result<std::path::PathBuf, String>,
     },
+    /// Result of an off-thread clipboard copy.
+    ClipboardCopied {
+        generation: u64,
+        copied: bool,
+        success: String,
+        failure: String,
+    },
     /// Namespace list for the switcher, fetched off-thread.
     Namespaces {
         generation: u64,

--- a/src/store.rs
+++ b/src/store.rs
@@ -64,6 +64,11 @@ pub enum Msg {
         generation: u64,
         list: Vec<String>,
     },
+    /// Kubeconfig context names for the switcher, fetched off-thread.
+    Contexts {
+        generation: u64,
+        list: Vec<String>,
+    },
     /// Result of an off-thread context switch (rebuilds client + discovery).
     ContextSwitched {
         generation: u64,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -31,133 +31,81 @@ use std::sync::{OnceLock, RwLock};
 use ratatui::style::{Color, Modifier, Style};
 use terminal_colorsaurus::{QueryOptions, ThemeMode};
 
-/// A full 25-swatch palette. Field names double as the override keys accepted
-/// under `[skin.colors]` in config.
-#[derive(Debug, Clone, Copy)]
-pub struct Palette {
-    pub rosewater: Color,
-    pub flamingo: Color,
-    pub pink: Color,
-    pub mauve: Color,
-    pub red: Color,
-    pub maroon: Color,
-    pub peach: Color,
-    pub yellow: Color,
-    pub green: Color,
-    pub teal: Color,
-    pub sky: Color,
-    pub sapphire: Color,
-    pub blue: Color,
-    pub lavender: Color,
-    pub text: Color,
-    pub subtext1: Color,
-    pub subtext0: Color,
-    pub overlay1: Color,
-    pub overlay0: Color,
-    pub surface2: Color,
-    pub surface1: Color,
-    pub surface0: Color,
-    pub base: Color,
-    pub mantle: Color,
-    pub crust: Color,
+macro_rules! palette_swatches {
+    ($($idx:expr => $field:ident),+ $(,)?) => {
+        /// A full 25-swatch palette. Field names double as the override keys
+        /// accepted under `[skin.colors]` in config.
+        #[derive(Debug, Clone, Copy)]
+        pub struct Palette {
+            $(pub $field: Color,)+
+        }
+
+        /// Swatch names in the order the built-in tables list their hex values.
+        const FIELDS: &[&str] = &[$(stringify!($field),)+];
+
+        impl Palette {
+            /// Build a palette from 25 hex strings in [`FIELDS`] order. Panics
+            /// on a malformed value — only ever called with the hardcoded
+            /// built-in tables, so a bad hex here is a programmer error, not
+            /// user input.
+            fn from_hexes(h: &[&str]) -> Palette {
+                assert_eq!(
+                    h.len(),
+                    FIELDS.len(),
+                    "built-in palette has {} colors but {} swatches are defined",
+                    h.len(),
+                    FIELDS.len()
+                );
+                let c = |i: usize| {
+                    parse_hex(h[i]).unwrap_or_else(|| panic!("bad built-in hex {}", h[i]))
+                };
+                Palette {
+                    $($field: c($idx),)+
+                }
+            }
+
+            /// Override one swatch by name. Returns `false` for an unknown key.
+            fn set(&mut self, key: &str, color: Color) -> bool {
+                match key {
+                    $(stringify!($field) => self.$field = color,)+
+                    _ => return false,
+                }
+                true
+            }
+        }
+
+        $(pub fn $field() -> Color {
+            palette().$field
+        })+
+    };
 }
 
-/// Swatch names in the order the built-in tables list their hex values.
-const FIELDS: [&str; 25] = [
-    "rosewater",
-    "flamingo",
-    "pink",
-    "mauve",
-    "red",
-    "maroon",
-    "peach",
-    "yellow",
-    "green",
-    "teal",
-    "sky",
-    "sapphire",
-    "blue",
-    "lavender",
-    "text",
-    "subtext1",
-    "subtext0",
-    "overlay1",
-    "overlay0",
-    "surface2",
-    "surface1",
-    "surface0",
-    "base",
-    "mantle",
-    "crust",
-];
-
-impl Palette {
-    /// Build a palette from 25 hex strings in [`FIELDS`] order. Panics on a
-    /// malformed value — only ever called with the hardcoded built-in tables,
-    /// so a bad hex here is a programmer error, not user input.
-    fn from_hexes(h: &[&str; 25]) -> Palette {
-        let c = |i: usize| parse_hex(h[i]).unwrap_or_else(|| panic!("bad built-in hex {}", h[i]));
-        Palette {
-            rosewater: c(0),
-            flamingo: c(1),
-            pink: c(2),
-            mauve: c(3),
-            red: c(4),
-            maroon: c(5),
-            peach: c(6),
-            yellow: c(7),
-            green: c(8),
-            teal: c(9),
-            sky: c(10),
-            sapphire: c(11),
-            blue: c(12),
-            lavender: c(13),
-            text: c(14),
-            subtext1: c(15),
-            subtext0: c(16),
-            overlay1: c(17),
-            overlay0: c(18),
-            surface2: c(19),
-            surface1: c(20),
-            surface0: c(21),
-            base: c(22),
-            mantle: c(23),
-            crust: c(24),
-        }
-    }
-
-    /// Override one swatch by name. Returns `false` for an unknown key.
-    fn set(&mut self, key: &str, color: Color) -> bool {
-        match key {
-            "rosewater" => self.rosewater = color,
-            "flamingo" => self.flamingo = color,
-            "pink" => self.pink = color,
-            "mauve" => self.mauve = color,
-            "red" => self.red = color,
-            "maroon" => self.maroon = color,
-            "peach" => self.peach = color,
-            "yellow" => self.yellow = color,
-            "green" => self.green = color,
-            "teal" => self.teal = color,
-            "sky" => self.sky = color,
-            "sapphire" => self.sapphire = color,
-            "blue" => self.blue = color,
-            "lavender" => self.lavender = color,
-            "text" => self.text = color,
-            "subtext1" => self.subtext1 = color,
-            "subtext0" => self.subtext0 = color,
-            "overlay1" => self.overlay1 = color,
-            "overlay0" => self.overlay0 = color,
-            "surface2" => self.surface2 = color,
-            "surface1" => self.surface1 = color,
-            "surface0" => self.surface0 = color,
-            "base" => self.base = color,
-            "mantle" => self.mantle = color,
-            "crust" => self.crust = color,
-            _ => return false,
-        }
-        true
-    }
+palette_swatches! {
+    0 => rosewater,
+    1 => flamingo,
+    2 => pink,
+    3 => mauve,
+    4 => red,
+    5 => maroon,
+    6 => peach,
+    7 => yellow,
+    8 => green,
+    9 => teal,
+    10 => sky,
+    11 => sapphire,
+    12 => blue,
+    13 => lavender,
+    14 => text,
+    15 => subtext1,
+    16 => subtext0,
+    17 => overlay1,
+    18 => overlay0,
+    19 => surface2,
+    20 => surface1,
+    21 => surface0,
+    22 => base,
+    23 => mantle,
+    24 => crust,
 }
 
 // ---------------------------------------------------------------------------
@@ -368,82 +316,6 @@ fn palette() -> Palette {
         Ok(active) => *active,
         Err(poisoned) => *poisoned.into_inner(),
     }
-}
-
-pub fn rosewater() -> Color {
-    palette().rosewater
-}
-pub fn flamingo() -> Color {
-    palette().flamingo
-}
-pub fn pink() -> Color {
-    palette().pink
-}
-pub fn mauve() -> Color {
-    palette().mauve
-}
-pub fn red() -> Color {
-    palette().red
-}
-pub fn maroon() -> Color {
-    palette().maroon
-}
-pub fn peach() -> Color {
-    palette().peach
-}
-pub fn yellow() -> Color {
-    palette().yellow
-}
-pub fn green() -> Color {
-    palette().green
-}
-pub fn teal() -> Color {
-    palette().teal
-}
-pub fn sky() -> Color {
-    palette().sky
-}
-pub fn sapphire() -> Color {
-    palette().sapphire
-}
-pub fn blue() -> Color {
-    palette().blue
-}
-pub fn lavender() -> Color {
-    palette().lavender
-}
-pub fn text() -> Color {
-    palette().text
-}
-pub fn subtext1() -> Color {
-    palette().subtext1
-}
-pub fn subtext0() -> Color {
-    palette().subtext0
-}
-pub fn overlay1() -> Color {
-    palette().overlay1
-}
-pub fn overlay0() -> Color {
-    palette().overlay0
-}
-pub fn surface2() -> Color {
-    palette().surface2
-}
-pub fn surface1() -> Color {
-    palette().surface1
-}
-pub fn surface0() -> Color {
-    palette().surface0
-}
-pub fn base() -> Color {
-    palette().base
-}
-pub fn mantle() -> Color {
-    palette().mantle
-}
-pub fn crust() -> Color {
-    palette().crust
 }
 
 // ---------------------------------------------------------------------------

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -26,7 +26,7 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
 use ratatui::style::{Color, Modifier, Style};
 use terminal_colorsaurus::{QueryOptions, ThemeMode};
@@ -344,16 +344,30 @@ fn parse_hex(s: &str) -> Option<Color> {
 // Active palette + accessors
 // ---------------------------------------------------------------------------
 
-static ACTIVE: OnceLock<Palette> = OnceLock::new();
+static ACTIVE: OnceLock<RwLock<Palette>> = OnceLock::new();
 
-/// Install the active palette. Call once at startup, before rendering; later
-/// calls are ignored. If never called, accessors fall back to Catppuccin Mocha.
+/// Install the active palette. If called after startup, replaces the active
+/// palette so `:skin` can update colors without restarting the TUI.
 pub fn init(p: Palette) {
-    let _ = ACTIVE.set(p);
+    if ACTIVE.set(RwLock::new(p)).is_err() {
+        set(p);
+    }
 }
 
-fn palette() -> &'static Palette {
-    ACTIVE.get_or_init(catppuccin_mocha)
+pub fn set(p: Palette) {
+    let lock = ACTIVE.get_or_init(|| RwLock::new(catppuccin_mocha()));
+    match lock.write() {
+        Ok(mut active) => *active = p,
+        Err(poisoned) => *poisoned.into_inner() = p,
+    }
+}
+
+fn palette() -> Palette {
+    let lock = ACTIVE.get_or_init(|| RwLock::new(catppuccin_mocha()));
+    match lock.read() {
+        Ok(active) => *active,
+        Err(poisoned) => *poisoned.into_inner(),
+    }
 }
 
 pub fn rosewater() -> Color {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -584,6 +584,12 @@ mod tests {
     }
 
     #[test]
+    fn mocha_base_matches_golden_swatch() {
+        let p = builtin("catppuccin-mocha").unwrap();
+        assert_eq!(p.base, Color::Rgb(30, 30, 46));
+    }
+
+    #[test]
     fn parse_hex_forms() {
         assert_eq!(parse_hex("#1e1e2e"), Some(Color::Rgb(30, 30, 46)));
         assert_eq!(parse_hex("1e1e2e"), Some(Color::Rgb(30, 30, 46)));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1287,8 +1287,6 @@ fn draw_help(frame: &mut Frame, area: Rect) {
 }
 
 fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
-    let popup = centered_rect(40, 60, area);
-    frame.render_widget(Clear, popup);
     let names = app.filtered_namespaces();
     let items: Vec<ListItem> = names
         .iter()
@@ -1307,23 +1305,18 @@ fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         format!(" Namespaces · /{}_ ", app.ns_filter)
     };
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(title, theme::title())),
-        );
-    frame.render_stateful_widget(list, popup, &mut app.ns_state);
+    render_popup_list(
+        frame,
+        area,
+        40,
+        60,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.ns_state,
+    );
 }
 
 fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
-    let popup = centered_rect(50, 60, area);
-    frame.render_widget(Clear, popup);
     let current = app.cluster.context.clone();
     let items: Vec<ListItem> = app
         .filtered_contexts()
@@ -1346,26 +1339,21 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         format!(" Contexts · /{}_ ", app.ctx_filter)
     };
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(title, theme::title())),
-        );
-    frame.render_stateful_widget(list, popup, &mut app.ctx_state);
+    render_popup_list(
+        frame,
+        area,
+        50,
+        60,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.ctx_state,
+    );
 }
 
 /// Flux suspend/resume action menu (`t`). Deliberately a menu rather than a
 /// single-key toggle, so acting on a live resource always takes an explicit,
 /// visible choice.
 fn draw_flux_menu(frame: &mut Frame, app: &mut App, area: Rect) {
-    let popup = centered_rect(36, 24, area);
-    frame.render_widget(Clear, popup);
     let count = app.marked.len().max(1);
     let target = if count == 1 {
         "current selection".to_string()
@@ -1383,18 +1371,15 @@ fn draw_flux_menu(frame: &mut Frame, app: &mut App, area: Rect) {
             ListItem::new(Span::styled(*label, Style::default().fg(color)))
         })
         .collect();
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(format!(" Flux: {target} "), theme::title())),
-        );
-    frame.render_stateful_widget(list, popup, &mut app.flux_menu_state);
+    render_popup_list(
+        frame,
+        area,
+        36,
+        24,
+        items,
+        Span::styled(format!(" Flux: {target} "), theme::title()),
+        &mut app.flux_menu_state,
+    );
 }
 
 /// Background port-forwards (`:pf`). A full-width view, not a popup — closing
@@ -1414,23 +1399,16 @@ fn draw_port_forwards(frame: &mut Frame, app: &mut App, area: Rect) {
         " Port-forwards [{}]  (x/s stop · esc close — others keep running) ",
         app.port_forwards.len()
     );
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(title, theme::title())),
-        );
-    frame.render_stateful_widget(list, area, &mut app.pf_state);
+    render_framed_list(
+        frame,
+        area,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.pf_state,
+    );
 }
 
 fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
-    let popup = centered_rect(42, 58, area);
-    frame.render_widget(Clear, popup);
     let items: Vec<ListItem> = app
         .skin_list
         .iter()
@@ -1441,46 +1419,32 @@ fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
             ))
         })
         .collect();
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(
-                    " Skins (enter apply · esc close) ",
-                    theme::title(),
-                )),
-        );
-    frame.render_stateful_widget(list, popup, &mut app.skin_state);
+    render_popup_list(
+        frame,
+        area,
+        42,
+        58,
+        items,
+        Span::styled(" Skins (enter apply · esc close) ", theme::title()),
+        &mut app.skin_state,
+    );
 }
 
 fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
-    let popup = centered_rect(50, 60, area);
-    frame.render_widget(Clear, popup);
     let items: Vec<ListItem> = app
         .container_list
         .iter()
         .map(|c| ListItem::new(Span::styled(c.clone(), Style::default().fg(theme::text()))))
         .collect();
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(
-                    " Containers (⏎ logs · p previous) ",
-                    theme::title(),
-                )),
-        );
-    frame.render_stateful_widget(list, popup, &mut app.container_state);
+    render_popup_list(
+        frame,
+        area,
+        50,
+        60,
+        items,
+        Span::styled(" Containers (⏎ logs · p previous) ", theme::title()),
+        &mut app.container_state,
+    );
 }
 
 fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {
@@ -1514,8 +1478,6 @@ fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_set_image(frame: &mut Frame, app: &mut App, area: Rect) {
-    let popup = centered_rect(70, 60, area);
-    frame.render_widget(Clear, popup);
     let items: Vec<ListItem> = app
         .container_list
         .iter()
@@ -1529,21 +1491,15 @@ fn draw_set_image(frame: &mut Frame, app: &mut App, area: Rect) {
             ]))
         })
         .collect();
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(
-                    " Set Image (⏎ to edit container) ",
-                    theme::title(),
-                )),
-        );
-    frame.render_stateful_widget(list, popup, &mut app.container_state);
+    render_popup_list(
+        frame,
+        area,
+        70,
+        60,
+        items,
+        Span::styled(" Set Image (⏎ to edit container) ", theme::title()),
+        &mut app.container_state,
+    );
 }
 
 fn draw_confirm(frame: &mut Frame, app: &App, area: Rect) {
@@ -1611,21 +1567,13 @@ fn draw_palette(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     let mut state = ListState::default();
     state.select(Some(app.cmd_sel));
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(
-                    " commands & resources (tab/↑↓ · ⏎) ",
-                    theme::title(),
-                )),
-        );
-    frame.render_stateful_widget(list, rect, &mut state);
+    render_framed_list(
+        frame,
+        rect,
+        items,
+        Span::styled(" commands & resources (tab/↑↓ · ⏎) ", theme::title()),
+        &mut state,
+    );
 }
 
 /// Xray hierarchical tree (owner → children → containers).
@@ -1665,18 +1613,13 @@ fn draw_xray(frame: &mut Frame, app: &mut App, area: Rect) {
         " Xray [{}]  (⏎ logs · r refresh · esc back) ",
         app.xray_items.len()
     );
-    let list = List::new(items)
-        .highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(title, theme::title())),
-        );
-    frame.render_stateful_widget(list, area, &mut app.xray_state);
+    render_framed_list(
+        frame,
+        area,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.xray_state,
+    );
 }
 
 /// Pulse dashboard: cluster-health tiles.
@@ -1882,6 +1825,45 @@ fn draw_status(frame: &mut Frame, app: &App, area: Rect) {
         .alignment(Alignment::Right),
         cols[1],
     );
+}
+
+fn render_popup_list<'a, T>(
+    frame: &mut Frame,
+    area: Rect,
+    percent_x: u16,
+    percent_y: u16,
+    items: Vec<ListItem<'a>>,
+    title: T,
+    state: &mut ListState,
+) where
+    T: Into<Line<'a>>,
+{
+    let popup = centered_rect(percent_x, percent_y, area);
+    frame.render_widget(Clear, popup);
+    render_framed_list(frame, popup, items, title, state);
+}
+
+fn render_framed_list<'a, T>(
+    frame: &mut Frame,
+    area: Rect,
+    items: Vec<ListItem<'a>>,
+    title: T,
+    state: &mut ListState,
+) where
+    T: Into<Line<'a>>,
+{
+    let list = List::new(items)
+        .highlight_style(theme::selected_row())
+        .highlight_symbol("▌ ")
+        .highlight_spacing(HighlightSpacing::Always)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(theme::border_focused())
+                .title(title.into()),
+        );
+    frame.render_stateful_widget(list, area, state);
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -431,9 +431,7 @@ fn draw_scrollable(
     let (start, end) = visible_line_window(view.lines.len(), view.scroll, inner_h);
     let text: Vec<Line> = view
         .lines
-        .get(start..end)
-        .unwrap_or_default()
-        .iter()
+        .range(start..end)
         .map(|l| Line::from(highlight_yaml(l)))
         .collect();
     let p = Paragraph::new(text).block(
@@ -1060,9 +1058,7 @@ fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
     let (start, end) = visible_line_window(view.lines.len(), view.scroll, inner_h);
     let lines: Vec<Line> = view
         .lines
-        .get(start..end)
-        .unwrap_or_default()
-        .iter()
+        .range(start..end)
         .map(|l| {
             let color = match l.chars().next() {
                 Some('+') => theme::green(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1448,7 +1448,7 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {
-    let popup = centered_rect(60, 34, area);
+    let popup = centered_rect_with_min(60, 34, 44, 8, area);
     frame.render_widget(Clear, popup);
     let lines = vec![
         Line::from(""),
@@ -1503,13 +1503,8 @@ fn draw_set_image(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_confirm(frame: &mut Frame, app: &App, area: Rect) {
-    let popup = centered_rect(50, 20, area);
+    let popup = centered_rect_with_min(50, 20, 56, 7, area);
     frame.render_widget(Clear, popup);
-    let action_hint = if app.confirm_allows_force_toggle() {
-        "  [y] confirm    [f] toggle force    [n] cancel"
-    } else {
-        "  [y] confirm    [n] cancel"
-    };
     let lines = vec![
         Line::from(""),
         Line::from(Span::styled(
@@ -1518,7 +1513,7 @@ fn draw_confirm(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Line::from(""),
         Line::from(Span::styled(
-            action_hint,
+            confirm_action_hint(app.confirm_allows_force_toggle(), ConfirmHintStyle::Popup),
             Style::default().fg(theme::yellow()),
         )),
     ];
@@ -1770,7 +1765,7 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("█", Style::default().fg(theme::teal())),
         ]),
         Mode::Confirm => Line::from(Span::styled(
-            "  y/enter: confirm   n/esc: cancel",
+            confirm_action_hint(app.confirm_allows_force_toggle(), ConfirmHintStyle::Prompt),
             Style::default().fg(theme::yellow()),
         )),
         Mode::Logs => {
@@ -1827,6 +1822,21 @@ fn draw_status(frame: &mut Frame, app: &App, area: Rect) {
     );
 }
 
+#[derive(Clone, Copy)]
+enum ConfirmHintStyle {
+    Popup,
+    Prompt,
+}
+
+fn confirm_action_hint(allows_force: bool, style: ConfirmHintStyle) -> &'static str {
+    match (allows_force, style) {
+        (true, ConfirmHintStyle::Popup) => "  [y] confirm    [f] toggle force    [n] cancel",
+        (false, ConfirmHintStyle::Popup) => "  [y] confirm    [n] cancel",
+        (true, ConfirmHintStyle::Prompt) => "  y/enter: confirm   f: toggle force   n/esc: cancel",
+        (false, ConfirmHintStyle::Prompt) => "  y/enter: confirm   n/esc: cancel",
+    }
+}
+
 fn render_popup_list<'a, T>(
     frame: &mut Frame,
     area: Rect,
@@ -1838,7 +1848,7 @@ fn render_popup_list<'a, T>(
 ) where
     T: Into<Line<'a>>,
 {
-    let popup = centered_rect(percent_x, percent_y, area);
+    let popup = centered_rect_with_min(percent_x, percent_y, 32, 8, area);
     frame.render_widget(Clear, popup);
     render_framed_list(frame, popup, items, title, state);
 }
@@ -1866,23 +1876,23 @@ fn render_framed_list<'a, T>(
     frame.render_stateful_widget(list, area, state);
 }
 
-fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
-    let vertical = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(r);
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(vertical[1])[1]
+fn centered_rect_with_min(
+    percent_x: u16,
+    percent_y: u16,
+    min_width: u16,
+    min_height: u16,
+    r: Rect,
+) -> Rect {
+    let pct_w = (u32::from(r.width) * u32::from(percent_x.min(100)) / 100) as u16;
+    let pct_h = (u32::from(r.height) * u32::from(percent_y.min(100)) / 100) as u16;
+    let width = pct_w.max(min_width).min(r.width);
+    let height = pct_h.max(min_height).min(r.height);
+    Rect {
+        x: r.x + (r.width - width) / 2,
+        y: r.y + (r.height - height) / 2,
+        width,
+        height,
+    }
 }
 
 #[cfg(test)]
@@ -1948,6 +1958,41 @@ mod tests {
         assert_eq!(visible_line_window(100, 95, 20), (95, 100));
         assert_eq!(visible_line_window(100, 150, 20), (100, 100));
         assert_eq!(visible_line_window(100, 10, 0), (10, 10));
+    }
+
+    #[test]
+    fn centered_rect_with_min_keeps_popups_readable() {
+        let area = Rect {
+            x: 10,
+            y: 20,
+            width: 100,
+            height: 20,
+        };
+        assert_eq!(
+            centered_rect_with_min(50, 20, 56, 7, area),
+            Rect {
+                x: 32,
+                y: 26,
+                width: 56,
+                height: 7,
+            }
+        );
+
+        let tiny = Rect {
+            x: 3,
+            y: 4,
+            width: 40,
+            height: 5,
+        };
+        assert_eq!(centered_rect_with_min(50, 20, 56, 7, tiny), tiny);
+    }
+
+    #[test]
+    fn confirm_hint_mentions_force_only_when_supported() {
+        assert!(confirm_action_hint(true, ConfirmHintStyle::Popup).contains("toggle force"));
+        assert!(confirm_action_hint(true, ConfirmHintStyle::Prompt).contains("toggle force"));
+        assert!(!confirm_action_hint(false, ConfirmHintStyle::Popup).contains("toggle force"));
+        assert!(!confirm_action_hint(false, ConfirmHintStyle::Prompt).contains("toggle force"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -180,9 +180,33 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let cpu_idx = headers.iter().position(|h| *h == "CPU");
     let mem_idx = headers.iter().position(|h| *h == "MEM");
 
+    let count = app.rows().len();
+    let visible_rows = area.height.saturating_sub(3).max(1) as usize;
+    if count == 0 {
+        *app.table_state.offset_mut() = 0;
+    } else {
+        if app.table_state.selected().is_some_and(|i| i >= count) {
+            app.table_state.select(Some(count - 1));
+        }
+        let selected = app.table_state.selected();
+        let mut offset = app.table_state.offset().min(count.saturating_sub(1));
+        if let Some(sel) = selected {
+            if sel < offset {
+                offset = sel;
+            } else if sel >= offset + visible_rows {
+                offset = sel + 1 - visible_rows;
+            }
+        }
+        *app.table_state.offset_mut() = offset;
+    }
+    let offset = app.table_state.offset();
+    let selected = app.table_state.selected();
+
     let rows: Vec<Row> = app
         .rows()
         .iter()
+        .skip(offset)
+        .take(visible_rows)
         .map(|obj| {
             let marked_row =
                 !app.marked.is_empty() && app.marked.contains(&crate::store::row_key(obj));
@@ -306,7 +330,6 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
-    let count = app.rows().len();
     let kind_label = app
         .kind
         .as_ref()
@@ -325,6 +348,13 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     }
     title.push(Span::raw(" "));
 
+    let mut render_state = ratatui::widgets::TableState::default();
+    let render_selected = if count > 0 {
+        selected.map(|i| i.saturating_sub(offset))
+    } else {
+        None
+    };
+    render_state.select(render_selected);
     let table = Table::new(rows, widths)
         .header(header_row)
         .row_highlight_style(theme::selected_row())
@@ -343,7 +373,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 .title(Line::from(title)),
         );
 
-    frame.render_stateful_widget(table, area, &mut app.table_state);
+    frame.render_stateful_widget(table, area, &mut render_state);
 }
 
 /// `true` when a `n/m` READY cell has every container ready. Cells that

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1258,8 +1258,12 @@ fn draw_help(frame: &mut Frame, area: Rect) {
             "t",
             "flux: suspend/resume/reconcile menu (ks/hr/repos/buckets…)",
         ),
+        bind("C · U · D", "nodes: cordon · uncordon · drain"),
         bind("space", "mark/unmark row for bulk actions (esc clears)"),
-        bind("ctrl-d · ctrl-k", "delete · kill (marked rows, or current)"),
+        bind(
+            "ctrl-d · ctrl-k",
+            "delete · force-delete (f toggles in confirm)",
+        ),
         Line::from(""),
         Line::from(Span::styled("  Logs view", theme::title())),
         bind("/ · s · w · t", "search · autoscroll · wrap · timestamps"),
@@ -1513,6 +1517,11 @@ fn draw_set_image(frame: &mut Frame, app: &mut App, area: Rect) {
 fn draw_confirm(frame: &mut Frame, app: &App, area: Rect) {
     let popup = centered_rect(50, 20, area);
     frame.render_widget(Clear, popup);
+    let action_hint = if app.confirm_allows_force_toggle() {
+        "  [y] confirm    [f] toggle force    [n] cancel"
+    } else {
+        "  [y] confirm    [n] cancel"
+    };
     let lines = vec![
         Line::from(""),
         Line::from(Span::styled(
@@ -1521,7 +1530,7 @@ fn draw_confirm(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Line::from(""),
         Line::from(Span::styled(
-            "  [y] confirm    [n] cancel",
+            action_hint,
             Style::default().fg(theme::yellow()),
         )),
     ];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -70,6 +70,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Prompt => draw_prompt_popup(frame, app, chunks[1]),
         Mode::Command => draw_palette(frame, app, chunks[1]),
         Mode::FluxMenu => draw_flux_menu(frame, app, chunks[1]),
+        Mode::Skins => draw_skins(frame, app, chunks[1]),
         _ => {}
     }
 
@@ -1223,6 +1224,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
         ),
         bind(":events · E", "events for the selected object"),
         bind(":pf", "view/stop background port-forwards"),
+        bind(":skin", "switch color skin live"),
         bind(
             "enter",
             "drill down (deploy→pods, pod→containers, ns→re-scope)",
@@ -1424,6 +1426,36 @@ fn draw_port_forwards(frame: &mut Frame, app: &mut App, area: Rect) {
                 .title(Span::styled(title, theme::title())),
         );
     frame.render_stateful_widget(list, area, &mut app.pf_state);
+}
+
+fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
+    let popup = centered_rect(42, 58, area);
+    frame.render_widget(Clear, popup);
+    let items: Vec<ListItem> = app
+        .skin_list
+        .iter()
+        .map(|name| {
+            ListItem::new(Span::styled(
+                name.clone(),
+                Style::default().fg(theme::text()),
+            ))
+        })
+        .collect();
+    let list = List::new(items)
+        .highlight_style(theme::selected_row())
+        .highlight_symbol("▌ ")
+        .highlight_spacing(HighlightSpacing::Always)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(theme::border_focused())
+                .title(Span::styled(
+                    " Skins (enter apply · esc close) ",
+                    theme::title(),
+                )),
+        );
+    frame.render_stateful_widget(list, popup, &mut app.skin_state);
 }
 
 fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -31,6 +31,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     match app.mode {
         Mode::Detail => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
         Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
+        Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
         Mode::Logs | Mode::LogFilter => draw_logs(frame, app, chunks[1]),
         Mode::Help => draw_help(frame, chunks[1]),
         Mode::Pulse => draw_pulse(frame, app, chunks[1]),
@@ -1171,6 +1172,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
             ":xray · :diff",
             "hierarchical tree · live-vs-last-applied diff",
         ),
+        bind(":events · E", "events for the selected object"),
         bind(":pf", "view/stop background port-forwards"),
         bind(
             "enter",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -181,7 +181,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let cpu_idx = headers.iter().position(|h| *h == "CPU");
     let mem_idx = headers.iter().position(|h| *h == "MEM");
 
-    let count = app.rows().len();
+    let count = app.row_count();
     let visible_rows = area.height.saturating_sub(3).max(1) as usize;
     if count == 0 {
         *app.table_state.offset_mut() = 0;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,27 @@ use crate::{columns, theme};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+enum TableCellText<'a> {
+    Borrowed(&'a str),
+    Owned(String),
+}
+
+impl<'a> TableCellText<'a> {
+    fn as_str(&self) -> &str {
+        match self {
+            TableCellText::Borrowed(value) => value,
+            TableCellText::Owned(value) => value,
+        }
+    }
+
+    fn into_cell(self) -> Cell<'a> {
+        match self {
+            TableCellText::Borrowed(value) => Cell::from(value),
+            TableCellText::Owned(value) => Cell::from(value),
+        }
+    }
+}
+
 pub fn draw(frame: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -203,36 +224,56 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let offset = app.table_state.offset();
     let selected = app.table_state.selected();
 
-    let rows: Vec<Row> = app
+    let visible_objects: Vec<_> = app
         .rows()
-        .iter()
+        .into_iter()
         .skip(offset)
         .take(visible_rows)
+        .collect();
+    app.ensure_table_cell_cache(&visible_objects);
+    let cell_cache = app.table_cell_cache();
+    let base_headers = columns::headers(&app.kind_plural);
+
+    let rows: Vec<Row> = visible_objects
+        .iter()
         .map(|obj| {
-            let marked_row =
-                !app.marked.is_empty() && app.marked.contains(&crate::store::row_key(obj));
-            let (mut cells, status_idx) = columns::cells(obj, &app.kind_plural);
+            let row_key = crate::store::row_key(obj);
+            let marked_row = !app.marked.is_empty() && app.marked.contains(&row_key);
+            let (base_cells, status_idx) = cell_cache
+                .get(&row_key)
+                .expect("visible rows are warmed in the table cell cache");
             let mut style_idx = status_idx;
+            let mut cells = Vec::with_capacity(headers.len());
             if show_ns {
-                cells.insert(0, obj.metadata.namespace.clone().unwrap_or_default());
+                cells.push(TableCellText::Borrowed(
+                    obj.metadata.namespace.as_deref().unwrap_or_default(),
+                ));
                 style_idx = status_idx.map(|i| i + 1);
+            }
+            for (i, cell) in base_cells.iter().enumerate() {
+                let header = base_headers.get(i).copied().unwrap_or_default();
+                if let Some(value) = columns::volatile_cell(obj, &app.kind_plural, header) {
+                    cells.push(TableCellText::Owned(value));
+                } else {
+                    cells.push(TableCellText::Borrowed(cell));
+                }
             }
             let mut metrics_raw = None;
             if metrics_cols {
-                let name = obj.metadata.name.clone().unwrap_or_default();
+                let name = obj.metadata.name.as_deref().unwrap_or_default();
                 let key = if pods_view {
                     format!(
                         "{}/{}",
-                        obj.metadata.namespace.as_deref().unwrap_or(""),
+                        obj.metadata.namespace.as_deref().unwrap_or_default(),
                         name
                     )
                 } else {
-                    name
+                    name.to_string()
                 };
                 let (cpu, mem) = app.metrics.get(&key).copied().unwrap_or((0, 0));
                 metrics_raw = Some((cpu, mem));
-                cells.push(columns::fmt_cpu(cpu));
-                cells.push(columns::fmt_mem(mem));
+                cells.push(TableCellText::Owned(columns::fmt_cpu(cpu)));
+                cells.push(TableCellText::Owned(columns::fmt_mem(mem)));
             }
             // Combined colorer: the whole row takes a k9s-style status tint
             // (errors red, pending peach, completed/terminating dimmed, healthy
@@ -242,7 +283,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             // and NAME highlights the active fuzzy filter's matched chars.
             let status_val = style_idx
                 .and_then(|i| cells.get(i))
-                .map(String::as_str)
+                .map(TableCellText::as_str)
                 .unwrap_or("");
             // A pod is phase=Running the moment its sandbox starts, long before
             // every container passes its readiness probe — until READY is n/n,
@@ -250,7 +291,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             let running_not_ready = status_val == "Running"
                 && ready_idx
                     .and_then(|i| cells.get(i))
-                    .is_some_and(|r| !all_ready(r));
+                    .is_some_and(|r| !all_ready(r.as_str()));
             let status_key = if running_not_ready {
                 "PodInitializing"
             } else {
@@ -265,33 +306,33 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     if marked_row {
                         // Marked rows override everything so a bulk selection
                         // stands out.
-                        Cell::from(c).style(
+                        c.into_cell().style(
                             Style::default()
                                 .fg(theme::mark())
                                 .add_modifier(Modifier::BOLD),
                         )
                     } else if Some(i) == style_idx {
-                        Cell::from(c).style(Style::default().fg(status_badge))
+                        c.into_cell().style(Style::default().fg(status_badge))
                     } else if i == name_col {
-                        render_name_cell(app, &c, row_color)
+                        render_name_cell(app, c.as_str(), row_color)
                     } else if Some(i) == age_idx {
-                        Cell::from(c).style(theme::dim())
+                        c.into_cell().style(theme::dim())
                     } else if Some(i) == restarts_idx {
-                        let n: i64 = c.trim().parse().unwrap_or(0);
+                        let n: i64 = c.as_str().trim().parse().unwrap_or(0);
                         let color = theme::restarts_severity(n).unwrap_or(row_color);
-                        Cell::from(c).style(Style::default().fg(color))
+                        c.into_cell().style(Style::default().fg(color))
                     } else if Some(i) == cpu_idx {
                         let color = metrics_raw
                             .and_then(|(cpu, _)| theme::cpu_severity(cpu))
                             .unwrap_or(row_color);
-                        Cell::from(c).style(Style::default().fg(color))
+                        c.into_cell().style(Style::default().fg(color))
                     } else if Some(i) == mem_idx {
                         let color = metrics_raw
                             .and_then(|(_, mem)| theme::mem_severity(mem))
                             .unwrap_or(row_color);
-                        Cell::from(c).style(Style::default().fg(color))
+                        c.into_cell().style(Style::default().fg(color))
                     } else {
-                        Cell::from(c).style(Style::default().fg(row_color))
+                        c.into_cell().style(Style::default().fg(row_color))
                     }
                 })
                 .collect();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -427,13 +427,16 @@ fn draw_scrollable(
     area: Rect,
     accent: ratatui::style::Color,
 ) {
+    let inner_h = area.height.saturating_sub(2) as usize;
+    let (start, end) = visible_line_window(view.lines.len(), view.scroll, inner_h);
     let text: Vec<Line> = view
         .lines
+        .get(start..end)
+        .unwrap_or_default()
         .iter()
         .map(|l| Line::from(highlight_yaml(l)))
         .collect();
-    let scroll = view.scroll.min(u16::MAX as usize) as u16;
-    let p = Paragraph::new(text).scroll((scroll, 0)).block(
+    let p = Paragraph::new(text).block(
         Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
@@ -1053,8 +1056,12 @@ fn klog_level(l: &str, level: char) -> bool {
 
 /// Unified-diff view with +/- line coloring.
 fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
+    let inner_h = area.height.saturating_sub(2) as usize;
+    let (start, end) = visible_line_window(view.lines.len(), view.scroll, inner_h);
     let lines: Vec<Line> = view
         .lines
+        .get(start..end)
+        .unwrap_or_default()
         .iter()
         .map(|l| {
             let color = match l.chars().next() {
@@ -1065,8 +1072,7 @@ fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
             Line::from(Span::styled(l.clone(), Style::default().fg(color)))
         })
         .collect();
-    let scroll = view.scroll.min(u16::MAX as usize) as u16;
-    let p = Paragraph::new(lines).scroll((scroll, 0)).block(
+    let p = Paragraph::new(lines).block(
         Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
@@ -1074,6 +1080,12 @@ fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
             .title(Span::styled(format!(" {} ", view.title), theme::title())),
     );
     frame.render_widget(p, area);
+}
+
+fn visible_line_window(len: usize, scroll: usize, height: usize) -> (usize, usize) {
+    let start = scroll.min(len);
+    let end = start.saturating_add(height).min(len);
+    (start, end)
 }
 
 /// YAML / `kubectl describe` colorization: comments dimmed, section headers in
@@ -1868,6 +1880,14 @@ mod tests {
         assert_eq!(wrapped_height("五五五五五五", 10), 2);
         // ANSI escapes don't consume columns.
         assert_eq!(wrapped_height("\x1b[31maaaaaaaaaa\x1b[0m", 10), 1);
+    }
+
+    #[test]
+    fn visible_line_window_clamps_to_viewport() {
+        assert_eq!(visible_line_window(100, 10, 20), (10, 30));
+        assert_eq!(visible_line_window(100, 95, 20), (95, 100));
+        assert_eq!(visible_line_window(100, 150, 20), (100, 100));
+        assert_eq!(visible_line_window(100, 10, 0), (10, 10));
     }
 
     #[test]


### PR DESCRIPTION
- **fix: refresh metric-sorted rows on metrics update**
- **perf: render only visible table rows**
- **perf: batch UI log delivery**
- **feat: show selected resource events**
- **chore: remove unused direct dependencies**
- **fix: drop stale async UI results**
- **perf: drop managed fields from watched objects**
- **perf: render only visible detail lines**
- **chore: tune release profile**
- **fix: save only filtered log lines**
- **fix: save logs asynchronously**
- **fix: load context list asynchronously**
- **feat: copy via async clipboard with OSC52 fallback**
- **perf: avoid cloning selected objects for reads**
- **perf: avoid materializing rows for table count**
- **test: assert curated column alignment**
- **test: pin mocha base swatch**
- **test: cover mutating patch payloads**
- **feat: add curated columns for common resources**
- **perf: use deque for scroll buffers**
- **perf: cache table cells per resource version**
- **feat: link jobs into xray trees**
- **feat: add node maintenance actions**
- **feat: switch skins live**
- **refactor: share list popup rendering**
- **refactor: define palette swatches once**
- **fix: keep confirm modal readable in small panes**
- **refactor: define resource columns as tables**
- **refactor: share patch action spawning**
