### PR TITLE
feat: cascade option on resource delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,37 +273,37 @@ header) and switching away restores write mode.
 
 ### Keys
 
-| Key                       | Action                                                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `:<resource>`             | command palette - fuzzy over kinds and built-in commands                                                      |
-| `:<resource> <ns>`        | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes) |
-| `[` / `]`                 | view history - back / forward through visited kind+namespace views                                            |
-| `enter`                   | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources)       |
-| `esc`                     | go back / pop the view stack / clear filter / clear marks                                                     |
-| `j`/`k`, `↓`/`↑`, `g`/`G` | navigate                                                                                                      |
-| `S` / `I`                 | cycle sort column / invert sort direction                                                                     |
-| `space`                   | mark/unmark row for bulk actions                                                                              |
-| `/`                       | fuzzy filter                                                                                                  |
-| `n` / `0`                 | namespace switcher / all namespaces                                                                           |
-| `shift-j`                 | jump to owner/controller                                                                                      |
-| `o`                       | show the node hosting the selected pod                                                                        |
-| `ctrl-r`                  | refresh the watch                                                                                             |
-| `y` / `d` / `E`           | view YAML / describe (`kubectl`) / live events                                                                |
-| `:ctx` / `:ctx <name>`    | context switcher popup / switch directly (the name tab-completes)                                             |
-| `:skin`                   | switch the color skin live (`:skin gruvbox-dark` applies directly)                                            |
-| `l` / `p`                 | logs (workload = all matching pods) / previous-container logs                                                 |
-| `c`                       | copy resource name to clipboard                                                                               |
-| `e`                       | edit in `$EDITOR` (`kubectl edit`)                                                                            |
-| `s`                       | shell into pod / scale a workload (context-dependent)                                                         |
-| `a`                       | attach to pod                                                                                                 |
-| `i`                       | set container image                                                                                           |
-| `r`                       | rollout restart (workloads) / refresh (elsewhere)                                                             |
-| `f` / `shift-f`           | port-forward (pods/services) - runs in the background                                                         |
-| `t`                       | Flux: suspend/resume/reconcile menu                                                                           |
-| `C` / `U` / `D`           | nodes: cordon / uncordon / drain                                                                              |
-| `ctrl-d` / `ctrl-k`       | delete / force-delete (marked rows, or current); `f` toggles force in confirm                                 |
-| `:q`, `ctrl-c`            | quit                                                                                                          |
-| `?`                       | help                                                                                                          |
+| Key                       | Action                                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `:<resource>`             | command palette - fuzzy over kinds and built-in commands                                                                              |
+| `:<resource> <ns>`        | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                         |
+| `[` / `]`                 | view history - back / forward through visited kind+namespace views                                                                    |
+| `enter`                   | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources)                               |
+| `esc`                     | go back / pop the view stack / clear filter / clear marks                                                                             |
+| `j`/`k`, `↓`/`↑`, `g`/`G` | navigate                                                                                                                              |
+| `S` / `I`                 | cycle sort column / invert sort direction                                                                                             |
+| `space`                   | mark/unmark row for bulk actions                                                                                                      |
+| `/`                       | fuzzy filter                                                                                                                          |
+| `n` / `0`                 | namespace switcher / all namespaces                                                                                                   |
+| `shift-j`                 | jump to owner/controller                                                                                                              |
+| `o`                       | show the node hosting the selected pod                                                                                                |
+| `ctrl-r`                  | refresh the watch                                                                                                                     |
+| `y` / `d` / `E`           | view YAML / describe (`kubectl`) / live events                                                                                        |
+| `:ctx` / `:ctx <name>`    | context switcher popup / switch directly (the name tab-completes)                                                                     |
+| `:skin`                   | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
+| `l` / `p`                 | logs (workload = all matching pods) / previous-container logs                                                                         |
+| `c`                       | copy resource name to clipboard                                                                                                       |
+| `e`                       | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |
+| `s`                       | shell into pod / scale a workload (context-dependent)                                                                                 |
+| `a`                       | attach to pod                                                                                                                         |
+| `i`                       | set container image                                                                                                                   |
+| `r`                       | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
+| `f` / `shift-f`           | port-forward (pods/services) - runs in the background                                                                                 |
+| `t`                       | Flux: suspend/resume/reconcile menu                                                                                                   |
+| `C` / `U` / `D`           | nodes: cordon / uncordon / drain                                                                                                      |
+| `ctrl-d` / `ctrl-k`       | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
+| `:q`, `ctrl-c`            | quit                                                                                                                                  |
+| `?`                       | help                                                                                                                                  |
 
 **Logs view:** `/` search+highlight · `s` autoscroll · `w` wrap · `t`
 timestamps · `x` stop/resume stream · `c` copy buffer · `ctrl-s` save to file

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -18,8 +18,13 @@ impl App {
         if targets.is_empty() {
             return;
         }
-        self.confirm_label = delete_confirm_label(&self.kind_plural, &targets, force);
-        self.confirm_action = Some(ConfirmAction::Delete { targets, force });
+        let cascade = Cascade::Background;
+        self.confirm_label = delete_confirm_label(&self.kind_plural, &targets, force, cascade);
+        self.confirm_action = Some(ConfirmAction::Delete {
+            targets,
+            force,
+            cascade,
+        });
         self.mode = Mode::Confirm;
     }
 
