### PR TITLE
feat: per-context skin overrides via `[skin.contexts]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ name = "gruvbox-dark"
 [skin.colors]            # optional per-swatch overrides
 red = "#fb4934"
 
+[skin.contexts]          # per-context skin overrides — e.g. prod goes light
+prod = "catppuccin-latte"
+
 [[plugins]]
 key = "g"
 name = "argocd-sync"

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ sofka [RESOURCE] [-n NAMESPACE] [-A]
 | ------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `:<resource>`             | command palette - fuzzy over kinds and built-in commands                                                |
 | `:<resource> <ns>`        | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces)                        |
+| `[` / `]`                 | view history - back / forward through visited kind+namespace views                                      |
 | `enter`                   | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources) |
 | `esc`                     | go back / pop the view stack / clear filter / clear marks                                               |
 | `j`/`k`, `↓`/`↑`, `g`/`G` | navigate                                                                                                |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -739,8 +739,31 @@ impl App {
         }
         let palette = crate::theme::resolve_skin(Some(name), &self.skin_colors);
         crate::theme::set(palette);
+        // A manual choice becomes the session skin, so it survives context
+        // switches into contexts without a `[skin.contexts]` override.
+        self.session_skin = Some(name.to_string());
         self.flash = format!("skin: {name}");
         self.flash_err = false;
+    }
+
+    /// Re-resolve the skin when the context changes: a `[skin.contexts]`
+    /// override for the new context wins, otherwise the session skin (config
+    /// `skin.name`, the auto-detected default, or the last `:skin` choice).
+    pub(super) fn apply_context_skin(&mut self, context: &str) {
+        let Some(name) = self
+            .context_skins
+            .get(context)
+            .cloned()
+            .or_else(|| self.session_skin.clone())
+        else {
+            return;
+        };
+        if crate::theme::builtin(&name.trim().to_ascii_lowercase()).is_none() {
+            self.flash_warn(&format!("unknown skin '{name}' for context {context}"));
+            return;
+        }
+        let palette = crate::theme::resolve_skin(Some(&name), &self.skin_colors);
+        crate::theme::set(palette);
     }
 
     /// Stop (kill) the selected forward. Others keep running.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -121,12 +121,16 @@ impl App {
             // `f`/Shift-F = port-forward.
             KeyCode::Char('f') | KeyCode::Char('F') => self.request_port_forward(),
             KeyCode::Char('n') => self.open_namespaces(),
+            // Browser-style view history: [ back, ] forward.
+            KeyCode::Char('[') => self.history_back(),
+            KeyCode::Char(']') => self.history_forward(),
             // k9s: 0 = all namespaces.
             KeyCode::Char('0') => {
                 self.namespace.clear();
                 self.flash = "namespace: all namespaces".into();
                 self.flash_err = false;
                 self.table_state.select(Some(0));
+                self.record_history();
                 self.start_watch();
             }
             // k9s: `r` = rollout restart on workloads, force-sync on external

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -25,6 +25,7 @@ impl App {
                     format!("Viewing {title}")
                 };
                 self.flash_err = false;
+                self.record_history();
                 self.start_watch();
             }
             None => {
@@ -57,6 +58,69 @@ impl App {
         } else {
             self.namespace.clone()
         }
+    }
+
+    // ----- view history (`[` / `]`) ---------------------------------------
+
+    /// Record the current root view (kind + namespace). Called after every
+    /// root switch; navigating with `[`/`]` bypasses this so hopping through
+    /// history doesn't rewrite it. A new entry truncates the forward tail.
+    pub(super) fn record_history(&mut self) {
+        if self.kind.is_none() {
+            return;
+        }
+        let entry = ViewEntry {
+            kind_plural: self.kind_plural.clone(),
+            namespace: self.namespace.clone(),
+        };
+        if self.history.get(self.history_pos) == Some(&entry) {
+            return;
+        }
+        self.history.truncate(self.history_pos + 1);
+        self.history.push(entry);
+        if self.history.len() > HISTORY_MAX {
+            self.history.remove(0);
+        }
+        self.history_pos = self.history.len() - 1;
+    }
+
+    pub(super) fn history_back(&mut self) {
+        if self.history_pos == 0 {
+            self.flash_warn("already at oldest view");
+            return;
+        }
+        self.history_pos -= 1;
+        self.apply_history_entry();
+    }
+
+    pub(super) fn history_forward(&mut self) {
+        if self.history_pos + 1 >= self.history.len() {
+            self.flash_warn("already at newest view");
+            return;
+        }
+        self.history_pos += 1;
+        self.apply_history_entry();
+    }
+
+    fn apply_history_entry(&mut self) {
+        let Some(entry) = self.history.get(self.history_pos).cloned() else {
+            return;
+        };
+        let Some(kind) = self.cluster.resolve(&entry.kind_plural) else {
+            self.flash_warn(&format!("cannot resolve '{}' anymore", entry.kind_plural));
+            return;
+        };
+        self.namespace = entry.namespace;
+        let title = kind.title();
+        self.set_root_view(kind);
+        self.flash = format!(
+            "history {}/{}: {title} in {}",
+            self.history_pos + 1,
+            self.history.len(),
+            self.namespace_label()
+        );
+        self.flash_err = false;
+        self.start_watch();
     }
 
     pub(super) fn push_frame(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -362,6 +362,18 @@ impl TableCellCache<'_> {
     }
 }
 
+/// Maximum root views kept in the `[`/`]` history.
+const HISTORY_MAX: usize = 50;
+
+/// One root view for the `[`/`]` history: which kind was listed in which
+/// namespace. Drill-down state (selectors, filter, scope) is deliberately not
+/// kept — history replays root views; the breadcrumb stack handles drills.
+#[derive(Clone, PartialEq, Eq)]
+struct ViewEntry {
+    kind_plural: String,
+    namespace: String,
+}
+
 /// A saved view, pushed onto the stack when drilling down.
 struct Frame {
     kind: Option<Kind>,
@@ -391,6 +403,12 @@ pub struct App {
     pub tasks: Vec<JoinHandle<()>>,
     pub tx: Sender<Msg>,
     stack: Vec<Frame>,
+    /// Browser-style history of root views for `[`/`]`: every root switch
+    /// (kind and/or namespace) is recorded; navigating with `[`/`]` moves the
+    /// cursor without re-recording, and a fresh switch truncates the forward
+    /// tail — exactly like browser history.
+    history: Vec<ViewEntry>,
+    history_pos: usize,
 
     pub mode: Mode,
     pub table_state: TableState,
@@ -503,6 +521,8 @@ impl App {
             tasks: Vec::new(),
             tx,
             stack: Vec::new(),
+            history: Vec::new(),
+            history_pos: 0,
             mode: Mode::Table,
             table_state: TableState::default(),
             marked: HashSet::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -465,6 +465,12 @@ pub struct App {
     pub skin_state: ListState,
     /// Per-swatch color overrides from config, re-applied when switching skins.
     pub skin_colors: HashMap<String, String>,
+    /// Per-context skin overrides from config (`[skin.contexts]`), so e.g. the
+    /// prod context can render light while everything else stays dark.
+    pub context_skins: HashMap<String, String>,
+    /// Skin for contexts without an override: config `skin.name` (or the
+    /// auto-detected default), replaced by a manual `:skin` choice.
+    pub session_skin: Option<String>,
 
     /// Current images aligned with `container_list`, for the Set-Image picker.
     pub image_values: Vec<String>,
@@ -559,6 +565,8 @@ impl App {
                 .collect(),
             skin_state: ListState::default(),
             skin_colors: HashMap::new(),
+            context_skins: HashMap::new(),
+            session_skin: None,
             image_values: Vec::new(),
             image_target: None,
             metrics: HashMap::new(),

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -156,14 +156,10 @@ impl App {
             self.reset_sort();
             self.table_state.select(Some(0));
         }
-        self.namespace = ns.clone();
-        let label = if ns.is_empty() {
-            "all namespaces".to_string()
-        } else {
-            ns
-        };
-        self.flash = format!("namespace: {label}");
+        self.namespace = ns;
+        self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
+        self.record_history();
         self.start_watch();
     }
 }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -108,21 +108,13 @@ impl App {
     }
 
     pub(super) fn set_namespace(&mut self, sel: String) {
-        self.namespace = if sel == "<all>" || sel.is_empty() {
-            String::new()
-        } else {
-            sel
-        };
-        let label = if self.namespace.is_empty() {
-            "all namespaces".to_string()
-        } else {
-            self.namespace.clone()
-        };
-        self.flash = format!("namespace: {label}");
+        self.namespace = normalize_ns(&sel);
+        self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
         self.ns_filter.clear();
         self.mode = Mode::Table;
         self.table_state.select(Some(0));
+        self.record_history();
         self.start_watch();
     }
 
@@ -238,6 +230,9 @@ impl App {
         self.namespace = cluster.default_namespace.clone();
         self.cluster = *cluster;
         self.stack.clear();
+        // View history references the old cluster's kinds and namespaces.
+        self.history.clear();
+        self.history_pos = 0;
         self.kind = None;
         self.kind_plural.clear();
         self.labels = None;

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -242,6 +242,7 @@ impl App {
         // Permissions differ per cluster — drop the old allow-list.
         self.rbac_allowed = None;
         self.last_rbac_ns = None;
+        self.apply_context_skin(&name);
         self.flash = format!("context: {name}");
         self.flash_err = false;
         self.switch_kind("pods");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1443,7 +1443,7 @@ fn trim_plural_suffix() {
     assert_eq!(trim_s("pods"), "pod");
 }
 
-// ----- `:kind namespace` --------------------------------------------------
+// ----- `:kind namespace` + view history -----------------------------------
 
 #[tokio::test]
 async fn command_with_namespace_switches_both() {
@@ -1472,4 +1472,79 @@ async fn command_namespace_all_means_all_namespaces() {
     assert!(app.all_namespaces());
     app.switch_kind_ns("deployments", Some("*"));
     assert!(app.all_namespaces());
+}
+
+#[tokio::test]
+async fn view_history_brackets_walk_back_and_forward() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind("pods");
+    app.switch_kind_ns("deployments", Some("social"));
+    app.switch_kind_ns("kustomizations", Some("all"));
+
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("deployments", "social")
+    );
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("pods", "default")
+    );
+    // At the oldest entry `[` stays put and warns.
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert!(app.flash_err);
+
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("kustomizations", "")
+    );
+    // At the newest entry `]` stays put and warns.
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    assert_eq!(app.kind_plural, "kustomizations");
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn new_switch_after_back_truncates_forward_history() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.switch_kind("deployments");
+    app.history_back(); // -> pods
+    app.switch_kind("services"); // truncates the deployments tail
+    app.history_forward();
+    assert_eq!(app.kind_plural, "services", "forward tail must be gone");
+    app.history_back();
+    assert_eq!(app.kind_plural, "pods");
+}
+
+#[tokio::test]
+async fn history_dedupes_consecutive_identical_views() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.switch_kind("pods");
+    app.history_back();
+    assert!(app.flash_err, "one entry recorded — nothing to go back to");
+}
+
+#[tokio::test]
+async fn namespace_switch_is_recorded_in_history() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind("pods");
+    app.set_namespace("social".into());
+    app.history_back();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("pods", "default")
+    );
+    app.history_forward();
+    assert_eq!(
+        (app.kind_plural.as_str(), app.namespace.as_str()),
+        ("pods", "social")
+    );
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,9 @@ pub struct Config {
 /// [`crate::theme::BUILTIN_NAMES`]); leaving it unset auto-detects the
 /// terminal's dark/light mode and picks `catppuccin-mocha`/`catppuccin-latte`
 /// accordingly. `colors` overrides individual swatches by name with
-/// `#rrggbb` hex values.
+/// `#rrggbb` hex values. `contexts` maps a kubeconfig context name to a skin
+/// that overrides `name` while that context is active — e.g. a light skin on
+/// prod as a visual "careful now" cue.
 ///
 /// ```toml
 /// [skin]
