### PR TITLE
feat: browse and manage Helm releases (:helm)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +745,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1432,6 +1457,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2335,6 +2370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,6 +2420,7 @@ dependencies = [
  "base64",
  "clap",
  "crossterm",
+ "flate2",
  "futures-util",
  "fuzzy-matcher",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.102"
 base64 = "0.22.1"
 clap = { version = "4.6.1", features = ["derive"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
+flate2 = "1.1.5"
 futures-util = "0.3.32"
 fuzzy-matcher = "0.3.7"
 k8s-openapi = { version = "0.28", features = ["latest"] }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -4,6 +4,13 @@ impl App {
     // ----- actions -------------------------------------------------------
 
     pub(super) fn request_delete(&mut self, force: bool) {
+        // A Helm release row's underlying object is its storage Secret —
+        // deleting that secret directly would corrupt Helm's own bookkeeping.
+        // The actual semantic action is `helm uninstall`.
+        if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") {
+            self.request_helm_uninstall();
+            return;
+        }
         let targets = self.action_targets();
         if targets.is_empty() {
             return;
@@ -949,5 +956,143 @@ impl App {
             argv.push(ctx.to_string());
         }
         argv
+    }
+
+    /// Base argv for a `helm` shell-out, pinned to the active context exactly
+    /// like [`Self::kubectl_base`]. Rollback and uninstall are the only two
+    /// Helm actions sofka can't do natively (see `crate::helm`) — Helm's own
+    /// three-way-merge apply/delete logic is delegated to the real `helm`
+    /// binary rather than reimplemented.
+    pub(super) fn helm_base(&self) -> Vec<String> {
+        let mut argv = vec!["helm".to_string()];
+        if let Some(ctx) = self.cluster.kubectl_context() {
+            argv.push("--kube-context".to_string());
+            argv.push(ctx.to_string());
+        }
+        argv
+    }
+
+    /// Roll back the selected revision's release to it (k9s: `r` in the
+    /// History view). Only ever acts on the single selected row — rolling
+    /// back is not a bulk action.
+    pub(super) fn request_helm_rollback(&mut self) {
+        if self.kind_plural != "helmhistory" {
+            self.flash_warn("rollback applies to a Helm release's revision history");
+            return;
+        }
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
+        let Some(name) = crate::helm::release_name(obj).map(str::to_string) else {
+            self.flash_warn("not a Helm release secret");
+            return;
+        };
+        let Some(revision) = crate::helm::revision(obj) else {
+            self.flash_warn("could not determine this revision's number");
+            return;
+        };
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        self.confirm_label = format!("Roll back {name} in {ns} to revision {revision}?");
+        self.confirm_action = Some(ConfirmAction::HelmRollback {
+            ns,
+            name,
+            revision: revision.to_string(),
+        });
+        self.mode = Mode::Confirm;
+    }
+
+    pub(super) fn do_helm_rollback(&mut self, ns: String, name: String, revision: String) {
+        let mut argv = self.helm_base();
+        argv.extend([
+            "rollback".to_string(),
+            name.clone(),
+            revision.clone(),
+            "-n".to_string(),
+            ns,
+        ]);
+        self.flash = format!("rolling back {name} to revision {revision}…");
+        self.flash_err = false;
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        // No manual re-watch on success: the live `secrets` watch backing the
+        // helm/helmhistory view picks up the new revision Secret on its own.
+        tokio::spawn(async move {
+            if let Err(e) = run_helm(&argv).await {
+                let _ = tx
+                    .send(Msg::Error {
+                        generation: genr,
+                        error: format!("helm rollback {name} failed: {e}"),
+                    })
+                    .await;
+            }
+        });
+    }
+
+    /// Uninstall the selected (or marked) Helm release(s) (k9s: `ctrl-d` /
+    /// Delete on the release list or its history).
+    pub(super) fn request_helm_uninstall(&mut self) {
+        let targets = self.helm_action_targets();
+        if targets.is_empty() {
+            return;
+        }
+        self.confirm_label = if targets.len() == 1 {
+            format!(
+                "Uninstall Helm release {} in {}? This deletes all its resources.",
+                targets[0].0, targets[0].1
+            )
+        } else {
+            format!(
+                "Uninstall {} Helm releases? This deletes all their resources.",
+                targets.len()
+            )
+        };
+        self.confirm_action = Some(ConfirmAction::HelmUninstall { targets });
+        self.mode = Mode::Confirm;
+    }
+
+    pub(super) fn do_helm_uninstall(&mut self, targets: Vec<(String, String)>) {
+        self.flash = if targets.len() == 1 {
+            format!("uninstalling {}…", targets[0].0)
+        } else {
+            format!("uninstalling {} Helm releases…", targets.len())
+        };
+        self.flash_err = false;
+        let helm_base = self.helm_base();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            for (name, ns) in targets {
+                let mut argv = helm_base.clone();
+                argv.extend(["uninstall".to_string(), name.clone(), "-n".to_string(), ns]);
+                if let Err(e) = run_helm(&argv).await {
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("helm uninstall {name} failed: {e}"),
+                        })
+                        .await;
+                }
+            }
+        });
+    }
+}
+
+/// Run a `helm` subprocess to completion, following the same
+/// missing-binary/non-zero-exit handling as `describe()`'s `kubectl` shell-out.
+async fn run_helm(argv: &[String]) -> std::result::Result<(), String> {
+    match tokio::process::Command::new(&argv[0])
+        .args(&argv[1..])
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => {
+            let err = String::from_utf8_lossy(&out.stderr);
+            Err(err.lines().next().unwrap_or("error").to_string())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err("helm not found on PATH".to_string())
+        }
+        Err(e) => Err(e.to_string()),
     }
 }

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -31,6 +31,22 @@ impl App {
         let Some(obj) = self.selected_ref() else {
             return;
         };
+        // Helm rows are backed by the raw storage Secret — `y` should show
+        // the rendered chart manifest, not that Secret's own YAML.
+        if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") {
+            match crate::helm::decode(obj) {
+                Some(rel) => {
+                    self.detail = Scrollable {
+                        title: format!("{} v{} — manifest", rel.name, rel.revision),
+                        lines: rel.manifest.lines().map(String::from).collect(),
+                        ..Default::default()
+                    };
+                    self.mode = Mode::Detail;
+                }
+                None => self.flash_warn("could not decode this Helm release revision"),
+            }
+            return;
+        }
         let title = obj.metadata.name.clone().unwrap_or_else(|| "object".into());
         self.detail = Scrollable {
             title: format!("{title} — YAML"),
@@ -48,6 +64,28 @@ impl App {
         let Some(obj) = self.selected_ref() else {
             return;
         };
+        // No `kubectl describe` for a Helm release's storage Secret — show
+        // the rendered NOTES.txt instead, decoded synchronously (cheap, no
+        // subprocess needed).
+        if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") {
+            match crate::helm::decode(obj) {
+                Some(rel) => {
+                    let lines = if rel.notes.is_empty() {
+                        vec!["<no notes>".to_string()]
+                    } else {
+                        rel.notes.lines().map(String::from).collect()
+                    };
+                    self.detail = Scrollable {
+                        title: format!("{} v{} — notes", rel.name, rel.revision),
+                        lines: lines.into(),
+                        ..Default::default()
+                    };
+                    self.mode = Mode::Detail;
+                }
+                None => self.flash_warn("could not decode this Helm release revision"),
+            }
+            return;
+        }
         let name = obj.metadata.name.clone().unwrap_or_default();
         let plural = self.kind_plural.clone();
         let ns = obj.metadata.namespace.clone();

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -135,7 +135,8 @@ impl App {
                 self.start_watch();
             }
             // k9s: `r` = rollout restart on workloads, force-sync on external
-            // secrets, else refresh the watch.
+            // secrets, rollback on a Helm release's revision history, else
+            // refresh the watch.
             KeyCode::Char('r') => {
                 if matches!(
                     self.kind_plural.as_str(),
@@ -144,6 +145,8 @@ impl App {
                     self.request_restart();
                 } else if EXTERNAL_SECRET_KINDS.contains(&self.kind_plural.as_str()) {
                     self.request_refresh_es();
+                } else if self.kind_plural == "helmhistory" {
+                    self.request_helm_rollback();
                 } else {
                     self.start_watch();
                 }
@@ -275,6 +278,7 @@ impl App {
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),
             PaletteAction::Skin => self.open_skins(),
+            PaletteAction::Helm => self.open_helm_releases(),
         }
     }
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -52,11 +52,79 @@ impl App {
         self.table_state.select(Some(0));
     }
 
+    /// Open the Helm release list (`:helm`): one row per release at its
+    /// latest revision, like `helm list`. Backed by the `secrets` kind
+    /// scoped to Helm's own storage labels/type — see `crate::helm` and the
+    /// `"helm"` dedup case in `rows::ensure_rows_cache`.
+    pub(super) fn open_helm_releases(&mut self) {
+        let Some(secrets) = self.cluster.resolve("secrets") else {
+            self.flash_warn("secrets kind unavailable");
+            return;
+        };
+        self.stack.clear();
+        self.kind = Some(secrets);
+        self.kind_plural = "helm".into();
+        self.labels = Some("owner=helm".into());
+        self.fields = Some("type=helm.sh/release.v1".into());
+        self.scope_label = None;
+        self.filter.clear();
+        self.reset_sort();
+        self.table_state.select(Some(0));
+        self.flash = "Viewing Helm releases".into();
+        self.flash_err = false;
+        // Deliberately not recorded in the `[`/`]` root-view history: that
+        // history replays entries via `cluster.resolve(kind_plural)` +
+        // `set_root_view`, neither of which know about the synthetic "helm"
+        // plural (resolve would fail, and set_root_view would reset it back
+        // to "secrets" even if it didn't) — recording it would produce a
+        // history entry that can't be replayed correctly.
+        self.start_watch();
+    }
+
     pub(super) fn namespace_label(&self) -> String {
         if self.namespace.is_empty() {
             "all namespaces".to_string()
         } else {
             self.namespace.clone()
+        }
+    }
+
+    /// Display name for synthetic views (Helm releases/history), which are
+    /// backed by a real kind (`secrets`) that has nothing to do with what's
+    /// on screen. `None` for ordinary kind-backed views.
+    fn synthetic_title(&self) -> Option<&'static str> {
+        match self.kind_plural.as_str() {
+            "helm" => Some("helm"),
+            "helmhistory" => Some("helm history"),
+            _ => None,
+        }
+    }
+
+    /// The "Resource:" label shown in the header. Usually just `self.kind`'s
+    /// title, but naming synthetic views after `kind_plural` instead keeps
+    /// the header honest about what's actually being browsed.
+    pub fn resource_title(&self) -> String {
+        match self.synthetic_title() {
+            Some(t) => t.to_string(),
+            None => self
+                .kind
+                .as_ref()
+                .map(|k| k.title())
+                .unwrap_or_else(|| "—".into()),
+        }
+    }
+
+    /// The list panel's border title (k9s-style bare plural), with the same
+    /// synthetic-view exception as `resource_title` so the Helm views don't
+    /// leak their backing `secrets` kind.
+    pub fn list_title(&self) -> String {
+        match self.synthetic_title() {
+            Some(t) => t.to_string(),
+            None => self
+                .kind
+                .as_ref()
+                .map(|k| k.ar.plural.clone())
+                .unwrap_or_else(|| "resources".into()),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -138,6 +138,17 @@ enum ConfirmAction {
     },
     /// One or more node names to cordon and drain.
     Drain { targets: Vec<String> },
+    /// Roll a Helm release back to an earlier revision (`helm rollback`) —
+    /// always a single revision, never bulk (mirrors k9s: rollback acts on
+    /// the one selected history row).
+    HelmRollback {
+        ns: String,
+        name: String,
+        revision: String,
+    },
+    /// Uninstall one or more Helm releases (`helm uninstall`), `(name, ns)`
+    /// per release — bulk when marked, like [`ConfirmAction::Delete`].
+    HelmUninstall { targets: Vec<(String, String)> },
 }
 
 /// What the logs view is currently streaming, so it can be re-streamed when
@@ -232,12 +243,17 @@ enum PaletteAction {
     Events,
     PortForwards,
     Skin,
+    Helm,
 }
 
 const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Ctx,
         names: &["ctx", "context", "contexts"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Helm,
+        names: &["helm", "hm"],
     },
     PaletteCommand {
         action: PaletteAction::Pulse,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -34,8 +34,53 @@ impl App {
             "pods" => self.open_containers(&obj),
             // enter on a CRD lists its custom resources, not its YAML.
             "customresourcedefinitions" => self.drill_into_crd(&obj),
+            // Helm: release -> every revision, revision -> its values.
+            "helm" => self.drill_into_helm_history(&obj),
+            "helmhistory" => self.open_helm_values(&obj),
             _ => self.open_detail(),
         }
+    }
+
+    /// Drill from an aggregated Helm release row into every revision of that
+    /// release (`helm history`) — re-scopes the same underlying `secrets`
+    /// watch with an added `name=<release>` label filter, narrowed to the
+    /// release's own namespace.
+    pub(super) fn drill_into_helm_history(&mut self, obj: &DynamicObject) {
+        let Some(release) = crate::helm::release_name(obj) else {
+            self.flash_warn("not a Helm release secret");
+            return;
+        };
+        let release = release.to_string();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        self.push_frame();
+        self.kind_plural = "helmhistory".into();
+        self.namespace = ns;
+        self.labels = Some(format!("owner=helm,name={release}"));
+        self.fields = Some("type=helm.sh/release.v1".into());
+        self.scope_label = Some(format!("helm/{release}"));
+        self.filter.clear();
+        self.reset_sort();
+        self.table_state.select(Some(0));
+        self.flash = format!("↳ {release} history");
+        self.flash_err = false;
+        self.start_watch();
+    }
+
+    /// Enter on a single revision (k9s: History view Enter -> Values): show
+    /// the user-supplied value overrides for that revision.
+    pub(super) fn open_helm_values(&mut self, obj: &DynamicObject) {
+        self.set_return_mode();
+        let Some(rel) = crate::helm::decode(obj) else {
+            self.flash_warn("could not decode this Helm release revision");
+            return;
+        };
+        let yaml = serde_yaml::to_string(&rel.config).unwrap_or_else(|e| format!("# error: {e}"));
+        self.detail = Scrollable {
+            title: format!("{} v{} — values", rel.name, rel.revision),
+            lines: yaml.lines().map(String::from).collect(),
+            ..Default::default()
+        };
+        self.mode = Mode::Detail;
     }
 
     /// Drill from a CustomResourceDefinition row into a listing of that CRD's

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -64,6 +64,13 @@ impl App {
                             self.do_drain_nodes(targets);
                             self.marked.clear();
                         }
+                        ConfirmAction::HelmRollback { ns, name, revision } => {
+                            self.do_helm_rollback(ns, name, revision);
+                        }
+                        ConfirmAction::HelmUninstall { targets } => {
+                            self.do_helm_uninstall(targets);
+                            self.marked.clear();
+                        }
                     }
                 }
                 self.mode = Mode::Table;

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -24,11 +24,15 @@ impl App {
         if self.filter.is_empty() {
             return true;
         }
-        let hay = format!(
-            "{} {}",
-            o.metadata.namespace.as_deref().unwrap_or(""),
+        // Helm rows are backed by the storage Secret, whose own name
+        // (`sh.helm.release.v1.<release>.v<n>`) isn't what a user typing a
+        // filter means — match the release name instead.
+        let name = if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") {
+            crate::helm::release_name(o).unwrap_or_default()
+        } else {
             o.metadata.name.as_deref().unwrap_or("")
-        );
+        };
+        let hay = format!("{} {}", o.metadata.namespace.as_deref().unwrap_or(""), name);
         self.matcher.fuzzy_match(&hay, &self.filter).is_some()
     }
 
