### PR TITLE
feat: switch kind and namespace at once with `:<kind> <namespace>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ sofka [RESOURCE] [-n NAMESPACE] [-A]
 | Key                       | Action                                                                                                  |
 | ------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `:<resource>`             | command palette - fuzzy over kinds and built-in commands                                                |
+| `:<resource> <ns>`        | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces)                        |
 | `enter`                   | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources) |
 | `esc`                     | go back / pop the view stack / clear filter / clear marks                                               |
 | `j`/`k`, `↓`/`↑`, `g`/`G` | navigate                                                                                                |

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -156,6 +156,17 @@ pub(super) fn container_names(obj: &DynamicObject) -> Vec<String> {
     names
 }
 
+/// Normalize a user-typed namespace argument: `all`, `*`, and `<all>` mean
+/// "all namespaces" (the empty string internally).
+pub(super) fn normalize_ns(ns: &str) -> String {
+    let t = ns.trim();
+    if t == "all" || t == "*" || t == "<all>" {
+        String::new()
+    } else {
+        t.to_string()
+    }
+}
+
 /// Trim a trailing plural "s" for breadcrumb labels (deployments -> deployment).
 pub(super) fn trim_s(plural: &str) -> &str {
     plural.strip_suffix('s').unwrap_or(plural)

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -208,6 +208,12 @@ impl App {
                 let picked = self.cmd_suggestions.get(self.cmd_sel).cloned();
                 self.mode = Mode::Table;
                 self.command.clear();
+                // `:kind namespace` switches both at once (`:deploy social`,
+                // `:cephclusters all`); only the first word selects the kind.
+                let (head, ns_arg) = match typed.split_once(char::is_whitespace) {
+                    Some((h, rest)) => (h.to_string(), rest.split_whitespace().next()),
+                    None => (typed.clone(), None),
+                };
                 // An exact typed built-in wins (stable muscle memory), then the
                 // highlighted suggestion, then the raw typed text as a resource.
                 if self.run_palette_command(&typed) {
@@ -217,10 +223,10 @@ impl App {
                         SuggestKind::Command => {
                             self.run_palette_command(&s.label);
                         }
-                        SuggestKind::Resource => self.switch_kind(&s.label),
+                        SuggestKind::Resource => self.switch_kind_ns(&s.label, ns_arg),
                     }
-                } else if !typed.is_empty() {
-                    self.switch_kind(&typed);
+                } else if !head.is_empty() {
+                    self.switch_kind_ns(&head, ns_arg);
                 }
             }
             KeyCode::Backspace => {
@@ -284,8 +290,10 @@ impl App {
     /// Recompute the command-palette suggestions: built-in commands and resource
     /// kinds, fuzzy-matched together. An empty query lists the resource catalog
     /// only (the browse default), so pressing `:`⏎ never fires a command.
+    /// Only the first word is matched — anything after it is the namespace
+    /// argument of `:kind namespace` and must not perturb the kind match.
     pub(super) fn update_suggestions(&mut self) {
-        let q = self.command.trim();
+        let q = self.command.split_whitespace().next().unwrap_or("");
         let mut scored: Vec<(i64, Suggestion)> = Vec::new();
 
         // Built-in commands: fuzzy over all names, display the canonical one.

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -6,24 +6,24 @@ impl App {
     /// Switch the active resource kind by user input. Pushes the current view
     /// so `esc` can return.
     pub fn switch_kind(&mut self, input: &str) {
+        self.switch_kind_ns(input, None);
+    }
+
+    /// Switch kind and (optionally) namespace in one move (`:deploy social`).
+    /// `all`/`*` as the namespace selects all namespaces.
+    pub fn switch_kind_ns(&mut self, input: &str, ns: Option<&str>) {
         match self.cluster.resolve(input) {
             Some(kind) => {
-                // A `:resource` switch is a fresh root view, not a drill-down:
-                // clear the breadcrumb so `esc` doesn't replay command history.
-                self.stack.clear();
-                self.kind_plural = kind.ar.plural.to_lowercase();
+                if let Some(ns) = ns {
+                    self.namespace = normalize_ns(ns);
+                }
                 let title = kind.title();
-                self.kind = Some(kind);
-                self.labels = None;
-                self.fields = None;
-                self.scope_label = None;
-                self.filter.clear();
-                self.reset_sort();
-                // A stale selection from the previous kind (e.g. row 5 on
-                // pods) would otherwise carry over — reset to the top so the
-                // new view always starts with its first row selected.
-                self.table_state.select(Some(0));
-                self.flash = format!("Viewing {title}");
+                self.set_root_view(kind);
+                self.flash = if ns.is_some() {
+                    format!("Viewing {title} in {}", self.namespace_label())
+                } else {
+                    format!("Viewing {title}")
+                };
                 self.flash_err = false;
                 self.start_watch();
             }
@@ -31,6 +31,31 @@ impl App {
                 self.flash = format!("No resource matches '{}'", input.trim());
                 self.flash_err = true;
             }
+        }
+    }
+
+    /// Install `kind` as a fresh root view (not a drill-down): clear the
+    /// breadcrumb so `esc` doesn't replay command history, drop drill
+    /// selectors, and reset filter/sort/cursor. A stale selection from the
+    /// previous kind (e.g. row 5 on pods) would otherwise carry over — the new
+    /// view always starts with its first row selected.
+    fn set_root_view(&mut self, kind: Kind) {
+        self.stack.clear();
+        self.kind_plural = kind.ar.plural.to_lowercase();
+        self.kind = Some(kind);
+        self.labels = None;
+        self.fields = None;
+        self.scope_label = None;
+        self.filter.clear();
+        self.reset_sort();
+        self.table_state.select(Some(0));
+    }
+
+    pub(super) fn namespace_label(&self) -> String {
+        if self.namespace.is_empty() {
+            "all namespaces".to_string()
+        } else {
+            self.namespace.clone()
         }
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1442,3 +1442,34 @@ fn trim_plural_suffix() {
     assert_eq!(trim_s("deployments"), "deployment");
     assert_eq!(trim_s("pods"), "pod");
 }
+
+// ----- `:kind namespace` --------------------------------------------------
+
+#[tokio::test]
+async fn command_with_namespace_switches_both() {
+    let (mut app, _rx) = test_app();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "deployments social".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    // Only the first word selects the kind — the namespace argument must not
+    // perturb the fuzzy match.
+    assert_eq!(
+        app.cmd_suggestions.first().map(|s| s.label.as_str()),
+        Some("deployments")
+    );
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    assert_eq!(app.namespace, "social");
+}
+
+#[tokio::test]
+async fn command_namespace_all_means_all_namespaces() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind_ns("pods", Some("all"));
+    assert_eq!(app.kind_plural, "pods");
+    assert!(app.all_namespaces());
+    app.switch_kind_ns("deployments", Some("*"));
+    assert!(app.all_namespaces());
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1217,6 +1217,10 @@ fn draw_help(frame: &mut Frame, area: Rect) {
             ":<resource>",
             "command palette — fuzzy over kinds + commands (tab/↑↓)",
         ),
+        bind(
+            ":<res> <ns>",
+            "switch kind and namespace at once (all/* = all namespaces)",
+        ),
         bind(":ctx · :pulse", "switch context · cluster-health dashboard"),
         bind(
             ":xray · :diff",


### PR DESCRIPTION
## Summary

The command palette now accepts an optional second word as the namespace: `:deploy social`, `:cephclusters all` (`all`/`*` = all namespaces). One command switches both.

- `switch_kind` is refactored into `switch_kind_ns` with a shared `set_root_view` helper; existing callers are unchanged.
- Suggestions fuzzy-match on the **first word only**, so typing `:deploy soc` still highlights `deployments` — the namespace argument never perturbs the kind match.
- The namespace argument is applied whether you accept a highlighted suggestion or type the kind in full; `all`, `*`, and `<all>` normalize to all-namespaces.
- Documented in the in-app help (`?`) and README.

## Test plan

- New tests: `command_with_namespace_switches_both`, `command_namespace_all_means_all_namespaces`.
- `just check` green (fmt, clippy, 111 tests); verified headlessly against a live cluster with `--check`/`--snapshot`.