@@ -44,12 +46,16 @@ pub struct Config {
 /// [skin.colors]
 /// red   = "#fb4934"
 /// mauve = "#d3869b"
+///
+/// [skin.contexts]
+/// prod = "catppuccin-latte"
 /// ```
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct Skin {
     pub name: Option<String>,
     pub colors: HashMap<String, String>,
+    pub contexts: HashMap<String, String>,
 }
 
 /// A shell-out plugin (k9s-style). Bound to `key` on resources matching
@@ -133,6 +139,23 @@ mod tests {
         assert_eq!(p.key, 'g');
         assert_eq!(p.args, vec!["app", "sync", "$NAME"]);
         assert_eq!(p.scopes, vec!["deployments"]);
+    }
+
+    #[test]
+    fn parses_per_context_skins() {
+        let toml = r#"
+            [skin]
+            name = "gruvbox-dark"
+
+            [skin.contexts]
+            prod = "catppuccin-latte"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.skin.name.as_deref(), Some("gruvbox-dark"));
+        assert_eq!(
+            cfg.skin.contexts.get("prod").map(String::as_str),
+            Some("catppuccin-latte")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,14 +55,6 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let cfg = config::Config::load();
 
-    // Install the initial color skin before anything renders. Auto-detecting
-    // dark/light mode queries the terminal directly, so it belongs before
-    // ratatui switches to the alternate screen.
-    theme::init(theme::resolve_skin(
-        cfg.skin.name.as_deref(),
-        &cfg.skin.colors,
-    ));
-
     // Connect before taking over the terminal so errors are readable.
     eprintln!("Connecting to cluster…");
     let mut cluster = match Cluster::connect().await {
@@ -100,11 +92,30 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Install the initial color skin before anything renders. Auto-detecting
+    // dark/light mode queries the terminal directly, so it must run before
+    // ratatui switches to the alternate screen. A `[skin.contexts]` override
+    // for the starting context wins over the global/auto-detected skin.
+    let session_skin = cfg
+        .skin
+        .name
+        .clone()
+        .unwrap_or_else(|| theme::auto_skin_name().to_string());
+    let initial_skin = cfg
+        .skin
+        .contexts
+        .get(&cluster.context)
+        .unwrap_or(&session_skin)
+        .clone();
+    theme::init(theme::resolve_skin(Some(&initial_skin), &cfg.skin.colors));
+
     let (tx, mut rx) = mpsc::channel(EVENT_CHANNEL_CAP);
     let mut app = App::new(cluster, tx);
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
     app.skin_colors = cfg.skin.colors.clone();
+    app.context_skins = cfg.skin.contexts.clone();
+    app.session_skin = Some(session_skin);
     if args.all_namespaces {
         app.namespace = String::new();
     } else if let Some(ns) = args.namespace {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -242,6 +242,16 @@ fn detect_terminal_mode() -> Option<ThemeMode> {
     terminal_colorsaurus::theme_mode(QueryOptions::default()).ok()
 }
 
+/// The skin used when config names none: auto-detected from the terminal's
+/// dark/light mode (OSC 11 query — run this before entering the alternate
+/// screen).
+pub fn auto_skin_name() -> &'static str {
+    match detect_terminal_mode() {
+        Some(ThemeMode::Light) => "catppuccin-latte",
+        _ => "catppuccin-mocha",
+    }
+}
+
 /// Resolve the active palette from config: start from the named built-in, or
 /// — when no name is configured — auto-detect the terminal's dark/light mode
 /// and pick `catppuccin-latte`/`catppuccin-mocha` accordingly. Then apply
@@ -249,10 +259,7 @@ fn detect_terminal_mode() -> Option<ThemeMode> {
 /// malformed hex, and carries on.
 pub fn resolve_skin(name: Option<&str>, colors: &HashMap<String, String>) -> Palette {
     let mut p = match name {
-        None => match detect_terminal_mode() {
-            Some(ThemeMode::Light) => catppuccin_latte(),
-            _ => catppuccin_mocha(),
-        },
+        None => builtin(auto_skin_name()).expect("auto skin is a built-in"),
         Some(n) => match builtin(&n.trim().to_ascii_lowercase()) {
             Some(p) => p,
             None => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1221,6 +1221,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
             ":<res> <ns>",
             "switch kind and namespace at once (all/* = all namespaces)",
         ),
+        bind("[ · ]", "view history — back · forward"),
         bind(":ctx · :pulse", "switch context · cluster-health dashboard"),
         bind(
             ":xray · :diff",


### PR DESCRIPTION
## Summary

Re-lands #13, which was merged into its stacked base branch instead of `main`. Depends on #14 — merge that first and this diff shrinks to just the skin feature.

New `[skin.contexts]` config table mapping kubeconfig context names to skins — e.g. render prod light as a visual "careful now" cue while everything else stays dark:

```toml
[skin]
name = "catppuccin-mocha"

[skin.contexts]
prod = "catppuccin-latte"
```

- Applied at startup and live on every `:ctx` switch.
- Contexts without an override fall back to the session skin: config `skin.name`, the auto-detected default, or the last manual `:skin` choice.
- Per-swatch `[skin.colors]` overrides still apply on top; unknown names flash a warning.

## Test plan

- Test: `parses_per_context_skins`.
- `just check` green; verified against a live cluster with an isolated `XDG_CONFIG_HOME`.