### PR TITLE
feat: structured filter grammar with server-side label/field selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ Not a marketing number - these are specific, checkable design choices:
   custom resources. `esc` pops back.
 - **Command palette** (`:`) - fuzzy over the full resource catalog _and_
   built-in commands (`ctx`, `pulse`, `xray`, `diff`, `events`, `pf`) together, plus
-  fuzzy row **filtering** (`/`) with matched-character highlighting.
+  row **filtering** (`/`) with matched-character highlighting: fuzzy text,
+  `!text` inverse match, `-l`/`-f` label & field selectors (evaluated by the
+  API server on ⏎), and typed column comparisons (`status=CrashLoopBackOff`,
+  `cpu>500m`, `memory>1Gi`, `restarts>=5`, `age<2h`) — space-separated terms
+  AND together.
 - **Multiselect** (`space`) for bulk delete/kill/suspend/resume/reconcile.
 - **Pulse dashboard** (`:pulse`) - cluster-health tiles, refreshed every 5s.
 - **Xray tree** (`:xray`) - hierarchical view from the current kind down
@@ -283,7 +287,7 @@ header) and switching away restores write mode.
 | `j`/`k`, `↓`/`↑`, `g`/`G` | navigate                                                                                                                              |
 | `S` / `I`                 | cycle sort column / invert sort direction                                                                                             |
 | `space`                   | mark/unmark row for bulk actions                                                                                                      |
-| `/`                       | fuzzy filter                                                                                                                          |
+| `/`                       | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |
 | `n` / `0`                 | namespace switcher / all namespaces                                                                                                   |
 | `shift-j`                 | jump to owner/controller                                                                                                              |
 | `o`                       | show the node hosting the selected pod                                                                                                |

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -163,6 +163,17 @@ pub(super) fn container_names(obj: &DynamicObject) -> Vec<String> {
     names
 }
 
