### PR TITLE
Shell into a specific container from the container picker

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -574,13 +574,19 @@ impl App {
         };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        self.exec_into(ns, name, None);
+    }
+
+    /// Shell into `pod`, optionally pinned to `container` (k9s-style `-c`).
+    /// Shared by the plain pod-row shell (`s`) and the per-container picker.
+    pub(super) fn exec_into(&mut self, ns: String, pod: String, container: Option<String>) {
         let mut argv = self.kubectl_base();
+        argv.extend(["exec".into(), "-it".into(), "-n".into(), ns, pod]);
+        if let Some(c) = container {
+            argv.push("-c".into());
+            argv.push(c);
+        }
         argv.extend([
-            "exec".into(),
-            "-it".into(),
-            "-n".into(),
-            ns,
-            name,
             "--".into(),
             "sh".into(),
             "-c".into(),

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -39,6 +39,14 @@ impl App {
                     );
                 }
             }
+            KeyCode::Char('s') => {
+                if let Some(i) = self.container_state.selected()
+                    && let Some(c) = self.container_list.get(i).cloned()
+                    && let Some((ns, name)) = self.container_pod.clone()
+                {
+                    self.exec_into(ns, name, Some(c));
+                }
+            }
             _ => {}
         }
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1182,6 +1182,31 @@ async fn shellouts_pin_to_active_context() {
 }
 
 #[tokio::test]
+async fn container_picker_shell_targets_selected_container() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "p", "namespace": "default"},
+               "spec": {"containers": [{"name": "app"}, {"name": "sidecar"}]}}),
+    );
+    app.table_state.select(Some(0));
+    let obj = app.selected_ref().unwrap().clone();
+    app.open_containers(&obj);
+    assert_eq!(app.mode, Mode::Containers);
+    app.container_state.select(Some(1)); // "sidecar"
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("expected a pending shell command");
+    };
+    assert!(argv.contains(&"-c".to_string()));
+    let c_idx = argv.iter().position(|a| a == "-c").unwrap();
+    assert_eq!(argv[c_idx + 1], "sidecar");
+    assert!(argv.contains(&"p".to_string()));
+}
+
+#[tokio::test]
 async fn paused_logs_do_not_trim_below_paused_cap() {
     let (mut app, _rx) = test_app();
     app.logs.follow = false; // autoscroll OFF

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1466,7 +1466,10 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         50,
         60,
         items,
-        Span::styled(" Containers (⏎ logs · p previous) ", theme::title()),
+        Span::styled(
+            " Containers (⏎ logs · p previous · s shell) ",
+            theme::title(),
+        ),
         &mut app.container_state,
     );
 }


### PR DESCRIPTION
## Summary
- Multi-container pods previously always execed into kubectl's default (first) container, with no way to pick another one.
- Adds an `s` binding to the pod → containers drill-down (`enter` on a pod) that shells into the selected container via `kubectl exec -c <container>`.
- Refactored `request_exec` to share a new `exec_into(ns, pod, container)` helper with the container picker.
- Updated the Containers popup title to advertise the new binding (`⏎ logs · p previous · s shell`).

## Test plan
- [x] `cargo test` — added `container_picker_shell_targets_selected_container`, all 125 tests pass
- [x] `cargo clippy --all-targets` — clean
- [ ] Manual: open a multi-container pod, drill into containers, select the sidecar, press `s`, confirm the shell lands in the sidecar container