### PR TITLE
feat: show per-container resource metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Not a marketing number - these are specific, checkable design choices:
   pick up their CRD's `additionalPrinterColumns`. `w` toggles wide-only
   columns (kubectl `-o wide`).
 - **Live CPU/MEM columns** for pods and nodes from the metrics API, with
-  outlier coloring; degrades gracefully when metrics-server is absent.
+  outlier coloring. The pod container picker also shows per-container CPU and
+  memory; both views degrade gracefully when metrics-server is absent.
 - **Drill-down navigation** with a breadcrumb stack: workload/service →
   pods, node → its pods, pod → containers, namespace → re-scope, CRD → its
   custom resources. `esc` pops back.

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -667,3 +667,30 @@ pub(super) fn usage_of(obj: &DynamicObject, is_node: bool) -> (i64, i64) {
         (cpu, mem)
     }
 }
+
+/// Extract each container's (CPU millicores, memory bytes) from a PodMetrics
+/// object. Malformed or missing quantities degrade to zero through the shared
+/// quantity parsers, matching the existing pod-total behavior.
+pub(super) fn container_usage_of(obj: &DynamicObject) -> Vec<(String, (i64, i64))> {
+    use crate::columns::{parse_cpu_milli, parse_mem_bytes};
+    obj.data
+        .pointer("/containers")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|container| {
+            let name = container.get("name")?.as_str()?.to_string();
+            let cpu = container
+                .pointer("/usage/cpu")
+                .and_then(Value::as_str)
+                .map(parse_cpu_milli)
+                .unwrap_or(0);
+            let memory = container
+                .pointer("/usage/memory")
+                .and_then(Value::as_str)
+                .map(parse_mem_bytes)
+                .unwrap_or(0);
+            Some((name, (cpu, memory)))
+        })
+        .collect()
+}

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -253,6 +253,7 @@ impl App {
         }
         self.store.clear();
         self.metrics.clear();
+        self.container_metrics.clear();
         self.marked.clear();
         self.invalidate_rows();
         if self.table_state.selected().is_none() {
@@ -450,18 +451,25 @@ impl App {
                 };
                 if let Ok(list) = api.list(&ListParams::default()).await {
                     let mut data = HashMap::new();
+                    let mut containers = HashMap::new();
                     for item in list {
                         let name = item.metadata.name.clone().unwrap_or_default();
                         let key = match &item.metadata.namespace {
                             Some(n) => format!("{n}/{name}"),
                             None => name,
                         };
+                        if !is_node {
+                            for (container, usage) in container_usage_of(&item) {
+                                containers.insert(format!("{key}/{container}"), usage);
+                            }
+                        }
                         data.insert(key, usage_of(&item, is_node));
                     }
                     if tx
                         .send(Msg::Metrics {
                             generation: genr,
                             data,
+                            containers,
                         })
                         .await
                         .is_err()
@@ -510,7 +518,11 @@ impl App {
             Msg::LogLines { generation, lines } if generation == self.log_gen => {
                 self.push_log_lines(lines);
             }
-            Msg::Metrics { generation, data } if generation == self.generation => {
+            Msg::Metrics {
+                generation,
+                data,
+                containers,
+            } if generation == self.generation => {
                 let sort_uses_metrics = self
                     .sort_column
                     .and_then(|i| {
@@ -519,6 +531,7 @@ impl App {
                     })
                     .is_some_and(|h| matches!(h.as_str(), "CPU" | "MEM"));
                 self.metrics = data;
+                self.container_metrics = containers;
                 if sort_uses_metrics {
                     self.invalidate_rows();
                 }

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -68,6 +68,16 @@ impl App {
         self.mode = Mode::Containers;
     }
 
+    /// Latest metrics for a container in the pod currently shown by the
+    /// container picker. `None` distinguishes unavailable Metrics Server data
+    /// from a measured zero value.
+    pub fn selected_pod_container_metrics(&self, container: &str) -> Option<(i64, i64)> {
+        let (namespace, pod) = self.container_pod.as_ref()?;
+        self.container_metrics
+            .get(&format!("{namespace}/{pod}/{container}"))
+            .copied()
+    }
+
     /// Logs for the current selection. For pods: stream every container. For
     /// workloads/services: list matching pods and aggregate all their logs.
     pub(super) fn open_logs(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -620,6 +620,8 @@ pub struct App {
 
     /// Latest metrics snapshot: "ns/name" (pods) or "name" (nodes) -> (cpu_m, mem_bytes).
     pub metrics: HashMap<String, (i64, i64)>,
+    /// Latest pod-container metrics: "ns/pod/container" -> (cpu_m, mem_bytes).
+    pub container_metrics: HashMap<String, (i64, i64)>,
 
     pub pulse: Pulse,
     pub xray_items: Vec<XrayItem>,
@@ -735,6 +737,7 @@ impl App {
             image_values: Vec::new(),
             image_target: None,
             metrics: HashMap::new(),
+            container_metrics: HashMap::new(),
             pulse: Pulse::default(),
             xray_items: Vec::new(),
             xray_state: ListState::default(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1218,6 +1218,7 @@ async fn metrics_update_invalidates_metric_sorted_rows() {
             ("default/a".to_string(), (10, 0)),
             ("default/b".to_string(), (100, 0)),
         ]),
+        containers: HashMap::new(),
     });
     let names: Vec<String> = app
         .rows()
@@ -1225,6 +1226,58 @@ async fn metrics_update_invalidates_metric_sorted_rows() {
         .map(|o| o.metadata.name.clone().unwrap())
         .collect();
     assert_eq!(names, ["b", "a"]);
+}
+
+#[test]
+fn pod_metrics_are_split_by_container() {
+    let metrics = obj(json!({
+        "apiVersion": "metrics.k8s.io/v1beta1",
+        "kind": "PodMetrics",
+        "metadata": {"name": "api", "namespace": "default"},
+        "containers": [
+            {"name": "app", "usage": {"cpu": "125m", "memory": "64Mi"}},
+            {"name": "sidecar", "usage": {"cpu": "50000000n", "memory": "16Mi"}}
+        ]
+    }));
+
+    assert_eq!(
+        container_usage_of(&metrics),
+        vec![
+            ("app".into(), (125, 64 * 1024 * 1024)),
+            ("sidecar".into(), (50, 16 * 1024 * 1024)),
+        ]
+    );
+    assert_eq!(usage_of(&metrics, false), (175, 80 * 1024 * 1024));
+}
+
+#[tokio::test]
+async fn container_picker_reads_latest_metrics_snapshot() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "api", "namespace": "default"},
+            "spec": {"containers": [{"name": "app"}, {"name": "sidecar"}]}
+        }),
+    );
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::from([("default/api".into(), (175, 80 * 1024 * 1024))]),
+        containers: HashMap::from([
+            ("default/api/app".into(), (125, 64 * 1024 * 1024)),
+            ("default/api/sidecar".into(), (50, 16 * 1024 * 1024)),
+        ]),
+    });
+
+    let pod = app.selected().unwrap();
+    app.open_containers(&pod);
+    assert_eq!(
+        app.selected_pod_container_metrics("app"),
+        Some((125, 64 * 1024 * 1024))
+    );
+    assert_eq!(app.selected_pod_container_metrics("missing"), None);
 }
 
 #[tokio::test]