@@ -54,7 +59,12 @@ impl App {
         });
     }
 
-    pub(super) fn do_delete(&mut self, targets: Vec<(String, String)>, force: bool) {
+    pub(super) fn do_delete(
+        &mut self,
+        targets: Vec<(String, String)>,
+        force: bool,
+        cascade: Cascade,
+    ) {
         let Some(kind) = self.kind.clone() else {
             return;
         };
@@ -68,7 +78,10 @@ impl App {
         };
         self.flash_err = false;
         tokio::spawn(async move {
-            let mut dp = DeleteParams::default();
+            let mut dp = DeleteParams {
+                propagation_policy: Some(cascade.policy()),
+                ..DeleteParams::default()
+            };
             if force {
                 dp = dp.grace_period(0);
             }

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -47,8 +47,15 @@ pub(super) fn delete_confirm_label(
     kind_plural: &str,
     targets: &[(String, String)],
     force: bool,
+    cascade: Cascade,
 ) -> String {
     let verb = if force { "Force delete" } else { "Delete" };
+    // Background is the kubectl default, so only surface the unusual modes.
+    let suffix = match cascade {
+        Cascade::Background => "",
+        Cascade::Foreground => " (cascade: foreground)",
+        Cascade::Orphan => " (orphan dependents)",
+    };
     if targets.len() == 1 {
         let (name, ns) = &targets[0];
         let where_ns = if ns.is_empty() {
@@ -56,9 +63,9 @@ pub(super) fn delete_confirm_label(
         } else {
             format!(" in {ns}")
         };
-        format!("{verb} {} {name}{where_ns}?", trim_s(kind_plural))
+        format!("{verb} {} {name}{where_ns}{suffix}?", trim_s(kind_plural))
     } else {
-        format!("{verb} {} {}?", targets.len(), kind_plural)
+        format!("{verb} {} {}{suffix}?", targets.len(), kind_plural)
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,7 +17,9 @@ use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use k8s_openapi::api::core::v1::Pod;
 use kube::Client;
-use kube::api::{Api, DeleteParams, EvictParams, ListParams, LogParams, Patch, PatchParams};
+use kube::api::{
+    Api, DeleteParams, EvictParams, ListParams, LogParams, Patch, PatchParams, PropagationPolicy,
+};
 use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;
 use kube::runtime::watcher;
@@ -130,11 +132,39 @@ impl Drop for PortForward {
     }
 }
 
+/// How dependents are handled on delete (kubectl `--cascade`, k9s propagation
+/// picker). Cycled with `c` in the delete confirm dialog.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Cascade {
+    Background,
+    Foreground,
+    Orphan,
+}
+
+impl Cascade {
+    fn next(self) -> Self {
+        match self {
+            Cascade::Background => Cascade::Foreground,
+            Cascade::Foreground => Cascade::Orphan,
+            Cascade::Orphan => Cascade::Background,
+        }
+    }
+
+    fn policy(self) -> PropagationPolicy {
+        match self {
+            Cascade::Background => PropagationPolicy::Background,
+            Cascade::Foreground => PropagationPolicy::Foreground,
+            Cascade::Orphan => PropagationPolicy::Orphan,
+        }
+    }
+}
+
 enum ConfirmAction {
     /// One or more `(name, ns)` targets to delete (bulk when marked).
     Delete {
         targets: Vec<(String, String)>,
         force: bool,
+        cascade: Cascade,
     },
     /// One or more node names to cordon and drain.
     Drain { targets: Vec<String> },

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -56,8 +56,12 @@ impl App {
             KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
                 if let Some(action) = self.confirm_action.take() {
                     match action {
-                        ConfirmAction::Delete { targets, force } => {
-                            self.do_delete(targets, force);
+                        ConfirmAction::Delete {
+                            targets,
+                            force,
+                            cascade,
+                        } => {
+                            self.do_delete(targets, force, cascade);
                             self.marked.clear();
                         }
                         ConfirmAction::Drain { targets } => {
@@ -77,14 +81,36 @@ impl App {
             }
             KeyCode::Char('f') | KeyCode::Char('F') => {
                 let update = match self.confirm_action.as_mut() {
-                    Some(ConfirmAction::Delete { targets, force }) => {
+                    Some(ConfirmAction::Delete {
+                        targets,
+                        force,
+                        cascade,
+                    }) => {
                         *force = !*force;
-                        Some((targets.clone(), *force))
+                        Some((targets.clone(), *force, *cascade))
                     }
                     _ => None,
                 };
-                if let Some((targets, force)) = update {
-                    self.confirm_label = delete_confirm_label(&self.kind_plural, &targets, force);
+                if let Some((targets, force, cascade)) = update {
+                    self.confirm_label =
+                        delete_confirm_label(&self.kind_plural, &targets, force, cascade);
+                }
+            }
+            KeyCode::Char('c') | KeyCode::Char('C') => {
+                let update = match self.confirm_action.as_mut() {
+                    Some(ConfirmAction::Delete {
+                        targets,
+                        force,
+                        cascade,
+                    }) => {
+                        *cascade = cascade.next();
+                        Some((targets.clone(), *force, *cascade))
+                    }
+                    _ => None,
+                };
+                if let Some((targets, force, cascade)) = update {
+                    self.confirm_label =
+                        delete_confirm_label(&self.kind_plural, &targets, force, cascade);
                 }
             }
             _ => {

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -314,13 +314,7 @@ impl App {
     }
 
     pub fn confirm_allows_force_toggle(&self) -> bool {
-        matches!(
-            self.confirm_action,
-            Some(ConfirmAction::Delete {
-                targets: _,
-                force: _
-            })
-        )
+        matches!(self.confirm_action, Some(ConfirmAction::Delete { .. }))
     }
 
     /// Toggle the mark on the current row (SPACE).

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -581,6 +581,70 @@ async fn delete_confirm_force_can_toggle() {
 }
 
 #[tokio::test]
+async fn delete_confirm_cascade_can_cycle() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "web", "namespace": "default"}}),
+    );
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    // Background is the default and doesn't clutter the label.
+    assert!(!app.confirm_label.contains("cascade"));
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::Delete {
+            cascade: Cascade::Background,
+            ..
+        })
+    ));
+
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm, "c must cycle, not cancel");
+    assert!(app.confirm_label.contains("(cascade: foreground)"));
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::Delete {
+            cascade: Cascade::Foreground,
+            ..
+        })
+    ));
+
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.confirm_label.contains("(orphan dependents)"));
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::Delete {
+            cascade: Cascade::Orphan,
+            ..
+        })
+    ));
+
+    // Cascade and force compose in the label.
+    app.handle_key(press(KeyCode::Char('f'))).unwrap();
+    assert!(
+        app.confirm_label
+            .starts_with("Force delete pod web in default (orphan dependents)"),
+        "{}",
+        app.confirm_label
+    );
+
+    // Full circle back to background.
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::Delete {
+            cascade: Cascade::Background,
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
 async fn node_drain_key_opens_confirm_for_marked_nodes() {
     let (mut app, _rx) = test_app();
     app.switch_kind("nodes");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1287,7 +1287,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
         bind("space", "mark/unmark row for bulk actions (esc clears)"),
         bind(
             "ctrl-d · ctrl-k",
-            "delete · force-delete (f toggles in confirm)",
+            "delete · force-delete (in confirm: f force, c cascade)",
         ),
         Line::from(""),
         Line::from(Span::styled("  Logs view", theme::title())),
@@ -1870,9 +1870,13 @@ enum ConfirmHintStyle {
 
 fn confirm_action_hint(allows_force: bool, style: ConfirmHintStyle) -> &'static str {
     match (allows_force, style) {
-        (true, ConfirmHintStyle::Popup) => "  [y] confirm    [f] toggle force    [n] cancel",
+        (true, ConfirmHintStyle::Popup) => {
+            "  [y] confirm    [f] toggle force    [c] cascade    [n] cancel"
+        }
         (false, ConfirmHintStyle::Popup) => "  [y] confirm    [n] cancel",
-        (true, ConfirmHintStyle::Prompt) => "  y/enter: confirm   f: toggle force   n/esc: cancel",
+        (true, ConfirmHintStyle::Prompt) => {
+            "  y/enter: confirm   f: toggle force   c: cascade   n/esc: cancel"
+        }
         (false, ConfirmHintStyle::Prompt) => "  y/enter: confirm   n/esc: cancel",
     }
 }
@@ -2089,6 +2093,10 @@ mod tests {
         assert!(confirm_action_hint(true, ConfirmHintStyle::Prompt).contains("toggle force"));
         assert!(!confirm_action_hint(false, ConfirmHintStyle::Popup).contains("toggle force"));
         assert!(!confirm_action_hint(false, ConfirmHintStyle::Prompt).contains("toggle force"));
+        assert!(confirm_action_hint(true, ConfirmHintStyle::Popup).contains("cascade"));
+        assert!(confirm_action_hint(true, ConfirmHintStyle::Prompt).contains("cascade"));
+        assert!(!confirm_action_hint(false, ConfirmHintStyle::Popup).contains("cascade"));
+        assert!(!confirm_action_hint(false, ConfirmHintStyle::Prompt).contains("cascade"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a k9s-style cascade (propagation policy) option to resource deletion: pressing `c` in the delete confirm dialog cycles background → foreground → orphan
- New `Cascade` enum maps to kube's `PropagationPolicy` and is carried on `ConfirmAction::Delete`; `do_delete` sets `propagation_policy` on `DeleteParams` (background by default, matching `kubectl delete --cascade`)
- Composes with the existing `f` force toggle; confirm label surfaces non-default modes, e.g. `Delete pod web in default (orphan dependents)?`
- Confirm popup/prompt hints, help screen, and README updated with the new key

## Test plan
- [x] `cargo test` — 144 passed, including new `delete_confirm_cascade_can_cycle` covering the full cycle, that `c` cycles rather than cancels, and force + cascade label composition
- [x] `cargo clippy` and `cargo fmt --check` clean
- [ ] Manual: `ctrl-d` a deployment, cycle to foreground/orphan with `c`, confirm and verify dependent handling