### PR TITLE
feat: add :reload with config validation and last-known-good fallback

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -826,6 +826,7 @@ impl App {
         // A manual choice becomes the session skin, so it survives context
         // switches into contexts without a config skin override.
         self.session_skin = Some(name.to_string());
+        self.active_skin = Some(name.to_string());
         self.flash = format!("skin: {name}");
         self.flash_err = false;
     }
@@ -843,6 +844,120 @@ impl App {
         }
         let palette = crate::theme::resolve_skin(Some(&name), &self.skin_colors);
         crate::theme::set(palette);
+        self.active_skin = Some(name);
+    }
+
+    /// `:reload` — re-read the configuration from disk and apply it live:
+    /// aliases, plugins, skin (+ per-swatch overrides), background fill, and
+    /// read-only mode. Launch defaults (`default_namespace`/`default_resource`)
+    /// are deliberately not re-applied — a reload must never yank the current
+    /// view. A reload that fails validation keeps the last known-good config
+    /// active and reports the precise error (file, key, what's wrong) instead.
+    pub(super) fn reload_config(&mut self) {
+        let loader = match self.config.reload() {
+            Ok(l) => l,
+            Err(e) => {
+                self.config_warnings = vec![e];
+                self.flash_warn(
+                    "config reload failed — previous config kept (:config for details)",
+                );
+                return;
+            }
+        };
+        self.config = loader;
+        let resolved = self
+            .config
+            .resolve(&self.cluster.context, &self.cluster.cluster_name);
+        let mut warnings = resolved.warnings;
+        self.user_aliases = resolved.config.aliases;
+        self.plugins = resolved.config.plugins;
+        self.skin_colors = resolved.config.skin.colors;
+        self.readonly = self.readonly_override.unwrap_or(resolved.config.readonly);
+        self.cluster.add_aliases(&self.user_aliases);
+        crate::theme::set_background(resolved.config.skin.background);
+        // The skin named by the base config (if any) becomes the session skin
+        // again — a reload is an explicit "use what the files say now". With
+        // none configured, the current session skin (auto-detected or the last
+        // `:skin` choice) stays put.
+        if let Some(name) = self.config.resolve("", "").config.skin.name {
+            self.session_skin = Some(name);
+        }
+        warnings.extend(crate::theme::validate_skin(
+            resolved
+                .skin_override
+                .as_deref()
+                .or(self.session_skin.as_deref()),
+            &self.skin_colors,
+        ));
+        self.apply_context_skin(resolved.skin_override);
+        self.config_warnings = warnings;
+        if self.config_warnings.is_empty() {
+            self.flash = "config reloaded".into();
+            self.flash_err = false;
+        } else {
+            self.flash_warn(&format!(
+                "config reloaded with {} warning(s) — :config for details",
+                self.config_warnings.len()
+            ));
+        }
+    }
+
+    /// `:config` — a document view of the configuration currently in effect:
+    /// every source path (and whether it loaded), the active skin and mode,
+    /// and any validation errors/warnings from the last (re)load.
+    pub(super) fn open_config_info(&mut self) {
+        self.set_return_mode();
+        let mut lines: Vec<String> = vec!["Sources".into()];
+        match self.config.base_path() {
+            Some(path) => {
+                let state = if self.config.has_base() {
+                    "loaded"
+                } else if path.exists() {
+                    "invalid — using defaults"
+                } else {
+                    "absent — using defaults"
+                };
+                lines.push(format!("  {} ({state})", path.display()));
+            }
+            None => lines.push("  no config directory — using defaults".into()),
+        }
+        for path in self
+            .config
+            .override_paths(&self.cluster.context, &self.cluster.cluster_name)
+        {
+            lines.push(format!(
+                "  {} ({})",
+                path.display(),
+                crate::config::file_state(&path)
+            ));
+        }
+        lines.push(String::new());
+        lines.push("Active".into());
+        lines.push(format!(
+            "  skin: {}",
+            self.active_skin.as_deref().unwrap_or("auto")
+        ));
+        lines.push(format!("  readonly: {}", self.readonly));
+        lines.push(format!("  aliases: {}", self.user_aliases.len()));
+        lines.push(format!("  plugins: {}", self.plugins.len()));
+        lines.push(String::new());
+        if self.config_warnings.is_empty() {
+            lines.push("No validation warnings.".into());
+        } else {
+            lines.push(format!("Warnings [{}]", self.config_warnings.len()));
+            for w in &self.config_warnings {
+                for (i, l) in w.lines().enumerate() {
+                    let bullet = if i == 0 { "• " } else { "  " };
+                    lines.push(format!("  {bullet}{l}"));
+                }
+            }
+        }
+        self.detail = Scrollable {
+            title: "config — :reload to re-read".into(),
+            lines: lines.into(),
+            ..Default::default()
+        };
+        self.mode = Mode::Detail;
     }
 
     /// Stop (kill) the selected forward. Others keep running.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -284,6 +284,8 @@ impl App {
             PaletteAction::PortForwards => self.open_port_forwards(),
             PaletteAction::Skin => self.open_skins(),
             PaletteAction::Helm => self.open_helm_releases(),
