### PR TITLE
feat: per-cluster / per-context config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,6 @@ background = true        # fill views with the skin's own background swatch
 [skin.colors]            # optional per-swatch overrides
 red = "#fb4934"
 
-[skin.contexts]          # per-context skin overrides — e.g. prod goes light
-prod = "catppuccin-latte"
-
 [[plugins]]
 key = "g"
 name = "argocd-sync"
@@ -206,6 +203,41 @@ command = "argocd"
 args = ["app", "sync", "$NAME"]
 scopes = ["deployments"]   # omit for all resources
 ```
+
+### Per-cluster / per-context overrides
+
+Any option can be overridden for a specific cluster or kubeconfig context,
+k9s-style. Drop partial config files under `clusters/`:
+
+```
+~/.config/sofka/
+├── config.toml                # base, applies everywhere
+└── clusters/
+    └── prod-cluster/          # kubeconfig *cluster* name
+        ├── config.toml        # every context on prod-cluster
+        └── prod-admin/        # kubeconfig *context* name
+            └── config.toml    # that context only
+```
+
+Overrides merge over the base config (cluster level first, then context
+level): tables like `[aliases]` and `[skin.colors]` merge key-by-key,
+everything else — strings, booleans, arrays like `[[plugins]]` — replaces the
+base value. Directory names are the kubeconfig names with any character other
+than letters, digits, `.`, `_`, `-` replaced by `-`, so an EKS context
+`arn:aws:eks:eu-west-1:123456789:cluster/prod` becomes the directory
+`arn-aws-eks-eu-west-1-123456789-cluster-prod`.
+
+```toml
+# clusters/prod-cluster/config.toml — make prod unmistakable
+[skin]
+name = "catppuccin-latte"
+background = true
+```
+
+A skin named in an override pins that context's colors; contexts without one
+keep the session skin (config `skin.name`, the auto-detected default, or your
+last `:skin` choice). Overrides are re-read on every `:ctx` switch, so edits
+apply without restarting.
 
 ### Headless modes (no TTY required)
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -753,26 +753,21 @@ impl App {
         let palette = crate::theme::resolve_skin(Some(name), &self.skin_colors);
         crate::theme::set(palette);
         // A manual choice becomes the session skin, so it survives context
-        // switches into contexts without a `[skin.contexts]` override.
+        // switches into contexts without a config skin override.
         self.session_skin = Some(name.to_string());
         self.flash = format!("skin: {name}");
         self.flash_err = false;
     }
 
-    /// Re-resolve the skin when the context changes: a `[skin.contexts]`
-    /// override for the new context wins, otherwise the session skin (config
+    /// Re-resolve the skin when the context changes: a skin named by a
+    /// cluster/context override file wins, otherwise the session skin (config
     /// `skin.name`, the auto-detected default, or the last `:skin` choice).
-    pub(super) fn apply_context_skin(&mut self, context: &str) {
-        let Some(name) = self
-            .context_skins
-            .get(context)
-            .cloned()
-            .or_else(|| self.session_skin.clone())
-        else {
+    pub(super) fn apply_context_skin(&mut self, override_skin: Option<String>) {
+        let Some(name) = override_skin.or_else(|| self.session_skin.clone()) else {
             return;
         };
         if crate::theme::builtin(&name.trim().to_ascii_lowercase()).is_none() {
-            self.flash_warn(&format!("unknown skin '{name}' for context {context}"));
+            self.flash_warn(&format!("unknown skin '{name}' in config"));
             return;
         }
         let palette = crate::theme::resolve_skin(Some(&name), &self.skin_colors);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -516,9 +516,9 @@ pub struct App {
     pub skin_state: ListState,
     /// Per-swatch color overrides from config, re-applied when switching skins.
     pub skin_colors: HashMap<String, String>,
-    /// Per-context skin overrides from config (`[skin.contexts]`), so e.g. the
-    /// prod context can render light while everything else stays dark.
-    pub context_skins: HashMap<String, String>,
+    /// Config loader kept for the session so `:ctx` switches can re-resolve
+    /// per-cluster/per-context override files against the new context.
+    pub config: crate::config::ConfigLoader,
     /// Skin for contexts without an override: config `skin.name` (or the
     /// auto-detected default), replaced by a manual `:skin` choice.
     pub session_skin: Option<String>,
@@ -617,7 +617,7 @@ impl App {
                 .collect(),
             skin_state: ListState::default(),
             skin_colors: HashMap::new(),
-            context_skins: HashMap::new(),
+            config: crate::config::ConfigLoader::default(),
             session_skin: None,
             image_values: Vec::new(),
             image_target: None,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -245,11 +245,20 @@ impl App {
         });
     }
 
-    /// Install a freshly-connected cluster from a context switch.
+    /// Install a freshly-connected cluster from a context switch. Config is
+    /// re-resolved so per-cluster/per-context overrides (aliases, plugins,
+    /// skin, defaults) follow the new context.
     pub(super) fn apply_context_switch(&mut self, name: String, mut cluster: Box<Cluster>) {
+        let resolved = self.config.resolve(&name, &cluster.cluster_name);
+        self.user_aliases = resolved.config.aliases;
+        self.plugins = resolved.config.plugins;
+        self.skin_colors = resolved.config.skin.colors;
         cluster.add_aliases(&self.user_aliases);
         self.bump_generation();
-        self.namespace = cluster.default_namespace.clone();
+        self.namespace = resolved
+            .config
+            .default_namespace
+            .unwrap_or_else(|| cluster.default_namespace.clone());
         self.cluster = *cluster;
         self.stack.clear();
         // View history references the old cluster's kinds and namespaces.
@@ -267,9 +276,17 @@ impl App {
         // Permissions differ per cluster — drop the old allow-list.
         self.rbac_allowed = None;
         self.last_rbac_ns = None;
-        self.apply_context_skin(&name);
+        crate::theme::set_background(resolved.config.skin.background);
+        self.apply_context_skin(resolved.skin_override);
         self.flash = format!("context: {name}");
         self.flash_err = false;
-        self.switch_kind("pods");
+        if let Some(w) = resolved.warnings.first() {
+            self.flash_warn(w);
+        }
+        let kind = resolved
+            .config
+            .default_resource
+            .unwrap_or_else(|| "pods".into());
+        self.switch_kind(&kind);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,25 @@
 //! User configuration loaded from `$XDG_CONFIG_HOME/sofka/config.toml`
-//! (falling back to `~/.config/sofka/config.toml`).
+//! (falling back to `~/.config/sofka/config.toml`), with optional
+//! per-cluster / per-context overrides, k9s-style:
+//!
+//! ```text
+//! sofka/
+//! ├── config.toml                  # base, applies everywhere
+//! └── clusters/
+//!     └── <cluster>/               # kubeconfig *cluster* name
+//!         ├── config.toml          # every context on this cluster
+//!         └── <context>/           # kubeconfig *context* name
+//!             └── config.toml      # this context only
+//! ```
+//!
+//! Override files are partial configs merged over the base (cluster level
+//! first, then context level): tables like `[aliases]` and `[skin.colors]`
+//! merge key-by-key, everything else — strings, booleans, arrays like
+//! `[[plugins]]` — replaces the base value. Directory names are the
+//! kubeconfig names sanitized for the filesystem: any character other than
+//! ASCII letters, digits, `.`, `_` and `-` becomes `-`, so an EKS context
+//! `arn:aws:eks:eu-west-1:123:cluster/prod` lives in
+//! `arn-aws-eks-eu-west-1-123-cluster-prod/`.
 //!
 //! Example:
 //! ```toml