@@ -2746,6 +2799,7 @@ async fn cpu_and_memory_filters_use_metrics_snapshot() {
     app.handle_msg(Msg::Metrics {
         generation: app.generation,
         data,
+        containers: HashMap::new(),
     });
 
     type_filter(&mut app, "cpu>500m");

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -254,10 +254,8 @@ fn split_cmp(tok: &str) -> Option<(&str, Op, &str)> {
         (Op::Eq, v)
     } else if let Some(v) = rest.strip_prefix('>') {
         (Op::Gt, v)
-    } else if let Some(v) = rest.strip_prefix('<') {
-        (Op::Lt, v)
     } else {
-        return None;
+        (Op::Lt, rest.strip_prefix('<')?)
     };
     Some((key, op, value))
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -31,6 +31,8 @@ pub enum Msg {
     Metrics {
         generation: u64,
         data: HashMap<String, (i64, i64)>,
+        /// Per-container usage keyed by `namespace/pod/container`.
+        containers: HashMap<String, (i64, i64)>,
     },
     /// CRD `additionalPrinterColumns` fallback for a custom-resource plural,
     /// fetched off-thread (`None` = CRD had nothing usable for the version).

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1740,19 +1740,47 @@ fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
+    let name_width = app
+        .container_list
+        .iter()
+        .map(|name| name.chars().count())
+        .max()
+        .unwrap_or(4)
+        .max(4);
     let items: Vec<ListItem> = app
         .container_list
         .iter()
-        .map(|c| ListItem::new(Span::styled(c.clone(), Style::default().fg(theme::text()))))
+        .map(|container| {
+            let (cpu, memory) = app
+                .selected_pod_container_metrics(container)
+                .map(|(cpu, memory)| {
+                    (
+                        crate::columns::fmt_cpu(cpu),
+                        crate::columns::fmt_mem(memory),
+                    )
+                })
+                .unwrap_or_else(|| ("-".into(), "-".into()));
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{container:<name_width$}"),
+                    Style::default().fg(theme::text()),
+                ),
+                Span::styled(format!("  {cpu:>8}"), Style::default().fg(theme::yellow())),
+                Span::styled(
+                    format!("  {memory:>10}"),
+                    Style::default().fg(theme::teal()),
+                ),
+            ]))
+        })
         .collect();
     render_popup_list(
         frame,
         area,
-        50,
+        64,
         60,
         items,
         Span::styled(
-            " Containers (⏎ logs · p previous · s shell) ",
+            " Containers · CPU · MEMORY (⏎ logs · p previous · s shell) ",
             theme::title(),
         ),
         &mut app.container_state,


### PR DESCRIPTION
## Summary

  - Retain per-container CPU and memory samples from PodMetrics.
  - Show live CPU and memory in the pod container picker.
  - Preserve pod totals and degrade gracefully without Metrics Server.

  ## Verification

  - `cargo fmt --check`
  - `cargo clippy`
  - `cargo test` — 215 passed