@@ -53,11 +57,19 @@ impl App {
 
         let headers = self.display_headers();
         let sort_header = self.sort_column.and_then(|i| headers.get(i).copied());
+        // The aggregated Helm release list (`helm list` semantics) shows only
+        // the latest revision per release; `helmhistory` (one release's full
+        // history) shows every revision, so it skips this.
+        let helm_latest = (self.kind_plural == "helm").then(|| self.helm_latest_revision_keys());
         // (primary sort key, (ns, name) tiebreak, store key)
         let mut entries: Vec<(SortKey, (String, String), String)> = self
             .store
             .iter()
             .filter(|(_, o)| self.matches_filter(o))
+            .filter(|(k, _)| match &helm_latest {
+                Some(keep) => keep.contains(*k),
+                None => true,
+            })
             .map(|(k, o)| {
                 let primary = match sort_header {
                     Some(h) => self.column_sort_key(o, h),
@@ -81,6 +93,26 @@ impl App {
         });
         cache.keys = entries.into_iter().map(|(_, _, k)| k).collect();
         cache.dirty = false;
+    }
+
+    /// Store keys of the highest-revision secret per (namespace, release) —
+    /// label-based (no gunzip/decode needed), used to dedup the aggregated
+    /// Helm release list down to one row per release, like `helm list`.
+    fn helm_latest_revision_keys(&self) -> HashSet<String> {
+        let mut latest: HashMap<(String, String), (i64, String)> = HashMap::new();
+        for (k, o) in self.store.iter() {
+            let Some(name) = crate::helm::release_name(o) else {
+                continue;
+            };
+            let ns = o.metadata.namespace.clone().unwrap_or_default();
+            let ver = crate::helm::revision(o).unwrap_or(0);
+            let key = (ns, name.to_string());
+            let better = latest.get(&key).is_none_or(|(v, _)| ver > *v);
+            if better {
+                latest.insert(key, (ver, k.clone()));
+            }
+        }
+        latest.into_values().map(|(_, k)| k).collect()
     }
 
     /// Display-ordered, filtered row count, backed by the same cache as
@@ -183,6 +215,20 @@ impl App {
             "AGE" => SortKey::Num(crate::columns::age_secs(o).unwrap_or(i64::MAX) as f64),
             "CPU" => SortKey::Num(self.metrics_for(o).0 as f64),
             "MEM" => SortKey::Num(self.metrics_for(o).1 as f64),
+            // Humanized time cells ("5d23h") must sort by the underlying
+            // timestamp, never the rendered string. Negated epoch seconds so
+            // ascending = most recent first, matching AGE; unknowns last.
+            "UPDATED" => SortKey::Num(
+                crate::helm::decode(o)
+                    .and_then(|r| r.last_deployed_secs)
+                    .map(|s| -(s as f64))
+                    .unwrap_or(f64::INFINITY),
+            ),
+            // Helm revisions are plain integers; flux REVISION cells (shas,
+            // `main@sha1:…`) stay text.
+            "REVISION" if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") => {
+                SortKey::Num(crate::helm::revision(o).unwrap_or(0) as f64)
+            }
             _ => {
                 let base = crate::columns::headers(&self.kind_plural);
                 match base.iter().position(|h| *h == header) {
@@ -295,6 +341,27 @@ impl App {
         let to_pair = |o: &DynamicObject| {
             (
                 o.metadata.name.clone().unwrap_or_default(),
+                o.metadata.namespace.clone().unwrap_or_default(),
+            )
+        };
+        if self.marked.is_empty() {
+            return self.selected_ref().map(to_pair).into_iter().collect();
+        }
+        self.rows()
+            .iter()
+            .filter(|o| self.marked.contains(&row_key(o)))
+            .map(|o| to_pair(o))
+            .collect()
+    }
+
+    /// Same as [`Self::action_targets`], but resolves each Helm storage
+    /// `Secret` to its release name via label instead of the raw
+    /// `sh.helm.release.v1.<release>.v<n>` secret name — `helm`/
+    /// `helmhistory` rows only.
+    pub(super) fn helm_action_targets(&self) -> Vec<(String, String)> {
+        let to_pair = |o: &DynamicObject| {
+            (
+                crate::helm::release_name(o).unwrap_or_default().to_string(),
                 o.metadata.namespace.clone().unwrap_or_default(),
             )
         };

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -26,6 +26,67 @@ fn apply(app: &mut App, v: serde_json::Value) {
     });
 }
 
+/// A Helm release storage Secret, encoded exactly like the real thing
+/// (base64 -> base64 -> gzip -> JSON — see `crate::helm`), for exercising the
+/// helm/helmhistory views without a live cluster.
+fn helm_release_secret(release: &str, ns: &str, revision: i64, status: &str) -> serde_json::Value {
+    helm_release_secret_deployed_at(release, ns, revision, status, "2024-01-15T10:30:00Z")
+}
+
+fn helm_release_secret_deployed_at(
+    release: &str,
+    ns: &str,
+    revision: i64,
+    status: &str,
+    last_deployed: &str,
+) -> serde_json::Value {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+
+    let release_json = json!({
+        "name": release,
+        "namespace": ns,
+        "version": revision,
+        "info": {
+            "status": status,
+            "description": format!("revision {revision}"),
+            "last_deployed": last_deployed,
+            "notes": "thanks for installing",
+        },
+        "chart": {
+            "metadata": { "name": "mychart", "version": "1.0.0", "appVersion": "2.0.0" },
+        },
+        "config": { "replicaCount": revision },
+        "manifest": "apiVersion: v1\nkind: ConfigMap\n",
+    })
+    .to_string();
+
+    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+    gz.write_all(release_json.as_bytes()).unwrap();
+    let helm_b64 = BASE64.encode(gz.finish().unwrap());
+    let wire_b64 = BASE64.encode(helm_b64);
+
+    json!({
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "type": "helm.sh/release.v1",
+        "metadata": {
+            "name": format!("sh.helm.release.v1.{release}.v{revision}"),
+            "namespace": ns,
+            "labels": {
+                "owner": "helm",
+                "name": release,
+                "version": revision.to_string(),
+                "status": status,
+            },
+        },
+        "data": { "release": wire_b64 },
+    })
+}
+
 #[tokio::test]
 async fn exact_alias_outranks_fuzzy_suggestions() {
     let (mut app, _rx) = test_app();
@@ -1630,4 +1691,276 @@ async fn namespace_switch_is_recorded_in_history() {
         (app.kind_plural.as_str(), app.namespace.as_str()),
         ("pods", "social")
     );
+}
+
+// ----- Helm ---------------------------------------------------------------
+
+#[tokio::test]
+async fn helm_list_shows_only_latest_revision_per_release() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "superseded"),
+    );
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 2, "deployed"),
+    );
+    // A second, unrelated release must not affect the first's dedup.
+    apply(
+        &mut app,
+        helm_release_secret("other", "default", 1, "deployed"),
+    );
+
+    let rows = app.rows();
+    assert_eq!(rows.len(), 2, "one row per release, not per revision");
+    let myapp_row = rows
+        .iter()
+        .find(|o| crate::helm::release_name(o) == Some("myapp"))
+        .expect("myapp row present");
+    assert_eq!(crate::helm::revision(myapp_row), Some(2));
+
+    let (cells, _) = crate::columns::cells(myapp_row, "helm");
+    assert_eq!(
+        cells[0], "myapp",
+        "NAME cell shows the release, not the secret"
+    );
+    assert_eq!(cells[1], "2");
+    assert_eq!(cells[2], "deployed");
+    assert_eq!(cells[3], "mychart-1.0.0");
+}
+
+#[tokio::test]
+async fn helm_filter_matches_release_name_not_secret_name() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "deployed"),
+    );
+
+    app.filter = "myapp".into();
+    app.invalidate_rows();
+    assert_eq!(app.rows().len(), 1, "filter matches the release name");
+
+    // The raw secret name would never be typed by a user filtering releases.
+    app.filter = "sh.helm.release".into();
+    app.invalidate_rows();
+    assert_eq!(
+        app.rows().len(),
+        0,
+        "filter must not fall back to the ugly secret name"
+    );
+}
+
+#[tokio::test]
+async fn helm_enter_drills_into_release_history() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 2, "deployed"),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "helmhistory");
+    assert_eq!(app.labels.as_deref(), Some("owner=helm,name=myapp"));
+    assert_eq!(app.scope_label.as_deref(), Some("helm/myapp"));
+    assert_eq!(app.stack.len(), 1);
+
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "helm");
+    assert!(app.stack.is_empty());
+}
+
+#[tokio::test]
+async fn helm_history_shows_every_revision_and_enter_shows_values() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 2, "deployed"),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // -> helmhistory, fresh watch
+
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "superseded"),
+    );
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 2, "deployed"),
+    );
+    assert_eq!(
+        app.rows().len(),
+        2,
+        "history shows every revision, no dedup"
+    );
+
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.title.contains("values"), "{}", app.detail.title);
+    assert!(app.detail.lines.iter().any(|l| l.contains("replicaCount")));
+}
+
+#[tokio::test]
+async fn helm_describe_shows_notes_and_yaml_key_shows_manifest() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "deployed"),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.title.contains("notes"), "{}", app.detail.title);
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|l| l.contains("thanks for installing"))
+    );
+
+    app.mode = Mode::Table;
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(
+        app.detail.title.contains("manifest"),
+        "{}",
+        app.detail.title
+    );
+    assert!(app.detail.lines.iter().any(|l| l.contains("ConfigMap")));
+}
+
+#[tokio::test]
+async fn helm_ctrl_d_opens_uninstall_confirm_not_generic_delete() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "deployed"),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("Uninstall"),
+        "{}",
+        app.confirm_label
+    );
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::HelmUninstall { .. })
+    ));
+
+    // Confirming runs the (off-thread) `helm uninstall` and returns to Table
+    // — it must not touch the k8s delete API for the release's own Secret.
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("uninstalling"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn helm_r_key_opens_rollback_confirm_with_selected_revision() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 2, "deployed"),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // -> helmhistory
+
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "superseded"),
+    );
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 2, "deployed"),
+    );
+    let old_idx = app
+        .rows()
+        .iter()
+        .position(|o| crate::helm::revision(o) == Some(1))
+        .unwrap();
+    app.table_state.select(Some(old_idx));
+
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("revision 1"),
+        "{}",
+        app.confirm_label
+    );
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::HelmRollback { ref revision, .. }) if revision == "1"
+    ));
+}
+
+#[tokio::test]
+async fn helm_base_pins_to_active_context() {
+    let (app, _rx) = test_app();
+    assert_eq!(app.helm_base(), vec!["helm", "--kube-context", "test"]);
+}
+
+#[tokio::test]
+async fn helm_sorts_updated_and_revision_by_value_not_text() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    let rel = |name, rev, at| helm_release_secret_deployed_at(name, "default", rev, "deployed", at);
+    apply(&mut app, rel("alpha", 4, "2024-03-01T00:00:00Z"));
+    apply(&mut app, rel("beta", 61, "2024-01-01T00:00:00Z"));
+    apply(&mut app, rel("gamma", 11951, "2024-02-01T00:00:00Z"));
+    let headers = app.display_headers();
+
+    // UPDATED sorts by the deploy timestamp (ascending = most recent first,
+    // like AGE), never the humanized "5d23h" cell text.
+    app.sort_column = headers.iter().position(|h| *h == "UPDATED");
+    app.invalidate_rows();
+    let names: Vec<&str> = app
+        .rows()
+        .into_iter()
+        .map(|o| crate::helm::release_name(o).unwrap())
+        .collect();
+    assert_eq!(names, ["alpha", "gamma", "beta"]);
+
+    // REVISION sorts numerically ("11951" would sort before "4" as text).
+    app.sort_column = headers.iter().position(|h| *h == "REVISION");
+    app.invalidate_rows();
+    let revs: Vec<i64> = app
+        .rows()
+        .into_iter()
+        .map(|o| crate::helm::revision(o).unwrap())
+        .collect();
+    assert_eq!(revs, [4, 61, 11951]);
+}
+
+#[tokio::test]
+async fn helm_resource_title_names_the_view_not_the_backing_secret() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    // The view is backed by the real `secrets` kind, but neither the header
+    // nor the list-panel title may say "secrets" — that's meaningless to
+    // someone browsing Helm releases.
+    assert_eq!(app.resource_title(), "helm");
+    assert_eq!(app.list_title(), "helm");
+
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "deployed"),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.resource_title(), "helm history");
+    assert_eq!(app.list_title(), "helm history");
 }

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -218,6 +218,28 @@ const FLUX_SOURCE_COLUMNS: &[Column] = &[
 
 const DEFAULT_COLUMNS: &[Column] = &[column("NAME", col_name), column("AGE", col_age)];
 
+/// One row per release, at its latest revision — like `helm list`. Backed by
+/// the release storage `Secret`s (see `crate::helm`), not a real discovered
+/// resource kind.
+const HELM_COLUMNS: &[Column] = &[
+    column("NAME", col_helm_name),
+    column("REVISION", col_helm_revision),
+    status_column("STATUS", col_helm_status),
+    column("CHART", col_helm_chart),
+    column("APP VERSION", col_helm_app_version),
+    column("UPDATED", col_helm_updated),
+];
+
+/// Every revision of one release — like `helm history <release>`.
+const HELM_HISTORY_COLUMNS: &[Column] = &[
+    column("REVISION", col_helm_revision),
+    status_column("STATUS", col_helm_status),
+    column("CHART", col_helm_chart),
+    column("APP VERSION", col_helm_app_version),
+    column("DESCRIPTION", col_helm_description),
+    column("UPDATED", col_helm_updated),
+];
+
 fn columns_for(plural: &str) -> &'static [Column] {
     match plural {
         "pods" => POD_COLUMNS,
@@ -244,6 +266,8 @@ fn columns_for(plural: &str) -> &'static [Column] {
         "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
             FLUX_SOURCE_COLUMNS
         }
+        "helm" => HELM_COLUMNS,
+        "helmhistory" => HELM_HISTORY_COLUMNS,
         _ => DEFAULT_COLUMNS,
     }
 }
