### PR TITLE
feat: per-context skin overrides via `[skin.contexts]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ name = "gruvbox-dark"
 [skin.colors]            # optional per-swatch overrides
 red = "#fb4934"
 
+[skin.contexts]          # per-context skin overrides — e.g. prod goes light
+prod = "catppuccin-latte"
+
 [[plugins]]
 key = "g"
 name = "argocd-sync"

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -739,8 +739,31 @@ impl App {
         }
         let palette = crate::theme::resolve_skin(Some(name), &self.skin_colors);
         crate::theme::set(palette);
+        // A manual choice becomes the session skin, so it survives context
+        // switches into contexts without a `[skin.contexts]` override.
+        self.session_skin = Some(name.to_string());
         self.flash = format!("skin: {name}");
         self.flash_err = false;
+    }
+
+    /// Re-resolve the skin when the context changes: a `[skin.contexts]`
+    /// override for the new context wins, otherwise the session skin (config
+    /// `skin.name`, the auto-detected default, or the last `:skin` choice).
+    pub(super) fn apply_context_skin(&mut self, context: &str) {
+        let Some(name) = self
+            .context_skins
+            .get(context)
+            .cloned()
+            .or_else(|| self.session_skin.clone())
+        else {
+            return;
+        };
+        if crate::theme::builtin(&name.trim().to_ascii_lowercase()).is_none() {
+            self.flash_warn(&format!("unknown skin '{name}' for context {context}"));
+            return;
+        }
+        let palette = crate::theme::resolve_skin(Some(&name), &self.skin_colors);
+        crate::theme::set(palette);
     }
 
     /// Stop (kill) the selected forward. Others keep running.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -465,6 +465,12 @@ pub struct App {
     pub skin_state: ListState,
     /// Per-swatch color overrides from config, re-applied when switching skins.
     pub skin_colors: HashMap<String, String>,
+    /// Per-context skin overrides from config (`[skin.contexts]`), so e.g. the
+    /// prod context can render light while everything else stays dark.
+    pub context_skins: HashMap<String, String>,
+    /// Skin for contexts without an override: config `skin.name` (or the
+    /// auto-detected default), replaced by a manual `:skin` choice.
+    pub session_skin: Option<String>,
 
     /// Current images aligned with `container_list`, for the Set-Image picker.
     pub image_values: Vec<String>,
@@ -559,6 +565,8 @@ impl App {
                 .collect(),
             skin_state: ListState::default(),
             skin_colors: HashMap::new(),
+            context_skins: HashMap::new(),
+            session_skin: None,
             image_values: Vec::new(),
             image_target: None,
             metrics: HashMap::new(),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -242,6 +242,7 @@ impl App {
         // Permissions differ per cluster — drop the old allow-list.
         self.rbac_allowed = None;
         self.last_rbac_ns = None;
+        self.apply_context_skin(&name);
         self.flash = format!("context: {name}");
         self.flash_err = false;
         self.switch_kind("pods");

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,9 @@ pub struct Config {
 /// [`crate::theme::BUILTIN_NAMES`]); leaving it unset auto-detects the
 /// terminal's dark/light mode and picks `catppuccin-mocha`/`catppuccin-latte`
 /// accordingly. `colors` overrides individual swatches by name with
-/// `#rrggbb` hex values.
+/// `#rrggbb` hex values. `contexts` maps a kubeconfig context name to a skin
+/// that overrides `name` while that context is active — e.g. a light skin on
+/// prod as a visual "careful now" cue.
 ///
 /// ```toml
 /// [skin]