+/// Merge a drill-down selector with a filter selector into one comma-joined
+/// Kubernetes selector (`None` when neither is set).
+pub(super) fn join_selectors(a: &Option<String>, b: &Option<String>) -> Option<String> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(format!("{a},{b}")),
+        (Some(a), None) => Some(a.clone()),
+        (None, Some(b)) => Some(b.clone()),
+        (None, None) => None,
+    }
+}
+
 /// Normalize a user-typed namespace argument: `all`, `*`, and `<all>` mean
 /// "all namespaces" (the empty string internally).
 pub(super) fn normalize_ns(ns: &str) -> String {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -66,6 +66,9 @@ impl App {
                 } else if !self.filter.is_empty() {
                     self.filter.clear();
                     self.invalidate_rows();
+                    // Dropping the filter also drops its server-side
+                    // selectors, so the watch must widen back out.
+                    self.sync_filter_selectors();
                 } else if !self.pop_frame() {
                     // at root, nothing to pop
                 }
@@ -465,13 +468,24 @@ impl App {
         self.cmd_sel = 0;
     }
 
+    /// Type the row filter. Local terms (fuzzy/inverse/column comparisons)
+    /// apply live per keystroke; `-l`/`-f` selectors are sent to the API on
+    /// ⏎, since that restarts the watch (see `sync_filter_selectors`).
     pub(super) fn key_filter(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Esc => {
                 self.filter.clear();
                 self.mode = Mode::Table;
+                self.sync_filter_selectors();
             }
-            KeyCode::Enter => self.mode = Mode::Table,
+            KeyCode::Enter => {
+                self.mode = Mode::Table;
+                if let Some(err) = self.filter_error() {
+                    self.flash_warn(&format!("filter: {err}"));
+                } else {
+                    self.sync_filter_selectors();
+                }
+            }
             KeyCode::Backspace => {
                 self.filter.pop();
             }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -229,11 +229,23 @@ impl App {
         }
     }
 
-    /// (Re)start the watch for the current kind/namespace/selectors.
+    /// (Re)start the watch for the current kind/namespace/selectors. `-l`/
+    /// `-f` selectors from the filter are merged with any drill-down
+    /// selectors and sent to the API, so those filter terms are evaluated
+    /// server-side; the generation bump drops the superseded stream.
     pub fn start_watch(&mut self) {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        let (filter_labels, filter_fields) = {
+            let parsed = self.parsed_filter();
+            (
+                parsed.labels().map(str::to_string),
+                parsed.fields().map(str::to_string),
+            )
+        };
+        self.applied_filter_labels = filter_labels;
+        self.applied_filter_fields = filter_fields;
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -249,8 +261,8 @@ impl App {
         let handle = self.cluster.spawn_watch(
             &kind,
             &self.namespace,
-            self.labels.clone(),
-            self.fields.clone(),
+            join_selectors(&self.labels, &self.applied_filter_labels),
+            join_selectors(&self.fields, &self.applied_filter_fields),
             self.generation,
             self.tx.clone(),
         );
@@ -265,6 +277,30 @@ impl App {
             self.last_rbac_ns = Some(self.namespace.clone());
             self.refresh_rbac();
         }
+    }
+
+    /// Restart the watch when the filter's `-l`/`-f` selectors no longer
+    /// match what it was started with — applying them server-side, or
+    /// dropping them once cleared. No-op otherwise, so local-only filter
+    /// edits never cost a rewatch.
+    pub(super) fn sync_filter_selectors(&mut self) {
+        if !self.filter_selectors_pending() {
+            return;
+        }
+        self.start_watch();
+        if self.filter_server_side() {
+            let mut parts = Vec::new();
+            if let Some(l) = &self.applied_filter_labels {
+                parts.push(format!("-l {l}"));
+            }
+            if let Some(f) = &self.applied_filter_fields {
+                parts.push(format!("-f {f}"));
+            }
+            self.flash = format!("server-side filter: {}", parts.join(" "));
+        } else {
+            self.flash = "server-side filter cleared".into();
+        }
+        self.flash_err = false;
     }
 
     /// Query SelfSubjectRulesReview for the active namespace to learn which

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -417,6 +417,13 @@ impl SortKey {
     }
 }
 
+/// The active filter string alongside its parsed form, so the grammar is
+/// reparsed only when the string actually changes — never per frame or row.
+struct FilterCache {
+    raw: String,
+    parsed: crate::filter::ParsedFilter,
+}
+
 /// Lazily-rebuilt cache of the display-ordered, filtered row keys. Recomputing
 /// the sort + fuzzy filter on every `rows()` call (per frame, per keystroke) is
 /// wasteful on large clusters; we rebuild only when the store or filter changes.
@@ -506,6 +513,14 @@ pub struct App {
     pub sort_column: Option<usize>,
     pub sort_desc: bool,
     pub filter: String,
+    /// Parsed form of `filter`, refreshed lazily when the string changes so
+    /// neither row matching nor rendering reparses it per frame.
+    filter_cache: RefCell<FilterCache>,
+    /// Server-side selectors (`-l`/`-f` filter terms) the running watch was
+    /// started with. Compared against the parsed filter to know when a
+    /// restart is needed and to mark the filter as server-side in the UI.
+    applied_filter_labels: Option<String>,
+    applied_filter_fields: Option<String>,
     pub command: String,
     pub cmd_suggestions: Vec<Suggestion>,
     pub cmd_sel: usize,
@@ -635,6 +650,12 @@ impl App {
             sort_column: None,
             sort_desc: false,
             filter: String::new(),
+            filter_cache: RefCell::new(FilterCache {
+                raw: String::new(),
+                parsed: crate::filter::parse(""),
+            }),
+            applied_filter_labels: None,
+            applied_filter_fields: None,
             command: String::new(),
             cmd_suggestions: Vec::new(),
             cmd_sel: 0,

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -19,34 +19,126 @@ impl App {
         cache.cells.remove(key);
     }
 
-    /// Does this object pass the current fuzzy filter?
+    /// The parsed form of the active filter, reparsed only when the string
+    /// has changed (never per frame — see [`FilterCache`]).
+    pub(super) fn parsed_filter(&self) -> Ref<'_, crate::filter::ParsedFilter> {
+        if self.filter_cache.borrow().raw != self.filter {
+            let mut cache = self.filter_cache.borrow_mut();
+            cache.raw = self.filter.clone();
+            cache.parsed = crate::filter::parse(&self.filter);
+        }
+        Ref::map(self.filter_cache.borrow(), |c| &c.parsed)
+    }
+
+    /// Does this object pass the current filter — the legacy fuzzy pattern,
+    /// or every local term of a structured expression? `-l`/`-f` selectors
+    /// are not evaluated here: the Kubernetes API already applied them to
+    /// the watch (see [`Self::sync_filter_selectors`]).
     pub(super) fn matches_filter(&self, o: &DynamicObject) -> bool {
+        use crate::filter::{ParsedFilter, Term};
         if self.filter.is_empty() {
             return true;
         }
-        // Helm rows are backed by the storage Secret, whose own name
-        // (`sh.helm.release.v1.<release>.v<n>`) isn't what a user typing a
-        // filter means — match the release name instead.
+        let parsed = self.parsed_filter();
+        match &*parsed {
+            ParsedFilter::Fuzzy(pat) => {
+                pat.is_empty() || self.matcher.fuzzy_match(&self.fuzzy_hay(o), pat).is_some()
+            }
+            ParsedFilter::Structured(s) => s.terms.iter().all(|t| match t {
+                Term::Fuzzy(pat) => self.matcher.fuzzy_match(&self.fuzzy_hay(o), pat).is_some(),
+                Term::NotFuzzy(pat) => self.matcher.fuzzy_match(&self.fuzzy_hay(o), pat).is_none(),
+                Term::Cmp(cmp) => self.eval_cmp(o, cmp),
+            }),
+        }
+    }
+
+    /// What fuzzy terms match against: "namespace name". Helm rows are backed
+    /// by the storage Secret, whose own name (`sh.helm.release.v1.<release>.
+    /// v<n>`) isn't what a user typing a filter means — match the release
+    /// name instead.
+    fn fuzzy_hay(&self, o: &DynamicObject) -> String {
         let name = if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") {
             crate::helm::release_name(o).unwrap_or_default()
         } else {
             o.metadata.name.as_deref().unwrap_or("")
         };
-        let hay = format!("{} {}", o.metadata.namespace.as_deref().unwrap_or(""), name);
-        self.matcher.fuzzy_match(&hay, &self.filter).is_some()
+        format!("{} {}", o.metadata.namespace.as_deref().unwrap_or(""), name)
     }
 
-    /// Char indices in `name` that matched the active row filter, for
-    /// highlighting them in the table. `None` when there's no active filter
-    /// (every visible row already passed [`matches_filter`], so this is
-    /// purely a rendering aid, not a second filter decision).
+    /// Evaluate one typed column comparison against an object. `cpu`/`mem`
+    /// read the live metrics snapshot, `age` the creation timestamp; any
+    /// other key names a displayed column (numeric values compare by the
+    /// cell's leading number, text case-insensitively).
+    fn eval_cmp(&self, o: &DynamicObject, cmp: &crate::filter::Cmp) -> bool {
+        use crate::filter::CmpValue;
+        match &cmp.value {
+            CmpValue::Cpu(want) => cmp.op.eval(self.metrics_for(o).0.cmp(want)),
+            CmpValue::Mem(want) => cmp.op.eval(self.metrics_for(o).1.cmp(want)),
+            CmpValue::Duration(want) => match crate::columns::age_secs(o) {
+                Some(age) => cmp.op.eval(age.cmp(want)),
+                None => false,
+            },
+            CmpValue::Num(want) => match self.column_cell(o, &cmp.key) {
+                Some(cell) => cmp.op.eval(parse_leading_num(&cell).total_cmp(want)),
+                None => false,
+            },
+            CmpValue::Str(want) => match self.column_cell(o, &cmp.key) {
+                Some(cell) => cmp.op.eval(cell.to_lowercase().cmp(&want.to_lowercase())),
+                None => false,
+            },
+        }
+    }
+
+    /// The displayed cell a comparison key names (case-insensitive column
+    /// header), plus NAMESPACE and a `/status/phase` fallback for kinds
+    /// without a STATUS column.
+    fn column_cell(&self, o: &DynamicObject, key: &str) -> Option<String> {
+        if key.eq_ignore_ascii_case("namespace") || key.eq_ignore_ascii_case("ns") {
+            return Some(o.metadata.namespace.clone().unwrap_or_default());
+        }
+        let base = crate::columns::headers(&self.kind_plural);
+        if let Some(i) = base.iter().position(|h| h.eq_ignore_ascii_case(key)) {
+            let (cells, _) = crate::columns::cells(o, &self.kind_plural);
+            return cells.get(i).cloned();
+        }
+        if key.eq_ignore_ascii_case("status") {
+            let phase = phase(o);
+            return (!phase.is_empty()).then_some(phase);
+        }
+        None
+    }
+
+    /// Whether the running watch is scoped by `-l`/`-f` selectors from the
+    /// filter — i.e. the active filter is (partly) server-side.
+    pub fn filter_server_side(&self) -> bool {
+        self.applied_filter_labels.is_some() || self.applied_filter_fields.is_some()
+    }
+
+    /// Parse error of the current filter input, if any.
+    pub fn filter_error(&self) -> Option<String> {
+        self.parsed_filter().error().map(str::to_string)
+    }
+
+    /// True when the filter's `-l`/`-f` selectors differ from what the watch
+    /// was started with — ⏎ in the filter prompt applies them server-side.
+    pub fn filter_selectors_pending(&self) -> bool {
+        let parsed = self.parsed_filter();
+        parsed.labels() != self.applied_filter_labels.as_deref()
+            || parsed.fields() != self.applied_filter_fields.as_deref()
+    }
+
+    /// Char indices in `name` that matched the active row filter's fuzzy
+    /// pattern, for highlighting them in the table. `None` when there's no
+    /// active filter or no fuzzy term (every visible row already passed
+    /// [`matches_filter`], so this is purely a rendering aid, not a second
+    /// filter decision).
     pub fn filter_match_indices(&self, name: &str) -> Option<Vec<usize>> {
         if self.filter.is_empty() {
             return None;
         }
-        self.matcher
-            .fuzzy_indices(name, &self.filter)
-            .map(|(_, idx)| idx)
+        let parsed = self.parsed_filter();
+        let needle = parsed.fuzzy_needle()?;
+        self.matcher.fuzzy_indices(name, needle).map(|(_, idx)| idx)
     }
 
     pub(super) fn ensure_rows_cache(&self) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2352,3 +2352,323 @@ async fn x_outside_secrets_is_left_to_plugins() {
         "x must not open a decode view for pods"
     );
 }
