### PR TITLE
feat: read-only mode (--readonly/--write, readonly config option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ which point this step won't be necessary.
 ```toml
 default_namespace = "kube-system"
 default_resource  = "deployments"
+readonly          = false  # true disables every mutating action (delete, edit,
+                           # scale, shell, plugins, …); --readonly/--write win
 
 [aliases]
 dep = "deployments"
@@ -228,7 +230,9 @@ than letters, digits, `.`, `_`, `-` replaced by `-`, so an EKS context
 `arn-aws-eks-eu-west-1-123456789-cluster-prod`.
 
 ```toml
-# clusters/prod-cluster/config.toml — make prod unmistakable
+# clusters/prod-cluster/config.toml — make prod unmistakable and hands-off
+readonly = true
+
 [skin]
 name = "catppuccin-latte"
 background = true
@@ -252,12 +256,20 @@ These double as CI smoke tests.
 ## Usage
 
 ```
-sofka [RESOURCE] [-n NAMESPACE] [-A]
+sofka [RESOURCE] [-n NAMESPACE] [-A] [--readonly | --write]
 
   RESOURCE          resource to open (alias/plural/kind), default: pods
   -n, --namespace   namespace to start in
   -A, --all-namespaces
+  --readonly        disable every mutating action for the session
+  --write           force write mode, overriding any config `readonly`
 ```
+
+`--readonly`/`--write` pin the mode for the whole session, winning over the
+config `readonly` option — including per-cluster/per-context overrides — on
+every `:ctx` switch. Without a flag, switching into a context whose config
+sets `readonly = true` enables read-only mode (shown as `[read-only]` in the
+header) and switching away restores write mode.
 
 ### Keys
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -4,6 +4,9 @@ impl App {
     // ----- actions -------------------------------------------------------
 
     pub(super) fn request_delete(&mut self, force: bool) {
+        if self.deny_readonly() {
+            return;
+        }
         // A Helm release row's underlying object is its storage Secret —
         // deleting that secret directly would corrupt Helm's own bookkeeping.
         // The actual semantic action is `helm uninstall`.
@@ -88,6 +91,9 @@ impl App {
     }
 
     pub(super) fn request_cordon(&mut self, unschedulable: bool) {
+        if self.deny_readonly() {
+            return;
+        }
         if self.kind_plural != "nodes" {
             self.flash_warn("cordon/uncordon applies to nodes");
             return;
@@ -127,6 +133,9 @@ impl App {
     }
 
     pub(super) fn request_drain(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         if self.kind_plural != "nodes" {
             self.flash_warn("drain applies to nodes");
             return;
@@ -235,6 +244,9 @@ impl App {
     }
 
     pub(super) fn request_attach(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         if self.kind_plural != "pods" {
             self.flash_warn("attach is only available for pods");
             return;
@@ -432,6 +444,9 @@ impl App {
 
     /// Rollout-restart a workload by stamping the template annotation (k9s `r`).
     pub(super) fn request_restart(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         let Some(obj) = self.selected_ref() else {
             return;
         };
@@ -453,6 +468,9 @@ impl App {
 
     /// Open the Set-Image picker for the selected workload/pod (k9s `i`).
     pub(super) fn request_set_image(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         let is_pod = self.kind_plural == "pods";
         let workload = matches!(
             self.kind_plural.as_str(),
@@ -558,6 +576,9 @@ impl App {
     }
 
     pub(super) fn request_edit(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         let Some(obj) = self.selected_ref() else {
             return;
         };
@@ -572,6 +593,9 @@ impl App {
     }
 
     pub(super) fn request_exec(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         if self.kind_plural != "pods" {
             self.flash_warn("shell is only available for pods");
             return;
@@ -587,6 +611,9 @@ impl App {
     /// Shell into `pod`, optionally pinned to `container` (k9s-style `-c`).
     /// Shared by the plain pod-row shell (`s`) and the per-container picker.
     pub(super) fn exec_into(&mut self, ns: String, pod: String, container: Option<String>) {
+        if self.deny_readonly() {
+            return;
+        }
         let mut argv = self.kubectl_base();
         argv.extend(["exec".into(), "-it".into(), "-n".into(), ns, pod]);
         if let Some(c) = container {
@@ -603,6 +630,9 @@ impl App {
     }
 
     pub(super) fn request_scale(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         if !matches!(
             self.kind_plural.as_str(),
             "deployments" | "statefulsets" | "replicasets"
@@ -811,6 +841,9 @@ impl App {
     /// toggle — suspending something always takes an explicit, visible
     /// choice (`j`/`k` + Enter) rather than one accidental keystroke.
     pub(super) fn request_flux_menu(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         if !FLUX_SUSPENDABLE_KINDS.contains(&self.kind_plural.as_str()) {
             self.flash_warn("suspend/resume only applies to Flux resources (ks/hr/git-, helm-, oci-repos, buckets, image automation, alerts, receivers)");
             return;
@@ -901,6 +934,9 @@ impl App {
     /// Force an immediate External Secrets Operator refresh on the marked rows
     /// (or the current selection), matching the k9s external-secrets plugin.
     pub(super) fn request_refresh_es(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         if !EXTERNAL_SECRET_KINDS.contains(&self.kind_plural.as_str()) {
             self.flash_warn(
                 "refresh only applies to external secrets (externalsecrets, pushsecrets)",
@@ -937,6 +973,15 @@ impl App {
         );
     }
 
+    /// Refuse a mutating action in read-only mode: flashes a warning and
+    /// returns true when the caller must bail out.
+    pub(super) fn deny_readonly(&mut self) -> bool {
+        if self.readonly {
+            self.flash_warn("read-only mode — action disabled");
+        }
+        self.readonly
+    }
+
     pub(super) fn flash_warn(&mut self, msg: &str) {
         self.flash = msg.to_string();
         self.flash_err = true;
@@ -971,6 +1016,9 @@ impl App {
     /// History view). Only ever acts on the single selected row — rolling
     /// back is not a bulk action.
     pub(super) fn request_helm_rollback(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         if self.kind_plural != "helmhistory" {
             self.flash_warn("rollback applies to a Helm release's revision history");
             return;
@@ -1026,6 +1074,9 @@ impl App {
     /// Uninstall the selected (or marked) Helm release(s) (k9s: `ctrl-d` /
     /// Delete on the release list or its history).
     pub(super) fn request_helm_uninstall(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
         let targets = self.helm_action_targets();
         if targets.is_empty() {
             return;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -160,7 +160,9 @@ impl App {
         }
     }
 
-    /// Run a config-defined plugin bound to `c` if it applies to the current kind.
+    /// Run a config-defined plugin bound to `c` if it applies to the current
+    /// kind. Blocked in read-only mode: plugins shell out to arbitrary
+    /// commands, so we can't know they won't mutate the cluster.
     pub(super) fn try_plugin(&mut self, c: char) {
         let Some(plugin) = self
             .plugins
@@ -173,6 +175,9 @@ impl App {
         else {
             return;
         };
+        if self.deny_readonly() {
+            return;
+        }
         let Some(obj) = self.selected_ref() else {
             self.flash_warn("no selection for plugin");
             return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -522,6 +522,11 @@ pub struct App {
     /// Skin for contexts without an override: config `skin.name` (or the
     /// auto-detected default), replaced by a manual `:skin` choice.
     pub session_skin: Option<String>,
+    /// Effective read-only mode: mutating actions are refused with a flash.
+    pub readonly: bool,
+    /// Session-wide pin from `--readonly`/`--write`; wins over any config
+    /// `readonly` value on every context switch. `None` = config decides.
+    pub readonly_override: Option<bool>,
 
     /// Current images aligned with `container_list`, for the Set-Image picker.
     pub image_values: Vec<String>,
@@ -619,6 +624,8 @@ impl App {
             skin_colors: HashMap::new(),
             config: crate::config::ConfigLoader::default(),
             session_skin: None,
+            readonly: false,
+            readonly_override: None,
             image_values: Vec::new(),
             image_target: None,
             metrics: HashMap::new(),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -253,6 +253,7 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
         self.skin_colors = resolved.config.skin.colors;
+        self.readonly = self.readonly_override.unwrap_or(resolved.config.readonly);
         cluster.add_aliases(&self.user_aliases);
         self.bump_generation();
         self.namespace = resolved

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1964,3 +1964,69 @@ async fn helm_resource_title_names_the_view_not_the_backing_secret() {
     assert_eq!(app.resource_title(), "helm history");
     assert_eq!(app.list_title(), "helm history");
 }
+
+#[tokio::test]
+async fn readonly_blocks_mutating_actions() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    app.readonly = true;
+
+    app.request_delete(false);
+    assert_eq!(app.mode, Mode::Table, "delete confirm must not open");
+    assert!(app.flash.contains("read-only"));
+
+    app.flash.clear();
+    app.request_edit();
+    assert!(app.pending.is_none(), "edit must not shell out");
+    assert!(app.flash.contains("read-only"));
+
+    app.flash.clear();
+    app.request_exec();
+    assert!(app.pending.is_none(), "shell must not open");
+    assert!(app.flash.contains("read-only"));
+
+    app.plugins = vec![crate::config::Plugin {
+        key: 'g',
+        name: "argocd-sync".into(),
+        command: "argocd".into(),
+        args: vec![],
+        scopes: vec![],
+    }];
+    app.flash.clear();
+    app.try_plugin('g');
+    assert!(app.pending.is_none(), "plugin must not run");
+    assert!(app.flash.contains("read-only"));
+
+    // Read paths stay open: describe still works.
+    app.flash.clear();
+    app.handle_key(press(KeyCode::Char('d'))).unwrap();
+    assert!(!app.flash.contains("read-only"));
+}
+
+#[tokio::test]
+async fn context_switch_resolves_readonly_and_cli_pin_wins() {
+    let dir = std::env::temp_dir().join(format!("sofka-readonly-test-{}", std::process::id()));
+    let cluster_dir = dir.join("clusters").join("test-cluster");
+    std::fs::create_dir_all(&cluster_dir).unwrap();
+    std::fs::write(cluster_dir.join("config.toml"), "readonly = true\n").unwrap();
+
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+
+    // No CLI pin: the per-cluster override flips read-only on.
+    app.apply_context_switch("prod".into(), Box::new(Cluster::fake()));
+    assert!(app.readonly);
+
+    // A `--write` pin survives switching into the read-only cluster.
+    app.readonly_override = Some(false);
+    app.apply_context_switch("prod-again".into(), Box::new(Cluster::fake()));
+    assert!(!app.readonly);
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,12 @@ pub struct Config {
     pub default_namespace: Option<String>,
     /// Resource to open on launch when none is given on the CLI.
     pub default_resource: Option<String>,
+    /// Disable every action that could modify the cluster (or run arbitrary
+    /// commands): delete, edit, scale, restart, set-image, cordon/drain,
+    /// Flux suspend/resume/reconcile, Helm rollback/uninstall, shell/attach,
+    /// and plugins. Overridden by the `--readonly`/`--write` CLI flags. Set
+    /// it in a per-cluster/per-context override file to lock down just prod.
+    pub readonly: bool,
     /// Custom alias -> canonical resource (plural/kind) mappings.
     pub aliases: HashMap<String, String>,
     /// User-defined shell-out plugins bound to keys.
@@ -147,7 +153,7 @@ impl ConfigLoader {
         loader
     }
 
-    fn from_dir(dir: Option<PathBuf>) -> Self {
+    pub(crate) fn from_dir(dir: Option<PathBuf>) -> Self {
         let base = dir.as_ref().and_then(|d| {
             let text = std::fs::read_to_string(d.join("config.toml")).ok()?;
             parse_doc(&text).ok()
@@ -390,7 +396,7 @@ mod tests {
             dir.join("clusters")
                 .join("prod-cluster")
                 .join("config.toml"),
-            "[skin]\nname = \"catppuccin-latte\"\nbackground = true\n",
+            "readonly = true\n[skin]\nname = \"catppuccin-latte\"\nbackground = true\n",
         )
         .unwrap();
         std::fs::write(
@@ -407,6 +413,7 @@ mod tests {
         assert_eq!(plain.config.default_namespace.as_deref(), Some("default"));
         assert_eq!(plain.config.skin.name.as_deref(), Some("gruvbox-dark"));
         assert_eq!(plain.skin_override, None);
+        assert!(!plain.config.readonly);
 
         // Cluster + context overrides stack over the base.
         let prod = loader.resolve("prod-ctx", "prod-cluster");
@@ -415,6 +422,7 @@ mod tests {
         assert!(prod.config.skin.background);
         assert_eq!(prod.config.aliases.len(), 2);
         assert_eq!(prod.skin_override.as_deref(), Some("catppuccin-latte"));
+        assert!(prod.config.readonly);
 
         // Empty cluster name (in-cluster): overrides skipped entirely.
         let bare = loader.resolve("prod-ctx", "");

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,17 @@ struct Args {
     #[arg(short = 'A', long)]
     all_namespaces: bool,
 
+    /// Disable every action that could modify the cluster (delete, edit,
+    /// scale, shell, plugins, …). Overrides the config `readonly` option,
+    /// including per-cluster/per-context overrides, for the whole session.
+    #[arg(long, conflicts_with = "write")]
+    readonly: bool,
+
+    /// Force write mode, overriding any config `readonly` option for the
+    /// whole session.
+    #[arg(long)]
+    write: bool,
+
     /// Connect, run discovery, print a summary, and exit (no TUI). Useful for
     /// verifying cluster connectivity in CI or a headless shell.
     #[arg(long)]
@@ -129,6 +140,14 @@ async fn main() -> Result<()> {
     app.skin_colors = cfg.skin.colors.clone();
     app.config = loader;
     app.session_skin = Some(session_skin);
+    // CLI flags pin the mode for the whole session; otherwise config decides,
+    // re-resolved per context on every `:ctx` switch.
+    app.readonly_override = match (args.readonly, args.write) {
+        (true, _) => Some(true),
+        (_, true) => Some(false),
+        _ => None,
+    };
+    app.readonly = app.readonly_override.unwrap_or(cfg.readonly);
     if args.all_namespaces {
         app.namespace = String::new();
     } else if let Some(ns) = args.namespace {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -110,8 +110,15 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
         ])
     };
 
+    let mut context_line = field("Context:", app.cluster.context.clone(), theme::mauve());
+    if app.readonly {
+        context_line.push_span(Span::styled(
+            "  [read-only]",
+            Style::default().fg(theme::red()),
+        ));
+    }
     let info = vec![
-        field("Context:", app.cluster.context.clone(), theme::mauve()),
+        context_line,
         field(
             "Cluster:",
             app.cluster.cluster_url.clone(),


### PR DESCRIPTION
Closes #25

Builds on the per-cluster/per-context config overrides from #26.

## Summary

- **`readonly` config option** (default `false`). Works in the base `config.toml` and in per-cluster/per-context override files, so a single `readonly = true` in `clusters/<prod-cluster>/config.toml` locks down just prod.
- **`--readonly` / `--write` CLI flags** (mutually exclusive). A flag pins the mode for the whole session and wins over config — launching with `--write` and switching into a `readonly = true` context stays in write mode, exactly as the issue specifies. Without a flag, every `:ctx` switch re-resolves the mode from config, so switching into a read-only context enables it and switching away restores write mode.
- **What's blocked in read-only mode:** delete, edit, scale, restart, set-image, cordon/uncordon, drain, Flux suspend/resume/reconcile, ExternalSecret force-sync, Helm rollback/uninstall, shell/attach into containers, and user-defined plugins (they shell out to arbitrary commands, so we can't know they're safe). Each refusal flashes `read-only mode — action disabled`.
- **What still works:** everything that only reads — describe, logs, YAML, diff, xray, pulse, events, copy, and port-forwards (a client-side tunnel; no cluster state is modified). Happy to gate port-forwards too if you'd rather match a stricter reading.
- The header shows a red `[read-only]` badge next to the context name whenever the mode is active.

## Test plan

- [x] Unit tests: all mutating entry points refuse and flash in read-only mode while reads keep working; context switches pick up `readonly` from a per-cluster override; a CLI pin survives switching into a read-only cluster (143 tests pass)
- [x] `--readonly --write` rejected by clap as conflicting
- [x] End-to-end against a real GKE cluster: `--readonly --snapshot` renders the `[read-only]` badge; a per-cluster `readonly = true` override enables it with no flag; adding `--write` disables it again