@@ -12,7 +32,7 @@
 //! ```
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -35,12 +55,12 @@ pub struct Config {
 /// [`crate::theme::BUILTIN_NAMES`]); leaving it unset auto-detects the
 /// terminal's dark/light mode and picks `catppuccin-mocha`/`catppuccin-latte`
 /// accordingly. `colors` overrides individual swatches by name with
-/// `#rrggbb` hex values. `contexts` maps a kubeconfig context name to a skin
-/// that overrides `name` while that context is active — e.g. a light skin on
-/// prod as a visual "careful now" cue. `background` fills every view with the
+/// `#rrggbb` hex values. Naming a skin in a per-cluster/per-context override
+/// file swaps it in while that context is active — e.g. a light skin on prod
+/// as a visual "careful now" cue. `background` fills every view with the
 /// skin's own background swatch instead of leaving the terminal background
-/// showing through; combined with a light `[skin.contexts]` skin it makes the
-/// prod context unmistakably bright.
+/// showing through; combined with a light per-context skin it makes the prod
+/// context unmistakably bright.
 ///
 /// ```toml
 /// [skin]
@@ -50,16 +70,12 @@ pub struct Config {
 /// [skin.colors]
 /// red   = "#fb4934"
 /// mauve = "#d3869b"
-///
-/// [skin.contexts]
-/// prod = "catppuccin-latte"
 /// ```
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct Skin {
     pub name: Option<String>,
     pub colors: HashMap<String, String>,
-    pub contexts: HashMap<String, String>,
     /// Fill views with the skin's `base` background swatch (default: false,
     /// i.e. transparent — inherit the terminal background).
     pub background: bool,
@@ -88,31 +104,167 @@ pub struct Plugin {
     pub scopes: Vec<String>,
 }
 
-impl Config {
-    /// Load config, returning defaults if the file is missing or malformed
-    /// (a warning is printed for malformed files).
+/// Config resolved for one (cluster, context) pair: the base config with any
+/// matching override files merged in.
+pub struct Resolved {
+    pub config: Config,
+    /// `skin.name` when an override file (not the base config) set it. Wins
+    /// over the session skin while the context is active, exactly so that a
+    /// manual `:skin` choice still survives switches into contexts that don't
+    /// pin their own skin.
+    pub skin_override: Option<String>,
+    /// Problems with override files (malformed TOML, type mismatches). The
+    /// offending layer is skipped, never fatal.
+    pub warnings: Vec<String>,
+}
+
+/// Holds the parsed base `config.toml` for the session and re-reads override
+/// files on demand, so `:ctx` switches pick up freshly edited overrides
+/// without a restart.
+#[derive(Default)]
+pub struct ConfigLoader {
+    /// Base `config.toml` as a raw TOML table (`None` when missing/invalid).
+    base: Option<toml::Value>,
+    /// The `sofka` config directory containing `config.toml` and `clusters/`.
+    dir: Option<PathBuf>,
+}
+
+impl ConfigLoader {
+    /// Read the base config, warning on stderr (we're pre-TUI) and falling
+    /// back to defaults if it's malformed — syntax or types.
     pub fn load() -> Self {
-        let Some(path) = config_path() else {
-            return Self::default();
-        };
-        let Ok(text) = std::fs::read_to_string(&path) else {
-            return Self::default();
-        };
-        match toml::from_str(&text) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                eprintln!("warning: ignoring invalid {}: {e}", path.display());
-                Self::default()
+        let mut loader = Self::from_dir(config_dir());
+        if let Some(dir) = &loader.dir
+            && let Ok(text) = std::fs::read_to_string(dir.join("config.toml"))
+            && let Err(e) = toml::from_str::<Config>(&text)
+        {
+            eprintln!(
+                "warning: ignoring invalid {}: {e}",
+                dir.join("config.toml").display()
+            );
+            loader.base = None;
+        }
+        loader
+    }
+
+    fn from_dir(dir: Option<PathBuf>) -> Self {
+        let base = dir.as_ref().and_then(|d| {
+            let text = std::fs::read_to_string(d.join("config.toml")).ok()?;
+            parse_doc(&text).ok()
+        });
+        Self { base, dir }
+    }
+
+    /// Merge override files for the given kubeconfig cluster/context over the
+    /// base config. Either name may be empty (e.g. in-cluster, no kubeconfig
+    /// context) — its level is simply skipped.
+    pub fn resolve(&self, context: &str, cluster: &str) -> Resolved {
+        let mut warnings = Vec::new();
+        let mut merged = self
+            .base
+            .clone()
+            .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
+        let mut overlay = toml::Value::Table(toml::map::Map::new());
+
+        if let (Some(dir), false) = (&self.dir, cluster.is_empty()) {
+            let cluster_dir = dir.join("clusters").join(sanitize(cluster));
+            let mut paths = vec![cluster_dir.join("config.toml")];
+            if !context.is_empty() {
+                paths.push(cluster_dir.join(sanitize(context)).join("config.toml"));
             }
+            for path in paths {
+                match read_value(&path) {
+                    Ok(Some(v)) => {
+                        merge(&mut merged, v.clone());
+                        merge(&mut overlay, v);
+                    }
+                    Ok(None) => {}
+                    Err(e) => warnings.push(format!("ignoring invalid {}: {e}", path.display())),
+                }
+            }
+        }
+
+        // A type mismatch introduced by an override drops back to the base
+        // config (validated at load time) rather than losing everything.
+        let config = merged.try_into().unwrap_or_else(|e| {
+            warnings.push(format!("ignoring cluster overrides: {e}"));
+            self.base
+                .clone()
+                .and_then(|b| b.try_into().ok())
+                .unwrap_or_default()
+        });
+        let skin_override = overlay
+            .get("skin")
+            .and_then(|s| s.get("name"))
+            .and_then(|n| n.as_str())
+            .map(String::from);
+        Resolved {
+            config,
+            skin_override,
+            warnings,
         }
     }
 }
 
-fn config_path() -> Option<PathBuf> {
+/// Recursively merge `overlay` into `base`: tables merge key-by-key, any
+/// other value (scalar or array) replaces the base one wholesale.
+fn merge(base: &mut toml::Value, overlay: toml::Value) {
+    match (base, overlay) {
+        (toml::Value::Table(b), toml::Value::Table(o)) => {
+            for (k, v) in o {
+                match b.get_mut(&k) {
+                    Some(slot) if slot.is_table() && v.is_table() => merge(slot, v),
+                    _ => {
+                        b.insert(k, v);
+                    }
+                }
+            }
+        }
+        (slot, v) => *slot = v,
+    }
+}
+
+/// Parse an override file. Missing/unreadable -> `Ok(None)` (overrides are
+/// optional); present but malformed -> `Err` so the caller can warn.
+fn read_value(path: &Path) -> Result<Option<toml::Value>, toml::de::Error> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => parse_doc(&text).map(Some),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Parse a TOML *document* into a `Value::Table` (a bare `Value` parse would
+/// expect a single TOML value, not a document).
+fn parse_doc(text: &str) -> Result<toml::Value, toml::de::Error> {
+    text.parse::<toml::Table>().map(toml::Value::Table)
+}
+
+/// Map a kubeconfig cluster/context name onto a safe directory name: any
+/// character outside `[A-Za-z0-9._-]` becomes `-` (EKS ARNs contain `:` and
+/// `/`). All-dot results (`.`, `..`) would be path navigation, not names.
+fn sanitize(name: &str) -> String {
+    let s: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if s.chars().all(|c| c == '.') {
+        "-".repeat(s.len().max(1))
+    } else {
+        s
+    }
+}
+
+fn config_dir() -> Option<PathBuf> {
     let base = std::env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
-    Some(base.join("sofka").join("config.toml"))
+    Some(base.join("sofka"))
 }
 
 #[cfg(test)]
@@ -149,27 +301,142 @@ mod tests {
     }
 
     #[test]
-    fn parses_per_context_skins() {
-        let toml = r#"
-            [skin]
-            name = "gruvbox-dark"
-
-            [skin.contexts]
-            prod = "catppuccin-latte"
-        "#;
-        let cfg: Config = toml::from_str(toml).unwrap();
-        assert_eq!(cfg.skin.name.as_deref(), Some("gruvbox-dark"));
-        assert_eq!(
-            cfg.skin.contexts.get("prod").map(String::as_str),
-            Some("catppuccin-latte")
-        );
-    }
-
-    #[test]
     fn empty_config_is_default() {
         let cfg: Config = toml::from_str("").unwrap();
         assert!(cfg.aliases.is_empty());
         assert!(cfg.plugins.is_empty());
         assert!(cfg.default_resource.is_none());
+    }
+
+    fn val(s: &str) -> toml::Value {
+        parse_doc(s).unwrap()
+    }
+
+    #[test]
+    fn merge_tables_key_by_key_scalars_and_arrays_replace() {
+        let mut base = val(r##"
+            default_namespace = "default"
+            default_resource = "pods"
+
+            [aliases]
+            dep = "deployments"
+
+            [[plugins]]
+            key = "g"
+            name = "base-plugin"
+            command = "true"
+
+            [skin]
+            name = "gruvbox-dark"
+            [skin.colors]
+            red = "#ff0000"
+        "##);
+        merge(
+            &mut base,
+            val(r##"
+                default_namespace = "kube-system"
+
+                [aliases]
+                ks = "kustomizations"
+
+                [[plugins]]
+                key = "h"
+                name = "override-plugin"
+                command = "false"
+
+                [skin]
+                name = "catppuccin-latte"
+                [skin.colors]
+                blue = "#0000ff"
+            "##),
+        );
+        let cfg: Config = base.try_into().unwrap();
+        // scalars replace
+        assert_eq!(cfg.default_namespace.as_deref(), Some("kube-system"));
+        assert_eq!(cfg.skin.name.as_deref(), Some("catppuccin-latte"));
+        // untouched base values survive
+        assert_eq!(cfg.default_resource.as_deref(), Some("pods"));
+        // tables merge
+        assert_eq!(cfg.aliases.len(), 2);
+        assert_eq!(cfg.skin.colors.len(), 2);
+        // arrays replace wholesale
+        assert_eq!(cfg.plugins.len(), 1);
+        assert_eq!(cfg.plugins[0].name, "override-plugin");
+    }
+
+    #[test]
+    fn sanitize_maps_unsafe_chars_to_dashes() {
+        assert_eq!(sanitize("prod-cluster_1.io"), "prod-cluster_1.io");
+        assert_eq!(
+            sanitize("arn:aws:eks:eu-west-1:123:cluster/prod"),
+            "arn-aws-eks-eu-west-1-123-cluster-prod"
+        );
+        assert_eq!(sanitize(".."), "--");
+        assert_eq!(sanitize(""), "-");
+    }
+
+    /// End-to-end: base + cluster override + context override on disk.
+    #[test]
+    fn resolves_cluster_and_context_overrides() {
+        let dir = std::env::temp_dir().join(format!("sofka-cfg-test-{}", std::process::id()));
+        let ctx_dir = dir.join("clusters").join("prod-cluster").join("prod-ctx");
+        std::fs::create_dir_all(&ctx_dir).unwrap();
+        std::fs::write(
+            dir.join("config.toml"),
+            "default_namespace = \"default\"\n[aliases]\ndep = \"deployments\"\n[skin]\nname = \"gruvbox-dark\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("clusters")
+                .join("prod-cluster")
+                .join("config.toml"),
+            "[skin]\nname = \"catppuccin-latte\"\nbackground = true\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ctx_dir.join("config.toml"),
+            "default_namespace = \"prod\"\n[aliases]\nks = \"kustomizations\"\n",
+        )
+        .unwrap();
+
+        let loader = ConfigLoader::from_dir(Some(dir.clone()));
+
+        // Unknown context/cluster: base only, no skin override.
+        let plain = loader.resolve("dev-ctx", "dev-cluster");
+        assert!(plain.warnings.is_empty());
+        assert_eq!(plain.config.default_namespace.as_deref(), Some("default"));
+        assert_eq!(plain.config.skin.name.as_deref(), Some("gruvbox-dark"));
+        assert_eq!(plain.skin_override, None);
+
+        // Cluster + context overrides stack over the base.
+        let prod = loader.resolve("prod-ctx", "prod-cluster");
+        assert!(prod.warnings.is_empty());
+        assert_eq!(prod.config.default_namespace.as_deref(), Some("prod"));
+        assert!(prod.config.skin.background);
+        assert_eq!(prod.config.aliases.len(), 2);
+        assert_eq!(prod.skin_override.as_deref(), Some("catppuccin-latte"));
+
+        // Empty cluster name (in-cluster): overrides skipped entirely.
+        let bare = loader.resolve("prod-ctx", "");
+        assert_eq!(bare.config.default_namespace.as_deref(), Some("default"));
+        assert_eq!(bare.skin_override, None);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn malformed_override_warns_and_is_skipped() {
+        let dir = std::env::temp_dir().join(format!("sofka-cfg-bad-test-{}", std::process::id()));
+        let cluster_dir = dir.join("clusters").join("c1");
+        std::fs::create_dir_all(&cluster_dir).unwrap();
+        std::fs::write(dir.join("config.toml"), "default_namespace = \"base\"\n").unwrap();
+        std::fs::write(cluster_dir.join("config.toml"), "not valid toml [[[").unwrap();
+
+        let loader = ConfigLoader::from_dir(Some(dir.clone()));
+        let r = loader.resolve("ctx", "c1");
+        assert_eq!(r.warnings.len(), 1);
+        assert_eq!(r.config.default_namespace.as_deref(), Some("base"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -37,6 +37,9 @@ impl Kind {
 pub struct Cluster {
     pub client: Client,
     pub context: String,
+    /// Kubeconfig cluster name referenced by `context` (empty when unknown,
+    /// e.g. in-cluster). Keys per-cluster config overrides.
+    pub cluster_name: String,
     pub cluster_url: String,
     pub default_namespace: String,
     /// Context name to pass to `kubectl` shell-outs (`--context`). `None` when
@@ -84,9 +87,11 @@ impl Cluster {
         let default_namespace = config.default_namespace.clone();
         let client = Client::try_from(config).context("building kube client")?;
 
+        let cluster_name = cluster_name_for(&context).unwrap_or_default();
         let mut cluster = Self {
             client,
             context,
+            cluster_name,
             cluster_url,
             default_namespace,
             cli_context,
@@ -279,6 +284,18 @@ fn current_context_name() -> Option<String> {
     kubeconfig.current_context
 }
 
+/// Kubeconfig cluster name a context points at, when the kubeconfig knows it.
+fn cluster_name_for(context: &str) -> Option<String> {
+    let kubeconfig = kube::config::Kubeconfig::read().ok()?;
+    kubeconfig
+        .contexts
+        .iter()
+        .find(|c| c.name == context)?
+        .context
+        .as_ref()
+        .map(|c| c.cluster.clone())
+}
+
 /// Built-in short aliases -> canonical plural. Mirrors common k9s/kubectl ones.
 pub const ALIASES: &[(&str, &str)] = &[
     ("po", "pods"),
@@ -395,6 +412,7 @@ impl Cluster {
         Self {
             client,
             context: "test".into(),
+            cluster_name: "test-cluster".into(),
             cluster_url: "https://127.0.0.1:6443".into(),
             default_namespace: "default".into(),
             cli_context: Some("test".into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let cfg = config::Config::load();
+    let loader = config::ConfigLoader::load();
 
     // Connect before taking over the terminal so errors are readable.
     eprintln!("Connecting to cluster…");
@@ -65,12 +65,19 @@ async fn main() -> Result<()> {
             std::process::exit(1);
         }
     };
+    // Per-cluster/per-context override files merge over the base config.
+    let resolved = loader.resolve(&cluster.context, &cluster.cluster_name);
+    for w in &resolved.warnings {
+        eprintln!("warning: {w}");
+    }
+    let cfg = resolved.config;
     cluster.add_aliases(&cfg.aliases);
 
     if args.check {
         println!("✓ connected");
         println!("  context:    {}", cluster.context);
-        println!("  cluster:    {}", cluster.cluster_url);
+        println!("  cluster:    {}", cluster.cluster_name);
+        println!("  server:     {}", cluster.cluster_url);
         println!("  namespace:  {}", cluster.default_namespace);
         println!(
             "  kinds:      {} resource types discovered",
@@ -95,19 +102,20 @@ async fn main() -> Result<()> {
 
     // Install the initial color skin before anything renders. Auto-detecting
     // dark/light mode queries the terminal directly, so it must run before
-    // ratatui switches to the alternate screen. A `[skin.contexts]` override
-    // for the starting context wins over the global/auto-detected skin.
-    let session_skin = cfg
+    // ratatui switches to the alternate screen. A skin named by an override
+    // file for the starting context wins over the base/auto-detected skin,
+    // but only the base skin becomes the session skin, so switching away
+    // from an overridden context falls back correctly.
+    let session_skin = loader
+        .resolve("", "")
+        .config
         .skin
         .name
-        .clone()
         .unwrap_or_else(|| theme::auto_skin_name().to_string());
-    let initial_skin = cfg
-        .skin
-        .contexts
-        .get(&cluster.context)
-        .unwrap_or(&session_skin)
-        .clone();
+    let initial_skin = resolved
+        .skin_override
+        .clone()
+        .unwrap_or_else(|| session_skin.clone());
     theme::init(theme::resolve_skin(Some(&initial_skin), &cfg.skin.colors));
     theme::set_background(cfg.skin.background);
 
@@ -119,7 +127,7 @@ async fn main() -> Result<()> {
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
     app.skin_colors = cfg.skin.colors.clone();
-    app.context_skins = cfg.skin.contexts.clone();
+    app.config = loader;
     app.session_skin = Some(session_skin);
     if args.all_namespaces {
         app.namespace = String::new();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -334,8 +334,8 @@ static BACKGROUND: AtomicBool = AtomicBool::new(false);
 /// Enable (or disable) painting the palette's `base` swatch as the app
 /// background. Off by default, so sofka inherits the terminal's — possibly
 /// transparent — background. On, every view is filled with the skin's own
-/// background color: pair it with `[skin.contexts]` to make e.g. a light prod
-/// skin visibly glow.
+/// background color: pair it with a per-context skin override to make e.g. a
+/// light prod skin visibly glow.
 pub fn set_background(on: bool) {
     BACKGROUND.store(on, Ordering::Relaxed);
 }


### PR DESCRIPTION
Closes #24

## Summary

- **Per-cluster / per-context config overrides, k9s-style.** Any option (aliases, plugins, skin, `default_namespace`, `default_resource`) can now be overridden for a specific kubeconfig cluster or context via partial config files:

  ```
  ~/.config/sofka/
  ├── config.toml                # base, applies everywhere
  └── clusters/
      └── <cluster>/             # kubeconfig *cluster* name
          ├── config.toml        # every context on this cluster
          └── <context>/         # kubeconfig *context* name
              └── config.toml    # that context only
  ```

  Cluster nests above context (k9s order) because context names like `default` (k3s), `minikube`, or `kind-kind` recur across clusters.
- **Merge semantics:** tables (`[aliases]`, `[skin.colors]`) merge key-by-key; scalars and arrays (`[[plugins]]`) replace the base value. Directory names are the kubeconfig names sanitized for the filesystem (`[^A-Za-z0-9._-]` → `-`, so EKS ARN contexts work).
- **Live re-resolution:** override files are re-read on every `:ctx` switch, which now also re-applies aliases, plugins, skin, background, and the new context's `default_namespace` / `default_resource`. Malformed override files warn and are skipped, never fatal.
- `Cluster` now carries the kubeconfig cluster name, and `--check` prints it — that's the name to use for the override directory.

## Breaking change

`[skin.contexts]` is removed. Set `skin.name` in a per-context override file instead; the old behavior is preserved — a skin named in an override pins that context, while a manual `:skin` choice still survives switches into contexts without one.

## Test plan

- [x] Unit tests for merge precedence, sanitization, on-disk resolution, and malformed-override handling (141 tests pass)
- [x] End-to-end against a real GKE cluster: base, cluster-level, and context-level configs each remapping the same alias — `--check` resolves the context-level value, then cluster-level, then base as files are removed
- [x] clippy clean, fmt applied