+
+/// Type `/`, the filter text, then ⏎ — the way a user applies a filter.
+fn type_filter(app: &mut App, text: &str) {
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in text.chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+}
+
+fn row_names(app: &App) -> Vec<String> {
+    app.rows()
+        .iter()
+        .map(|o| o.metadata.name.clone().unwrap_or_default())
+        .collect()
+}
+
+#[tokio::test]
+async fn legacy_fuzzy_filter_with_spaces_is_one_pattern() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["alpha", "beta"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+    // "default alp" fuzzy-matches across the "namespace name" haystack —
+    // exactly the pre-grammar behavior (spaces are pattern chars, not ANDs).
+    type_filter(&mut app, "default alp");
+    assert_eq!(row_names(&app), ["alpha"]);
+    assert!(!app.filter_server_side());
+}
+
+#[tokio::test]
+async fn inverse_filter_hides_fuzzy_matches() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["api-1", "api-1-canary", "worker"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+    type_filter(&mut app, "!canary");
+    assert_eq!(row_names(&app), ["api-1", "worker"]);
+
+    // Terms AND together: positive fuzzy + inverse.
+    app.filter = "api !canary".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["api-1"]);
+}
+
+#[tokio::test]
+async fn status_filter_matches_status_column() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "crashy", "namespace": "default"},
+        "status": {"phase": "Running", "containerStatuses": [
+            {"ready": false, "restartCount": 3,
+             "state": {"waiting": {"reason": "CrashLoopBackOff"}}}
+        ]}}),
+    );
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "healthy", "namespace": "default"},
+        "status": {"phase": "Running", "containerStatuses": [
+            {"ready": true, "restartCount": 0, "state": {"running": {}}}
+        ]}}),
+    );
+
+    // Equality is case-insensitive so nobody has to remember CamelCase.
+    type_filter(&mut app, "status=crashloopbackoff");
+    assert_eq!(row_names(&app), ["crashy"]);
+
+    app.filter = "status!=CrashLoopBackOff".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["healthy"]);
+}
+
+#[tokio::test]
+async fn restarts_filter_compares_numerically() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for (name, restarts) in [("calm", 0), ("flappy", 7)] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": name, "namespace": "default"},
+            "status": {"phase": "Running", "containerStatuses": [
+                {"ready": true, "restartCount": restarts, "state": {"running": {}}}
+            ]}}),
+        );
+    }
+    type_filter(&mut app, "restarts>=5");
+    assert_eq!(row_names(&app), ["flappy"]);
+
+    app.filter = "restarts<5".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["calm"]);
+}
+
+#[tokio::test]
+async fn age_filter_compares_creation_timestamp() {
+    use k8s_openapi::jiff::Timestamp;
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let now = Timestamp::now().as_second();
+    for (name, age_secs) in [("old", 3 * 3600), ("fresh", 600)] {
+        let created = Timestamp::from_second(now - age_secs).unwrap().to_string();
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": name, "namespace": "default",
+                                "creationTimestamp": created}}),
+        );
+    }
+    type_filter(&mut app, "age<2h");
+    assert_eq!(row_names(&app), ["fresh"]);
+
+    app.filter = "age>2h".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["old"]);
+}
+
+#[tokio::test]
+async fn cpu_and_memory_filters_use_metrics_snapshot() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["hungry", "light"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+    let mut data = HashMap::new();
+    data.insert("default/hungry".to_string(), (600, 2 * 1024 * 1024 * 1024));
+    data.insert("default/light".to_string(), (100, 64 * 1024 * 1024));
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data,
+    });
+
+    type_filter(&mut app, "cpu>500m");
+    assert_eq!(row_names(&app), ["hungry"]);
+
+    app.filter = "memory>1Gi".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["hungry"]);
+
+    app.filter = "mem<=512Mi".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["light"]);
+}
+
+#[tokio::test]
+async fn label_selector_goes_server_side_on_enter_and_survives_navigation() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let before = app.generation;
+
+    type_filter(&mut app, "-l app=api,env=prod");
+    assert_eq!(
+        app.applied_filter_labels.as_deref(),
+        Some("app=api,env=prod")
+    );
+    assert!(app.filter_server_side());
+    assert_eq!(
+        app.generation,
+        before + 1,
+        "⏎ must restart the watch with the selector"
+    );
+    assert!(app.flash.contains("server-side"), "{}", app.flash);
+
+    // A refresh (ctrl-r) keeps the selector: it derives from the filter.
+    app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert_eq!(
+        app.applied_filter_labels.as_deref(),
+        Some("app=api,env=prod")
+    );
+
+    // Switching namespace with `0` keeps the filter — and the selector.
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    assert!(app.all_namespaces());
+    assert_eq!(
+        app.applied_filter_labels.as_deref(),
+        Some("app=api,env=prod")
+    );
+
+    // Esc clears the filter and widens the watch back out.
+    let gen_before_clear = app.generation;
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert!(app.filter.is_empty());
+    assert_eq!(app.applied_filter_labels, None);
+    assert!(!app.filter_server_side());
+    assert_eq!(app.generation, gen_before_clear + 1);
+}
+
+#[tokio::test]
+async fn field_selector_goes_server_side_on_enter() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    type_filter(&mut app, "-f spec.nodeName=node-3");
+    assert_eq!(
+        app.applied_filter_fields.as_deref(),
+        Some("spec.nodeName=node-3")
+    );
+    assert_eq!(app.applied_filter_labels, None);
+    assert!(app.filter_server_side());
+}
+
+#[tokio::test]
+async fn local_filter_edits_never_restart_the_watch() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let before = app.generation;
+    type_filter(&mut app, "api");
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.generation, before, "no `-l`/`-f` → no rewatch");
+    assert!(!app.filter_server_side());
+}
+
+#[tokio::test]
+async fn drill_clears_server_selector_and_pop_restores_it() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    type_filter(&mut app, "-l env=prod");
+    assert_eq!(app.applied_filter_labels.as_deref(), Some("env=prod"));
+
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "apps/v1", "kind": "Deployment",
+            "metadata": {"name": "web", "namespace": "default"},
+            "spec": {"selector": {"matchLabels": {"app": "web"}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+
+    // Drill: like the fuzzy filter, the filter (and with it the server-side
+    // selector) is cleared for the child view; the drill's own selector takes
+    // over.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert!(app.filter.is_empty());
+    assert_eq!(app.applied_filter_labels, None);
+    assert_eq!(app.labels.as_deref(), Some("app=web"));
+
+    // Pop: the saved frame restores the filter, and the rewatch re-applies
+    // its selector server-side.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    assert_eq!(app.filter, "-l env=prod");
+    assert_eq!(app.applied_filter_labels.as_deref(), Some("env=prod"));
+    assert_eq!(app.labels, None);
+}
+
+#[tokio::test]
+async fn root_switch_and_history_clear_server_selector_like_fuzzy() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    type_filter(&mut app, "-l app=api");
+    assert!(app.filter_server_side());
+
+    // A fresh root view clears the filter (fuzzy always worked this way) —
+    // and therefore the selector.
+    app.switch_kind("deployments");
+    assert!(app.filter.is_empty());
+    assert_eq!(app.applied_filter_labels, None);
+
+    // History replay lands on the root view without the old filter.
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert!(app.filter.is_empty());
+    assert_eq!(app.applied_filter_labels, None);
+}
+
+#[tokio::test]
+async fn malformed_filter_enter_warns_and_stays_local() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let before = app.generation;
+    type_filter(&mut app, "-l");
+    assert!(app.flash_err);
+    assert!(app.flash.contains("-l"), "{}", app.flash);
+    assert_eq!(app.generation, before, "broken selector must not rewatch");
+    assert!(!app.filter_server_side());
+    assert!(app.filter_error().is_some());
+}
+
+#[tokio::test]
+async fn structured_filter_highlights_first_fuzzy_term() {
+    let (mut app, _rx) = test_app();
+    app.filter = "!zzz khc status=Running".into();
+    let idx = app.filter_match_indices("kube-httpcache-0").unwrap();
+    assert_eq!(idx.len(), 3);
+
+    // No positive fuzzy term → nothing to highlight.
+    app.filter = "-l app=api".into();
+    assert_eq!(app.filter_match_indices("kube-httpcache-0"), None);
+}
+
+#[test]
+fn join_selectors_merges_drill_and_filter() {
+    let some = |s: &str| Some(s.to_string());
+    assert_eq!(join_selectors(&None, &None), None);
+    assert_eq!(join_selectors(&some("a=b"), &None), some("a=b"));
+    assert_eq!(join_selectors(&None, &some("c=d")), some("c=d"));
+    assert_eq!(join_selectors(&some("a=b"), &some("c=d")), some("a=b,c=d"));
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,604 @@
+//! Structured row-filter grammar.
+//!
+//! Plain text with no structured markers stays exactly what it always was:
+//! one fuzzy pattern over "namespace name". Once any structured marker
+//! appears, the input is split on whitespace and every term must match
+//! (terms are AND-ed; there is no OR/grouping — deliberately small):
+//!
+//! - `text`                   fuzzy match (namespace + name)
+//! - `!text`                  inverse fuzzy match
+//! - `-l app=api,env=prod`    Kubernetes label selector (sent server-side)
+//! - `-f spec.nodeName=n1`    Kubernetes field selector (sent server-side)
+//! - `status=CrashLoopBackOff` column equality (case-insensitive)
+//! - `cpu>500m` `memory>1Gi` `restarts>=5` `age<2h` typed comparisons
+//!
+//! Comparison operators: `=` (or `==`), `!=`, `>`, `>=`, `<`, `<=`. The
+//! value's type follows the key: `cpu` parses CPU quantities (millicores),
+//! `mem`/`memory` memory quantities (bytes), `age` durations (`90s`, `2h`,
+//! `1d2h`); any other key compares numerically when the value is a number
+//! and as case-insensitive text otherwise. Parsing never fails hard — a
+//! broken term is skipped and reported via [`Structured::error`] so the
+//! table doesn't blank out mid-keystroke.
+
+/// The parsed form of the filter input.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedFilter {
+    /// The whole input is one fuzzy pattern (no structured markers) — the
+    /// original `/text` behavior, kept byte-for-byte compatible.
+    Fuzzy(String),
+    Structured(Structured),
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Structured {
+    /// Locally-evaluated terms, AND-ed together.
+    pub terms: Vec<Term>,
+    /// Combined `-l` selectors, ready for the Kubernetes API.
+    pub labels: Option<String>,
+    /// Combined `-f` selectors, ready for the Kubernetes API.
+    pub fields: Option<String>,
+    /// First malformed term, for surfacing in the UI.
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Term {
+    Fuzzy(String),
+    NotFuzzy(String),
+    Cmp(Cmp),
+}
+
+/// One `key<op>value` column comparison.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cmp {
+    /// Lowercased column key (`status`, `cpu`, `restarts`, …).
+    pub key: String,
+    pub op: Op,
+    pub value: CmpValue,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Op {
+    Eq,
+    Ne,
+    Gt,
+    Ge,
+    Lt,
+    Le,
+}
+
+impl Op {
+    /// Apply the operator to an already-computed `actual.cmp(&wanted)`.
+    pub fn eval(self, ord: std::cmp::Ordering) -> bool {
+        use std::cmp::Ordering::*;
+        match self {
+            Op::Eq => ord == Equal,
+            Op::Ne => ord != Equal,
+            Op::Gt => ord == Greater,
+            Op::Ge => ord != Less,
+            Op::Lt => ord == Less,
+            Op::Le => ord != Greater,
+        }
+    }
+}
+
+/// A comparison value, typed at parse time from the key it belongs to.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CmpValue {
+    /// Plain number (`restarts>=5`).
+    Num(f64),
+    /// CPU quantity in millicores (`cpu>500m`).
+    Cpu(i64),
+    /// Memory quantity in bytes (`memory>1Gi`).
+    Mem(i64),
+    /// Duration in seconds (`age<2h`).
+    Duration(i64),
+    /// Anything else: case-insensitive text comparison.
+    Str(String),
+}
+
+impl ParsedFilter {
+    pub fn labels(&self) -> Option<&str> {
+        match self {
+            ParsedFilter::Fuzzy(_) => None,
+            ParsedFilter::Structured(s) => s.labels.as_deref(),
+        }
+    }
+
+    pub fn fields(&self) -> Option<&str> {
+        match self {
+            ParsedFilter::Fuzzy(_) => None,
+            ParsedFilter::Structured(s) => s.fields.as_deref(),
+        }
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        match self {
+            ParsedFilter::Fuzzy(_) => None,
+            ParsedFilter::Structured(s) => s.error.as_deref(),
+        }
+    }
+
+    /// The pattern NAME-cell highlighting should mark: the legacy fuzzy
+    /// pattern, or the first positive fuzzy term of a structured filter.
+    pub fn fuzzy_needle(&self) -> Option<&str> {
+        match self {
+            ParsedFilter::Fuzzy(pat) => (!pat.is_empty()).then_some(pat.as_str()),
+            ParsedFilter::Structured(s) => s.terms.iter().find_map(|t| match t {
+                Term::Fuzzy(pat) => Some(pat.as_str()),
+                _ => None,
+            }),
+        }
+    }
+}
+
+pub fn parse(input: &str) -> ParsedFilter {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || !is_structured(trimmed) {
+        return ParsedFilter::Fuzzy(trimmed.to_string());
+    }
+
+    let mut terms = Vec::new();
+    let mut labels: Vec<&str> = Vec::new();
+    let mut fields: Vec<&str> = Vec::new();
+    let mut error: Option<String> = None;
+    let fail = |slot: &mut Option<String>, msg: String| {
+        if slot.is_none() {
+            *slot = Some(msg);
+        }
+    };
+
+    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    let mut i = 0;
+    while i < tokens.len() {
+        let tok = tokens[i];
+        i += 1;
+        // `-l <sel>` / `-f <sel>`, or attached (`-lapp=api`).
+        if tok == "-l" || tok == "-f" {
+            match tokens.get(i) {
+                Some(sel) => {
+                    if tok == "-l" {
+                        &mut labels
+                    } else {
+                        &mut fields
+                    }
+                    .push(sel);
+                    i += 1;
+                }
+                None => fail(&mut error, format!("expected selector after {tok}")),
+            }
+            continue;
+        }
+        if let Some(sel) = attached_selector(tok, "-l") {
+            labels.push(sel);
+            continue;
+        }
+        if let Some(sel) = attached_selector(tok, "-f") {
+            fields.push(sel);
+            continue;
+        }
+        if let Some((key, op, value)) = split_cmp(tok) {
+            if value.is_empty() {
+                fail(&mut error, format!("missing value in '{tok}'"));
+                continue;
+            }
+            match typed_value(key, value) {
+                Ok(v) => terms.push(Term::Cmp(Cmp {
+                    key: key.to_ascii_lowercase(),
+                    op,
+                    value: v,
+                })),
+                Err(e) => fail(&mut error, e),
+            }
+            continue;
+        }
+        if let Some(pat) = tok.strip_prefix('!') {
+            if pat.is_empty() {
+                fail(&mut error, "expected text after '!'".into());
+            } else {
+                terms.push(Term::NotFuzzy(pat.to_string()));
+            }
+            continue;
+        }
+        terms.push(Term::Fuzzy(tok.to_string()));
+    }
+
+    ParsedFilter::Structured(Structured {
+        terms,
+        labels: (!labels.is_empty()).then(|| labels.join(",")),
+        fields: (!fields.is_empty()).then(|| fields.join(",")),
+        error,
+    })
+}
+
+/// Whether any token flips the input from a single legacy fuzzy pattern into
+/// the structured grammar. Mirrors the markers `parse` acts on.
+fn is_structured(input: &str) -> bool {
+    input.split_whitespace().any(|tok| {
+        tok == "-l"
+            || tok == "-f"
+            || attached_selector(tok, "-l").is_some()
+            || attached_selector(tok, "-f").is_some()
+            || tok.starts_with('!')
+            || split_cmp(tok).is_some()
+    })
+}
+
+/// The selector of an attached `-l`/`-f` form (`-lapp=api`). Requires an `=`
+/// so ordinary fuzzy text starting with those letters isn't swallowed.
+fn attached_selector<'a>(tok: &'a str, flag: &str) -> Option<&'a str> {
+    tok.strip_prefix(flag).filter(|rest| rest.contains('='))
+}
+
+/// Split `key<op>value` at the operator following a valid key. `None` when
+/// the token has no operator or no leading key — i.e. plain fuzzy text.
+fn split_cmp(tok: &str) -> Option<(&str, Op, &str)> {
+    if !tok
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return None;
+    }
+    let key_end = tok.find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '-'))?;
+    let (key, rest) = tok.split_at(key_end);
+    let (op, value) = if let Some(v) = rest.strip_prefix("!=") {
+        (Op::Ne, v)
+    } else if let Some(v) = rest.strip_prefix(">=") {
+        (Op::Ge, v)
+    } else if let Some(v) = rest.strip_prefix("<=") {
+        (Op::Le, v)
+    } else if let Some(v) = rest.strip_prefix("==") {
+        (Op::Eq, v)
+    } else if let Some(v) = rest.strip_prefix('=') {
+        (Op::Eq, v)
+    } else if let Some(v) = rest.strip_prefix('>') {
+        (Op::Gt, v)
+    } else if let Some(v) = rest.strip_prefix('<') {
+        (Op::Lt, v)
+    } else {
+        return None;
+    };
+    Some((key, op, value))
+}
+
+/// Type a comparison value from its key: quantities for `cpu`/`mem`/`memory`,
+/// durations for `age`, and number-or-text for everything else.
+fn typed_value(key: &str, raw: &str) -> Result<CmpValue, String> {
+    match key.to_ascii_lowercase().as_str() {
+        "cpu" => parse_cpu(raw)
+            .map(CmpValue::Cpu)
+            .ok_or_else(|| format!("bad cpu quantity '{raw}'")),
+        "mem" | "memory" => parse_mem(raw)
+            .map(CmpValue::Mem)
+            .ok_or_else(|| format!("bad memory quantity '{raw}'")),
+        "age" => parse_duration(raw)
+            .map(CmpValue::Duration)
+            .ok_or_else(|| format!("bad duration '{raw}'")),
+        _ => Ok(raw
+            .parse::<f64>()
+            .map(CmpValue::Num)
+            .unwrap_or_else(|_| CmpValue::Str(raw.to_string()))),
+    }
+}
+
+/// CPU quantity → millicores: `250m` → 250, `1` → 1000, `500000000n` → 500.
+/// Unlike [`crate::columns::parse_cpu_milli`] this rejects garbage instead of
+/// defaulting to 0, so a typo can be reported.
+fn parse_cpu(s: &str) -> Option<i64> {
+    let s = s.trim();
+    let (num, scale) = match s.chars().last()? {
+        'n' => (&s[..s.len() - 1], 1.0 / 1_000_000.0),
+        'u' => (&s[..s.len() - 1], 1.0 / 1_000.0),
+        'm' => (&s[..s.len() - 1], 1.0),
+        _ => (s, 1000.0),
+    };
+    let v: f64 = num.parse().ok()?;
+    (v >= 0.0).then(|| (v * scale).round() as i64)
+}
+
+/// Memory quantity → bytes: `1Gi`, `512Mi`, `2000000`. Validating twin of
+/// [`crate::columns::parse_mem_bytes`].
+fn parse_mem(s: &str) -> Option<i64> {
+    let s = s.trim();
+    let suffixes: &[(&str, f64)] = &[
+        ("Ki", 1024.0),
+        ("Mi", 1024.0 * 1024.0),
+        ("Gi", 1024.0 * 1024.0 * 1024.0),
+        ("Ti", 1024.0f64.powi(4)),
+        ("K", 1e3),
+        ("M", 1e6),
+        ("G", 1e9),
+        ("T", 1e12),
+    ];
+    for (suf, mult) in suffixes {
+        if let Some(num) = s.strip_suffix(suf) {
+            let v: f64 = num.trim().parse().ok()?;
+            return (v >= 0.0).then(|| (v * mult) as i64);
+        }
+    }
+    let v: f64 = s.parse().ok()?;
+    (v >= 0.0).then_some(v as i64)
+}
+
+/// Duration → seconds: `90s`, `2h`, `1d2h`, `1h30m`, bare `300` (seconds).
+/// Units: s, m, h, d, w.
+fn parse_duration(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Ok(v) = s.parse::<i64>() {
+        return (v >= 0).then_some(v);
+    }
+    let mut total = 0i64;
+    let mut num = String::new();
+    for c in s.chars() {
+        if c.is_ascii_digit() {
+            num.push(c);
+            continue;
+        }
+        let unit = match c {
+            's' => 1,
+            'm' => 60,
+            'h' => 3_600,
+            'd' => 86_400,
+            'w' => 604_800,
+            _ => return None,
+        };
+        if num.is_empty() {
+            return None;
+        }
+        total += num.parse::<i64>().ok()? * unit;
+        num.clear();
+    }
+    // Trailing digits without a unit (`2h30`) are malformed.
+    num.is_empty().then_some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn structured(input: &str) -> Structured {
+        match parse(input) {
+            ParsedFilter::Structured(s) => s,
+            other => panic!("expected structured parse for '{input}', got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plain_text_stays_one_legacy_fuzzy_pattern() {
+        assert_eq!(parse(""), ParsedFilter::Fuzzy(String::new()));
+        assert_eq!(parse("api"), ParsedFilter::Fuzzy("api".into()));
+        // Spaces included: the whole string is the pattern, as before.
+        assert_eq!(
+            parse("kube system dns"),
+            ParsedFilter::Fuzzy("kube system dns".into())
+        );
+        // Leading/trailing whitespace is not part of the pattern.
+        assert_eq!(parse("  api "), ParsedFilter::Fuzzy("api".into()));
+        // A lone dash or dashed name is still fuzzy text, not a flag.
+        assert_eq!(parse("-longname"), ParsedFilter::Fuzzy("-longname".into()));
+    }
+
+    #[test]
+    fn inverse_term() {
+        let s = structured("!canary");
+        assert_eq!(s.terms, vec![Term::NotFuzzy("canary".into())]);
+        assert_eq!(s.error, None);
+    }
+
+    #[test]
+    fn label_selector_variants() {
+        let s = structured("-l app=api,env=prod");
+        assert_eq!(s.labels.as_deref(), Some("app=api,env=prod"));
+        assert!(s.terms.is_empty());
+        assert_eq!(s.error, None);
+
+        // Attached form and repeated flags joining with a comma.
+        let s = structured("-lapp=api -l env=prod");
+        assert_eq!(s.labels.as_deref(), Some("app=api,env=prod"));
+
+        // Bare-key (existence) selectors work in the spaced form.
+        let s = structured("-l app");
+        assert_eq!(s.labels.as_deref(), Some("app"));
+    }
+
+    #[test]
+    fn field_selector() {
+        let s = structured("-f spec.nodeName=node-3");
+        assert_eq!(s.fields.as_deref(), Some("spec.nodeName=node-3"));
+        assert_eq!(s.labels, None);
+        assert!(s.terms.is_empty());
+    }
+
+    #[test]
+    fn status_equality_and_inequality() {
+        let s = structured("status=CrashLoopBackOff");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "status".into(),
+                op: Op::Eq,
+                value: CmpValue::Str("CrashLoopBackOff".into()),
+            })]
+        );
+
+        let s = structured("status!=Running");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "status".into(),
+                op: Op::Ne,
+                value: CmpValue::Str("Running".into()),
+            })]
+        );
+    }
+
+    #[test]
+    fn typed_quantity_comparisons() {
+        let s = structured("cpu>500m");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "cpu".into(),
+                op: Op::Gt,
+                value: CmpValue::Cpu(500),
+            })]
+        );
+
+        let s = structured("cpu>=1");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "cpu".into(),
+                op: Op::Ge,
+                value: CmpValue::Cpu(1000),
+            })]
+        );
+
+        let s = structured("memory>1Gi");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "memory".into(),
+                op: Op::Gt,
+                value: CmpValue::Mem(1024 * 1024 * 1024),
+            })]
+        );
+
+        let s = structured("mem<=512Mi");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "mem".into(),
+                op: Op::Le,
+                value: CmpValue::Mem(512 * 1024 * 1024),
+            })]
+        );
+
+        let s = structured("restarts>=5");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "restarts".into(),
+                op: Op::Ge,
+                value: CmpValue::Num(5.0),
+            })]
+        );
+    }
+
+    #[test]
+    fn age_durations() {
+        let s = structured("age<2h");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "age".into(),
+                op: Op::Lt,
+                value: CmpValue::Duration(7_200),
+            })]
+        );
+
+        let s = structured("age>1d2h");
+        assert_eq!(
+            s.terms,
+            vec![Term::Cmp(Cmp {
+                key: "age".into(),
+                op: Op::Gt,
+                value: CmpValue::Duration(93_600),
+            })]
+        );
+    }
+
+    #[test]
+    fn duration_parsing() {
+        assert_eq!(parse_duration("90s"), Some(90));
+        assert_eq!(parse_duration("2h"), Some(7_200));
+        assert_eq!(parse_duration("1h30m"), Some(5_400));
+        assert_eq!(parse_duration("1w"), Some(604_800));
+        assert_eq!(parse_duration("300"), Some(300));
+        assert_eq!(parse_duration("2h30"), None); // trailing digits, no unit
+        assert_eq!(parse_duration("xyz"), None);
+        assert_eq!(parse_duration(""), None);
+    }
+
+    #[test]
+    fn quantity_parsing() {
+        assert_eq!(parse_cpu("250m"), Some(250));
+        assert_eq!(parse_cpu("1"), Some(1_000));
+        assert_eq!(parse_cpu("1.5"), Some(1_500));
+        assert_eq!(parse_cpu("500000000n"), Some(500));
+        assert_eq!(parse_cpu("abc"), None);
+        assert_eq!(parse_mem("1Ki"), Some(1_024));
+        assert_eq!(parse_mem("512Mi"), Some(512 * 1024 * 1024));
+        assert_eq!(parse_mem("2000000"), Some(2_000_000));
+        assert_eq!(parse_mem("1Xi"), None);
+    }
+
+    #[test]
+    fn terms_combine_with_and_semantics() {
+        let s = structured("api !canary -l app=api status=Running");
+        assert_eq!(s.labels.as_deref(), Some("app=api"));
+        assert_eq!(s.error, None);
+        assert_eq!(
+            s.terms,
+            vec![
+                Term::Fuzzy("api".into()),
+                Term::NotFuzzy("canary".into()),
+                Term::Cmp(Cmp {
+                    key: "status".into(),
+                    op: Op::Eq,
+                    value: CmpValue::Str("Running".into()),
+                }),
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_terms_report_without_blanking() {
+        // Mid-typing states must degrade to "term skipped + error", never a
+        // hard failure.
+        let s = structured("-l");
+        assert_eq!(s.labels, None);
+        assert!(s.error.as_deref().is_some_and(|e| e.contains("-l")));
+
+        let s = structured("cpu>");
+        assert!(s.terms.is_empty());
+        assert!(s.error.as_deref().is_some_and(|e| e.contains("cpu>")));
+
+        let s = structured("cpu>abc");
+        assert!(s.terms.is_empty());
+        assert!(s.error.as_deref().is_some_and(|e| e.contains("abc")));
+
+        let s = structured("age<soon");
+        assert!(s.error.as_deref().is_some_and(|e| e.contains("soon")));
+
+        let s = structured("! api");
+        assert_eq!(s.terms, vec![Term::Fuzzy("api".into())]);
+        assert!(s.error.is_some());
+    }
+
+    #[test]
+    fn fuzzy_needle_prefers_first_positive_term() {
+        assert_eq!(parse("khc").fuzzy_needle(), Some("khc"));
+        assert_eq!(parse("").fuzzy_needle(), None);
+        assert_eq!(parse("!x khc status=Running").fuzzy_needle(), Some("khc"));
+        assert_eq!(parse("-l app=api").fuzzy_needle(), None);
+    }
+
+    #[test]
+    fn server_side_selectors_only_from_l_and_f() {
+        for local in ["api", "status=Running", "!x cpu>1"] {
+            let p = parse(local);
+            assert_eq!(p.labels(), None, "{local}");
+            assert_eq!(p.fields(), None, "{local}");
+        }
+        assert_eq!(parse("-l app=api").labels(), Some("app=api"));
+        assert_eq!(
+            parse("-f spec.nodeName=n1").fields(),
+            Some("spec.nodeName=n1")
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod app;
 mod columns;
 mod config;
+mod filter;
 mod helm;
 mod k8s;
 mod store;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -543,6 +543,25 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             Style::default().fg(theme::mark()),
         ));
     }
+    // Keep the active filter visible after leaving the `/` prompt (esc
+    // clears it, `/` re-opens it for editing), and say whether the API or
+    // this process is doing the filtering. Malformed input turns red.
+    if !app.filter.is_empty() {
+        let style = if app.filter_error().is_some() {
+            Style::default().fg(theme::red())
+        } else {
+            Style::default().fg(theme::teal())
+        };
+        title.push(Span::styled(format!(" /{}", app.filter), style));
+        title.push(Span::styled(
+            if app.filter_server_side() {
+                " ·server"
+            } else {
+                " ·local"
+            },
+            theme::dim(),
+        ));
+    }
     title.push(Span::raw(" "));
 
     let mut render_state = ratatui::widgets::TableState::default();
@@ -1449,7 +1468,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("esc", "go back / pop view / clear filter"),
         bind("j/k g/G", "move · top/bottom"),
         bind("S · I", "sort by column (cycle) · invert direction"),
-        bind("/", "fuzzy filter"),
+        bind(
+            "/",
+            "filter: fuzzy · !inverse · -l/-f selectors (server-side on ⏎) · col=val cpu>500m age<2h",
+        ),
         bind("n · 0-9", "namespace switcher · 0 = all namespaces"),
         bind("ctrl-r", "refresh watch"),
         Line::from(""),
@@ -1988,16 +2010,35 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(app.command.clone(), Style::default().fg(theme::text())),
             Span::styled("█", Style::default().fg(theme::mauve())),
         ]),
