### PR TITLE
feat: user-configurable views with custom columns and CRD printer-column fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Not a marketing number - these are specific, checkable design choices:
   statefulsets, daemonsets, services, nodes, namespaces, configmaps, secrets,
   jobs, cronjobs, PVC/PV, ingresses, endpoints, CustomResourceDefinitions)
   with a NAME/AGE fallback for everything else.
+- **Custom views** - user-defined columns for any resource in config
+  (`[views]`), extracted via JSON Pointer with typed sorting (quantities,
+  numbers, timestamps sort by value). Unknown custom resources automatically
+  pick up their CRD's `additionalPrinterColumns`. `w` toggles wide-only
+  columns (kubectl `-o wide`).
 - **Live CPU/MEM columns** for pods and nodes from the metrics API, with
   outlier coloring; degrades gracefully when metrics-server is absent.
 - **Drill-down navigation** with a breadcrumb stack: workload/service →
@@ -134,7 +139,8 @@ Not a marketing number - these are specific, checkable design choices:
 - **Skinnable** - built-in Catppuccin, Gruvbox, Solarized, Nord, Dracula,
   Tokyo Night, One Dark, Rosé Pine, and Monokai palettes, auto-detected
   dark/light default, plus per-swatch overrides in config.
-- **Config file** (TOML): aliases, default namespace/resource, plugins, skin.
+- **Config file** (TOML): aliases, default namespace/resource, plugins,
+  views, skin.
 
 ## Installation
 