@@ -567,6 +591,55 @@ fn col_flux_source_url(ctx: &CellContext<'_>) -> String {
 
 fn col_flux_suspended(ctx: &CellContext<'_>) -> String {
     bget(ctx.data, &["spec", "suspend"]).to_string()
+}
+
+// A Helm release row's underlying object is the raw storage `Secret`
+// (`ctx.name`/`ctx.obj` are the ugly `sh.helm.release.v1.<release>.v<n>`
+// name), never the release itself — every cell here goes through
+// `crate::helm` instead of `ctx.name`/`ctx.data`.
+
+fn col_helm_name(ctx: &CellContext<'_>) -> String {
+    crate::helm::release_name(ctx.obj)
+        .unwrap_or(ctx.name)
+        .to_string()
+}
+
+fn col_helm_revision(ctx: &CellContext<'_>) -> String {
+    crate::helm::revision(ctx.obj)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".into())
+}
+
+fn col_helm_status(ctx: &CellContext<'_>) -> String {
+    crate::helm::decode(ctx.obj)
+        .map(|r| r.status)
+        .unwrap_or_else(|| "<invalid>".into())
+}
+
+fn col_helm_chart(ctx: &CellContext<'_>) -> String {
+    match crate::helm::decode(ctx.obj) {
+        Some(r) if !r.chart_name.is_empty() => format!("{}-{}", r.chart_name, r.chart_version),
+        _ => "<unknown>".into(),
+    }
+}
+
+fn col_helm_app_version(ctx: &CellContext<'_>) -> String {
+    crate::helm::decode(ctx.obj)
+        .map(|r| r.app_version)
+        .unwrap_or_default()
+}
+
+fn col_helm_description(ctx: &CellContext<'_>) -> String {
+    crate::helm::decode(ctx.obj)
+        .map(|r| r.description)
+        .unwrap_or_default()
+}
+
+fn col_helm_updated(ctx: &CellContext<'_>) -> String {
+    match crate::helm::decode(ctx.obj).and_then(|r| r.last_deployed_secs) {
+        Some(secs) => humanize((Timestamp::now().as_second() - secs).max(0)),
+        None => "<unknown>".into(),
+    }
 }
 
 // ----- helpers ------------------------------------------------------------

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -1,0 +1,236 @@
+//! Decoding of Helm release storage `Secret`s.
+//!
+//! Helm (the package manager, not Flux's `HelmRelease` CRD) stores each
+//! release revision as a `Secret` named `sh.helm.release.v1.<release>.v<rev>`
+//! with `type: helm.sh/release.v1` and labels `owner=helm`, `name=<release>`,
+//! `version=<revision>`, `status=<status>`. `data.release` is the release
+//! JSON, base64-encoded and gzip-compressed by Helm itself, then base64
+//! re-encoded by Kubernetes' own wire JSON for `Secret.data` bytes — so
+//! decoding needs base64 twice, then gunzip, then JSON
+//! (see helm/helm `pkg/storage/driver/util.go`).
+//!
+//! Only the Secret storage driver is supported (Helm's default; the
+//! ConfigMap driver is out of scope).
+
+use std::io::Read;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use k8s_openapi::jiff::Timestamp;
+use kube::core::DynamicObject;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// A decoded Helm release revision. The k8s namespace is deliberately not
+/// carried here — callers already have the storage Secret's own namespace,
+/// which is the trustworthy source (not whatever the embedded JSON claims).
+pub struct Release {
+    pub name: String,
+    pub revision: i64,
+    pub status: String,
+    pub chart_name: String,
+    pub chart_version: String,
+    pub app_version: String,
+    pub description: String,
+    /// `info.last_deployed` as a unix timestamp, when parseable.
+    pub last_deployed_secs: Option<i64>,
+    pub notes: String,
+    /// User-supplied value overrides (`helm install/upgrade -f`/`--set`) —
+    /// the "values" k9s' History-view Enter shows. The chart's own default
+    /// `values.yaml` ("all values") isn't surfaced; see the plan's explicit
+    /// scope note.
+    pub config: Value,
+    pub manifest: String,
+}
+
+#[derive(Deserialize, Default)]
+struct RawRelease {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    info: RawInfo,
+    #[serde(default)]
+    chart: RawChart,
+    #[serde(default)]
+    config: Value,
+    #[serde(default)]
+    manifest: String,
+    #[serde(default)]
+    version: i64,
+}
+
+#[derive(Deserialize, Default)]
+struct RawInfo {
+    #[serde(default)]
+    last_deployed: Option<String>,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    notes: String,
+}
+
+#[derive(Deserialize, Default)]
+struct RawChart {
+    #[serde(default)]
+    metadata: RawMetadata,
+}
+
+#[derive(Deserialize, Default)]
+struct RawMetadata {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default, rename = "appVersion")]
+    app_version: String,
+}
+
+/// Decode a release Secret into its `Release`. `None` if the secret doesn't
+/// carry a `data.release` payload or it can't be decoded (corrupt, unknown
+/// format, or not a Helm release secret at all) — callers treat that as
+/// "unrenderable", not a crash.
+pub fn decode(secret: &DynamicObject) -> Option<Release> {
+    let wire = secret.data.pointer("/data/release")?.as_str()?;
+    let helm_encoded = BASE64.decode(wire).ok()?;
+    let gzipped = BASE64.decode(helm_encoded).ok()?;
+    let mut gz = flate2::read::GzDecoder::new(&gzipped[..]);
+    let mut json = Vec::new();
+    gz.read_to_end(&mut json).ok()?;
+    let raw: RawRelease = serde_json::from_slice(&json).ok()?;
+
+    let last_deployed_secs = raw
+        .info
+        .last_deployed
+        .as_deref()
+        .and_then(|s| s.parse::<Timestamp>().ok())
+        .map(|ts| ts.as_second());
+
+    Some(Release {
+        name: raw.name,
+        revision: raw.version,
+        status: raw.info.status,
+        chart_name: raw.chart.metadata.name,
+        chart_version: raw.chart.metadata.version,
+        app_version: raw.chart.metadata.app_version,
+        description: raw.info.description,
+        last_deployed_secs,
+        notes: raw.info.notes,
+        config: raw.config,
+        manifest: raw.manifest,
+    })
+}
+
+/// The release name from the secret's `name` label — cheap, no decode needed.
+pub fn release_name(secret: &DynamicObject) -> Option<&str> {
+    secret
+        .metadata
+        .labels
+        .as_ref()?
+        .get("name")
+        .map(String::as_str)
+}
+
+/// The revision number from the secret's `version` label — cheap, no decode
+/// needed. Used to pick the latest revision per release without decoding
+/// every revision's payload.
+pub fn revision(secret: &DynamicObject) -> Option<i64> {
+    secret
+        .metadata
+        .labels
+        .as_ref()?
+        .get("version")?
+        .parse()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+
+    fn fixture_secret(release_json: &str) -> DynamicObject {
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        gz.write_all(release_json.as_bytes()).unwrap();
+        let gzipped = gz.finish().unwrap();
+        let helm_b64 = BASE64.encode(gzipped);
+        let wire_b64 = BASE64.encode(helm_b64);
+
+        let data: Value = serde_json::from_value(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": "sh.helm.release.v1.myrelease.v2",
+                "namespace": "default",
+                "labels": {
+                    "owner": "helm",
+                    "name": "myrelease",
+                    "version": "2",
+                    "status": "deployed",
+                },
+            },
+            "type": "helm.sh/release.v1",
+            "data": { "release": wire_b64 },
+        }))
+        .unwrap();
+
+        serde_json::from_value(data).unwrap()
+    }
+
+    #[test]
+    fn decodes_a_release_secret() {
+        let secret = fixture_secret(
+            r#"{
+                "name": "myrelease",
+                "namespace": "default",
+                "version": 2,
+                "info": {
+                    "status": "deployed",
+                    "description": "Upgrade complete",
+                    "last_deployed": "2024-01-15T10:30:00Z",
+                    "notes": "Thanks for installing!"
+                },
+                "chart": {
+                    "metadata": { "name": "mychart", "version": "1.2.3", "appVersion": "4.5.6" },
+                    "values": { "replicaCount": 1 }
+                },
+                "config": { "replicaCount": 3 },
+                "manifest": "apiVersion: v1\nkind: ConfigMap\n"
+            }"#,
+        );
+
+        let rel = decode(&secret).expect("should decode");
+        assert_eq!(rel.name, "myrelease");
+        assert_eq!(rel.revision, 2);
+        assert_eq!(rel.status, "deployed");
+        assert_eq!(rel.chart_name, "mychart");
+        assert_eq!(rel.chart_version, "1.2.3");
+        assert_eq!(rel.app_version, "4.5.6");
+        assert_eq!(rel.description, "Upgrade complete");
+        assert_eq!(rel.notes, "Thanks for installing!");
+        assert!(rel.manifest.contains("ConfigMap"));
+        assert_eq!(
+            rel.config.get("replicaCount").and_then(Value::as_i64),
+            Some(3)
+        );
+        assert!(rel.last_deployed_secs.is_some());
+
+        assert_eq!(release_name(&secret), Some("myrelease"));
+        assert_eq!(revision(&secret), Some(2));
+    }
+
+    #[test]
+    fn decode_returns_none_for_non_release_secret() {
+        let data: Value = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": { "name": "some-secret", "namespace": "default" },
+            "data": { "password": "aHVudGVyMg==" },
+        });
+        let secret: DynamicObject = serde_json::from_value(data).unwrap();
+        assert!(decode(&secret).is_none());
+    }
+}

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -348,6 +348,7 @@ impl Cluster {
             mk("apps", "Deployment", "deployments", true),
         );
         registry.insert("services".to_string(), mk("", "Service", "services", true));
