### PR TITLE
feat: launch into context picker when current context is unreachable

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -526,7 +526,14 @@ impl App {
                 result,
             } if generation == self.generation => match result {
                 Ok(cluster) => self.apply_context_switch(name, cluster),
-                Err(e) => self.flash_warn(&format!("context switch failed: {e}")),
+                Err(e) => {
+                    self.flash_warn(&format!("context switch failed: {e}"));
+                    // Never connected anywhere yet — put the picker back up
+                    // instead of stranding the user on an empty table.
+                    if !self.cluster.connected {
+                        self.open_contexts();
+                    }
+                }
             },
             _ => {} // stale generation, drop
         }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -140,6 +140,19 @@ impl App {
         self.start_watch();
     }
 
+    /// Start the session in the context picker because the current context's
+    /// API server was unreachable at launch (k9s behavior). The connect error
+    /// stays visible in the status line while picking.
+    pub fn start_disconnected(&mut self, error: &str) {
+        let label = if self.cluster.context.is_empty() {
+            "cannot connect".to_string()
+        } else {
+            format!("cannot connect to '{}'", self.cluster.context)
+        };
+        self.open_contexts();
+        self.flash_warn(&format!("{label}: {error} — pick another context"));
+    }
+
     pub(super) fn open_contexts(&mut self) {
         self.ctx_filter.clear();
         self.ctx_list.clear();
@@ -218,7 +231,9 @@ impl App {
     /// Reconnecting re-runs API discovery, which can take seconds, so it runs
     /// off-thread; the new cluster (or error) arrives as `Msg::ContextSwitched`.
     pub(super) fn switch_context(&mut self, name: String) {
-        if name == self.cluster.context {
+        // Re-selecting the current context is a no-op — unless we never
+        // connected to it, in which case picking it again is a retry.
+        if name == self.cluster.context && self.cluster.connected {
             return;
         }
         self.flash = format!("switching to {name}…");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2094,3 +2094,61 @@ async fn context_switch_resolves_readonly_and_cli_pin_wins() {
 
     std::fs::remove_dir_all(&dir).unwrap();
 }
+
+#[tokio::test]
+async fn disconnected_start_opens_context_picker() {
+    let (tx, _rx) = mpsc::channel(1024);
+    let mut cluster = Cluster::fake();
+    cluster.connected = false;
+    let mut app = App::new(cluster, tx);
+
+    app.start_disconnected("tcp connect error: Connection refused");
+    assert_eq!(app.mode, Mode::Contexts);
+    assert!(app.flash_err);
+    assert!(
+        app.flash.contains("cannot connect to 'test'"),
+        "{}",
+        app.flash
+    );
+    assert!(app.flash.contains("Connection refused"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn reselecting_never_connected_context_retries() {
+    let (mut app, _rx) = test_app();
+
+    // Connected: picking the current context again is a no-op.
+    app.flash.clear();
+    app.switch_context("test".into());
+    assert!(app.flash.is_empty());
+
+    // Never connected: picking the same context retries the connection.
+    app.cluster.connected = false;
+    app.switch_context("test".into());
+    assert!(app.flash.contains("switching to test"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn failed_switch_while_disconnected_reopens_picker() {
+    let (mut app, _rx) = test_app();
+    app.cluster.connected = false;
+    app.mode = Mode::Table;
+
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: "prod".into(),
+        result: Err("connection refused".into()),
+    });
+    assert!(app.flash.contains("context switch failed"), "{}", app.flash);
+    assert_eq!(app.mode, Mode::Contexts, "picker must come back up");
+
+    // Once connected, a failed switch just flashes — no picker takeover.
+    app.cluster.connected = true;
+    app.mode = Mode::Table;
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: "prod".into(),
+        result: Err("connection refused".into()),
+    });
+    assert_eq!(app.mode, Mode::Table);
+}

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -50,6 +50,10 @@ pub struct Cluster {
     registry: HashMap<String, Kind>,
     /// stable, de-duplicated list of plural names for completion
     pub catalog: Vec<String>,
+    /// False for the placeholder built by [`Cluster::disconnected`] when the
+    /// current context is unreachable at launch — the app then starts in the
+    /// context picker instead of a resource view.
+    pub connected: bool,
 }
 
 impl Cluster {
@@ -97,9 +101,61 @@ impl Cluster {
             cli_context,
             registry: HashMap::new(),
             catalog: Vec::new(),
+            connected: true,
         };
         cluster.discover().await?;
         Ok(cluster)
+    }
+
+    /// A placeholder for launching when the current context's API server is
+    /// unreachable (k9s drops you into the context picker in this situation
+    /// instead of exiting). Identity fields come straight from the kubeconfig
+    /// so the header still names the broken context; the client points at the
+    /// configured server but nothing uses it until a real context connects.
+    pub fn disconnected() -> Self {
+        let kubeconfig = Kubeconfig::read().ok();
+        let context = kubeconfig
+            .as_ref()
+            .and_then(|k| k.current_context.clone())
+            .unwrap_or_default();
+        let cluster_name = kubeconfig
+            .as_ref()
+            .and_then(|k| {
+                k.contexts
+                    .iter()
+                    .find(|c| c.name == context)?
+                    .context
+                    .as_ref()
+                    .map(|c| c.cluster.clone())
+            })
+            .unwrap_or_default();
+        let cluster_url = kubeconfig
+            .as_ref()
+            .and_then(|k| {
+                k.clusters
+                    .iter()
+                    .find(|c| c.name == cluster_name)?
+                    .cluster
+                    .as_ref()?
+                    .server
+                    .clone()
+            })
+            .unwrap_or_default();
+        let url = cluster_url
+            .parse()
+            .unwrap_or_else(|_| "http://127.0.0.1:8080".parse().expect("static url"));
+        let client = Client::try_from(Config::new(url)).expect("building offline client");
+        Self {
+            client,
+            cli_context: (!context.is_empty()).then(|| context.clone()),
+            context,
+            cluster_name,
+            cluster_url,
+            default_namespace: "default".into(),
+            registry: HashMap::new(),
+            catalog: Vec::new(),
+            connected: false,
+        }
     }
 
     /// Context name to pass to `kubectl` (`--context`), when known. Keeps
@@ -416,6 +472,7 @@ impl Cluster {
             cluster_url: "https://127.0.0.1:6443".into(),
             default_namespace: "default".into(),
             cli_context: Some("test".into()),
+            connected: true,
             registry,
             catalog: vec![
                 "deployments".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,13 +67,20 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let loader = config::ConfigLoader::load();
 
-    // Connect before taking over the terminal so errors are readable.
+    // Connect before taking over the terminal so errors are readable. An
+    // unreachable current context isn't fatal for the interactive TUI: start
+    // in the context picker instead (k9s behavior). Headless modes still exit
+    // with the error, since there is no picker to fall back to.
     eprintln!("Connecting to cluster…");
-    let mut cluster = match Cluster::connect().await {
-        Ok(c) => c,
-        Err(e) => {
+    let (mut cluster, connect_error) = match Cluster::connect().await {
+        Ok(c) => (c, None),
+        Err(e) if args.check || args.snapshot => {
             eprintln!("\x1b[31merror:\x1b[0m {e:#}");
             std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("\x1b[33mwarning:\x1b[0m {e:#}");
+            (Cluster::disconnected(), Some(format!("{e:#}")))
         }
     };
     // Per-cluster/per-context override files merge over the base config.
@@ -159,7 +166,12 @@ async fn main() -> Result<()> {
         .resource
         .or(cfg.default_resource)
         .unwrap_or_else(|| "pods".into());
-    app.switch_kind(&resource);
+    match &connect_error {
+        // No cluster to watch — open the context picker over the empty table;
+        // a successful pick connects and lands on the default resource.
+        Some(err) => app.start_disconnected(err),
+        None => app.switch_kind(&resource),
+    }
 
     if args.snapshot {
         return snapshot(&mut app, &mut rx).await;


### PR DESCRIPTION
## Summary
- An unreachable current context no longer aborts startup. The TUI launches on a disconnected placeholder `Cluster` (identity read from the kubeconfig, no discovery) with the context picker open and the connect error in the status line — matching k9s.
- `Cluster` gains a `connected` flag. While never-connected: re-picking the *same* context retries the connection (normally a no-op), and a failed switch reopens the picker instead of leaving an empty table.
- Headless modes (`--check`, `--snapshot`) keep the old behavior and exit with the error, since there is no picker to fall back to.

Closes #30

## Test plan
- [x] `just check` (fmt, clippy, 147 tests) passes
- [x] New tests: disconnected start opens the picker with the error flashed; same-context re-pick retries only when never connected; failed switch reopens the picker only while disconnected
- [x] Manually with a kubeconfig pointing at an unreachable server: `--check` still exits with the discovery error; the TUI starts into the picker (`q` filters instead of quitting, Esc then `q` exits)
- [x] Manually: pick a reachable context from the picker → connects and lands on the default resource view