### PR TITLE
feat: horizontal scroll and word wrap in describe/events/diff

### DIFF
--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -35,7 +35,7 @@ impl App {
         self.detail = Scrollable {
             title: format!("{title} — YAML"),
             lines: self.object_yaml(obj).into(),
-            scroll: 0,
+            ..Default::default()
         };
         self.mode = Mode::Detail;
     }
@@ -172,7 +172,7 @@ impl App {
         self.detail = Scrollable {
             title: format!("{name} — diff (last-applied → live)"),
             lines: lines.into(),
-            scroll: 0,
+            ..Default::default()
         };
         self.mode = Mode::Diff;
     }
@@ -218,7 +218,7 @@ impl App {
         self.detail = Scrollable {
             title: title.clone(),
             lines: vec!["loading events…".into()].into(),
-            scroll: 0,
+            ..Default::default()
         };
         self.flash = format!("events: {name}");
         self.flash_err = false;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -496,11 +496,23 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => target.scroll_by(1),
             KeyCode::Char('k') | KeyCode::Up => target.scroll_by(-1),
+            KeyCode::Char('h') | KeyCode::Left => target.scroll_h(-5),
+            KeyCode::Char('l') | KeyCode::Right => target.scroll_h(5),
             KeyCode::PageDown | KeyCode::Char(' ') => target.scroll_by(20),
             KeyCode::PageUp => target.scroll_by(-20),
-            KeyCode::Char('g') | KeyCode::Home => target.scroll = 0,
+            KeyCode::Char('g') | KeyCode::Home => {
+                target.scroll = 0;
+                target.hscroll = 0;
+            }
             KeyCode::Char('G') | KeyCode::End => {
                 target.scroll = target.lines.len().saturating_sub(1)
+            }
+            // k9s: `w` toggles line wrap; folding long lines is the other way to
+            // read content that runs past the right edge.
+            KeyCode::Char('w') => {
+                let on = target.toggle_wrap();
+                self.flash = format!("wrap: {}", if on { "on" } else { "off" });
+                self.flash_err = false;
             }
             _ => {}
         }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -395,7 +395,7 @@ impl App {
                 self.detail = Scrollable {
                     title,
                     lines: lines.into(),
-                    scroll: 0,
+                    ..Default::default()
                 };
                 self.mode = Mode::Detail;
                 if let Some(w) = warn {

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -119,7 +119,7 @@ impl App {
         self.logs.view = Scrollable {
             title,
             lines: VecDeque::new(),
-            scroll: 0,
+            ..Default::default()
         };
         self.logs.follow = true;
         self.logs.filter.clear();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -178,6 +178,7 @@ enum PromptKind {
     },
 }
 
+#[derive(Default)]
 pub struct Scrollable {
     pub title: String,
     pub lines: VecDeque<String>,
@@ -185,6 +186,12 @@ pub struct Scrollable {
     /// (100k lines, wrapped) far exceeds `u16`; views that hand this to a
     /// ratatui `Paragraph` clamp at the edge instead.
     pub scroll: usize,
+    /// Horizontal scroll offset in columns, for views (`describe`, events) whose
+    /// lines run past the right edge. Ignored while `wrap` is on.
+    pub hscroll: usize,
+    /// Word-wrap toggle. When on, long lines fold instead of being clipped, and
+    /// horizontal scrolling is disabled.
+    pub wrap: bool,
 }
 
 /// One command-palette suggestion — a built-in command (`:ctx`, `:pulse`), a
@@ -264,15 +271,35 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
 
 impl Scrollable {
     fn empty() -> Self {
-        Self {
-            title: String::new(),
-            lines: VecDeque::new(),
-            scroll: 0,
-        }
+        Self::default()
     }
     pub fn scroll_by(&mut self, delta: i32) {
         let max = self.lines.len().saturating_sub(1) as i64;
         self.scroll = (self.scroll as i64 + delta as i64).clamp(0, max) as usize;
+    }
+    /// Scroll horizontally by `delta` columns, clamped to the widest line. A
+    /// no-op while wrapping, since wrapped lines have no off-screen right edge.
+    pub fn scroll_h(&mut self, delta: i32) {
+        if self.wrap {
+            return;
+        }
+        let widest = self
+            .lines
+            .iter()
+            .map(|l| l.chars().count())
+            .max()
+            .unwrap_or(0);
+        let max = widest.saturating_sub(1) as i64;
+        self.hscroll = (self.hscroll as i64 + delta as i64).clamp(0, max) as usize;
+    }
+    /// Toggle word wrap. Turning it on resets the horizontal offset so the view
+    /// snaps back to the left margin. Returns the new state.
+    pub fn toggle_wrap(&mut self) -> bool {
+        self.wrap = !self.wrap;
+        if self.wrap {
+            self.hscroll = 0;
+        }
+        self.wrap
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -67,12 +67,41 @@ fn scrollable_scroll_clamps() {
     let mut s = Scrollable {
         title: String::new(),
         lines: vec!["a".into(), "b".into(), "c".into()].into(),
-        scroll: 0,
+        ..Default::default()
     };
     s.scroll_by(100);
     assert_eq!(s.scroll, 2); // last line index
     s.scroll_by(-100);
     assert_eq!(s.scroll, 0);
+}
+
+#[test]
+fn scrollable_hscroll_clamps_to_widest_line() {
+    let mut s = Scrollable {
+        title: String::new(),
+        lines: vec!["short".into(), "a much longer line".into()].into(),
+        ..Default::default()
+    };
+    s.scroll_h(100);
+    assert_eq!(s.hscroll, "a much longer line".len() - 1); // widest line - 1
+    s.scroll_h(-100);
+    assert_eq!(s.hscroll, 0);
+}
+
+#[test]
+fn scrollable_wrap_disables_hscroll_and_resets_offset() {
+    let mut s = Scrollable {
+        title: String::new(),
+        lines: vec!["a much longer line".into()].into(),
+        ..Default::default()
+    };
+    s.scroll_h(5);
+    assert_eq!(s.hscroll, 5);
+    assert!(s.toggle_wrap()); // wrap on
+    assert_eq!(s.hscroll, 0); // snapped back to the left margin
+    s.scroll_h(5); // no-op while wrapping
+    assert_eq!(s.hscroll, 0);
+    assert!(!s.toggle_wrap()); // wrap off again
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ async fn snapshot(app: &mut App, rx: &mut mpsc::Receiver<store::Msg>) -> Result<
                         "+  - containerPort: 9090".into(),
                     ]
                     .into(),
-                    scroll: 0,
+                    ..Default::default()
                 };
                 app.mode = app::Mode::Diff;
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
-    Paragraph, Row, Table,
+    Paragraph, Row, Table, Wrap,
 };
 use unicode_width::UnicodeWidthChar;
 
@@ -485,13 +485,19 @@ fn draw_scrollable(
         .range(start..end)
         .map(|l| Line::from(highlight_yaml(l)))
         .collect();
-    let p = Paragraph::new(text).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(accent))
-            .title(Span::styled(format!(" {} ", view.title), theme::title())),
-    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(accent))
+        .title(Span::styled(format!(" {} ", view.title), theme::title()));
+    let p = Paragraph::new(text).block(block);
+    // Wrap folds long lines; otherwise honor the horizontal offset so content
+    // past the right edge can be scrolled into view.
+    let p = if view.wrap {
+        p.wrap(Wrap { trim: false })
+    } else {
+        p.scroll((0, view.hscroll.min(u16::MAX as usize) as u16))
+    };
     frame.render_widget(p, area);
 }
 
@@ -1119,13 +1125,17 @@ fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
             Line::from(Span::styled(l.clone(), Style::default().fg(color)))
         })
         .collect();