+        registry.insert("secrets".to_string(), mk("", "Secret", "secrets", true));
         registry.insert("nodes".to_string(), mk("", "Node", "nodes", false));
         registry.insert(
             "namespaces".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod app;
 mod columns;
 mod config;
+mod helm;
 mod k8s;
 mod store;
 mod theme;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -414,16 +414,17 @@ pub fn accent() -> Style {
 /// against the row tint.
 pub fn status_color(s: &str) -> Color {
     match s {
-        "Running" | "Ready" | "Active" | "Bound" | "True" => green(),
+        "Running" | "Ready" | "Active" | "Bound" | "True" | "deployed" => green(),
         // Faded, not "healthy green" — a finished pod isn't running.
-        "Succeeded" | "Completed" => overlay0(),
-        "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" => yellow(),
+        "Succeeded" | "Completed" | "superseded" | "uninstalled" => overlay0(),
+        "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" | "pending-install"
+        | "pending-upgrade" | "pending-rollback" => yellow(),
         // Matches row_color's killColor — a distinct "on its way out" hue,
         // not the same bucket as Pending.
-        "Terminating" => mauve(),
+        "Terminating" | "uninstalling" => mauve(),
         "Failed" | "Error" | "CrashLoopBackOff" | "ImagePullBackOff" | "ErrImagePull"
-        | "Evicted" | "OOMKilled" | "NotReady" | "False" => red(),
-        "Unknown" | "" => overlay1(),
+        | "Evicted" | "OOMKilled" | "NotReady" | "False" | "failed" => red(),
+        "Unknown" | "" | "unknown" => overlay1(),
         _ => text(),
     }
 }
@@ -441,11 +442,12 @@ pub fn status_color(s: &str) -> Color {
 pub fn row_color(s: &str) -> Color {
     match s {
         "Failed" | "Error" | "CrashLoopBackOff" | "ImagePullBackOff" | "ErrImagePull"
-        | "Evicted" | "OOMKilled" | "NotReady" | "Unhealthy" | "False" => red(),
-        "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" => peach(),
-        "Completed" | "Succeeded" => overlay0(),
+        | "Evicted" | "OOMKilled" | "NotReady" | "Unhealthy" | "False" | "failed" => red(),
+        "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" | "pending-install"
+        | "pending-upgrade" | "pending-rollback" => peach(),
+        "Completed" | "Succeeded" | "superseded" | "uninstalled" => overlay0(),
         // k9s killColor — terminating/deleting rows.
-        "Terminating" => mauve(),
+        "Terminating" | "uninstalling" => mauve(),
         _ => blue(),
     }
 }
@@ -552,6 +554,18 @@ mod tests {
         // Pending pops distinct from the row's peach.
         assert_eq!(status_color("Pending"), yellow());
         assert_ne!(status_color("Pending"), row_color("Pending"));
+    }
+
+    #[test]
+    fn helm_release_statuses_are_colored() {
+        // Helm's own Status.String() values are lowercase, unlike k8s phases.
+        assert_eq!(row_color("deployed"), blue());
+        assert_eq!(status_color("deployed"), green());
+        assert_eq!(row_color("failed"), red());
+        assert_eq!(status_color("failed"), red());
+        assert_eq!(row_color("superseded"), overlay0());
+        assert_eq!(row_color("pending-upgrade"), peach());
+        assert_eq!(status_color("pending-upgrade"), yellow());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -98,11 +98,7 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         app.namespace.clone()
     };
-    let mut kind = app
-        .kind
-        .as_ref()
-        .map(|k| k.title())
-        .unwrap_or_else(|| "—".into());
+    let mut kind = app.resource_title();
     if let Some(scope) = &app.scope_label {
         kind = format!("{kind}  ‹ {scope}");
     }
@@ -382,11 +378,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
-    let kind_label = app
-        .kind
-        .as_ref()
-        .map(|k| k.ar.plural.clone())
-        .unwrap_or_else(|| "resources".into());
+    let kind_label = app.list_title();
     // k9s title: resource name (teal, bold) then a yellow [count].
     let mut title = vec![
         Span::styled(format!(" {kind_label} "), theme::title()),


### PR DESCRIPTION
## Summary
- New `:helm` / `:hm` command lists Helm releases like `helm list` — one row per release at its latest revision, backed by Helm's own storage Secrets (no `helm` binary needed for browsing)
- <kbd>⏎</kbd> drills into a release's revision history (`helm history`); <kbd>⏎</kbd> on a revision shows its user-supplied values
- <kbd>r</kbd> on a revision rolls back, <kbd>^d</kbd> uninstalls — both shell out to the real `helm`, pinned to the active kube context, so Helm's own bookkeeping stays consistent
- Release status strings (`deployed`, `failed`, `superseded`, `pending-upgrade`, …) get proper status/row colors
- Header and list titles name the synthetic views (`helm` / `helm history`) instead of leaking the backing `secrets` kind
- `UPDATED` sorts by the release's last-deployed timestamp and `REVISION` numerically — previously both sorted the rendered cell text, so `"5m"` / `"5d23h"` and `"11951"` / `"4"` ordered nonsensically
- Fuzzy filter matches the release name, not the `sh.helm.release.v1.<name>.v<n>` secret name

## Test plan
- [x] `cargo test` — 138 tests pass, including new coverage for release decoding, list dedup, history drill, titles, and value-based sorting
- [ ] `:helm` on a live cluster: releases listed once each, statuses colored, UPDATED sort ordered by recency
- [ ] Drill into history, roll back a revision, verify the new revision appears