@@ -205,6 +211,48 @@ command = "argocd"
 args = ["app", "sync", "$NAME"]
 scopes = ["deployments"]   # omit for all resources
 ```
+
+### Custom views
+
+Define table columns for any resource — most usefully for custom resources
+that would otherwise fall back to NAME/AGE. Views are keyed by
+apiVersion/plural (`"cert-manager.io/v1/certificates"`, `"v1/pods"`),
+group/plural, bare plural, or lowercased kind; the most specific key wins.
+
+```toml
+[views."cert-manager.io/v1/certificates"]
+sort = "EXPIRES:desc"     # initial sort column, ":asc" (default) or ":desc"
+# replace = true          # replace the curated columns instead of overlaying
+
+[[views."cert-manager.io/v1/certificates".columns]]
+name = "READY"
+path = "/status/conditions/0/status"
+type = "status"           # colors the row like other status columns
+
+[[views."cert-manager.io/v1/certificates".columns]]
+name = "EXPIRES"
+path = "/status/notAfter"
+type = "time"             # rendered as elapsed ("3d4h") / "in 30d"
+
+[[views."cert-manager.io/v1/certificates".columns]]
+name = "ISSUER"
+path = "/spec/issuerRef/name"
+wide = true               # only shown in wide mode (`w`)
+```
+
+`path` is a JSON Pointer (RFC 6901) into the object as served by the API —
+`/metadata/…`, `/spec/…`, `/status/…`, array indices like
+`/status/conditions/0/status`. Column `type` is `text` (default), `status`,
+`number`, `quantity` (`500m`, `1Gi`), or `time`; typed columns sort by value,
+not lexically. Optional `width` (fixed columns) and `align`
+(`left`/`center`/`right`) tune the layout. By default columns overlay the
+curated ones: a matching header replaces it in place, new columns land before
+AGE. Invalid entries are skipped with a warning shown in-app — they never
+take the TUI down.
+
+Custom resources without an explicit view automatically use their CRD's
+`additionalPrinterColumns` (columns with `priority > 0` become wide-only),
+so most CRs get useful columns with zero configuration.
 
 ### Per-cluster / per-context overrides
 

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -202,32 +202,6 @@ impl App {
     }
 }
 
-/// Columns whose cell is a count/number and should sort numerically.
-pub(super) fn is_numeric_header(header: &str) -> bool {
-    matches!(
-        header,
-        "READY"
-            | "RESTARTS"
-            | "DATA"
-            | "ACTIVE"
-            | "DESIRED"
-            | "CURRENT"
-            | "AVAILABLE"
-            | "UP-TO-DATE"
-            | "COMPLETIONS"
-            | "ENDPOINTS"
-    )
-}
-
-/// Parse the leading number of a cell (`"3"`, `"1/2"` → 1, `"<none>"` → 0).
-pub(super) fn parse_leading_num(s: &str) -> f64 {
-    let t = s.trim_start_matches(|c: char| !c.is_ascii_digit() && c != '-');
-    let end = t
-        .find(|c: char| !c.is_ascii_digit() && c != '-')
-        .unwrap_or(t.len());
-    t[..end].parse::<f64>().unwrap_or(0.0)
-}
-
 /// Move a list selection one step, clamped to `[0, len)`. Shared by every
 /// modal picker (namespaces, contexts, containers, set-image, xray).
 pub(super) fn list_step(state: &mut ListState, len: usize, down: bool) {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -116,6 +116,8 @@ impl App {
             // Sorting: S cycles the column, I inverts the direction.
             KeyCode::Char('S') => self.cycle_sort(),
             KeyCode::Char('I') => self.toggle_sort_dir(),
+            // Wide mode: show wide-only columns (kubectl `-o wide`).
+            KeyCode::Char('w') => self.toggle_wide(),
             // `f`/Shift-F = port-forward.
             KeyCode::Char('f') | KeyCode::Char('F') => self.request_port_forward(),
             KeyCode::Char('n') => self.open_namespaces(),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -246,6 +246,9 @@ impl App {
         if self.table_state.selected().is_none() {
             self.table_state.select(Some(0));
         }
+        self.refresh_view_spec();
+        self.apply_view_sort();
+        self.maybe_fetch_printer_columns(&kind);
         let handle = self.cluster.spawn_watch(
             &kind,
             &self.namespace,
@@ -265,6 +268,49 @@ impl App {
             self.last_rbac_ns = Some(self.namespace.clone());
             self.refresh_rbac();
         }
+    }
+
+    /// For a custom resource with neither curated columns nor a user view,
+    /// fetch its CRD off-thread and read `additionalPrinterColumns` for the
+    /// watched version — a better automatic fallback than NAME/AGE. Results
+    /// (including "nothing usable") are cached per plural for the session.
+    fn maybe_fetch_printer_columns(&mut self, kind: &Kind) {
+        let user_has_columns = self
+            .active_user_view()
+            .is_some_and(|v| !v.columns.is_empty());
+        if crate::columns::has_curated(&self.kind_plural)
+            || kind.ar.group.is_empty()
+            || kind.ar.plural.to_lowercase() != self.kind_plural
+            || self.crd_views.contains_key(&self.kind_plural)
+            || user_has_columns
+        {
+            return;
+        }
+        let Some(crd_kind) = self.cluster.resolve("customresourcedefinitions") else {
+            return;
+        };
+        let client = self.cluster.client.clone();
+        let name = format!("{}.{}", self.kind_plural, kind.ar.group);
+        let version = kind.ar.version.clone();
+        let plural = self.kind_plural.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        let handle = tokio::spawn(async move {
+            let api: Api<DynamicObject> = Api::all_with(client, &crd_kind.ar);
+            // No CRD (aggregated API) or no permission → stay on NAME/AGE.
+            let Ok(crd) = api.get(&name).await else {
+                return;
+            };
+            let view = crate::views::printer_columns_view(&crd.data, &version);
+            let _ = tx
+                .send(Msg::PrinterColumns {
+                    generation: genr,
+                    plural,
+                    view: Box::new(view),
+                })
+                .await;
+        });
+        self.tasks.push(handle);
     }
 
     /// Query SelfSubjectRulesReview for the active namespace to learn which
@@ -431,11 +477,25 @@ impl App {
             Msg::Metrics { generation, data } if generation == self.generation => {
                 let sort_uses_metrics = self
                     .sort_column
-                    .and_then(|i| self.display_headers().get(i).copied())
-                    .is_some_and(|h| matches!(h, "CPU" | "MEM"));
+                    .and_then(|i| {
+                        let headers = self.display_headers();
+                        headers.get(i).cloned()
+                    })
+                    .is_some_and(|h| matches!(h.as_str(), "CPU" | "MEM"));
                 self.metrics = data;
                 if sort_uses_metrics {
                     self.invalidate_rows();
+                }
+            }
+            Msg::PrinterColumns {
+                generation,
+                plural,
+                view,
+            } if generation == self.generation => {
+                let for_current = plural == self.kind_plural;
+                self.crd_views.insert(plural, *view);
+                if for_current {
+                    self.refresh_view_spec();
                 }
             }
             Msg::PulseData { generation, data } if generation == self.generation => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -404,6 +404,15 @@ enum SortKey {
     Text(String),
 }
 
+impl From<crate::views::SortValue> for SortKey {
+    fn from(v: crate::views::SortValue) -> Self {
+        match v {
+            crate::views::SortValue::Num(n) => SortKey::Num(n),
+            crate::views::SortValue::Text(t) => SortKey::Text(t),
+        }
+    }
+}
+
 impl SortKey {
     fn cmp_to(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
@@ -608,6 +617,17 @@ pub struct App {
     pub should_quit: bool,
     matcher: SkimMatcherV2,
     rows_cache: RefCell<RowsCache>,
+
+    /// Compiled custom views from config, re-resolved on context switch.
+    pub user_views: HashMap<String, crate::views::View>,
+    /// CRD printer-column fallbacks fetched per plural for this cluster
+    /// (`None` = fetched, nothing usable). Cleared on context switch.
+    crd_views: HashMap<String, Option<crate::views::View>>,
+    /// Wide mode (`w`): show wide-only columns.
+    pub wide: bool,
+    /// Active column layout for the current view; rebuilt by
+    /// [`App::refresh_view_spec`] whenever kind/views/wide change.
+    spec: crate::columns::ViewSpec,
 }
 
 impl App {
@@ -698,6 +718,10 @@ impl App {
                 keys: Vec::new(),
                 cells: HashMap::new(),
             }),
+            user_views: HashMap::new(),
+            crd_views: HashMap::new(),
+            wide: false,
+            spec: crate::columns::build_spec("", None, None, false),
         }
     }
 

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -138,6 +138,11 @@ impl App {
         };
 
         let crd_name = obj.metadata.name.clone().unwrap_or_default();
+        // We already hold the CRD, so seed its printer-column fallback here
+        // instead of re-fetching it when the watch starts.
+        self.crd_views
+            .entry(kind.ar.plural.to_lowercase())
+            .or_insert_with(|| crate::views::printer_columns_view(d, &kind.ar.version));
         self.push_frame();
         self.kind_plural = kind.ar.plural.to_lowercase();
         self.kind = Some(kind);

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -267,6 +267,10 @@ impl App {
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
+        let (views, view_warnings) = crate::views::compile(&resolved.config.views);
+        self.user_views = views;
+        // Printer-column fallbacks came from the old cluster's CRDs.
+        self.crd_views.clear();
         self.skin_colors = resolved.config.skin.colors;
         self.readonly = self.readonly_override.unwrap_or(resolved.config.readonly);
         cluster.add_aliases(&self.user_aliases);
@@ -296,7 +300,7 @@ impl App {
         self.apply_context_skin(resolved.skin_override);
         self.flash = format!("context: {name}");
         self.flash_err = false;
-        if let Some(w) = resolved.warnings.first() {
+        if let Some(w) = resolved.warnings.first().or(view_warnings.first()) {
             self.flash_warn(w);
         }
         let kind = resolved

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -56,7 +56,9 @@ impl App {
         }
 
         let headers = self.display_headers();
-        let sort_header = self.sort_column.and_then(|i| headers.get(i).copied());
+        let sort_header = self
+            .sort_column
+            .and_then(|i| headers.get(i).map(String::as_str));
         // The aggregated Helm release list (`helm list` semantics) shows only
         // the latest revision per release; `helmhistory` (one release's full
         // history) shows every revision, so it skips this.
@@ -144,7 +146,7 @@ impl App {
                 entry.plural != self.kind_plural || entry.resource_version != resource_version
             });
             if stale {
-                let (cells, status_idx) = crate::columns::cells(obj, &self.kind_plural);
+                let (cells, status_idx) = self.spec.cells(obj);
                 cache.cells.insert(
                     key,
                     CellCacheEntry {
@@ -164,19 +166,89 @@ impl App {
         }
     }
 
-    /// The headers as displayed: kind columns, with NAMESPACE prepended when
-    /// listing across namespaces and CPU/MEM appended for pods/nodes. Kept in
-    /// one place so sorting and rendering agree on the column layout.
-    pub fn display_headers(&self) -> Vec<&'static str> {
-        let mut h = crate::columns::headers(&self.kind_plural);
+    /// The headers as displayed: the active view spec's columns, with
+    /// NAMESPACE prepended when listing across namespaces and CPU/MEM appended
+    /// for pods/nodes. Kept in one place so sorting and rendering agree on the
+    /// column layout.
+    pub fn display_headers(&self) -> Vec<String> {
+        let mut h = self.spec.headers();
         if self.show_namespace_column() {
-            h.insert(0, "NAMESPACE");
+            h.insert(0, "NAMESPACE".into());
         }
         if self.metrics_columns() {
-            h.push("CPU");
-            h.push("MEM");
+            h.push("CPU".into());
+            h.push("MEM".into());
         }
         h
+    }
+
+    pub(crate) fn view_spec(&self) -> &crate::columns::ViewSpec {
+        &self.spec
+    }
+
+    /// Rebuild the active column layout from the current kind, user views,
+    /// printer-column fallback, and wide mode. An active sort stays pinned to
+    /// its column *header* — indices shift when columns appear/disappear (wide
+    /// toggle, printer columns arriving) — and resets if the column is gone.
+    /// Cached cells are laid out for the old spec, so they're always dropped.
+    pub(super) fn refresh_view_spec(&mut self) {
+        let sort_header = self
+            .sort_column
+            .and_then(|i| self.display_headers().get(i).cloned());
+        let spec = crate::columns::build_spec(
+            &self.kind_plural,
+            self.active_user_view(),
+            self.crd_views
+                .get(&self.kind_plural)
+                .and_then(Option::as_ref),
+            self.wide,
+        );
+        self.spec = spec;
+        if let Some(h) = sort_header {
+            self.sort_column = self.display_headers().iter().position(|x| *x == h);
+            if self.sort_column.is_none() {
+                self.sort_desc = false;
+            }
+        }
+        self.clear_rows_cache();
+    }
+
+    /// The user-configured view matching the current kind, if any. Synthetic
+    /// views (helm/helmhistory) are backed by an unrelated kind (`secrets`),
+    /// so they never match.
+    pub(super) fn active_user_view(&self) -> Option<&crate::views::View> {
+        let kind = self.kind.as_ref()?;
+        if kind.ar.plural.to_lowercase() != self.kind_plural {
+            return None;
+        }
+        crate::views::lookup(&self.user_views, &kind.ar)
+    }
+
+    /// Apply a view's configured initial sort, unless a sort is already
+    /// active (a refresh must not clobber the user's choice).
+    pub(super) fn apply_view_sort(&mut self) {
+        if self.sort_column.is_some() {
+            return;
+        }
+        let Some((header, desc)) = self.active_user_view().and_then(|v| v.sort.clone()) else {
+            return;
+        };
+        match self.display_headers().iter().position(|h| *h == header) {
+            Some(i) => {
+                self.sort_column = Some(i);
+                self.sort_desc = desc;
+                self.invalidate_rows();
+            }
+            None => self.flash_warn(&format!("view sort column '{header}' not found")),
+        }
+    }
+
+    /// Toggle wide mode (`w`): show/hide wide-only columns.
+    pub(super) fn toggle_wide(&mut self) {
+        self.wide = !self.wide;
+        self.refresh_view_spec();
+        self.flash = format!("wide columns: {}", if self.wide { "on" } else { "off" });
+        self.flash_err = false;
     }
 
     pub fn show_namespace_column(&self) -> bool {
@@ -203,6 +275,14 @@ impl App {
 
     /// Comparable value of `header`'s cell for object `o`.
     pub(super) fn column_sort_key(&self, o: &DynamicObject, header: &str) -> SortKey {
+        // User/printer columns sort by their declared type (quantity, number,
+        // time…), and win over the curated special cases so an overlay that
+        // redefines a header sorts by its own values.
+        if self.spec.is_user_column(header)
+            && let Some(v) = self.spec.sort_value(o, header)
+        {
+            return SortKey::from(v);
+        }
         match header {
             "NAMESPACE" => SortKey::Text(
                 o.metadata
@@ -237,21 +317,10 @@ impl App {
             "REVISION" if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") => {
                 SortKey::Num(crate::helm::revision(o).unwrap_or(0) as f64)
             }
-            _ => {
-                let base = crate::columns::headers(&self.kind_plural);
-                match base.iter().position(|h| *h == header) {
-                    Some(i) => {
-                        let (cells, _) = crate::columns::cells(o, &self.kind_plural);
-                        let v = cells.get(i).cloned().unwrap_or_default();
-                        if is_numeric_header(header) {
-                            SortKey::Num(parse_leading_num(&v))
-                        } else {
-                            SortKey::Text(v.to_lowercase())
-                        }
-                    }
-                    None => SortKey::Text(String::new()),
-                }
-            }
+            _ => match self.spec.sort_value(o, header) {
+                Some(v) => SortKey::from(v),
+                None => SortKey::Text(String::new()),
+            },
         }
     }
 
@@ -274,12 +343,7 @@ impl App {
         self.sort_desc = false;
         self.invalidate_rows();
         let label = match self.sort_column {
-            Some(i) => self
-                .display_headers()
-                .get(i)
-                .copied()
-                .unwrap_or("")
-                .to_string(),
+            Some(i) => self.display_headers().get(i).cloned().unwrap_or_default(),
             None => "default (ns/name)".to_string(),
         };
         self.flash = format!("sort by {label}");
@@ -294,12 +358,7 @@ impl App {
         };
         self.sort_desc = !self.sort_desc;
         self.invalidate_rows();
-        let label = self
-            .display_headers()
-            .get(i)
-            .copied()
-            .unwrap_or("")
-            .to_string();
+        let label = self.display_headers().get(i).cloned().unwrap_or_default();
         self.flash = format!(
             "sort by {label} {}",
             if self.sort_desc {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -250,6 +250,7 @@ async fn filter_match_indices_highlight_matched_chars() {
 async fn table_cell_cache_invalidates_on_apply() {
     let (mut app, _rx) = test_app();
     app.kind_plural = "pods".into();
+    app.refresh_view_spec();
     apply(
         &mut app,
         json!({
@@ -2351,4 +2352,249 @@ async fn x_outside_secrets_is_left_to_plugins() {
         Mode::Table,
         "x must not open a decode view for pods"
     );
+}
+
+// ----- custom views, printer columns, wide mode ---------------------------
+
+fn install_views(app: &mut App, toml_text: &str) {
+    let cfg: crate::config::Config = toml::from_str(toml_text).unwrap();
+    let (views, warnings) = crate::views::compile(&cfg.views);
+    assert!(warnings.is_empty(), "{warnings:?}");
+    app.user_views = views;
+}
+
+fn certificate(name: &str, ready: &str, not_after: &str, cpu: &str) -> serde_json::Value {
+    json!({
+        "apiVersion": "cert-manager.io/v1",
+        "kind": "Certificate",
+        "metadata": {"name": name, "namespace": "default"},
+        "spec": {"cpu": cpu},
+        "status": {
+            "conditions": [{"type": "Ready", "status": ready}],
+            "notAfter": not_after
+        }
+    })
+}
+
+#[tokio::test]
+async fn user_view_overlays_columns_and_applies_initial_sort() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."cert-manager.io/v1/certificates"]
+        sort = "EXPIRES:desc"
+
+        [[views."cert-manager.io/v1/certificates".columns]]
+        name = "READY"
+        path = "/status/conditions/0/status"
+        type = "status"
+
+        [[views."cert-manager.io/v1/certificates".columns]]
+        name = "EXPIRES"
+        path = "/status/notAfter"
+        type = "time"
+        "#,
+    );
+    app.switch_kind("certificates");
+
+    // Overlay: custom columns slot in before the trailing AGE.
+    assert_eq!(app.display_headers(), ["NAME", "READY", "EXPIRES", "AGE"]);
+    // The configured initial sort is active (EXPIRES, descending).
+    assert_eq!(app.sort_column, Some(2));
+    assert!(app.sort_desc);
+
+    apply(
+        &mut app,
+        certificate("old", "True", "2020-01-01T00:00:00Z", "1"),
+    );
+    apply(
+        &mut app,
+        certificate("new", "False", "2099-01-01T00:00:00Z", "1"),
+    );
+
+    // Descending time = oldest (largest elapsed) first.
+    let rows = app.rows();
+    assert_eq!(rows[0].metadata.name.as_deref(), Some("old"));
+
+    // Cells come from the JSON Pointers; the status column drives coloring.
+    let rows = app.rows();
+    app.ensure_table_cell_cache(&rows);
+    let key = row_key(rows[1]);
+    let cache = app.table_cell_cache();
+    let (cells, status_idx) = cache.get(&key).unwrap();
+    assert_eq!(cells[0], "new");
+    assert_eq!(cells[1], "False");
+    // Humanized future timestamp ("in 27000d"-ish, drifting with wall time).
+    assert!(cells[2].starts_with("in "), "{}", cells[2]);
+    assert_eq!(status_idx, Some(1));
+}
+
+#[tokio::test]
+async fn user_view_replace_swaps_out_curated_columns() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views.certificates]
+        replace = true
+
+        [[views.certificates.columns]]
+        name = "NAME"
+        path = "/metadata/name"
+
+        [[views.certificates.columns]]
+        name = "CPU"
+        path = "/spec/cpu"
+        type = "quantity"
+        "#,
+    );
+    app.switch_kind("certificates");
+    assert_eq!(app.display_headers(), ["NAME", "CPU"]);
+
+    // Quantities sort by value: 500m < 2 despite "2" < "500m" lexically.
+    apply(&mut app, certificate("big", "True", "", "2"));
+    apply(&mut app, certificate("small", "True", "", "500m"));
+    app.sort_column = Some(1);
+    app.invalidate_rows();
+    let rows = app.rows();
+    assert_eq!(rows[0].metadata.name.as_deref(), Some("small"));
+    assert_eq!(rows[1].metadata.name.as_deref(), Some("big"));
+}
+
+#[tokio::test]
+async fn printer_columns_msg_upgrades_name_age_fallback() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("certificates");
+    assert_eq!(app.display_headers(), ["NAME", "AGE"]);
+
+    let crd = json!({
+        "spec": {
+            "versions": [{
+                "name": "v1", "served": true, "storage": true,
+                "additionalPrinterColumns": [
+                    {"name": "Ready", "type": "string", "jsonPath": ".status.ready"},
+                    {"name": "Detail", "type": "string", "priority": 1,
+                     "jsonPath": ".status.message"}
+                ]
+            }]
+        }
+    });
+    let view = crate::views::printer_columns_view(&crd, "v1");
+    app.handle_msg(Msg::PrinterColumns {
+        generation: app.generation,
+        plural: "certificates".into(),
+        view: Box::new(view),
+    });
+    // Narrow mode hides the priority>0 column; wide shows it.
+    assert_eq!(app.display_headers(), ["NAME", "READY", "AGE"]);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.display_headers(), ["NAME", "READY", "DETAIL", "AGE"]);
+
+    // A stale-generation message must be dropped.
+    app.switch_kind("pods");
+    app.handle_msg(Msg::PrinterColumns {
+        generation: app.generation - 1,
+        plural: "widgets".into(),
+        view: Box::new(None),
+    });
+    assert!(!app.crd_views.contains_key("widgets"));
+}
+
+#[tokio::test]
+async fn user_view_wins_over_printer_columns() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [[views.certificates.columns]]
+        name = "MINE"
+        path = "/status/mine"
+        "#,
+    );
+    app.switch_kind("certificates");
+    app.handle_msg(Msg::PrinterColumns {
+        generation: app.generation,
+        plural: "certificates".into(),
+        view: Box::new(Some(crate::views::View {
+            columns: vec![crate::views::UserColumn {
+                header: "THEIRS".into(),
+                pointer: "/status/theirs".into(),
+                kind: crate::views::ColumnKind::Text,
+                wide: false,
+                width: None,
+                align: None,
+            }],
+            sort: None,
+            replace: false,
+        })),
+    });
+    assert_eq!(app.display_headers(), ["NAME", "MINE", "AGE"]);
+}
+
+#[tokio::test]
+async fn wide_toggle_reveals_pod_columns_and_keeps_sort() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    assert_eq!(
+        app.display_headers(),
+        ["NAME", "READY", "STATUS", "RESTARTS", "AGE", "CPU", "MEM"]
+    );
+
+    // Sort by AGE, then widen: the sort must follow the column's new index.
+    app.sort_column = Some(4);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(
+        app.display_headers(),
+        [
+            "NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE", "CPU", "MEM"
+        ]
+    );
+    assert_eq!(app.sort_column, Some(6));
+
+    // Narrow again while sorted on a wide-only column: sort resets.
+    app.sort_column = Some(4); // IP
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.sort_column, None);
+}
+
+#[tokio::test]
+async fn crd_drill_seeds_printer_columns_from_the_crd() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let crd = obj(json!({
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {"name": "widgets.example.com"},
+        "spec": {
+            "group": "example.com",
+            "names": {"plural": "widgets", "kind": "Widget"},
+            "scope": "Namespaced",
+            "versions": [{
+                "name": "v1", "served": true, "storage": true,
+                "additionalPrinterColumns": [
+                    {"name": "Phase", "type": "string", "jsonPath": ".status.phase"}
+                ]
+            }]
+        }
+    }));
+    app.drill_into_crd(&crd);
+    assert_eq!(app.kind_plural, "widgets");
+    assert_eq!(app.display_headers(), ["NAMESPACE", "NAME", "PHASE", "AGE"]);
+}
+
+#[tokio::test]
+async fn invalid_view_sort_column_warns_instead_of_crashing() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views.certificates]
+        sort = "NOPE"
+        "#,
+    );
+    app.switch_kind("certificates");
+    assert_eq!(app.sort_column, None);
+    assert!(app.flash.contains("NOPE"), "{}", app.flash);
+    assert!(app.flash_err);
 }

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -14,6 +14,8 @@ struct Column {
     header: &'static str,
     extract: CellFn,
     is_status: bool,
+    /// Only shown in wide mode (`w`), like kubectl's `-o wide` extras.
+    wide: bool,
 }
 
 struct CellContext<'a> {
@@ -28,6 +30,7 @@ const fn column(header: &'static str, extract: CellFn) -> Column {
         header,
         extract,
         is_status: false,
+        wide: false,
     }
 }
 
@@ -36,6 +39,16 @@ const fn status_column(header: &'static str, extract: CellFn) -> Column {
         header,
         extract,
         is_status: true,
+        wide: false,
+    }
+}
+
+const fn wide_column(header: &'static str, extract: CellFn) -> Column {
+    Column {
+        header,
+        extract,
+        is_status: false,
+        wide: true,
     }
 }
 
@@ -44,8 +57,8 @@ const POD_COLUMNS: &[Column] = &[
     column("READY", col_pod_ready),
     status_column("STATUS", col_pod_status),
     column("RESTARTS", col_pod_restarts),
-    column("IP", col_pod_ip),
-    column("NODE", col_pod_node),
+    wide_column("IP", col_pod_ip),
+    wide_column("NODE", col_pod_node),
     column("AGE", col_age),
 ];
 
@@ -272,14 +285,25 @@ fn columns_for(plural: &str) -> &'static [Column] {
     }
 }
 
-/// Headers for a kind, excluding the leading NAMESPACE column (the table view
-/// prepends that when listing across namespaces).
+/// Whether `plural` has curated columns (anything beyond the NAME/AGE
+/// fallback). Kinds without them are candidates for the CRD printer-column
+/// fallback.
+pub fn has_curated(plural: &str) -> bool {
+    columns_for(plural).as_ptr() != DEFAULT_COLUMNS.as_ptr()
+}
+
+/// The full curated headers for a kind (wide columns included), excluding the
+/// leading NAMESPACE column (the table view prepends that when listing across
+/// namespaces). Live views go through [`ViewSpec`] instead, which folds in
+/// user views, printer columns, and wide-mode filtering.
+#[cfg(test)]
 pub fn headers(plural: &str) -> Vec<&'static str> {
     columns_for(plural).iter().map(|c| c.header).collect()
 }
 
 /// Cells for one object, aligned with [`headers`]. The 2nd return value is the
 /// index of the column that should be colorized as a status (or None).
+#[cfg(test)]
 pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) {
     let name = obj.metadata.name.clone().unwrap_or_default();
     let age = age(obj);
@@ -293,6 +317,215 @@ pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) 
     let values = columns.iter().map(|c| (c.extract)(&ctx)).collect();
     let status_idx = columns.iter().position(|c| c.is_status);
     (values, status_idx)
+}
+
+/// The resolved column layout for one table view: the kind's curated columns,
+/// overlaid with (or replaced by) a user-configured view — or CRD printer
+/// columns when the kind is unknown — then filtered by wide mode. Built once
+/// per view change, never per row.
+pub struct ViewSpec {
+    columns: Vec<SpecColumn>,
+    status_idx: Option<usize>,
+}
+
+struct SpecColumn {
+    header: String,
+    source: SpecSource,
+    is_status: bool,
+    wide: bool,
+}
+
+enum SpecSource {
+    Curated(CellFn),
+    User(crate::views::UserColumn),
+}
+
+fn spec_curated(c: &Column) -> SpecColumn {
+    SpecColumn {
+        header: c.header.to_string(),
+        source: SpecSource::Curated(c.extract),
+        is_status: c.is_status,
+        wide: c.wide,
+    }
+}
+
+fn spec_user(uc: &crate::views::UserColumn) -> SpecColumn {
+    SpecColumn {
+        header: uc.header.clone(),
+        is_status: uc.kind == crate::views::ColumnKind::Status,
+        wide: uc.wide,
+        source: SpecSource::User(uc.clone()),
+    }
+}
+
+/// Resolve the columns for a view. `user` is the explicit view configured for
+/// the kind; `crd` is the printer-column fallback, consulted only when the
+/// user view defines no columns and `plural` has no curated ones.
+pub fn build_spec(
+    plural: &str,
+    user: Option<&crate::views::View>,
+    crd: Option<&crate::views::View>,
+    wide: bool,
+) -> ViewSpec {
+    let mut cols: Vec<SpecColumn> = columns_for(plural).iter().map(spec_curated).collect();
+    // A user view only counts as explicit column config when it has columns —
+    // a sort-only view (or one whose columns all failed validation) still
+    // benefits from the printer-column fallback.
+    let view = match user {
+        Some(v) if !v.columns.is_empty() => Some(v),
+        _ => {
+            if has_curated(plural) {
+                None
+            } else {
+                crd
+            }
+        }
+    };
+    if let Some(v) = view {
+        if v.replace && !v.columns.is_empty() {
+            cols = v.columns.iter().map(spec_user).collect();
+        } else {
+            for uc in &v.columns {
+                let sc = spec_user(uc);
+                match cols.iter().position(|c| c.header == sc.header) {
+                    // A matching header replaces the curated column in place.
+                    Some(i) => cols[i] = sc,
+                    // New columns land before a trailing AGE so it stays last.
+                    None => {
+                        let at = if cols.last().is_some_and(|c| c.header == "AGE") {
+                            cols.len() - 1
+                        } else {
+                            cols.len()
+                        };
+                        cols.insert(at, sc);
+                    }
+                }
+            }
+        }
+    }
+    cols.retain(|c| wide || !c.wide);
+    let status_idx = cols.iter().position(|c| c.is_status);
+    ViewSpec {
+        columns: cols,
+        status_idx,
+    }
+}
+
+impl ViewSpec {
+    pub fn headers(&self) -> Vec<String> {
+        self.columns.iter().map(|c| c.header.clone()).collect()
+    }
+
+    /// Cells for one object, aligned with [`Self::headers`], plus the index
+    /// of the status column (if any).
+    pub fn cells(&self, obj: &DynamicObject) -> (Vec<String>, Option<usize>) {
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let age = age(obj);
+        let ctx = CellContext {
+            obj,
+            data: &obj.data,
+            name: &name,
+            age: &age,
+        };
+        let values = self
+            .columns
+            .iter()
+            .map(|c| match &c.source {
+                SpecSource::Curated(extract) => extract(&ctx),
+                SpecSource::User(uc) => crate::views::render_cell(obj, uc),
+            })
+            .collect();
+        (values, self.status_idx)
+    }
+
+    /// See [`volatile_cell`]. User `time` columns re-render every frame too:
+    /// their humanized elapsed value drifts with wall time.
+    pub fn volatile(&self, obj: &DynamicObject, plural: &str, idx: usize) -> Option<String> {
+        let col = self.columns.get(idx)?;
+        match &col.source {
+            SpecSource::User(uc) if uc.kind == crate::views::ColumnKind::Time => {
+                Some(crate::views::render_cell(obj, uc))
+            }
+            SpecSource::User(_) => None,
+            SpecSource::Curated(_) => volatile_cell(obj, plural, &col.header),
+        }
+    }
+
+    /// Whether `header` is a user/printer column (typed sorting applies) as
+    /// opposed to a curated one.
+    pub fn is_user_column(&self, header: &str) -> bool {
+        self.columns
+            .iter()
+            .any(|c| c.header == header && matches!(c.source, SpecSource::User(_)))
+    }
+
+    /// Comparable value of `header`'s cell for `obj`, or `None` when the
+    /// header isn't in this spec.
+    pub fn sort_value(&self, obj: &DynamicObject, header: &str) -> Option<crate::views::SortValue> {
+        let col = self.columns.iter().find(|c| c.header == header)?;
+        Some(match &col.source {
+            SpecSource::User(uc) => crate::views::sort_value(obj, uc),
+            SpecSource::Curated(extract) => {
+                let name = obj.metadata.name.clone().unwrap_or_default();
+                let age = age(obj);
+                let ctx = CellContext {
+                    obj,
+                    data: &obj.data,
+                    name: &name,
+                    age: &age,
+                };
+                let v = extract(&ctx);
+                if is_numeric_header(header) {
+                    crate::views::SortValue::Num(parse_leading_num(&v))
+                } else {
+                    crate::views::SortValue::Text(v.to_lowercase())
+                }
+            }
+        })
+    }
+
+    /// Configured fixed width for the column at `idx`, when it's a user
+    /// column that set one.
+    pub fn width_at(&self, idx: usize) -> Option<u16> {
+        match &self.columns.get(idx)?.source {
+            SpecSource::User(uc) => uc.width,
+            SpecSource::Curated(_) => None,
+        }
+    }
+
+    /// Configured alignment for the column at `idx`.
+    pub fn align_at(&self, idx: usize) -> Option<crate::views::Align> {
+        match &self.columns.get(idx)?.source {
+            SpecSource::User(uc) => uc.align,
+            SpecSource::Curated(_) => None,
+        }
+    }
+}
+
+/// Columns whose curated cell is a count/number and should sort numerically.
+fn is_numeric_header(header: &str) -> bool {
+    matches!(
+        header,
+        "READY"
+            | "RESTARTS"
+            | "DATA"
+            | "ACTIVE"
+            | "DESIRED"
+            | "CURRENT"
+            | "AVAILABLE"
+            | "UP-TO-DATE"
+            | "COMPLETIONS"
+            | "ENDPOINTS"
+    )
+}
+
+/// Parse the leading number of a cell (`"3"`, `"1/2"` → 1, `"<none>"` → 0).
+fn parse_leading_num(s: &str) -> f64 {
+    let t = s.trim_start_matches(|c: char| !c.is_ascii_digit() && c != '-');
+    let end = t
+        .find(|c: char| !c.is_ascii_digit() && c != '-')
+        .unwrap_or(t.len());
+    t[..end].parse::<f64>().unwrap_or(0.0)
 }
 
 /// Cells whose display value changes with wall time even when the Kubernetes
@@ -841,7 +1074,8 @@ fn job_duration(d: &Value) -> String {
     humanize((end - start).max(0))
 }
 
-fn humanize(secs: i64) -> String {
+/// Compact duration, e.g. `3d4h`, `12m`, `45s`.
+pub(crate) fn humanize(secs: i64) -> String {
     let d = secs / 86_400;
     let h = (secs % 86_400) / 3600;
     let m = (secs % 3600) / 60;
@@ -1709,5 +1943,141 @@ mod tests {
                 assert!(idx < cells.len(), "{kind} status index");
             }
         }
+    }
+
+    // ----- view specs (curated + user/printer columns + wide) --------------
+
+    fn user_col(
+        header: &str,
+        pointer: &str,
+        kind: crate::views::ColumnKind,
+    ) -> crate::views::UserColumn {
+        crate::views::UserColumn {
+            header: header.into(),
+            pointer: pointer.into(),
+            kind,
+            wide: false,
+            width: None,
+            align: None,
+        }
+    }
+
+    fn view(columns: Vec<crate::views::UserColumn>, replace: bool) -> crate::views::View {
+        crate::views::View {
+            columns,
+            sort: None,
+            replace,
+        }
+    }
+
+    #[test]
+    fn spec_overlay_replaces_matching_headers_and_inserts_before_age() {
+        use crate::views::ColumnKind;
+        let v = view(
+            vec![
+                // Collides with the curated STATUS header: replaces in place.
+                user_col("STATUS", "/status/phase", ColumnKind::Status),
+                // New column: lands before the trailing AGE.
+                user_col("NODE-IP", "/status/hostIP", ColumnKind::Text),
+            ],
+            false,
+        );
+        let spec = build_spec("pods", Some(&v), None, false);
+        assert_eq!(
+            spec.headers(),
+            vec!["NAME", "READY", "STATUS", "RESTARTS", "NODE-IP", "AGE"]
+        );
+        let o = obj(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web"},
+            "status": {"phase": "Running", "hostIP": "10.0.0.9"}
+        }));
+        let (cells, status_idx) = spec.cells(&o);
+        assert_eq!(cells[2], "Running");
+        assert_eq!(cells[4], "10.0.0.9");
+        assert_eq!(status_idx, Some(2));
+    }
+
+    #[test]
+    fn spec_replace_swaps_out_curated_columns_entirely() {
+        use crate::views::ColumnKind;
+        let v = view(
+            vec![
+                user_col("NAME", "/metadata/name", ColumnKind::Text),
+                user_col("PHASE", "/status/phase", ColumnKind::Text),
+            ],
+            true,
+        );
+        let spec = build_spec("pods", Some(&v), None, true);
+        assert_eq!(spec.headers(), vec!["NAME", "PHASE"]);
+    }
+
+    #[test]
+    fn spec_wide_mode_gates_wide_only_columns() {
+        let narrow = build_spec("pods", None, None, false);
+        assert_eq!(
+            narrow.headers(),
+            vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
+        );
+        let wide = build_spec("pods", None, None, true);
+        assert_eq!(
+            wide.headers(),
+            vec!["NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE"]
+        );
+    }
+
+    #[test]
+    fn spec_crd_fallback_applies_only_without_curated_or_user_view() {
+        use crate::views::ColumnKind;
+        let crd = view(
+            vec![user_col("PHASE", "/status/phase", ColumnKind::Text)],
+            false,
+        );
+        // Unknown kind: printer columns upgrade the NAME/AGE fallback.
+        let spec = build_spec("widgets", None, Some(&crd), false);
+        assert_eq!(spec.headers(), vec!["NAME", "PHASE", "AGE"]);
+        // Curated kind: printer columns never apply.
+        let spec = build_spec("pods", None, Some(&crd), false);
+        assert_eq!(
+            spec.headers(),
+            vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
+        );
+        // Explicit user view outranks printer columns.
+        let user = view(
+            vec![user_col("MINE", "/status/mine", ColumnKind::Text)],
+            false,
+        );
+        let spec = build_spec("widgets", Some(&user), Some(&crd), false);
+        assert_eq!(spec.headers(), vec!["NAME", "MINE", "AGE"]);
+        // A sort-only user view (no columns) still gets printer columns.
+        let sort_only = crate::views::View {
+            columns: vec![],
+            sort: Some(("PHASE".into(), false)),
+            replace: false,
+        };
+        let spec = build_spec("widgets", Some(&sort_only), Some(&crd), false);
+        assert_eq!(spec.headers(), vec!["NAME", "PHASE", "AGE"]);
+    }
+
+    #[test]
+    fn spec_sort_value_is_typed_for_user_columns() {
+        use crate::views::{ColumnKind, SortValue};
+        let v = view(
+            vec![user_col("CPU", "/spec/cpu", ColumnKind::Quantity)],
+            false,
+        );
+        let spec = build_spec("widgets", Some(&v), None, false);
+        let o = obj(json!({
+            "apiVersion": "example.com/v1", "kind": "Widget",
+            "metadata": {"name": "w"},
+            "spec": {"cpu": "500m"}
+        }));
+        assert!(spec.is_user_column("CPU"));
+        assert!(!spec.is_user_column("NAME"));
+        match spec.sort_value(&o, "CPU").unwrap() {
+            SortValue::Num(n) => assert_eq!(n, 0.5),
+            SortValue::Text(t) => panic!("expected numeric sort, got '{t}'"),
+        }
+        assert!(spec.sort_value(&o, "MISSING").is_none());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,8 +53,64 @@ pub struct Config {
     pub aliases: HashMap<String, String>,
     /// User-defined shell-out plugins bound to keys.
     pub plugins: Vec<Plugin>,
+    /// Custom table views keyed by resource — see [`ViewConfig`]. Compiled
+    /// and validated by [`crate::views::compile`].
+    pub views: HashMap<String, ViewConfig>,
     /// Color skin: a built-in palette name plus optional per-swatch overrides.
     pub skin: Skin,
+}
+
+/// A custom table view for one resource kind. Keyed in `[views]` by
+/// apiVersion/plural (`"cert-manager.io/v1/certificates"`, `"v1/pods"`),
+/// group/plural, bare plural, or lowercased kind. Columns overlay the curated
+/// defaults (matching headers replace in place, new ones land before AGE)
+/// unless `replace = true` swaps them out entirely. `path` is a JSON Pointer
+/// (RFC 6901) into the object as served by the API.
+///
+/// ```toml
+/// [views."cert-manager.io/v1/certificates"]
+/// sort = "EXPIRES:desc"   # initial sort column, ":asc" (default) or ":desc"
+///
+/// [[views."cert-manager.io/v1/certificates".columns]]
+/// name = "READY"
+/// path = "/status/conditions/0/status"
+/// type = "status"         # text (default) / status / number / quantity / time
+///
+/// [[views."cert-manager.io/v1/certificates".columns]]
+/// name = "EXPIRES"
+/// path = "/status/notAfter"
+/// type = "time"
+/// wide = true              # only shown in wide mode (`w`)
+/// ```
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct ViewConfig {
+    /// Initial sort: a column header, optionally suffixed `:asc`/`:desc`.
+    pub sort: Option<String>,
+    /// Replace the curated columns instead of overlaying them.
+    pub replace: bool,
+    pub columns: Vec<ViewColumnConfig>,
+}
+
+/// One column of a [`ViewConfig`]. Everything is optional at parse time so a
+/// half-written column degrades to a validation warning instead of discarding
+/// the whole config file.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct ViewColumnConfig {
+    /// Column header (displayed uppercased).
+    pub name: String,
+    /// JSON Pointer to the cell value, e.g. `/status/phase`.
+    pub path: String,
+    /// Value type: `text` (default), `status`, `number`, `quantity`, `time`.
+    #[serde(rename = "type")]
+    pub kind: Option<String>,
+    /// Only shown in wide mode.
+    pub wide: bool,
+    /// Fixed display width in columns (defaults to a flexible share).
+    pub width: Option<u16>,
+    /// Cell alignment: `left` (default), `center`, `right`.
+    pub align: Option<String>,
 }
 
 /// Skin selection. `name` picks a built-in palette (see

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -465,6 +465,11 @@ impl Cluster {
                 true,
             ),
         );
