### PR TITLE
feat: browser-style view history with `[` / `]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ sofka [RESOURCE] [-n NAMESPACE] [-A]
 | ------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `:<resource>`             | command palette - fuzzy over kinds and built-in commands                                                |
 | `:<resource> <ns>`        | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces)                        |
+| `[` / `]`                 | view history - back / forward through visited kind+namespace views                                      |
 | `enter`                   | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources) |
 | `esc`                     | go back / pop the view stack / clear filter / clear marks                                               |
 | `j`/`k`, `↓`/`↑`, `g`/`G` | navigate                                                                                                |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -121,12 +121,16 @@ impl App {
             // `f`/Shift-F = port-forward.
             KeyCode::Char('f') | KeyCode::Char('F') => self.request_port_forward(),
             KeyCode::Char('n') => self.open_namespaces(),
+            // Browser-style view history: [ back, ] forward.
+            KeyCode::Char('[') => self.history_back(),
+            KeyCode::Char(']') => self.history_forward(),
             // k9s: 0 = all namespaces.
             KeyCode::Char('0') => {
                 self.namespace.clear();
                 self.flash = "namespace: all namespaces".into();
                 self.flash_err = false;
                 self.table_state.select(Some(0));
+                self.record_history();
                 self.start_watch();
             }
             // k9s: `r` = rollout restart on workloads, force-sync on external

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -25,6 +25,7 @@ impl App {
                     format!("Viewing {title}")
                 };
                 self.flash_err = false;
+                self.record_history();
                 self.start_watch();
             }
             None => {
@@ -57,6 +58,69 @@ impl App {
         } else {
             self.namespace.clone()
         }
+    }
+
+    // ----- view history (`[` / `]`) ---------------------------------------
+
+    /// Record the current root view (kind + namespace). Called after every
+    /// root switch; navigating with `[`/`]` bypasses this so hopping through
+    /// history doesn't rewrite it. A new entry truncates the forward tail.
+    pub(super) fn record_history(&mut self) {
+        if self.kind.is_none() {
+            return;
+        }
+        let entry = ViewEntry {
+            kind_plural: self.kind_plural.clone(),
+            namespace: self.namespace.clone(),
+        };
+        if self.history.get(self.history_pos) == Some(&entry) {
+            return;
+        }
+        self.history.truncate(self.history_pos + 1);
+        self.history.push(entry);
+        if self.history.len() > HISTORY_MAX {
+            self.history.remove(0);
+        }
+        self.history_pos = self.history.len() - 1;
+    }
+
+    pub(super) fn history_back(&mut self) {
+        if self.history_pos == 0 {
+            self.flash_warn("already at oldest view");
+            return;
+        }
+        self.history_pos -= 1;
+        self.apply_history_entry();
+    }
+
+    pub(super) fn history_forward(&mut self) {
+        if self.history_pos + 1 >= self.history.len() {
+            self.flash_warn("already at newest view");
+            return;
+        }
+        self.history_pos += 1;
+        self.apply_history_entry();
+    }
+
+    fn apply_history_entry(&mut self) {
+        let Some(entry) = self.history.get(self.history_pos).cloned() else {
+            return;
+        };
+        let Some(kind) = self.cluster.resolve(&entry.kind_plural) else {
+            self.flash_warn(&format!("cannot resolve '{}' anymore", entry.kind_plural));
+            return;
+        };
+        self.namespace = entry.namespace;
+        let title = kind.title();
+        self.set_root_view(kind);
+        self.flash = format!(
+            "history {}/{}: {title} in {}",
+            self.history_pos + 1,
+            self.history.len(),
+            self.namespace_label()
+        );
+        self.flash_err = false;
+        self.start_watch();
     }
 
     pub(super) fn push_frame(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -362,6 +362,18 @@ impl TableCellCache<'_> {
     }
 }
 
+/// Maximum root views kept in the `[`/`]` history.
+const HISTORY_MAX: usize = 50;
+
+/// One root view for the `[`/`]` history: which kind was listed in which
+/// namespace. Drill-down state (selectors, filter, scope) is deliberately not
+/// kept — history replays root views; the breadcrumb stack handles drills.
+#[derive(Clone, PartialEq, Eq)]
+struct ViewEntry {
+    kind_plural: String,
+    namespace: String,
+}
+
 /// A saved view, pushed onto the stack when drilling down.
 struct Frame {
     kind: Option<Kind>,
@@ -391,6 +403,12 @@ pub struct App {
     pub tasks: Vec<JoinHandle<()>>,
     pub tx: Sender<Msg>,
     stack: Vec<Frame>,
+    /// Browser-style history of root views for `[`/`]`: every root switch
+    /// (kind and/or namespace) is recorded; navigating with `[`/`]` moves the
+    /// cursor without re-recording, and a fresh switch truncates the forward
+    /// tail — exactly like browser history.
+    history: Vec<ViewEntry>,
+    history_pos: usize,
 
     pub mode: Mode,
     pub table_state: TableState,
@@ -503,6 +521,8 @@ impl App {
             tasks: Vec::new(),
             tx,
             stack: Vec::new(),
+            history: Vec::new(),
+            history_pos: 0,
             mode: Mode::Table,
             table_state: TableState::default(),
             marked: HashSet::new(),

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -156,14 +156,10 @@ impl App {
             self.reset_sort();
             self.table_state.select(Some(0));
         }
-        self.namespace = ns.clone();
-        let label = if ns.is_empty() {
-            "all namespaces".to_string()
-        } else {
-            ns
-        };
-        self.flash = format!("namespace: {label}");
+        self.namespace = ns;
+        self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
+        self.record_history();
         self.start_watch();
     }
 }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -108,21 +108,13 @@ impl App {
     }
 
     pub(super) fn set_namespace(&mut self, sel: String) {
-        self.namespace = if sel == "<all>" || sel.is_empty() {
-            String::new()
-        } else {
-            sel
-        };
-        let label = if self.namespace.is_empty() {
-            "all namespaces".to_string()
-        } else {
-            self.namespace.clone()
-        };
-        self.flash = format!("namespace: {label}");
+        self.namespace = normalize_ns(&sel);
+        self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
         self.ns_filter.clear();
         self.mode = Mode::Table;
         self.table_state.select(Some(0));
+        self.record_history();
         self.start_watch();
     }
 
@@ -238,6 +230,9 @@ impl App {
         self.namespace = cluster.default_namespace.clone();
         self.cluster = *cluster;
         self.stack.clear();
+        // View history references the old cluster's kinds and namespaces.
+        self.history.clear();
+        self.history_pos = 0;
         self.kind = None;
         self.kind_plural.clear();
         self.labels = None;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1443,7 +1443,7 @@ fn trim_plural_suffix() {
     assert_eq!(trim_s("pods"), "pod");
 }
 
-// ----- `:kind namespace` --------------------------------------------------
+// ----- `:kind namespace` + view history -----------------------------------
 
 #[tokio::test]
 async fn command_with_namespace_switches_both() {
@@ -1472,4 +1472,79 @@ async fn command_namespace_all_means_all_namespaces() {
     assert!(app.all_namespaces());
     app.switch_kind_ns("deployments", Some("*"));
     assert!(app.all_namespaces());
+}
+
+#[tokio::test]
+async fn view_history_brackets_walk_back_and_forward() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind("pods");
+    app.switch_kind_ns("deployments", Some("social"));
+    app.switch_kind_ns("kustomizations", Some("all"));
+
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("deployments", "social")
+    );
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("pods", "default")
+    );
+    // At the oldest entry `[` stays put and warns.
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert!(app.flash_err);
+
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("kustomizations", "")
+    );
+    // At the newest entry `]` stays put and warns.
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    assert_eq!(app.kind_plural, "kustomizations");
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn new_switch_after_back_truncates_forward_history() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.switch_kind("deployments");
+    app.history_back(); // -> pods
+    app.switch_kind("services"); // truncates the deployments tail
+    app.history_forward();
+    assert_eq!(app.kind_plural, "services", "forward tail must be gone");
+    app.history_back();
+    assert_eq!(app.kind_plural, "pods");
+}
+
+#[tokio::test]
+async fn history_dedupes_consecutive_identical_views() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.switch_kind("pods");
+    app.history_back();
+    assert!(app.flash_err, "one entry recorded — nothing to go back to");
+}
+
+#[tokio::test]
+async fn namespace_switch_is_recorded_in_history() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind("pods");
+    app.set_namespace("social".into());
+    app.history_back();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("pods", "default")
+    );
+    app.history_forward();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("pods", "social")
+    );
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1221,6 +1221,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
             ":<res> <ns>",
             "switch kind and namespace at once (all/* = all namespaces)",
         ),
+        bind("[ · ]", "view history — back · forward"),
         bind(":ctx · :pulse", "switch context · cluster-health dashboard"),
         bind(
             ":xray · :diff",


### PR DESCRIPTION
## Summary

Re-lands #12, which was merged into its stacked base branch instead of `main` (the base branch wasn't deleted, so GitHub never retargeted it).

Every root-view switch — `:resource`, `:resource <ns>`, the `n` namespace picker, `0`, and entering a namespace row — is recorded as a `(kind, namespace)` history entry. `[` walks back, `]` walks forward, so you can bounce between e.g. `cephclusters all` and `deploy social` with two keys.

- Browser semantics: bracket navigation moves the cursor without re-recording; a fresh switch while back in history truncates the forward tail.
- Consecutive duplicates are deduped; history is capped at 50 entries.
- Cleared on context switch (entries reference the old cluster's kinds/namespaces).
- Drill-downs stay on the esc/breadcrumb stack and are not recorded.

## Test plan

- Tests: bracket walk with edge warnings, forward-tail truncation, dedupe, namespace-switch recording.
- `just check` green.