-        Mode::Filter => Line::from(vec![
-            Span::styled(
-                "/",
-                Style::default()
-                    .fg(theme::teal())
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(app.filter.clone(), Style::default().fg(theme::text())),
-            Span::styled("█", Style::default().fg(theme::teal())),
-        ]),
+        Mode::Filter => {
+            let mut spans = vec![
+                Span::styled(
+                    "/",
+                    Style::default()
+                        .fg(theme::teal())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(app.filter.clone(), Style::default().fg(theme::text())),
+                Span::styled("█", Style::default().fg(theme::teal())),
+            ];
+            // Structured-grammar feedback: a parse error, a `-l`/`-f`
+            // selector waiting for ⏎ to restart the watch server-side, or
+            // confirmation that the watch is already selector-scoped.
+            if let Some(err) = app.filter_error() {
+                spans.push(Span::styled(
+                    format!("  ✗ {err}"),
+                    Style::default().fg(theme::red()),
+                ));
+            } else if app.filter_selectors_pending() {
+                spans.push(Span::styled(
+                    "  ⏎ apply server-side",
+                    Style::default().fg(theme::yellow()),
+                ));
+            } else if app.filter_server_side() {
+                spans.push(Span::styled("  ·server", theme::dim()));
+            }
+            Line::from(spans)
+        }
         Mode::LogFilter => Line::from(vec![
             Span::styled(
                 "log search /",


### PR DESCRIPTION
## Summary

Implements the structured-filter half of the P0 "structured filtering and selectors" roadmap item (Milestone 1: structured filter parser + server-side label/field selectors), while keeping the existing fuzzy filter untouched as the fast default.

### Grammar (`src/filter.rs`)

Plain text with no structured markers stays exactly what it always was: one fuzzy pattern over "namespace name" (spaces included). Once any structured marker appears, whitespace-separated terms are AND-ed together (deliberately small grammar — no OR/grouping):

| Term | Meaning |
|---|---|
| `text` | fuzzy match (namespace + name) |
| `!text` | inverse fuzzy match |
| `-l app=api,env=prod` | Kubernetes label selector — sent to the API server |
| `-f spec.nodeName=node-3` | field selector — sent to the API server |
| `status=CrashLoopBackOff` | column equality (case-insensitive; any displayed column header works) |
| `cpu>500m` `memory>1Gi` `restarts>=5` `age<2h` | typed comparisons — CPU quantities in millicores, memory quantities in bytes, durations (`90s`, `2h`, `1d2h`), plain numbers via the cell's leading number |

Operators: `=`/`==`, `!=`, `>`, `>=`, `<`, `<=`. Parsing never fails hard: a malformed term is skipped and its error surfaced in the UI, so the table doesn't blank out mid-keystroke.

### Server-side selectors

- `-l`/`-f` terms are merged with any drill-down selectors and passed to the watch (`watcher::Config` labels/fields), so the API server does the filtering instead of the client downloading everything. Applied on ⏎ in the filter prompt (a rewatch per keystroke would thrash); the prompt shows a "⏎ apply server-side" hint while pending.
- Watch restarts reuse the existing generation-tag mechanism, so superseded streams are dropped.
- The selectors derive from the filter string, so they **survive refreshes (`ctrl-r`) and namespace changes (`0`)** automatically, and are **restored when popping a drill frame**. They are cleared — together with the rest of the filter, matching how the fuzzy filter has always behaved — on root switches, drill-down, and `[`/`]` history navigation.

### UI

- The table title keeps the active filter visible (`pods [12] /cpu>500m ·local`) with a `·server`/`·local` marker; malformed input renders red. `esc` clears it, `/` re-opens it for editing (existing behavior, now with the text always visible).
- The filter prompt surfaces parse errors inline and confirms when the watch is selector-scoped; applying/clearing a server-side selector flashes in the status bar.

### Performance

- The parsed filter is cached beside the raw string and only reparsed when the string changes — never per frame or per row. The legacy fuzzy path and the dirty-flag-guarded row cache are unchanged.

## Test plan

- [x] Parser unit tests in `src/filter.rs`: legacy fuzzy pass-through (incl. spaces), inverse, label/field selector variants, status equality/inequality, CPU/memory/number comparisons, duration parsing (`90s`/`2h`/`1d2h`), malformed-term error reporting, fuzzy-needle selection
- [x] Behavior tests in `src/app/tests.rs`: inverse/status/restarts/age/cpu/memory filters against injected rows and metrics; `-l`/`-f` applying server-side on ⏎ (generation bump) and surviving refresh + namespace change; drill clearing and pop restoring the selector; root switch/history clearing it like the fuzzy filter; malformed input warning without a rewatch; local edits never restarting the watch
- [x] `just check` (fmt-check + clippy `-D warnings` + 182 tests) passes