+        // A CR without curated columns, for custom-view tests.
+        registry.insert(
+            "certificates".to_string(),
+            mk("cert-manager.io", "Certificate", "certificates", true),
+        );
         Self {
             client,
             context: "test".into(),
@@ -475,6 +480,7 @@ impl Cluster {
             connected: true,
             registry,
             catalog: vec![
+                "certificates".to_string(),
                 "deployments".to_string(),
                 "helmreleases".to_string(),
                 "horizontalpodautoscalers".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod k8s;
 mod store;
 mod theme;
 mod ui;
+mod views;
 
 use std::time::Duration;
 
@@ -144,6 +145,11 @@ async fn main() -> Result<()> {
     app.all_contexts = Cluster::list_contexts();
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
+    let (user_views, view_warnings) = views::compile(&cfg.views);
+    for w in &view_warnings {
+        eprintln!("warning: {w}");
+    }
+    app.user_views = user_views;
     app.skin_colors = cfg.skin.colors.clone();
     app.config = loader;
     app.session_skin = Some(session_skin);
@@ -171,6 +177,12 @@ async fn main() -> Result<()> {
         // a successful pick connects and lands on the default resource.
         Some(err) => app.start_disconnected(err),
         None => app.switch_kind(&resource),
+    }
+    // View config problems must be visible inside the TUI, not only on the
+    // (about-to-be-hidden) stderr.
+    if let Some(w) = view_warnings.first() {
+        app.flash = w.clone();
+        app.flash_err = true;
     }
 
     if args.snapshot {

--- a/src/store.rs
+++ b/src/store.rs
@@ -32,6 +32,13 @@ pub enum Msg {
         generation: u64,
         data: HashMap<String, (i64, i64)>,
     },
+    /// CRD `additionalPrinterColumns` fallback for a custom-resource plural,
+    /// fetched off-thread (`None` = CRD had nothing usable for the version).
+    PrinterColumns {
+        generation: u64,
+        plural: String,
+        view: Box<Option<crate::views::View>>,
+    },
     PulseData {
         generation: u64,
         data: Pulse,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,7 +3,7 @@
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
     Paragraph, Row, Table, Wrap,
@@ -33,6 +33,26 @@ impl<'a> TableCellText<'a> {
             TableCellText::Borrowed(value) => Cell::from(value),
             TableCellText::Owned(value) => Cell::from(value),
         }
+    }
+
+    /// Like [`Self::into_cell`], honoring a custom column's alignment.
+    fn into_cell_aligned(self, align: Option<Alignment>) -> Cell<'a> {
+        let Some(align) = align else {
+            return self.into_cell();
+        };
+        match self {
+            TableCellText::Borrowed(value) => Cell::from(Text::from(value).alignment(align)),
+            TableCellText::Owned(value) => Cell::from(Text::from(value).alignment(align)),
+        }
+    }
+}
+
+/// Map a view column's configured alignment onto ratatui's.
+fn cell_alignment(align: crate::views::Align) -> Alignment {
+    match align {
+        crate::views::Align::Left => Alignment::Left,
+        crate::views::Align::Center => Alignment::Center,
+        crate::views::Align::Right => Alignment::Right,
     }
 }
 
@@ -321,10 +341,22 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
 fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let show_ns = app.show_namespace_column();
     let metrics_cols = app.metrics_columns();
-    let headers: Vec<&str> = app.display_headers();
+    let headers: Vec<String> = app.display_headers();
     let pods_view = app.kind_plural == "pods";
     let sort_col = app.sort_column;
     let sort_arrow = if app.sort_desc { " ↓" } else { " ↑" };
+    // Offset from a displayed column index back to the view spec's (the spec
+    // doesn't know about the prepended NAMESPACE or appended CPU/MEM).
+    let ns_off = usize::from(show_ns);
+    // Per-column custom alignment, precomputed so cells don't re-borrow app.
+    let aligns: Vec<Option<Alignment>> = (0..headers.len())
+        .map(|i| {
+            i.checked_sub(ns_off)
+                .and_then(|si| app.view_spec().align_at(si))
+                .map(cell_alignment)
+        })
+        .collect();
+    let align_of = |i: usize| aligns.get(i).copied().flatten();
 
     let header_row = Row::new(
         headers
@@ -334,17 +366,24 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 // Active sort column gets a direction arrow in the sorter color
                 // (sky, bold), matching k9s; the label inherits the header color.
                 if Some(i) == sort_col {
-                    Cell::from(Line::from(vec![
-                        Span::raw(h.to_string()),
+                    let mut line = Line::from(vec![
+                        Span::raw(h.clone()),
                         Span::styled(
                             sort_arrow,
                             Style::default()
                                 .fg(theme::sorter())
                                 .add_modifier(Modifier::BOLD),
                         ),
-                    ]))
+                    ]);
+                    if let Some(a) = align_of(i) {
+                        line = line.alignment(a);
+                    }
+                    Cell::from(line)
                 } else {
-                    Cell::from(h.to_string())
+                    match align_of(i) {
+                        Some(a) => Cell::from(Text::from(h.clone()).alignment(a)),
+                        None => Cell::from(h.clone()),
+                    }
                 }
             })
             .collect::<Vec<_>>(),
@@ -355,11 +394,11 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // their own visibility treatment below, computed once rather than
     // string-compared per cell.
     let name_col = if show_ns { 1 } else { 0 };
-    let age_idx = headers.iter().position(|h| *h == "AGE");
-    let ready_idx = headers.iter().position(|h| *h == "READY");
-    let restarts_idx = headers.iter().position(|h| *h == "RESTARTS");
-    let cpu_idx = headers.iter().position(|h| *h == "CPU");
-    let mem_idx = headers.iter().position(|h| *h == "MEM");
+    let age_idx = headers.iter().position(|h| h == "AGE");
+    let ready_idx = headers.iter().position(|h| h == "READY");
+    let restarts_idx = headers.iter().position(|h| h == "RESTARTS");
+    let cpu_idx = headers.iter().position(|h| h == "CPU");
+    let mem_idx = headers.iter().position(|h| h == "MEM");
 
     let count = app.row_count();
     let visible_rows = area.height.saturating_sub(3).max(1) as usize;
@@ -391,7 +430,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     app.ensure_table_cell_cache(&visible_objects);
     let cell_cache = app.table_cell_cache();
-    let base_headers = columns::headers(&app.kind_plural);
+    let spec = app.view_spec();
 
     let rows: Vec<Row> = visible_objects
         .iter()
@@ -410,8 +449,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 style_idx = status_idx.map(|i| i + 1);
             }
             for (i, cell) in base_cells.iter().enumerate() {
-                let header = base_headers.get(i).copied().unwrap_or_default();
-                if let Some(value) = columns::volatile_cell(obj, &app.kind_plural, header) {
+                if let Some(value) = spec.volatile(obj, &app.kind_plural, i) {
                     cells.push(TableCellText::Owned(value));
                 } else {
                     cells.push(TableCellText::Borrowed(cell));
@@ -462,36 +500,39 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 .into_iter()
                 .enumerate()
                 .map(|(i, c)| {
+                    let align = align_of(i);
                     if marked_row {
                         // Marked rows override everything so a bulk selection
                         // stands out.
-                        c.into_cell().style(
+                        c.into_cell_aligned(align).style(
                             Style::default()
                                 .fg(theme::mark())
                                 .add_modifier(Modifier::BOLD),
                         )
                     } else if Some(i) == style_idx {
-                        c.into_cell().style(Style::default().fg(status_badge))
+                        c.into_cell_aligned(align)
+                            .style(Style::default().fg(status_badge))
                     } else if i == name_col {
                         render_name_cell(app, c.as_str(), row_color)
                     } else if Some(i) == age_idx {
-                        c.into_cell().style(theme::dim())
+                        c.into_cell_aligned(align).style(theme::dim())
                     } else if Some(i) == restarts_idx {
                         let n: i64 = c.as_str().trim().parse().unwrap_or(0);
                         let color = theme::restarts_severity(n).unwrap_or(row_color);
-                        c.into_cell().style(Style::default().fg(color))
+                        c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else if Some(i) == cpu_idx {
                         let color = metrics_raw
                             .and_then(|(cpu, _)| theme::cpu_severity(cpu))
                             .unwrap_or(row_color);
-                        c.into_cell().style(Style::default().fg(color))
+                        c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else if Some(i) == mem_idx {
                         let color = metrics_raw
                             .and_then(|(_, mem)| theme::mem_severity(mem))
                             .unwrap_or(row_color);
-                        c.into_cell().style(Style::default().fg(color))
+                        c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else {
-                        c.into_cell().style(Style::default().fg(row_color))
+                        c.into_cell_aligned(align)
+                            .style(Style::default().fg(row_color))
                     }
                 })
                 .collect();
@@ -501,33 +542,43 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let widths: Vec<Constraint> = headers
         .iter()
-        .map(|h| match *h {
-            // NAME is the column you actually read — give it most of the
-            // remaining space so long pod/deployment names don't truncate
-            // while NODE (a full GKE node name) crowds it out.
-            "NAME" => Constraint::Fill(6),
-            "NAMESPACE" => Constraint::Fill(2),
-            "NODE" | "CLAIM" | "VOLUME" | "HOSTS" => Constraint::Fill(1),
-            "AGE" => Constraint::Length(7),
-            "CPU" | "MEM" => Constraint::Length(8),
-            // Wide enough for the long pod reasons (ContainerCreating,
-            // CrashLoopBackOff, ImagePullBackOff…) so status is never clipped.
-            "STATUS" => Constraint::Length(19),
-            "READY" | "RESTARTS" => Constraint::Length(10),
-            // CRD view: group domains run long (e.g.
-            // "kustomize.toolkit.fluxcd.io"), so give GROUP/KIND/VERSIONS a
-            // fixed floor wide enough that real-world values don't clip —
-            // Fill(1) alongside NAME's Fill(6) would crush them.
-            "GROUP" => Constraint::Length(30),
-            "KIND" => Constraint::Length(20),
-            "VERSIONS" => Constraint::Length(20),
-            "SCOPE" => Constraint::Length(12),
-            // Flux views: the Ready condition message and git/chart revision
-            // are the columns you read — split the leftover space with NAME.
-            "MESSAGE" => Constraint::Fill(4),
-            "REVISION" => Constraint::Fill(2),
-            "SUSPENDED" => Constraint::Length(9),
-            _ => Constraint::Fill(1),
+        .enumerate()
+        .map(|(i, h)| {
+            // A custom column's configured width wins over the curated rules.
+            if let Some(w) = i
+                .checked_sub(ns_off)
+                .and_then(|si| app.view_spec().width_at(si))
+            {
+                return Constraint::Length(w);
+            }
+            match h.as_str() {
+                // NAME is the column you actually read — give it most of the
+                // remaining space so long pod/deployment names don't truncate
+                // while NODE (a full GKE node name) crowds it out.
+                "NAME" => Constraint::Fill(6),
+                "NAMESPACE" => Constraint::Fill(2),
+                "NODE" | "CLAIM" | "VOLUME" | "HOSTS" => Constraint::Fill(1),
+                "AGE" => Constraint::Length(7),
+                "CPU" | "MEM" => Constraint::Length(8),
+                // Wide enough for the long pod reasons (ContainerCreating,
+                // CrashLoopBackOff, ImagePullBackOff…) so status is never clipped.
+                "STATUS" => Constraint::Length(19),
+                "READY" | "RESTARTS" => Constraint::Length(10),
+                // CRD view: group domains run long (e.g.
+                // "kustomize.toolkit.fluxcd.io"), so give GROUP/KIND/VERSIONS a
+                // fixed floor wide enough that real-world values don't clip —
+                // Fill(1) alongside NAME's Fill(6) would crush them.
+                "GROUP" => Constraint::Length(30),
+                "KIND" => Constraint::Length(20),
+                "VERSIONS" => Constraint::Length(20),
+                "SCOPE" => Constraint::Length(12),
+                // Flux views: the Ready condition message and git/chart revision
+                // are the columns you read — split the leftover space with NAME.
+                "MESSAGE" => Constraint::Fill(4),
+                "REVISION" => Constraint::Fill(2),
+                "SUSPENDED" => Constraint::Length(9),
+                _ => Constraint::Fill(1),
+            }
         })
         .collect();
 
@@ -1449,6 +1500,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("esc", "go back / pop view / clear filter"),
         bind("j/k g/G", "move · top/bottom"),
         bind("S · I", "sort by column (cycle) · invert direction"),
+        bind("w", "toggle wide columns (kubectl -o wide)"),
         bind("/", "fuzzy filter"),
         bind("n · 0-9", "namespace switcher · 0 = all namespaces"),
         bind("ctrl-r", "refresh watch"),
@@ -2050,9 +2102,9 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             // Per-resource verbs live in the header hint column when it
             // fits; only repeat the full line when the header dropped it.
             let hint = if header_hints_fit(frame.area().width) {
-                "  :resource  /filter  S:sort I:invert  space:mark  [ ]:history  0:all-ns  ?:help"
+                "  :resource  /filter  S:sort I:invert  w:wide  space:mark  [ ]:history  0:all-ns  ?:help"
             } else {
-                "  :resource  /filter  S:sort I:invert  ⏎drill  y:yaml d:describe l:logs e:edit s:shell/scale i:image r:restart f:fwd ^d:del  ?:help"
+                "  :resource  /filter  S:sort I:invert  w:wide  ⏎drill  y:yaml d:describe l:logs e:edit s:shell/scale i:image r:restart f:fwd ^d:del  ?:help"
             };
             Line::from(Span::styled(hint, theme::dim()))
         }

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,0 +1,730 @@
+//! User-configurable table views: custom columns for any resource kind, plus
+//! the CRD `additionalPrinterColumns` fallback for unknown custom resources.
+//!
+//! Views come from config (see [`crate::config::ViewConfig`]) keyed by
+//! apiVersion/plural (`"cert-manager.io/v1/certificates"`, `"v1/pods"`),
+//! group/plural, bare plural, or lowercased kind — most specific key wins.
+//! Column values are extracted with JSON Pointer (RFC 6901) against the
+//! object as served by the API: `/metadata/…`, `/apiVersion` and `/kind`
+//! resolve alongside `/spec/…` and `/status/…`. Config is validated here at
+//! load time; problems become warnings, never panics, so a bad view can't
+//! take down the TUI.
+
+use std::collections::HashMap;
+
+use k8s_openapi::jiff::Timestamp;
+use kube::core::DynamicObject;
+use kube::discovery::ApiResource;
+use serde_json::Value;
+
+/// How a custom column's value is rendered and sorted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ColumnKind {
+    #[default]
+    Text,
+    /// Text that also drives the row's status coloring.
+    Status,
+    /// Sorted numerically.
+    Number,
+    /// Kubernetes quantity (`500m`, `1Gi`, `2k`) — sorted by value.
+    Quantity,
+    /// RFC 3339 timestamp — rendered as compact elapsed time (`3d4h`, or
+    /// `in 30d` for the future), sorted by the timestamp.
+    Time,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Align {
+    Left,
+    Center,
+    Right,
+}
+
+/// One compiled custom column.
+#[derive(Debug, Clone)]
+pub struct UserColumn {
+    /// Header, uppercased for display.
+    pub header: String,
+    /// JSON Pointer into the object.
+    pub pointer: String,
+    pub kind: ColumnKind,
+    /// Shown only in wide mode (`w`).
+    pub wide: bool,
+    pub width: Option<u16>,
+    pub align: Option<Align>,
+}
+
+/// A compiled per-kind view.
+#[derive(Debug, Clone, Default)]
+pub struct View {
+    pub columns: Vec<UserColumn>,
+    /// Initial sort: (header, descending).
+    pub sort: Option<(String, bool)>,
+    /// Replace the curated columns entirely instead of overlaying them.
+    pub replace: bool,
+}
+
+/// A comparable cell value for typed sorting, mirrored into the app's private
+/// sort key (quantities, numbers, and times sort by value, not lexically).
+pub enum SortValue {
+    Num(f64),
+    Text(String),
+}
+
+/// Validate and compile the raw `[views]` config. Invalid columns/sorts are
+/// skipped with an actionable warning instead of dropping the whole config.
+pub fn compile(
+    raw: &HashMap<String, crate::config::ViewConfig>,
+) -> (HashMap<String, View>, Vec<String>) {
+    let mut views = HashMap::new();
+    let mut warnings = Vec::new();
+    for (key, cfg) in raw {
+        let mut columns = Vec::new();
+        for c in &cfg.columns {
+            let header = c.name.trim().to_uppercase();
+            if header.is_empty() {
+                warnings.push(format!("views.\"{key}\": column with empty name skipped"));
+                continue;
+            }
+            if !c.path.starts_with('/') {
+                warnings.push(format!(
+                    "views.\"{key}\": column {header}: path '{}' is not a JSON Pointer \
+                     (must start with '/', e.g. /status/phase); column skipped",
+                    c.path
+                ));
+                continue;
+            }
+            let kind = match c.kind.as_deref() {
+                None | Some("text") => ColumnKind::Text,
+                Some("status") => ColumnKind::Status,
+                Some("number") => ColumnKind::Number,
+                Some("quantity") => ColumnKind::Quantity,
+                Some("time") => ColumnKind::Time,
+                Some(other) => {
+                    warnings.push(format!(
+                        "views.\"{key}\": column {header}: unknown type '{other}' \
+                         (expected text/status/number/quantity/time); using text"
+                    ));
+                    ColumnKind::Text
+                }
+            };
+            let align = match c.align.as_deref() {
+                None => None,
+                Some("left") => Some(Align::Left),
+                Some("center") => Some(Align::Center),
+                Some("right") => Some(Align::Right),
+                Some(other) => {
+                    warnings.push(format!(
+                        "views.\"{key}\": column {header}: unknown align '{other}' \
+                         (expected left/center/right); using left"
+                    ));
+                    None
+                }
+            };
+            columns.push(UserColumn {
+                header,
+                pointer: c.path.clone(),
+                kind,
+                wide: c.wide,
+                width: c.width,
+                align,
+            });
+        }
+        let mut replace = cfg.replace;
+        if replace && columns.is_empty() {
+            warnings.push(format!(
+                "views.\"{key}\": replace = true with no valid columns; overlaying instead"
+            ));
+            replace = false;
+        }
+        let sort = cfg
+            .sort
+            .as_deref()
+            .and_then(|s| parse_sort(key, s, &mut warnings));
+        views.insert(
+            key.to_lowercase(),
+            View {
+                columns,
+                sort,
+                replace,
+            },
+        );
+    }
+    (views, warnings)
+}
+
+/// Parse a view's `sort` value: `"READY"`, `"READY:asc"`, or `"READY:desc"`.
+fn parse_sort(key: &str, s: &str, warnings: &mut Vec<String>) -> Option<(String, bool)> {
+    let (col, dir) = match s.rsplit_once(':') {
+        Some((c, d)) => (c, Some(d.trim())),
+        None => (s, None),
+    };
+    let desc = match dir {
+        None | Some("asc") => false,
+        Some("desc") => true,
+        Some(other) => {
+            warnings.push(format!(
+                "views.\"{key}\": sort direction '{other}' is not asc/desc; using asc"
+            ));
+            false
+        }
+    };
+    let col = col.trim().to_uppercase();
+    if col.is_empty() {
+        warnings.push(format!("views.\"{key}\": empty sort column ignored"));
+        return None;
+    }
+    Some((col, desc))
+}
+
+/// Find the view for a resource, most specific key first:
+/// `apiVersion/plural`, `group/plural`, plural, then lowercased kind.
+pub fn lookup<'a>(views: &'a HashMap<String, View>, ar: &ApiResource) -> Option<&'a View> {
+    let plural = ar.plural.to_lowercase();
+    let mut keys = vec![format!("{}/{plural}", ar.api_version.to_lowercase())];
+    if !ar.group.is_empty() {
+        keys.push(format!("{}/{plural}", ar.group.to_lowercase()));
+    }
+    keys.push(plural);
+    keys.push(ar.kind.to_lowercase());
+    keys.iter().find_map(|k| views.get(k))
+}
+
+/// Resolve a JSON Pointer against the object as served by the API:
+/// `/metadata/…` and `/apiVersion`/`/kind` come from the typed fields, the
+/// rest from the body (`DynamicObject::data` holds spec/status/…).
+pub fn extract(obj: &DynamicObject, pointer: &str) -> Option<Value> {
+    if let Some(rest) = pointer.strip_prefix("/metadata")
+        && (rest.is_empty() || rest.starts_with('/'))
+    {
+        let meta = serde_json::to_value(&obj.metadata).ok()?;
+        return if rest.is_empty() {
+            Some(meta)
+        } else {
+            meta.pointer(rest).cloned()
+        };
+    }
+    match pointer {
+        "/apiVersion" => {
+            return obj
+                .types
+                .as_ref()
+                .map(|t| Value::String(t.api_version.clone()));
+        }
+        "/kind" => return obj.types.as_ref().map(|t| Value::String(t.kind.clone())),
+        _ => {}
+    }
+    obj.data.pointer(pointer).cloned()
+}
+
+/// Render one custom column's cell. Missing values read as `<none>`.
+pub fn render_cell(obj: &DynamicObject, col: &UserColumn) -> String {
+    let Some(v) = extract(obj, &col.pointer) else {
+        return "<none>".into();
+    };
+    match col.kind {
+        ColumnKind::Time => render_time(&v),
+        _ => render_value(&v),
+    }
+}
+
+fn render_value(v: &Value) -> String {
+    match v {
+        Value::Null => "<none>".into(),
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Timestamps render as compact elapsed time (`3d4h`); a future timestamp
+/// (e.g. a certificate's `notAfter`) reads `in 30d`. Values that don't parse
+/// as RFC 3339 fall back to the raw string.
+fn render_time(v: &Value) -> String {
+    let Some(s) = v.as_str() else {
+        return render_value(v);
+    };
+    match s.parse::<Timestamp>() {
+        Ok(ts) => {
+            let delta = Timestamp::now().as_second() - ts.as_second();
+            if delta >= 0 {
+                crate::columns::humanize(delta)
+            } else {
+                format!("in {}", crate::columns::humanize(-delta))
+            }
+        }
+        Err(_) => s.to_string(),
+    }
+}
+
+/// Comparable value of a custom column's cell: numbers, quantities, and times
+/// sort by value (missing/unparseable last in ascending order), text sorts
+/// case-insensitively.
+pub fn sort_value(obj: &DynamicObject, col: &UserColumn) -> SortValue {
+    let v = extract(obj, &col.pointer);
+    match col.kind {
+        ColumnKind::Number => SortValue::Num(v.as_ref().and_then(number_of).unwrap_or(f64::MAX)),
+        ColumnKind::Quantity => {
+            SortValue::Num(v.as_ref().and_then(quantity_of).unwrap_or(f64::MAX))
+        }
+        // Elapsed seconds, like AGE: ascending = most recent (or furthest in
+        // the future) first, unknowns last.
+        ColumnKind::Time => SortValue::Num(
+            v.as_ref()
+                .and_then(Value::as_str)
+                .and_then(|s| s.parse::<Timestamp>().ok())
+                .map(|ts| (Timestamp::now().as_second() - ts.as_second()) as f64)
+                .unwrap_or(f64::MAX),
+        ),
+        ColumnKind::Text | ColumnKind::Status => SortValue::Text(
+            v.as_ref()
+                .map(render_value)
+                .unwrap_or_default()
+                .to_lowercase(),
+        ),
+    }
+}
+
+fn number_of(v: &Value) -> Option<f64> {
+    v.as_f64()
+        .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
+}
+
+fn quantity_of(v: &Value) -> Option<f64> {
+    match v {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => parse_quantity(s),
+        _ => None,
+    }
+}
+
+/// Parse a Kubernetes quantity (`500m` → 0.5, `1Gi` → 1073741824, `2k` →
+/// 2000) into its base-unit value.
+pub fn parse_quantity(s: &str) -> Option<f64> {
+    let s = s.trim();
+    // Two-char binary suffixes must be tried before the one-char decimal ones
+    // (`1Gi` would otherwise strip a bogus trailing `i`).
+    const SUFFIXES: &[(&str, f64)] = &[
+        ("Ki", 1024.0),
+        ("Mi", 1024.0 * 1024.0),
+        ("Gi", 1024.0 * 1024.0 * 1024.0),
+        ("Ti", 1024.0 * 1024.0 * 1024.0 * 1024.0),
+        ("Pi", 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0),
+        ("Ei", 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0),
+        ("n", 1e-9),
+        ("u", 1e-6),
+        ("m", 1e-3),
+        ("k", 1e3),
+        ("M", 1e6),
+        ("G", 1e9),
+        ("T", 1e12),
+        ("P", 1e15),
+        ("E", 1e18),
+    ];
+    for (suf, mult) in SUFFIXES {
+        if let Some(num) = s.strip_suffix(suf) {
+            return num.trim().parse::<f64>().ok().map(|n| n * mult);
+        }
+    }
+    s.parse::<f64>().ok()
+}
+
+/// Build a fallback view from a CRD's `additionalPrinterColumns` for one
+/// served `version` — the automatic upgrade over NAME/AGE for custom
+/// resources without an explicit user view. Columns whose JSONPath can't be
+/// expressed as a JSON Pointer (filters, wildcards) are skipped; columns with
+/// `priority > 0` become wide-only, matching kubectl's `-o wide`.
+pub fn printer_columns_view(crd: &Value, version: &str) -> Option<View> {
+    let versions = crd.pointer("/spec/versions")?.as_array()?;
+    let ver = versions
+        .iter()
+        .find(|v| v.get("name").and_then(Value::as_str) == Some(version))?;
+    let cols = ver.get("additionalPrinterColumns")?.as_array()?;
+    let columns: Vec<UserColumn> = cols
+        .iter()
+        .filter_map(|c| {
+            let name = c.get("name").and_then(Value::as_str)?;
+            let pointer = json_path_to_pointer(c.get("jsonPath").and_then(Value::as_str)?)?;
+            let kind = match c.get("type").and_then(Value::as_str) {
+                Some("integer" | "number") => ColumnKind::Number,
+                Some("date") => ColumnKind::Time,
+                _ => ColumnKind::Text,
+            };
+            let wide = c.get("priority").and_then(Value::as_i64).unwrap_or(0) > 0;
+            Some(UserColumn {
+                header: name.to_uppercase(),
+                pointer,
+                kind,
+                wide,
+                width: None,
+                align: None,
+            })
+        })
+        .collect();
+    if columns.is_empty() {
+        None
+    } else {
+        Some(View {
+            columns,
+            sort: None,
+            replace: false,
+        })
+    }
+}
+
+/// Convert a simple kubectl JSONPath (`.status.phase`,
+/// `.spec.ports[0].port`) to a JSON Pointer. Expressions with filters,
+/// wildcards, quoting, or recursive descent aren't representable — `None`.
+pub fn json_path_to_pointer(path: &str) -> Option<String> {
+    let path = path.trim();
+    let path = path
+        .strip_prefix('{')
+        .and_then(|p| p.strip_suffix('}'))
+        .unwrap_or(path);
+    let rest = path.strip_prefix('.')?;
+    if rest.is_empty()
+        || rest.contains(['*', '?', '@', '(', ')', '"', '\'', '\\', ' '])
+        || rest.contains("..")
+    {
+        return None;
+    }
+    let mut out = String::new();
+    for seg in rest.split('.') {
+        if seg.is_empty() {
+            return None;
+        }
+        let mut seg = seg;
+        loop {
+            match seg.split_once('[') {
+                Some((head, tail)) => {
+                    if !head.is_empty() {
+                        out.push('/');
+                        out.push_str(&escape_segment(head));
+                    }
+                    let (idx, more) = tail.split_once(']')?;
+                    idx.parse::<usize>().ok()?;
+                    out.push('/');
+                    out.push_str(idx);
+                    if more.is_empty() {
+                        break;
+                    }
+                    seg = more;
+                }
+                None => {
+                    out.push('/');
+                    out.push_str(&escape_segment(seg));
+                    break;
+                }
+            }
+        }
+    }
+    Some(out)
+}
+
+/// RFC 6901 escaping for one pointer segment.
+fn escape_segment(seg: &str) -> String {
+    seg.replace('~', "~0").replace('/', "~1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn obj(v: serde_json::Value) -> DynamicObject {
+        serde_json::from_value(v).unwrap()
+    }
+
+    fn col(pointer: &str, kind: ColumnKind) -> UserColumn {
+        UserColumn {
+            header: "COL".into(),
+            pointer: pointer.into(),
+            kind,
+            wide: false,
+            width: None,
+            align: None,
+        }
+    }
+
+    fn compile_toml(text: &str) -> (HashMap<String, View>, Vec<String>) {
+        let cfg: crate::config::Config = toml::from_str(text).unwrap();
+        compile(&cfg.views)
+    }
+
+    #[test]
+    fn compiles_roadmap_example() {
+        let (views, warnings) = compile_toml(
+            r#"
+            [views."cert-manager.io/v1/certificates"]
+            sort = "READY"
+
+            [[views."cert-manager.io/v1/certificates".columns]]
+            name = "READY"
+            path = "/status/conditions/0/status"
+            type = "status"
+
+            [[views."cert-manager.io/v1/certificates".columns]]
+            name = "EXPIRES"
+            path = "/status/notAfter"
+            type = "time"
+            wide = true
+            "#,
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+        let v = &views["cert-manager.io/v1/certificates"];
+        assert_eq!(v.sort, Some(("READY".into(), false)));
+        assert!(!v.replace);
+        assert_eq!(v.columns.len(), 2);
+        assert_eq!(v.columns[0].kind, ColumnKind::Status);
+        assert_eq!(v.columns[1].kind, ColumnKind::Time);
+        assert!(v.columns[1].wide);
+    }
+
+    #[test]
+    fn invalid_columns_warn_and_are_skipped_not_fatal() {
+        let (views, warnings) = compile_toml(
+            r#"
+            [views.widgets]
+            sort = "PHASE:desc"
+            replace = true
+
+            [[views.widgets.columns]]
+            name = "BAD"
+            path = "status.phase"
+
+            [[views.widgets.columns]]
+            name = "ODD"
+            path = "/status/phase"
+            type = "fancy"
+            align = "diagonal"
+            "#,
+        );
+        // Bad pointer skipped, unknown type/align degrade to defaults.
+        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert!(warnings[0].contains("JSON Pointer"));
+        let v = &views["widgets"];
+        assert_eq!(v.columns.len(), 1);
+        assert_eq!(v.columns[0].kind, ColumnKind::Text);
+        assert_eq!(v.columns[0].align, None);
+        assert_eq!(v.sort, Some(("PHASE".into(), true)));
+    }
+
+    #[test]
+    fn replace_without_columns_degrades_to_overlay() {
+        let (views, warnings) = compile_toml(
+            r#"
+            [views.widgets]
+            replace = true
+
+            [[views.widgets.columns]]
+            name = "BAD"
+            path = "no-slash"
+            "#,
+        );
+        assert!(!views["widgets"].replace);
+        assert!(warnings.iter().any(|w| w.contains("replace")));
+    }
+
+    #[test]
+    fn lookup_prefers_most_specific_key() {
+        let ar = ApiResource {
+            group: "cert-manager.io".into(),
+            version: "v1".into(),
+            api_version: "cert-manager.io/v1".into(),
+            kind: "Certificate".into(),
+            plural: "certificates".into(),
+        };
+        let mk = |sort: &str| View {
+            sort: Some((sort.to_uppercase(), false)),
+            ..Default::default()
+        };
+        let mut views = HashMap::new();
+        views.insert("certificate".to_string(), mk("by-kind"));
+        assert_eq!(
+            lookup(&views, &ar).unwrap().sort,
+            Some(("BY-KIND".into(), false))
+        );
+        views.insert("certificates".to_string(), mk("by-plural"));
+        assert_eq!(
+            lookup(&views, &ar).unwrap().sort,
+            Some(("BY-PLURAL".into(), false))
+        );
+        views.insert("cert-manager.io/certificates".to_string(), mk("by-group"));
+        assert_eq!(
+            lookup(&views, &ar).unwrap().sort,
+            Some(("BY-GROUP".into(), false))
+        );
+        views.insert("cert-manager.io/v1/certificates".to_string(), mk("by-gvr"));
+        assert_eq!(
+            lookup(&views, &ar).unwrap().sort,
+            Some(("BY-GVR".into(), false))
+        );
+    }
+
+    #[test]
+    fn extracts_pointers_across_metadata_typemeta_and_body() {
+        let o = obj(json!({
+            "apiVersion": "example.com/v1",
+            "kind": "Widget",
+            "metadata": {"name": "w1", "labels": {"app": "web"}},
+            "spec": {"size": 3, "tags": ["a", "b"]},
+            "status": {"phase": "Ready"}
+        }));
+        assert_eq!(extract(&o, "/status/phase"), Some(json!("Ready")));
+        assert_eq!(extract(&o, "/spec/tags/1"), Some(json!("b")));
+        assert_eq!(extract(&o, "/metadata/name"), Some(json!("w1")));
+        assert_eq!(extract(&o, "/metadata/labels/app"), Some(json!("web")));
+        assert_eq!(extract(&o, "/apiVersion"), Some(json!("example.com/v1")));
+        assert_eq!(extract(&o, "/kind"), Some(json!("Widget")));
+        assert_eq!(extract(&o, "/spec/missing"), None);
+        // `/metadataX` must not be mistaken for a metadata pointer.
+        assert_eq!(extract(&o, "/metadataX"), None);
+    }
+
+    #[test]
+    fn renders_missing_scalars_and_compound_values() {
+        let o = obj(json!({
+            "apiVersion": "example.com/v1", "kind": "Widget",
+            "metadata": {"name": "w1"},
+            "spec": {"size": 3, "on": true, "tags": ["a"]}
+        }));
+        assert_eq!(render_cell(&o, &col("/spec/size", ColumnKind::Text)), "3");
+        assert_eq!(render_cell(&o, &col("/spec/on", ColumnKind::Text)), "true");
+        assert_eq!(
+            render_cell(&o, &col("/spec/tags", ColumnKind::Text)),
+            "[\"a\"]"
+        );
+        assert_eq!(
+            render_cell(&o, &col("/spec/nope", ColumnKind::Text)),
+            "<none>"
+        );
+    }
+
+    #[test]
+    fn renders_time_as_elapsed_and_future_with_prefix() {
+        let past = Timestamp::now().as_second() - 3600;
+        let future = Timestamp::now().as_second() + 86_400 * 30;
+        let o = obj(json!({
+            "apiVersion": "v1", "kind": "W",
+            "metadata": {"name": "w"},
+            "spec": {
+                "past": Timestamp::from_second(past).unwrap().to_string(),
+                "future": Timestamp::from_second(future).unwrap().to_string(),
+                "junk": "not-a-time"
+            }
+        }));
+        assert_eq!(render_cell(&o, &col("/spec/past", ColumnKind::Time)), "1h");
+        assert_eq!(
+            render_cell(&o, &col("/spec/future", ColumnKind::Time)),
+            "in 30d"
+        );
+        assert_eq!(
+            render_cell(&o, &col("/spec/junk", ColumnKind::Time)),
+            "not-a-time"
+        );
+    }
+
+    #[test]
+    fn parses_quantities_by_value() {
+        assert_eq!(parse_quantity("500m"), Some(0.5));
+        assert_eq!(parse_quantity("2"), Some(2.0));
+        assert_eq!(parse_quantity("1Gi"), Some(1024.0 * 1024.0 * 1024.0));
+        assert_eq!(parse_quantity("2k"), Some(2000.0));
+        let nanos = parse_quantity("100n").unwrap();
+        assert!((nanos - 1e-7).abs() < 1e-12);
+        assert_eq!(parse_quantity("nope"), None);
+    }
+
+    fn num(sv: SortValue) -> f64 {
+        match sv {
+            SortValue::Num(n) => n,
+            SortValue::Text(t) => panic!("expected Num, got Text({t})"),
+        }
+    }
+
+    #[test]
+    fn quantities_numbers_and_times_sort_by_value_not_lexically() {
+        let o = obj(json!({
+            "apiVersion": "v1", "kind": "W",
+            "metadata": {"name": "w"},
+            "spec": {
+                "small": "500m", "big": "1Gi",
+                "nine": 9, "ten": "10",
+                "old": "2020-01-01T00:00:00Z", "new": "2030-01-01T00:00:00Z"
+            }
+        }));
+        // Lexically "1Gi" < "500m" — by value it must be the other way.
+        let q = |p: &str| num(sort_value(&o, &col(p, ColumnKind::Quantity)));
+        assert!(q("/spec/small") < q("/spec/big"));
+        // Lexically "10" < "9".
+        let n = |p: &str| num(sort_value(&o, &col(p, ColumnKind::Number)));
+        assert!(n("/spec/nine") < n("/spec/ten"));
+        // Ascending time = most recent first (smaller elapsed).
+        let t = |p: &str| num(sort_value(&o, &col(p, ColumnKind::Time)));
+        assert!(t("/spec/new") < t("/spec/old"));
+        // Missing values sort last in ascending order.
+        assert_eq!(q("/spec/missing"), f64::MAX);
+        assert_eq!(n("/spec/missing"), f64::MAX);
+        assert_eq!(t("/spec/missing"), f64::MAX);
+    }
+
+    #[test]
+    fn converts_simple_json_paths_to_pointers() {
+        assert_eq!(
+            json_path_to_pointer(".status.phase"),
+            Some("/status/phase".into())
+        );
+        assert_eq!(
+            json_path_to_pointer(".spec.ports[0].port"),
+            Some("/spec/ports/0/port".into())
+        );
+        assert_eq!(
+            json_path_to_pointer("{.metadata.name}"),
+            Some("/metadata/name".into())
+        );
+        assert_eq!(json_path_to_pointer(".spec.a~b"), Some("/spec/a~0b".into()));
+        // Filters, wildcards, recursion: not representable as pointers.
+        assert_eq!(
+            json_path_to_pointer(r#".status.conditions[?(@.type=="Ready")].status"#),
+            None
+        );
+        assert_eq!(json_path_to_pointer(".spec.containers[*].image"), None);
+        assert_eq!(json_path_to_pointer("..name"), None);
+        assert_eq!(json_path_to_pointer("status.phase"), None);
+    }
+
+    #[test]
+    fn builds_printer_column_view_from_crd() {
+        let crd = json!({
+            "spec": {
+                "group": "example.com",
+                "versions": [
+                    {"name": "v1alpha1", "served": true},
+                    {"name": "v1", "served": true, "storage": true,
+                     "additionalPrinterColumns": [
+                        {"name": "Phase", "type": "string", "jsonPath": ".status.phase"},
+                        {"name": "Replicas", "type": "integer", "jsonPath": ".spec.replicas"},
+                        {"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"},
+                        {"name": "Detail", "type": "string", "priority": 1,
+                         "jsonPath": ".status.message"},
+                        {"name": "Skipped", "type": "string",
+                         "jsonPath": ".status.conditions[?(@.type=='Ready')].status"}
+                     ]}
+                ]
+            }
+        });
+        let view = printer_columns_view(&crd, "v1").unwrap();
+        assert!(!view.replace);
+        let headers: Vec<&str> = view.columns.iter().map(|c| c.header.as_str()).collect();
+        // The filter-expression column is skipped, the rest map over.
+        assert_eq!(headers, vec!["PHASE", "REPLICAS", "AGE", "DETAIL"]);
+        assert_eq!(view.columns[0].kind, ColumnKind::Text);
+        assert_eq!(view.columns[1].kind, ColumnKind::Number);
+        assert_eq!(view.columns[2].kind, ColumnKind::Time);
+        assert!(view.columns[3].wide, "priority>0 becomes wide-only");
+        // The version without printer columns yields nothing.
+        assert!(printer_columns_view(&crd, "v1alpha1").is_none());
+        assert!(printer_columns_view(&crd, "v9").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Implements the P0 "custom columns and views" roadmap item (plus wide/narrow table modes) from `future.md`, covering three Milestone 1 checkboxes: custom columns/view overlays, CRD `additionalPrinterColumns` support, and wide/narrow column visibility.

- **Custom views in config** — new `[views]` tables in `config.toml`, keyed by apiVersion/plural (`"cert-manager.io/v1/certificates"`, `"v1/pods"`), group/plural, bare plural, or lowercased kind (most specific key wins). Each view defines columns with `name`, `path`, `type`, and optional `wide`/`width`/`align`, plus an initial `sort = "HEADER[:asc|:desc]"`.
- **JSON Pointer extraction (RFC 6901)** — `path` resolves against the object as served by the API: `/spec/…`, `/status/…`, array indices, `/metadata/…`, and `/apiVersion`/`/kind`. Documented in the README and module docs.
- **Typed sorting** — column types `text`, `status`, `number`, `quantity`, and `time` sort by value: `500m < 2 < 1Gi` for quantities, `9 < 10` for numbers, timestamps by instant (missing values last). `status` columns drive the existing row status coloring.
- **Overlay vs replace** — by default user columns overlay the curated set (matching headers replace in place, new columns land before AGE); `replace = true` swaps the whole layout.
- **CRD printer columns** — custom resources with no curated columns and no user view automatically pick up `additionalPrinterColumns` from their CRD for the served version being watched (fetched lazily off-thread, seeded directly on CRD drill-down). Simple kubectl JSONPaths are converted to pointers; filter/wildcard expressions are skipped; `priority > 0` maps to wide-only, matching `kubectl -o wide`.
- **Wide/narrow toggle** — new `w` binding gates wide-only columns (user, printer, and the curated pod IP/NODE columns). The active sort stays pinned to its header across layout changes and resets when its column disappears.
- **Fail-safe validation** — view config is validated at load: bad pointers, unknown types/alignments, and unusable sorts degrade to actionable warnings surfaced in the status line (and stderr), never a crash. A view whose columns all fail validation still falls back to printer columns.

The generic object→cells pipeline stays the single rendering path: curated columns, user columns, and printer columns all resolve into one `ViewSpec` built per view change, feeding the existing cached row/cell machinery.

## Example

```toml
[views."cert-manager.io/v1/certificates"]
sort = "EXPIRES:desc"

[[views."cert-manager.io/v1/certificates".columns]]
name = "READY"
path = "/status/conditions/0/status"
type = "status"

[[views."cert-manager.io/v1/certificates".columns]]
name = "EXPIRES"
path = "/status/notAfter"
type = "time"
```

## Test plan

- [x] `just check` (fmt-check, `clippy --all-targets -- -D warnings`, tests) passes — 178 tests
- [x] Unit tests: config parsing/validation warnings, JSON Pointer extraction (metadata/typemeta/body), quantity parsing, typed sort comparisons, JSONPath→pointer conversion, printer-column mapping (types, priority, skipped filters)
- [x] App-level tests: overlay vs replace, initial sort application, printer-column fallback upgrade + stale-generation drop, user view precedence over printer columns, wide toggle revealing pod IP/NODE while remapping the sort, invalid sort column warning
- [x] Verified live against a dev cluster with `--snapshot`: narrow pods view hides IP/NODE; `certificates` picks up CRD printer columns automatically; a user view renders READY/EXPIRES with the configured sort arrow and `in 35d` future timestamps; an invalid pointer produces an in-app warning and no crash