+            PaletteAction::Reload => self.reload_config(),
+            PaletteAction::ConfigInfo => self.open_config_info(),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -281,6 +281,8 @@ enum PaletteAction {
     PortForwards,
     Skin,
     Helm,
+    Reload,
+    ConfigInfo,
 }
 
 const PALETTE_COMMANDS: &[PaletteCommand] = &[
@@ -315,6 +317,14 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Skin,
         names: &["skin", "skins"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Reload,
+        names: &["reload"],
+    },
+    PaletteCommand {
+        action: PaletteAction::ConfigInfo,
+        names: &["config", "cfg"],
     },
     PaletteCommand {
         action: PaletteAction::Quit,
@@ -566,6 +576,13 @@ pub struct App {
     /// Skin for contexts without an override: config `skin.name` (or the
     /// auto-detected default), replaced by a manual `:skin` choice.
     pub session_skin: Option<String>,
+    /// Name of the palette currently installed (session skin or a per-context
+    /// override), shown by `:config`. `None` until any skin is applied.
+    pub active_skin: Option<String>,
+    /// Validation problems from the most recent config (re)load — invalid
+    /// base config, skipped override layers, bad skin values. Shown by
+    /// `:config`; replaced wholesale on every `:reload`.
+    pub config_warnings: Vec<String>,
     /// Effective read-only mode: mutating actions are refused with a flash.
     pub readonly: bool,
     /// Session-wide pin from `--readonly`/`--write`; wins over any config
@@ -670,6 +687,8 @@ impl App {
             skin_colors: HashMap::new(),
             config: crate::config::ConfigLoader::default(),
             session_skin: None,
+            active_skin: None,
+            config_warnings: Vec::new(),
             readonly: false,
             readonly_override: None,
             image_values: Vec::new(),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -299,6 +299,8 @@ impl App {
         if let Some(w) = resolved.warnings.first() {
             self.flash_warn(w);
         }
+        // Keep `:config` in sync with the layers just resolved for this context.
+        self.config_warnings = resolved.warnings;
         let kind = resolved
             .config
             .default_resource

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2352,3 +2352,149 @@ async fn x_outside_secrets_is_left_to_plugins() {
         "x must not open a decode view for pods"
     );
 }
+
+// ----- config reload (`:reload`) and validation (`:config`) ---------------
+
+fn write_config(dir: &std::path::Path, text: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(dir.join("config.toml"), text).unwrap();
+}
+
+#[tokio::test]
+async fn reload_applies_config_changes_live() {
+    let dir = std::env::temp_dir().join(format!("sofka-app-reload-ok-{}", std::process::id()));
+    write_config(&dir, "[aliases]\ndep = \"deployments\"\n");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+
+    app.reload_config();
+    assert_eq!(
+        app.user_aliases.get("dep").map(String::as_str),
+        Some("deployments")
+    );
+    assert!(app.cluster.resolve("dep").is_some(), "alias registered");
+    assert!(!app.flash_err);
+    assert!(app.config_warnings.is_empty());
+
+    // Edit the file on disk: `:reload` picks up new aliases, mode, and skin
+    // without a restart. (The skin is the built-in default so the write to
+    // the global palette is value-identical — parallel tests read it.)
+    write_config(
+        &dir,
+        "readonly = true\n[aliases]\nks = \"services\"\n[skin]\nname = \"catppuccin-mocha\"\n",
+    );
+    app.reload_config();
+    assert!(app.readonly);
+    assert_eq!(
+        app.user_aliases.get("ks").map(String::as_str),
+        Some("services")
+    );
+    assert!(!app.user_aliases.contains_key("dep"), "aliases replaced");
+    assert_eq!(app.session_skin.as_deref(), Some("catppuccin-mocha"));
+    assert_eq!(app.active_skin.as_deref(), Some("catppuccin-mocha"));
+    assert!(app.flash.contains("config reloaded"), "{}", app.flash);
+    assert!(!app.flash_err);
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn failed_reload_keeps_last_known_good_config() {
+    let dir = std::env::temp_dir().join(format!("sofka-app-reload-bad-{}", std::process::id()));
+    write_config(&dir, "readonly = true\n[aliases]\ndep = \"deployments\"\n");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    app.reload_config();
+    assert!(app.readonly);
+
+    // A type error on disk: the running config must stay exactly as it was.
+    write_config(&dir, "readonly = \"yes\"\n");
+    app.reload_config();
+    assert!(app.readonly, "previous readonly kept");
+    assert_eq!(
+        app.user_aliases.get("dep").map(String::as_str),
+        Some("deployments")
+    );
+    assert!(app.flash_err);
+    assert!(app.flash.contains("previous config kept"), "{}", app.flash);
+    // The recorded error names the file, the offending key, and the problem.
+    let err = &app.config_warnings[0];
+    assert!(err.contains("config.toml"), "{err}");
+    assert!(err.contains("readonly"), "{err}");
+    assert!(err.contains("expected a boolean"), "{err}");
+
+    // A later good edit recovers without a restart.
+    write_config(&dir, "readonly = false\n");
+    app.reload_config();
+    assert!(!app.readonly);
+    assert!(app.config_warnings.is_empty());
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn reload_reports_skin_validation_warnings() {
+    let dir = std::env::temp_dir().join(format!("sofka-app-reload-skin-{}", std::process::id()));
+    write_config(
+        &dir,
+        "[skin]\nname = \"no-such-skin\"\n[skin.colors]\ngreen = \"zzz\"\n",
+    );
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    app.reload_config();
+    assert!(app.flash_err);
+    assert!(app.flash.contains("warning"), "{}", app.flash);
+    assert!(
+        app.config_warnings
+            .iter()
+            .any(|w| w.contains("skin.name") && w.contains("no-such-skin")),
+        "{:?}",
+        app.config_warnings
+    );
+    assert!(
+        app.config_warnings
+            .iter()
+            .any(|w| w.contains("skin.colors.green") && w.contains("invalid hex")),
+        "{:?}",
+        app.config_warnings
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn reload_palette_command_dispatches() {
+    let (mut app, _rx) = test_app();
+    assert!(app.run_palette_command("reload"));
+    assert!(app.flash.contains("config reloaded"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn config_view_lists_sources_active_skin_and_warnings() {
+    let dir = std::env::temp_dir().join(format!("sofka-app-cfg-view-{}", std::process::id()));
+    write_config(&dir, "[skin]\nname = \"catppuccin-mocha\"\n");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    app.reload_config();
+    app.config_warnings = vec!["skin.colors.red: invalid hex 'x' (expected #rrggbb)".into()];
+
+    assert!(app.run_palette_command("config"));
+    assert_eq!(app.mode, Mode::Detail);
+    let text = app
+        .detail
+        .lines
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    let base = dir.join("config.toml").display().to_string();
+    assert!(text.contains(&base) && text.contains("(loaded)"), "{text}");
+    assert!(text.contains("skin: catppuccin-mocha"), "{text}");
+    assert!(text.contains("skin.colors.red"), "{text}");
+
+    // Esc returns to the table, like any doc view.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,28 +137,80 @@ pub struct ConfigLoader {
 
 impl ConfigLoader {
     /// Read the base config, warning on stderr (we're pre-TUI) and falling
-    /// back to defaults if it's malformed — syntax or types.
-    pub fn load() -> Self {
-        let mut loader = Self::from_dir(config_dir());
-        if let Some(dir) = &loader.dir
-            && let Ok(text) = std::fs::read_to_string(dir.join("config.toml"))
-            && let Err(e) = toml::from_str::<Config>(&text)
-        {
-            eprintln!(
-                "warning: ignoring invalid {}: {e}",
-                dir.join("config.toml").display()
-            );
-            loader.base = None;
+    /// back to defaults if it's malformed — syntax or types. The validation
+    /// errors are also returned so the TUI can keep showing them (`:config`).
+    pub fn load() -> (Self, Vec<String>) {
+        let dir = config_dir();
+        let empty = Self {
+            base: None,
+            dir: dir.clone(),
+        };
+        match empty.reload() {
+            Ok(loader) => (loader, Vec::new()),
+            Err(e) => {
+                eprintln!("warning: ignoring invalid {e}");
+                (Self { base: None, dir }, vec![e])
+            }
         }
-        loader
     }
 
+    #[cfg(test)]
     pub(crate) fn from_dir(dir: Option<PathBuf>) -> Self {
         let base = dir.as_ref().and_then(|d| {
             let text = std::fs::read_to_string(d.join("config.toml")).ok()?;
             parse_doc(&text).ok()
         });
         Self { base, dir }
+    }
+
+    /// Re-read the base `config.toml` from disk, validated end-to-end (TOML
+    /// syntax *and* the typed [`Config`] shape). `Ok` carries a fresh loader
+    /// ready to [`resolve`](Self::resolve); `Err` carries the precise error —
+    /// file, offending key, and what's wrong — so the caller keeps the last
+    /// known-good loader instead. A missing base file is not an error: it
+    /// loads as defaults, like at startup.
+    pub fn reload(&self) -> Result<Self, String> {
+        let dir = self.dir.clone();
+        let Some(path) = self.base_path() else {
+            return Ok(Self { base: None, dir });
+        };
+        match std::fs::read_to_string(&path) {
+            Err(_) => Ok(Self { base: None, dir }),
+            Ok(text) => match validate(&text) {
+                Ok(value) => Ok(Self {
+                    base: Some(value),
+                    dir,
+                }),
+                Err(e) => Err(format!("{}: {e}", path.display())),
+            },
+        }
+    }
+
+    /// The base `config.toml` path, when a config directory is known.
+    pub fn base_path(&self) -> Option<PathBuf> {
+        self.dir.as_ref().map(|d| d.join("config.toml"))
+    }
+
+    /// Whether a parsed base config is active (as opposed to a missing or
+    /// invalid file, both of which fall back to defaults).
+    pub fn has_base(&self) -> bool {
+        self.base.is_some()
+    }
+
+    /// Override files consulted for the given kubeconfig cluster/context, in
+    /// merge order (cluster level first, then context level). The files need
+    /// not exist — this is the search path, for [`resolve`](Self::resolve)
+    /// and the `:config` view.
+    pub fn override_paths(&self, context: &str, cluster: &str) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        if let (Some(dir), false) = (&self.dir, cluster.is_empty()) {
+            let cluster_dir = dir.join("clusters").join(sanitize(cluster));
+            paths.push(cluster_dir.join("config.toml"));
+            if !context.is_empty() {
+                paths.push(cluster_dir.join(sanitize(context)).join("config.toml"));
+            }
+        }
+        paths
     }
 
     /// Merge override files for the given kubeconfig cluster/context over the
@@ -172,21 +224,14 @@ impl ConfigLoader {
             .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
         let mut overlay = toml::Value::Table(toml::map::Map::new());
 
-        if let (Some(dir), false) = (&self.dir, cluster.is_empty()) {
-            let cluster_dir = dir.join("clusters").join(sanitize(cluster));
-            let mut paths = vec![cluster_dir.join("config.toml")];
-            if !context.is_empty() {
-                paths.push(cluster_dir.join(sanitize(context)).join("config.toml"));
-            }
-            for path in paths {
-                match read_value(&path) {
-                    Ok(Some(v)) => {
-                        merge(&mut merged, v.clone());
-                        merge(&mut overlay, v);
-                    }
-                    Ok(None) => {}
-                    Err(e) => warnings.push(format!("ignoring invalid {}: {e}", path.display())),
+        for path in self.override_paths(context, cluster) {
+            match read_value(&path) {
+                Ok(Some(v)) => {
+                    merge(&mut merged, v.clone());
+                    merge(&mut overlay, v);
                 }
+                Ok(None) => {}
+                Err(e) => warnings.push(format!("ignoring invalid {}: {e}", path.display())),
             }
         }
 
@@ -227,6 +272,27 @@ fn merge(base: &mut toml::Value, overlay: toml::Value) {
             }
         }
         (slot, v) => *slot = v,
+    }
+}
+
+/// Validate a config document end-to-end — TOML syntax and the typed
+/// [`Config`] shape — returning the raw table (kept raw for later override
+/// merging) only when both pass. The typed pass is what turns e.g.
+/// `readonly = "yes"` into a precise "expected a boolean" error pointing at
+/// the offending line instead of silently loading defaults.
+fn validate(text: &str) -> Result<toml::Value, toml::de::Error> {
+    toml::from_str::<Config>(text)?;
+    parse_doc(text)
+}
+
+/// Human-readable state of one config file, for the `:config` view:
+/// `loaded` (present and parseable), `absent`, or `invalid` (present but
+/// malformed TOML — it is being skipped).
+pub fn file_state(path: &Path) -> &'static str {
+    match read_value(path) {
+        Ok(Some(_)) => "loaded",
+        Ok(None) => "absent",
+        Err(_) => "invalid — skipped",
     }
 }
 
@@ -430,6 +496,67 @@ mod tests {
         assert_eq!(bare.skin_override, None);
 
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn reload_swaps_base_and_rejects_invalid_with_precise_errors() {
+        let dir =
+            std::env::temp_dir().join(format!("sofka-cfg-reload-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+
+        std::fs::write(&path, "default_namespace = \"one\"\n").unwrap();
+        let loader = ConfigLoader::from_dir(Some(dir.clone()));
+        assert!(loader.has_base());
+        assert_eq!(loader.base_path(), Some(path.clone()));
+
+        // A valid edit on disk is picked up.
+        std::fs::write(&path, "default_namespace = \"two\"\n").unwrap();
+        let loader = loader.reload().unwrap();
+        let r = loader.resolve("", "");
+        assert_eq!(r.config.default_namespace.as_deref(), Some("two"));
+
+        // A type error is rejected, naming the file and the offending key.
+        std::fs::write(&path, "readonly = \"yes\"\n").unwrap();
+        let err = loader.reload().err().unwrap();
+        assert!(err.contains("config.toml"), "{err}");
+        assert!(err.contains("readonly"), "{err}");
+        assert!(err.contains("expected a boolean"), "{err}");
+
+        // Malformed TOML syntax is rejected too.
+        std::fs::write(&path, "not toml [[[").unwrap();
+        assert!(loader.reload().err().unwrap().contains("config.toml"));
+        assert_eq!(file_state(&path), "invalid — skipped");
+
+        // A missing base file reloads as defaults, never an error.
+        std::fs::remove_file(&path).unwrap();
+        let loader = loader.reload().unwrap();
+        assert!(!loader.has_base());
+        assert_eq!(file_state(&path), "absent");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn override_paths_follow_cluster_then_context() {
+        let dir = PathBuf::from("/tmp/sofka-nowhere");
+        let loader = ConfigLoader::from_dir(Some(dir.clone()));
+        assert_eq!(
+            loader.override_paths("prod-ctx", "prod-cluster"),
+            vec![
+                dir.join("clusters")
+                    .join("prod-cluster")
+                    .join("config.toml"),
+                dir.join("clusters")
+                    .join("prod-cluster")
+                    .join("prod-ctx")
+                    .join("config.toml"),
+            ]
+        );
+        // No cluster name (in-cluster) — no override levels at all.
+        assert!(loader.override_paths("ctx", "").is_empty());
+        // No context name — cluster level only.
+        assert_eq!(loader.override_paths("", "c1").len(), 1);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let loader = config::ConfigLoader::load();
+    let (loader, mut config_warnings) = config::ConfigLoader::load();
 
     // Connect before taking over the terminal so errors are readable. An
     // unreachable current context isn't fatal for the interactive TUI: start
@@ -88,6 +88,7 @@ async fn main() -> Result<()> {
     for w in &resolved.warnings {
         eprintln!("warning: {w}");
     }
+    config_warnings.extend(resolved.warnings.clone());
     let cfg = resolved.config;
     cluster.add_aliases(&cfg.aliases);
 
@@ -147,6 +148,10 @@ async fn main() -> Result<()> {
     app.skin_colors = cfg.skin.colors.clone();
     app.config = loader;
     app.session_skin = Some(session_skin);
+    app.active_skin = Some(initial_skin);
+    // Keep initial-load validation problems visible in-app (`:config`), not
+    // just on the stderr that the alternate screen is about to cover.
+    app.config_warnings = config_warnings;
     // CLI flags pin the mode for the whole session; otherwise config decides,
     // re-resolved per context on every `:ctx` switch.
     app.readonly_override = match (args.readonly, args.write) {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -283,6 +283,36 @@ pub fn resolve_skin(name: Option<&str>, colors: &HashMap<String, String>) -> Pal
     p
 }
 
+/// Check a skin selection without applying it: an unknown built-in name, an
+/// unknown swatch key under `[skin.colors]`, or a malformed hex value. One
+/// human-readable warning per problem (sorted for stable output), empty when
+/// the selection is clean — the validation half of [`resolve_skin`], for the
+/// `:reload`/`:config` report.
+pub fn validate_skin(name: Option<&str>, colors: &HashMap<String, String>) -> Vec<String> {
+    let mut warns = Vec::new();
+    if let Some(n) = name
+        && builtin(&n.trim().to_ascii_lowercase()).is_none()
+    {
+        warns.push(format!(
+            "skin.name: unknown skin '{n}' (known: {})",
+            BUILTIN_NAMES.join(", ")
+        ));
+    }
+    let mut probe = catppuccin_mocha();
+    for (k, v) in colors {
+        let key = k.trim().to_ascii_lowercase();
+        match parse_hex(v) {
+            Some(c) if probe.set(&key, c) => {}
+            Some(_) => warns.push(format!("skin.colors.{k}: unknown swatch name")),
+            None => warns.push(format!(
+                "skin.colors.{k}: invalid hex '{v}' (expected #rrggbb)"
+            )),
+        }
+    }
+    warns.sort();
+    warns
+}
+
 /// Parse `#rrggbb` (or `rrggbb`) into a `Color::Rgb`. Returns `None` for any
 /// other length or non-hex content.
 fn parse_hex(s: &str) -> Option<Color> {
@@ -581,6 +611,34 @@ mod tests {
         assert_eq!(mem_severity(100 * 1024 * 1024), None); // 100Mi
         assert_eq!(mem_severity(300 * 1024 * 1024), Some(peach())); // 300Mi
         assert_eq!(mem_severity(2048 * 1024 * 1024), Some(red())); // 2Gi
+    }
+
+    #[test]
+    fn validate_skin_reports_each_problem_and_passes_clean_config() {
+        let mut colors = HashMap::new();
+        colors.insert("red".to_string(), "#010203".to_string());
+        assert!(validate_skin(Some("gruvbox-dark"), &colors).is_empty());
+        assert!(validate_skin(None, &HashMap::new()).is_empty());
+
+        colors.insert("nope".to_string(), "#040506".to_string());
+        colors.insert("green".to_string(), "zzzzzz".to_string());
+        let warns = validate_skin(Some("no-such-skin"), &colors);
+        assert_eq!(warns.len(), 3);
+        assert!(
+            warns
+                .iter()
+                .any(|w| w.contains("skin.name") && w.contains("no-such-skin"))
+        );
+        assert!(
+            warns
+                .iter()
+                .any(|w| w.contains("skin.colors.nope") && w.contains("unknown swatch"))
+        );
+        assert!(
+            warns
+                .iter()
+                .any(|w| w.contains("skin.colors.green") && w.contains("invalid hex"))
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1441,6 +1441,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind(":pf", "view/stop background port-forwards"),
         bind(":skin", "switch color skin live"),
         bind(
+            ":reload · :config",
+            "reload config from disk · config sources + warnings",
+        ),
+        bind(
             "enter",
             "drill down (deploy→pods, pod→containers, ns→re-scope)",
         ),


### PR DESCRIPTION
## Summary

Implements the "Config reload and validation" item from the K9s parity backlog (Milestone 1 in `future.md`).

- **`:reload` palette command** — re-reads the configuration from disk and applies it live, without restarting the TUI: aliases (also registered on the cluster's resolve registry), plugins, skin + per-swatch `[skin.colors]` overrides, `skin.background` fill, and `readonly` mode. The `--readonly`/`--write` CLI pin still wins. Launch defaults (`default_namespace`/`default_resource`) are deliberately not re-applied so a reload never yanks the current view.
- **Validation before swap** — `ConfigLoader::reload()` validates the base `config.toml` end-to-end (TOML syntax *and* the typed `Config` shape) before anything is replaced. Errors are precise, naming the file, the offending key, and what's wrong (e.g. `…/config.toml: TOML parse error at line 1 … invalid type: string "yes", expected a boolean` for `readonly = "yes"`).
- **Last known-good retained** — a failed reload changes nothing: the previous loader, aliases, plugins, skin, and read-only mode all stay active, and the status bar says so (`config reload failed — previous config kept (:config for details)`).
- **`:config` view** — a document view listing every config source path with its state (loaded / absent / invalid), the active skin, read-only mode, alias/plugin counts, and the validation errors/warnings from the last (re)load. Initial-load and context-switch warnings are stored there too, so they stay visible after the alternate screen covers stderr. This doubles as groundwork for the roadmap's runtime-diagnostics view.
- **Skin validation** — new `theme::validate_skin()` reports an unknown skin name, unknown swatch keys, and malformed hex values as warnings on reload instead of only stderr noise; the reload flash summarizes the warning count.

### Decisions

- **File-watch auto reload was skipped on purpose**: it would add a `notify` dependency plus debounce/event-loop plumbing for little gain over an explicit `:reload`, and the backlog allows reactive *or* command-driven reload. Easy to layer on later.
- `ConfigLoader::load()` now returns the validation errors alongside the loader so `main` can hand them to the app; `from_dir` became test-only.

## Test plan

- [x] `just check` (fmt-check + clippy `-D warnings` + tests) — 163 passed
- [x] `reload_applies_config_changes_live` — `:reload` swaps aliases, read-only mode, and skin from disk
- [x] `failed_reload_keeps_last_known_good_config` — invalid config keeps the previous config and records an error naming file + key + problem, and a later good edit recovers
- [x] `reload_reports_skin_validation_warnings` — unknown skin / bad hex surface as warnings
- [x] `config_view_lists_sources_active_skin_and_warnings` — `:config` shows source paths, active skin, warnings; esc returns to the table
- [x] `reload_swaps_base_and_rejects_invalid_with_precise_errors`, `override_paths_follow_cluster_then_context` (config), `validate_skin_reports_each_problem_and_passes_clean_config` (theme)