### PR TITLE
feat: decode secrets in the secrets view with x

### DIFF
--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -56,6 +56,35 @@ impl App {
         self.mode = Mode::Detail;
     }
 
+    /// Show the selected Secret with its `data` base64-decoded (k9s `x`), as
+    /// it would appear in `stringData`. A plain [`Mode::Detail`] view, so `/`
+    /// search and `c` copy work like every other single-document view.
+    pub(super) fn open_decoded_secret(&mut self) {
+        self.set_return_mode();
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
+        let Some(data) = obj.data.get("data").and_then(Value::as_object) else {
+            self.flash_warn("secret has no data");
+            return;
+        };
+        if data.is_empty() {
+            self.flash_warn("secret has no data");
+            return;
+        }
+        let mut lines: Vec<String> = Vec::new();
+        for (key, value) in data {
+            lines.extend(decoded_secret_entry(key, value));
+        }
+        let title = obj.metadata.name.clone().unwrap_or_else(|| "secret".into());
+        self.detail = Scrollable {
+            title: format!("{title} — decoded"),
+            lines: lines.into(),
+            ..Default::default()
+        };
+        self.mode = Mode::Detail;
+    }
+
     /// Describe the selection via `kubectl describe`, off-thread so the UI loop
     /// keeps rendering. Falls back to the object's YAML if kubectl is missing
     /// or fails. The result arrives as `Msg::Detail`.
@@ -313,5 +342,33 @@ impl App {
         if let Some(task) = self.event_task.take() {
             task.abort();
         }
+    }
+}
+
+/// Render one Secret `data` entry as stringData-style YAML lines: single-line
+/// values inline (`key: value`), multiline ones as a literal block (`key: |`).
+/// Values that aren't valid base64 or don't decode to UTF-8 text (TLS certs
+/// in DER, random binary) get a placeholder instead of mojibake.
+fn decoded_secret_entry(key: &str, value: &Value) -> Vec<String> {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+
+    let Some(b64) = value.as_str() else {
+        return vec![format!("{key}: <not a string>")];
+    };
+    let Ok(bytes) = BASE64.decode(b64) else {
+        return vec![format!("{key}: <invalid base64>")];
+    };
+    let text = match String::from_utf8(bytes) {
+        Ok(text) => text,
+        Err(e) => return vec![format!("{key}: <binary: {} bytes>", e.as_bytes().len())],
+    };
+    let text = text.trim_end_matches('\n');
+    if text.contains('\n') {
+        let mut lines = vec![format!("{key}: |")];
+        lines.extend(text.lines().map(|l| format!("  {l}")));
+        lines
+    } else {
+        vec![format!("{key}: {text}")]
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -90,6 +90,9 @@ impl App {
             KeyCode::Enter => self.drill(),
             KeyCode::Char('y') => self.open_detail(),
             KeyCode::Char('d') => self.describe(),
+            // k9s: `x` shows a secret's data base64-decoded. Elsewhere `x`
+            // stays free for user plugins (the fallthrough arm below).
+            KeyCode::Char('x') if self.kind_plural == "secrets" => self.open_decoded_secret(),
             KeyCode::Char('E') => self.open_events(),
             KeyCode::Char('l') => self.open_logs(),
             KeyCode::Char('p') => self.open_previous_logs(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2220,3 +2220,77 @@ async fn copy_doc_on_empty_view_warns() {
     assert!(app.flash.contains("nothing to copy"));
     assert_eq!(app.mode, Mode::Detail, "copy must not leave the view");
 }
+
+#[tokio::test]
+async fn x_decodes_secret_data_into_detail_view() {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+
+    let (mut app, _rx) = test_app();
+    app.switch_kind("secrets");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Secret",
+        "metadata": {"name": "creds", "namespace": "default"},
+        "type": "Opaque",
+        "data": {
+            "password": BASE64.encode("hunter2"),
+            "config.yaml": BASE64.encode("a: 1\nb: 2\n"),
+            "cert.der": BASE64.encode([0u8, 159, 146, 150]),
+        }}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.title.contains("decoded"), "{}", app.detail.title);
+    let lines: Vec<&str> = app.detail.lines.iter().map(String::as_str).collect();
+    assert!(lines.contains(&"password: hunter2"), "{lines:?}");
+    // Multiline values render as a stringData-style literal block.
+    let block_start = lines
+        .iter()
+        .position(|l| *l == "config.yaml: |")
+        .expect("literal block header");
+    assert_eq!(lines[block_start + 1], "  a: 1");
+    assert_eq!(lines[block_start + 2], "  b: 2");
+    // Binary values get a placeholder, not mojibake.
+    assert!(lines.contains(&"cert.der: <binary: 4 bytes>"), "{lines:?}");
+
+    // Esc returns to the table on the same row.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn x_on_secret_without_data_warns() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("secrets");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Secret",
+            "metadata": {"name": "empty", "namespace": "default"},
+            "type": "Opaque"}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    assert_eq!(app.mode, Mode::Table, "no data — stay on the table");
+    assert!(app.flash.contains("no data"));
+}
+
+#[tokio::test]
+async fn x_outside_secrets_is_left_to_plugins() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    assert_eq!(
+        app.mode,
+        Mode::Table,
+        "x must not open a decode view for pods"
+    );
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -296,6 +296,11 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             hint_line(&[("⏎", "resources"), ("y", "yaml"), ("d", "describe")]),
             hint_line(&[("e", "edit"), ("^d", "delete")]),
         ],
+        "secrets" => vec![
+            hint_line(&[("x", "decode"), ("y", "yaml"), ("d", "describe")]),
+            hint_line(&[("e", "edit"), ("E", "events"), ("c", "copy name")]),
+            hint_line(&[("^d", "delete")]),
+        ],
         _ => vec![
             hint_line(&[("⏎", "yaml"), ("d", "describe"), ("E", "events")]),
             hint_line(&[("e", "edit"), ("c", "copy name")]),
@@ -1453,6 +1458,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("l · p", "logs (workload = all pods) · previous logs"),
         bind("c", "copy resource name · in doc views: copy the document"),
         bind("/", "search within YAML/describe/diff/events/help"),
+        bind("x", "secrets: show data base64-decoded"),
         Line::from(""),
         Line::from(Span::styled("  Act", theme::title())),
         bind("e", "edit in $EDITOR (kubectl edit)"),


### PR DESCRIPTION
> [!NOTE]
> Stacked on #36 (`feat/doc-copy`) — merge #35 → #36 → this. Until then this diff also shows their commits.

## Summary
- `x` on a `:secrets` row opens the secret's `data` base64-decoded in a single-document view, rendered stringData-style: single-line values inline (`key: value`), multiline values as YAML literal blocks (`key: |`).
- Values that aren't valid base64 or don't decode to UTF-8 (DER certs, random bytes) show a `<binary: N bytes>`-style placeholder instead of mojibake.
- The decoded view is a regular detail view, so `/` search (#35) and `c` copy (#36) work in it, matching the k9s behavior requested in the issue.
- Secrets with no `data` flash a warning and stay on the table. Outside `:secrets`, `x` still falls through to user plugins.
- Added a per-kind header hint block for secrets and a `?` help entry.

Closes #33

## Test plan
- [x] `just check` (fmt, clippy, 152 tests) passes
- [x] New tests: decode (inline, literal block, binary placeholder), esc returns to the table, no-data warning, `x` on non-secrets is a no-op
- [x] Manually: `:secrets` → `x` on a TLS secret and an Opaque secret → decoded view, `/` and `c` work