### PR TITLE
feat: copy single-document views with c

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -399,6 +399,34 @@ impl App {
             .join("\n")
     }
 
+    /// Copy the current single-document view (YAML/describe/diff/events) to
+    /// the clipboard (k9s `c` in those views). Mirrors [`Self::copy_logs`]:
+    /// with a `/` search active, only the matching lines are copied.
+    pub(super) fn copy_doc(&mut self) {
+        let text = self.filtered_doc_text();
+        if text.is_empty() {
+            self.flash_warn("nothing to copy");
+            return;
+        }
+        let n = text.lines().count();
+        self.copy_to_clipboard_async(
+            text,
+            format!("copied {n} lines"),
+            "no clipboard target found (pbcopy/xclip/wl-copy/OSC 52)",
+        );
+    }
+
+    pub(super) fn filtered_doc_text(&self) -> String {
+        let f = self.detail.filter.to_lowercase();
+        self.detail
+            .lines
+            .iter()
+            .filter(|l| f.is_empty() || l.to_lowercase().contains(&f))
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// Copy the selected resource's name to the system clipboard (k9s `c`).
     pub(super) fn copy_name(&mut self) {
         let Some(obj) = self.selected_ref() else {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -510,6 +510,11 @@ impl App {
                 self.doc_filter_return = self.mode;
                 self.mode = Mode::DocFilter;
             }
+            // Copy the document to the clipboard (k9s `c`), same as the logs
+            // view: an active search copies only the matching lines.
+            KeyCode::Char('c') if detail => {
+                self.copy_doc();
+            }
             KeyCode::Char('j') | KeyCode::Down => target.scroll_by(1),
             KeyCode::Char('k') | KeyCode::Up => target.scroll_by(-1),
             KeyCode::Char('h') | KeyCode::Left => target.scroll_h(-5),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -33,14 +33,8 @@ impl App {
             Mode::Detail | Mode::Diff | Mode::Events => self.key_scroll(key, true),
             Mode::Logs => self.key_logs(key),
             Mode::LogFilter => self.key_log_filter(key),
-            Mode::Help => {
-                if matches!(
-                    key.code,
-                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?')
-                ) {
-                    self.mode = Mode::Table;
-                }
-            }
+            Mode::DocFilter => self.key_doc_filter(key),
+            Mode::Help => self.key_help(key),
             Mode::Namespaces => self.key_namespaces(key),
             Mode::Contexts => self.key_contexts(key),
             Mode::Containers => self.key_containers(key),
@@ -153,7 +147,10 @@ impl App {
             }
             // Flux CD: toggle suspend/resume on the marked rows, or current.
             KeyCode::Char('t') => self.request_flux_menu(),
-            KeyCode::Char('?') => self.mode = Mode::Help,
+            KeyCode::Char('?') => {
+                self.help_filter.clear();
+                self.mode = Mode::Help;
+            }
             // User-defined plugins fall through here (built-ins take priority).
             KeyCode::Char(c) => self.try_plugin(c),
             _ => {}
@@ -489,6 +486,11 @@ impl App {
             &mut self.logs.view
         };
         match key.code {
+            // Esc backs out of an active search first (like the table view);
+            // `q` always leaves.
+            KeyCode::Esc if detail && !target.filter.is_empty() => {
+                target.filter.clear();
+            }
             KeyCode::Esc | KeyCode::Char('q') => {
                 // The underlying view (table/xray) watch kept running, so there
                 // is nothing to restart — just stop the log streams and return,
@@ -502,6 +504,11 @@ impl App {
                 if self.return_mode == Mode::Table {
                     self.restore_selection();
                 }
+            }
+            // Search within the document (k9s `/` in YAML/describe views).
+            KeyCode::Char('/') if detail => {
+                self.doc_filter_return = self.mode;
+                self.mode = Mode::DocFilter;
             }
             KeyCode::Char('j') | KeyCode::Down => target.scroll_by(1),
             KeyCode::Char('k') | KeyCode::Up => target.scroll_by(-1),
@@ -653,6 +660,60 @@ impl App {
             }
             KeyCode::Char(c) => self.logs.filter.push(c),
             _ => {}
+        }
+    }
+
+    pub(super) fn key_help(&mut self, key: KeyEvent) {
+        match key.code {
+            // Esc backs out of an active search first, then closes help.
+            KeyCode::Esc if !self.help_filter.is_empty() => self.help_filter.clear(),
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.mode = Mode::Table,
+            KeyCode::Char('/') => {
+                self.doc_filter_return = self.mode;
+                self.mode = Mode::DocFilter;
+            }
+            _ => {}
+        }
+    }
+
+    /// Type the search query for a single-document view (YAML/describe, diff,
+    /// events, help). Mirrors [`Self::key_log_filter`]: enter keeps the query,
+    /// esc clears it; either returns to the view it was opened from.
+    pub(super) fn key_doc_filter(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => {
+                self.doc_filter_mut().clear();
+                self.reset_doc_scroll();
+                self.mode = self.doc_filter_return;
+            }
+            KeyCode::Enter => self.mode = self.doc_filter_return,
+            KeyCode::Backspace => {
+                self.doc_filter_mut().pop();
+                self.reset_doc_scroll();
+            }
+            KeyCode::Char(c) => {
+                self.doc_filter_mut().push(c);
+                self.reset_doc_scroll();
+            }
+            _ => {}
+        }
+    }
+
+    /// The query the doc search edits: the help view has its own buffer; every
+    /// other doc view is backed by `detail`.
+    fn doc_filter_mut(&mut self) -> &mut String {
+        if self.doc_filter_return == Mode::Help {
+            &mut self.help_filter
+        } else {
+            &mut self.detail.filter
+        }
+    }
+
+    /// Snap back to the top when the query changes, so the first match is
+    /// visible instead of a stale offset past the (now shorter) filtered list.
+    fn reset_doc_scroll(&mut self) {
+        if self.doc_filter_return != Mode::Help {
+            self.detail.scroll = 0;
         }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -86,6 +86,9 @@ pub enum Mode {
     Detail,
     Logs,
     LogFilter,
+    /// Typing a search query for a single-document view (YAML/describe, diff,
+    /// events, help) — the doc-view counterpart of [`Mode::LogFilter`].
+    DocFilter,
     Help,
     Namespaces,
     Contexts,
@@ -233,6 +236,10 @@ pub struct Scrollable {
     /// Word-wrap toggle. When on, long lines fold instead of being clipped, and
     /// horizontal scrolling is disabled.
     pub wrap: bool,
+    /// Case-insensitive substring search (`/`): only matching lines are shown,
+    /// with matches highlighted — same behavior as the logs filter. Reset
+    /// whenever a fresh document replaces the view.
+    pub filter: String,
 }
 
 /// One command-palette suggestion — a built-in command (`:ctx`, `:pulse`), a
@@ -506,6 +513,13 @@ pub struct App {
     pub flash_err: bool,
 
     pub detail: Scrollable,
+    /// Search query for the help view (`?`), which has no backing
+    /// [`Scrollable`] — its lines are built at render time.
+    pub help_filter: String,
+    /// Which doc view (`Detail`/`Diff`/`Events`/`Help`) the `/` search prompt
+    /// was opened from, so the renderer keeps drawing it underneath and
+    /// enter/esc return to it.
+    pub doc_filter_return: Mode,
     pub logs: LogsView,
 
     pub ns_list: Vec<String>,
@@ -628,6 +642,8 @@ impl App {
                 .into(),
             flash_err: false,
             detail: Scrollable::empty(),
+            help_filter: String::new(),
+            doc_filter_return: Mode::Detail,
             logs: LogsView::default(),
             ns_list: Vec::new(),
             ns_state: ListState::default(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2094,3 +2094,89 @@ async fn context_switch_resolves_readonly_and_cli_pin_wins() {
 
     std::fs::remove_dir_all(&dir).unwrap();
 }
+
+#[tokio::test]
+async fn doc_search_filters_detail_view() {
+    let (mut app, _rx) = test_app();
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+
+    // `/` opens the search prompt for the detail view; typing builds the query.
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    assert_eq!(app.mode, Mode::DocFilter);
+    assert_eq!(app.doc_filter_return, Mode::Detail);
+    for c in "kind".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    assert_eq!(app.detail.filter, "kind");
+
+    // Enter keeps the query and returns to the view.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert_eq!(app.detail.filter, "kind");
+
+    // First esc clears the search (stays), second esc leaves the view.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.filter.is_empty());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn doc_search_esc_clears_and_scroll_resets() {
+    let (mut app, _rx) = test_app();
+    app.detail = Scrollable {
+        title: "x — YAML".into(),
+        lines: (0..100).map(|i| format!("line {i}")).collect(),
+        scroll: 50,
+        ..Default::default()
+    };
+    app.mode = Mode::Detail;
+
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    app.handle_key(press(KeyCode::Char('9'))).unwrap();
+    // Typing snaps the view back to the top so the first match is visible.
+    assert_eq!(app.detail.scroll, 0);
+    // Esc in the prompt aborts the search entirely.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.filter.is_empty());
+}
+
+#[tokio::test]
+async fn help_search_uses_own_buffer() {
+    let (mut app, _rx) = test_app();
+    app.handle_key(press(KeyCode::Char('?'))).unwrap();
+    assert_eq!(app.mode, Mode::Help);
+
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    assert_eq!(app.mode, Mode::DocFilter);
+    assert_eq!(app.doc_filter_return, Mode::Help);
+    for c in "logs".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Help);
+    assert_eq!(app.help_filter, "logs");
+    assert!(
+        app.detail.filter.is_empty(),
+        "help search must not touch detail"
+    );
+
+    // Esc clears the search first, then closes help; reopening starts clean.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Help);
+    assert!(app.help_filter.is_empty());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    app.help_filter = "stale".into();
+    app.handle_key(press(KeyCode::Char('?'))).unwrap();
+    assert!(app.help_filter.is_empty());
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2180,3 +2180,43 @@ async fn help_search_uses_own_buffer() {
     app.handle_key(press(KeyCode::Char('?'))).unwrap();
     assert!(app.help_filter.is_empty());
 }
+
+#[tokio::test]
+async fn copy_doc_respects_active_search() {
+    let (mut app, _rx) = test_app();
+    app.detail = Scrollable {
+        title: "web — YAML".into(),
+        lines: vec![
+            "apiVersion: v1".to_string(),
+            "kind: Pod".to_string(),
+            "metadata:".to_string(),
+            "  name: web".to_string(),
+        ]
+        .into(),
+        ..Default::default()
+    };
+
+    // No search: the whole document.
+    assert_eq!(
+        app.filtered_doc_text(),
+        "apiVersion: v1\nkind: Pod\nmetadata:\n  name: web"
+    );
+
+    // Active search: only the matching lines (case-insensitive).
+    app.detail.filter = "KIND".into();
+    assert_eq!(app.filtered_doc_text(), "kind: Pod");
+}
+
+#[tokio::test]
+async fn copy_doc_on_empty_view_warns() {
+    let (mut app, _rx) = test_app();
+    app.detail = Scrollable {
+        title: "empty".into(),
+        ..Default::default()
+    };
+    app.mode = Mode::Detail;
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.flash_err);
+    assert!(app.flash.contains("nothing to copy"));
+    assert_eq!(app.mode, Mode::Detail, "copy must not leave the view");
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -63,7 +63,15 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
         Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
         Mode::Logs | Mode::LogFilter => draw_logs(frame, app, chunks[1]),
-        Mode::Help => draw_help(frame, chunks[1]),
+        // While typing a doc search, keep drawing the view it was opened from
+        // so the matches narrow live under the prompt.
+        Mode::DocFilter => match app.doc_filter_return {
+            Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
+            Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
+            Mode::Help => draw_help(frame, app, chunks[1]),
+            _ => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
+        },
+        Mode::Help => draw_help(frame, app, chunks[1]),
         Mode::Pulse => draw_pulse(frame, app, chunks[1]),
         Mode::Xray => draw_xray(frame, app, chunks[1]),
         Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
@@ -229,6 +237,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             | Mode::Events
             | Mode::Logs
             | Mode::LogFilter
+            | Mode::DocFilter
             | Mode::Help
             | Mode::Pulse
             | Mode::Xray
@@ -610,17 +619,20 @@ fn draw_scrollable(
     accent: ratatui::style::Color,
 ) {
     let inner_h = area.height.saturating_sub(2) as usize;
-    let (start, end) = visible_line_window(view.lines.len(), view.scroll, inner_h);
-    let text: Vec<Line> = view
-        .lines
-        .range(start..end)
-        .map(|l| Line::from(highlight_yaml(l)))
+    let shown = doc_filtered_lines(view);
+    // The scroll offset is clamped against the unfiltered length by the key
+    // handlers; re-clamp against the (shorter) filtered list.
+    let scroll = view.scroll.min(shown.len().saturating_sub(1));
+    let (start, end) = visible_line_window(shown.len(), scroll, inner_h);
+    let text: Vec<Line> = shown[start..end]
+        .iter()
+        .map(|l| highlight_matches(Line::from(highlight_yaml(l)), &view.filter))
         .collect();
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(accent))
-        .title(Span::styled(format!(" {} ", view.title), theme::title()));
+        .title(Span::styled(doc_title(view, shown.len()), theme::title()));
     let p = Paragraph::new(text).block(block);
     // Wrap folds long lines; otherwise honor the horizontal offset so content
     // past the right edge can be scrolled into view.
@@ -1243,24 +1255,26 @@ fn klog_level(l: &str, level: char) -> bool {
 /// Unified-diff view with +/- line coloring.
 fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
     let inner_h = area.height.saturating_sub(2) as usize;
-    let (start, end) = visible_line_window(view.lines.len(), view.scroll, inner_h);
-    let lines: Vec<Line> = view
-        .lines
-        .range(start..end)
+    let shown = doc_filtered_lines(view);
+    let scroll = view.scroll.min(shown.len().saturating_sub(1));
+    let (start, end) = visible_line_window(shown.len(), scroll, inner_h);
+    let lines: Vec<Line> = shown[start..end]
+        .iter()
         .map(|l| {
             let color = match l.chars().next() {
                 Some('+') => theme::green(),
                 Some('-') => theme::red(),
                 _ => theme::overlay1(),
             };
-            Line::from(Span::styled(l.clone(), Style::default().fg(color)))
+            let line = Line::from(Span::styled((*l).clone(), Style::default().fg(color)));
+            highlight_matches(line, &view.filter)
         })
         .collect();
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme::peach()))
-        .title(Span::styled(format!(" {} ", view.title), theme::title()));
+        .title(Span::styled(doc_title(view, shown.len()), theme::title()));
     let p = Paragraph::new(lines).block(block);
     let p = if view.wrap {
         p.wrap(Wrap { trim: false })
@@ -1274,6 +1288,47 @@ fn visible_line_window(len: usize, scroll: usize, height: usize) -> (usize, usiz
     let start = scroll.min(len);
     let end = start.saturating_add(height).min(len);
     (start, end)
+}
+
+/// The lines a doc view shows: all of them, or only those matching the active
+/// `/` search (case-insensitive substring, like the logs filter).
+fn doc_filtered_lines(view: &crate::app::Scrollable) -> Vec<&String> {
+    let filter = view.filter.to_lowercase();
+    view.lines
+        .iter()
+        .filter(|l| filter.is_empty() || l.to_lowercase().contains(&filter))
+        .collect()
+}
+
+/// Doc-view title, extended with the active search query and its match count
+/// (` title · /query [n] `), mirroring the logs title.
+fn doc_title(view: &crate::app::Scrollable, shown: usize) -> String {
+    if view.filter.is_empty() {
+        format!(" {} ", view.title)
+    } else {
+        format!(" {} · /{} [{}] ", view.title, view.filter, shown)
+    }
+}
+
+/// Overlay search-match highlights on an already-styled line, preserving each
+/// span's own style for the unmatched stretches. A needle spanning two spans
+/// (e.g. across a YAML key/value boundary) is not highlighted — the line is
+/// still *shown* (filtering matches on the raw text), just not marked.
+fn highlight_matches(line: Line<'static>, needle: &str) -> Line<'static> {
+    if needle.is_empty() {
+        return line;
+    }
+    let mut spans = Vec::with_capacity(line.spans.len());
+    for span in line.spans {
+        push_highlighted(&mut spans, &span.content, needle, span.style);
+    }
+    Line::from(spans)
+}
+
+/// Concatenated plain text of a styled line, for filtering render-time-built
+/// views (help) where no raw string backs the line.
+fn line_text(line: &Line) -> String {
+    line.spans.iter().map(|s| s.content.as_ref()).collect()
 }
 
 /// YAML / `kubectl describe` colorization: comments dimmed, section headers in
@@ -1354,7 +1409,7 @@ fn value_style(value: &str) -> Style {
     Style::default().fg(theme::text())
 }
 
-fn draw_help(frame: &mut Frame, area: Rect) {
+fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
     let bind = |k: &str, d: &str| {
         Line::from(vec![
             Span::styled(format!("  {k:<14}"), Style::default().fg(theme::yellow())),
@@ -1397,6 +1452,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
         bind("y · d", "view YAML · describe (kubectl)"),
         bind("l · p", "logs (workload = all pods) · previous logs"),
         bind("c", "copy resource name to clipboard"),
+        bind("/", "search within YAML/describe/diff/events/help"),
         Line::from(""),
         Line::from(Span::styled("  Act", theme::title())),
         bind("e", "edit in $EDITOR (kubectl edit)"),
@@ -1429,13 +1485,27 @@ fn draw_help(frame: &mut Frame, area: Rect) {
         bind(":q / ctrl-c", "quit"),
         bind("?", "toggle help"),
     ];
+    // `/` search: keep only matching binding lines (section headers and
+    // spacers match like any other text), highlighting the matched runs.
+    let needle = app.help_filter.to_lowercase();
+    let (lines, title) = if needle.is_empty() {
+        (lines, " Help ".to_string())
+    } else {
+        let shown: Vec<Line> = lines
+            .into_iter()
+            .filter(|l| line_text(l).to_lowercase().contains(&needle))
+            .map(|l| highlight_matches(l, &app.help_filter))
+            .collect();
+        let title = format!(" Help · /{} [{}] ", app.help_filter, shown.len());
+        (shown, title)
+    };
     frame.render_widget(
         Paragraph::new(lines).block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(theme::border_focused())
-                .title(Span::styled(" Help ", theme::title())),
+                .title(Span::styled(title, theme::title())),
         ),
         area,
     );
@@ -1932,6 +2002,23 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(app.logs.filter.clone(), Style::default().fg(theme::text())),
             Span::styled("█", Style::default().fg(theme::teal())),
         ]),
+        Mode::DocFilter => {
+            let query = if app.doc_filter_return == Mode::Help {
+                app.help_filter.clone()
+            } else {
+                app.detail.filter.clone()
+            };
+            Line::from(vec![
+                Span::styled(
+                    "search /",
+                    Style::default()
+                        .fg(theme::teal())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(query, Style::default().fg(theme::text())),
+                Span::styled("█", Style::default().fg(theme::teal())),
+            ])
+        }
         Mode::Confirm => Line::from(Span::styled(
             confirm_action_hint(app.confirm_allows_force_toggle(), ConfirmHintStyle::Prompt),
             Style::default().fg(theme::yellow()),
@@ -1941,9 +2028,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Detail | Mode::Events | Mode::Diff => {
-            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  w:wrap  esc:back";
+            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  w:wrap  esc:back";
             Line::from(Span::styled(hint, theme::dim()))
         }
+        Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),
         Mode::FluxMenu => Line::from(Span::styled(
             "  j/k: move   enter: confirm   esc: cancel",
             theme::dim(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1451,7 +1451,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(Span::styled("  Inspect", theme::title())),
         bind("y · d", "view YAML · describe (kubectl)"),
         bind("l · p", "logs (workload = all pods) · previous logs"),
-        bind("c", "copy resource name to clipboard"),
+        bind("c", "copy resource name · in doc views: copy the document"),
         bind("/", "search within YAML/describe/diff/events/help"),
         Line::from(""),
         Line::from(Span::styled("  Act", theme::title())),
@@ -2028,7 +2028,7 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Detail | Mode::Events | Mode::Diff => {
-            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  w:wrap  esc:back";
+            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  w:wrap  c:copy  esc:back";
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),


### PR DESCRIPTION
> [!NOTE]
> Stacked on #35 (`feat/doc-search`) — merge that first. Until then this diff also shows #35's commits.

## Summary
- `c` in the YAML, describe, diff, and events views copies the document plaintext to the clipboard, using the same async clipboard path (pbcopy/xclip/wl-copy/OSC 52 fallback) as the logs view's `c`.
- Consistent with `copy_logs`: while a `/` search is active, only the matching lines are copied; the flash reports how many lines were copied.
- An empty view flashes "nothing to copy" instead of copying an empty string.
- Doc-view hint line and `?` help updated to mention it.

Closes #32

## Test plan
- [x] `just check` (fmt, clippy, 149 tests) passes
- [x] New tests: filtered vs unfiltered copy text, empty-view warning without leaving the view
- [x] Manually: `y` on a resource → `c` → paste the full YAML; `/` search then `c` → paste only matching lines