@@ -44,12 +46,16 @@ pub struct Config {
 /// [skin.colors]
 /// red   = "#fb4934"
 /// mauve = "#d3869b"
+///
+/// [skin.contexts]
+/// prod = "catppuccin-latte"
 /// ```
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct Skin {
     pub name: Option<String>,
     pub colors: HashMap<String, String>,
+    pub contexts: HashMap<String, String>,
 }
 
 /// A shell-out plugin (k9s-style). Bound to `key` on resources matching
@@ -133,6 +139,23 @@ mod tests {
         assert_eq!(p.key, 'g');
         assert_eq!(p.args, vec!["app", "sync", "$NAME"]);
         assert_eq!(p.scopes, vec!["deployments"]);
+    }
+
+    #[test]
+    fn parses_per_context_skins() {
+        let toml = r#"
+            [skin]
+            name = "gruvbox-dark"
+
+            [skin.contexts]
+            prod = "catppuccin-latte"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.skin.name.as_deref(), Some("gruvbox-dark"));
+        assert_eq!(
+            cfg.skin.contexts.get("prod").map(String::as_str),
+            Some("catppuccin-latte")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,14 +55,6 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let cfg = config::Config::load();
 
-    // Install the initial color skin before anything renders. Auto-detecting
-    // dark/light mode queries the terminal directly, so it belongs before
-    // ratatui switches to the alternate screen.
-    theme::init(theme::resolve_skin(
-        cfg.skin.name.as_deref(),
-        &cfg.skin.colors,
-    ));
-
     // Connect before taking over the terminal so errors are readable.
     eprintln!("Connecting to cluster…");
     let mut cluster = match Cluster::connect().await {
@@ -100,11 +92,30 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Install the initial color skin before anything renders. Auto-detecting
+    // dark/light mode queries the terminal directly, so it must run before
+    // ratatui switches to the alternate screen. A `[skin.contexts]` override
+    // for the starting context wins over the global/auto-detected skin.
+    let session_skin = cfg
+        .skin
+        .name
+        .clone()
+        .unwrap_or_else(|| theme::auto_skin_name().to_string());
+    let initial_skin = cfg
+        .skin
+        .contexts
+        .get(&cluster.context)
+        .unwrap_or(&session_skin)
+        .clone();
+    theme::init(theme::resolve_skin(Some(&initial_skin), &cfg.skin.colors));
+
     let (tx, mut rx) = mpsc::channel(EVENT_CHANNEL_CAP);
     let mut app = App::new(cluster, tx);
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
     app.skin_colors = cfg.skin.colors.clone();
+    app.context_skins = cfg.skin.contexts.clone();
+    app.session_skin = Some(session_skin);
     if args.all_namespaces {
         app.namespace = String::new();
     } else if let Some(ns) = args.namespace {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -242,6 +242,16 @@ fn detect_terminal_mode() -> Option<ThemeMode> {
     terminal_colorsaurus::theme_mode(QueryOptions::default()).ok()
 }
 
+/// The skin used when config names none: auto-detected from the terminal's
+/// dark/light mode (OSC 11 query — run this before entering the alternate
+/// screen).
+pub fn auto_skin_name() -> &'static str {
+    match detect_terminal_mode() {
+        Some(ThemeMode::Light) => "catppuccin-latte",
+        _ => "catppuccin-mocha",
+    }
+}
+
 /// Resolve the active palette from config: start from the named built-in, or
 /// — when no name is configured — auto-detect the terminal's dark/light mode
 /// and pick `catppuccin-latte`/`catppuccin-mocha` accordingly. Then apply
@@ -249,10 +259,7 @@ fn detect_terminal_mode() -> Option<ThemeMode> {
 /// malformed hex, and carries on.
 pub fn resolve_skin(name: Option<&str>, colors: &HashMap<String, String>) -> Palette {
     let mut p = match name {
-        None => match detect_terminal_mode() {
-            Some(ThemeMode::Light) => catppuccin_latte(),
-            _ => catppuccin_mocha(),
-        },
+        None => builtin(auto_skin_name()).expect("auto skin is a built-in"),
         Some(n) => match builtin(&n.trim().to_ascii_lowercase()) {
             Some(p) => p,
             None => {


### PR DESCRIPTION
## Summary

Stacked on #11 and #12.

New `[skin.contexts]` config table mapping kubeconfig context names to skins — e.g. render prod light as a visual "careful now" cue while everything else stays dark:

```toml
[skin]
name = "catppuccin-mocha"

[skin.contexts]
prod = "catppuccin-latte"
```

- Applied at startup (theme init moved after cluster connect, still before the alternate screen so dark/light auto-detection keeps working) and live on every `:ctx` switch.
- Contexts without an override fall back to the session skin: config `skin.name`, the auto-detected default (`theme::auto_skin_name`), or the last manual `:skin` choice — whichever came last.
- Per-swatch `[skin.colors]` overrides still apply on top of whichever skin wins.
- Unknown skin names flash a warning in the TUI instead of writing to stderr mid-render.

## Test plan

- New test: `parses_per_context_skins`.
- `just check` green (fmt, clippy, 116 tests).
- Verified against a live cluster with an isolated `XDG_CONFIG_HOME`: a per-context override for the active context resolves at startup, and an unknown name falls back with the expected warning.