-    let p = Paragraph::new(lines).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(theme::peach()))
-            .title(Span::styled(format!(" {} ", view.title), theme::title())),
-    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme::peach()))
+        .title(Span::styled(format!(" {} ", view.title), theme::title()));
+    let p = Paragraph::new(lines).block(block);
+    let p = if view.wrap {
+        p.wrap(Wrap { trim: false })
+    } else {
+        p.scroll((0, view.hscroll.min(u16::MAX as usize) as u16))
+    };
     frame.render_widget(p, area);
 }
 
@@ -1794,6 +1804,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Mode::Logs => {
             let hint = "  /search  s:autoscroll  w:wrap  t:timestamps  x:stop/resume  c:copy  ^s:save  esc:back";
+            Line::from(Span::styled(hint, theme::dim()))
+        }
+        Mode::Detail | Mode::Events | Mode::Diff => {
+            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  w:wrap  esc:back";
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::FluxMenu => Line::from(Span::styled(


### PR DESCRIPTION
## Problem

Long lines in the describe (`d`), events (`E`), and diff views were clipped at the right edge with no way to reach content past it — e.g. pod status conditions and event messages ran off-screen, and there was no word-wrap toggle to fold them into view.

## Changes

- **`Scrollable`** gains `hscroll` (horizontal column offset) and `wrap` (word-wrap toggle), plus `scroll_h()` (clamps to the widest line) and `toggle_wrap()` (resets `hscroll` when wrap turns on).
- **Key handling** for Detail/Events/Diff modes:
  - `h`/`l` or `←`/`→` scroll horizontally
  - `w` toggles word wrap (k9s-style, matches the logs view)
  - `g`/Home also resets the horizontal offset
- **Renderers** (`draw_scrollable`, `draw_diff`) apply `Paragraph::wrap(...)` when wrap is on, otherwise `Paragraph::scroll((0, hscroll))`.
- **Footer** now shows the scroll-view keybindings for these modes instead of the (wrong) table hint.

## Tests

Added coverage for `scroll_h` clamping and wrap toggle behavior. All 121 tests pass; clippy clean.