### PR TITLE
feat: request/limit utilization and QoS in container picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Not a marketing number - these are specific, checkable design choices:
   columns (kubectl `-o wide`).
 - **Live CPU/MEM columns** for pods and nodes from the metrics API, with
   outlier coloring. The pod container picker also shows per-container CPU and
-  memory; both views degrade gracefully when metrics-server is absent.
+  memory, each container's usage as a percentage of its request and limit
+  (`-` marks an unset request/limit), and the pod's QoS class; all of it
+  degrades gracefully when metrics-server is absent.
 - **Drill-down navigation** with a breadcrumb stack: workload/service →
   pods, node → its pods, pod → containers, namespace → re-scope, CRD → its
   custom resources. `esc` pops back.

--- a/README.md
+++ b/README.md
@@ -417,6 +417,70 @@ The recipe switches to a clean, up-to-date `main`, bumps `Cargo.toml` /
 Release. The release workflow runs from that published release and uploads
 platform binaries, publishes crates.io, and warms the Nix cache.
 
+## Future roadmap
+
+### Milestone 1: power-user foundation
+
+- [x] Custom columns and view overlays.
+- [x] CRD `additionalPrinterColumns` support.
+- [x] Structured filter parser.
+- [x] Server-side label and field selectors.
+- [x] Config reload and validation view.
+- [x] Wide/narrow column visibility.
+
+### Milestone 2: actionable health
+
+- [x] Container metrics.
+- [x] Request/limit percentages and QoS.
+- [ ] Configurable thresholds.
+- [ ] Explain-unhealthy view.
+- [ ] Direct evidence navigation.
+- [ ] Initial session-local timeline.
+
+### Milestone 3: extensibility and repeatable workflows
+
+- [ ] Modifier-aware hotkeys.
+- [ ] Rich plugin execution and output modes.
+- [ ] Bulk plugins.
+- [ ] Bookmarks and saved queries.
+- [ ] Operational workspaces.
+- [ ] Namespace favourites and recents.
+
+### Milestone 4: GitOps and safety
+
+- [ ] Flux ownership and dependency navigation.
+- [ ] Revision and reconciliation-chain visibility.
+- [ ] Managed-resource mutation warnings.
+- [ ] Action-aware authorization checks.
+- [ ] Declarative guardrails.
+- [ ] Local action journal.
+
+### Milestone 5: debugging and collaboration
+
+- [ ] Ephemeral container workflow.
+- [ ] Node debug pod workflow.
+- [ ] Redacted diagnostic bundles.
+- [ ] Screen dumps and structured snapshots.
+- [ ] Runtime diagnostics and structured logs.
+- [ ] Richer log controls.
+
+### Milestone 6: fleet and integrations
+
+- [ ] Opt-in cross-context health dashboard.
+- [ ] Historical metrics provider interface.
+- [ ] Log and trace provider interfaces.
+- [ ] Extended relationship graph.
+- [ ] Vulnerability scanner integration.
+- [ ] Historical right-sizing recommendations.
+
+### Milestone 7: distribution polish
+
+- [ ] Signed and notarized macOS releases.
+- [ ] Homebrew distribution.
+- [ ] Checksums, attestations, and SBOM.
+- [ ] Evaluate Windows support.
+- [ ] Document a Kubernetes compatibility matrix.
+
 ## License
 
 Dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE), at

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -694,3 +694,103 @@ pub(super) fn container_usage_of(obj: &DynamicObject) -> Vec<(String, (i64, i64)
         })
         .collect()
 }
+
+/// Extract each container's declared CPU/memory requests and limits from a Pod
+/// spec, covering regular, init, and ephemeral containers so the map matches
+/// [`container_names`]. Missing quantities stay `None` to keep "unset" distinct
+/// from a real zero.
+pub(super) fn container_resources_of(
+    obj: &DynamicObject,
+) -> Vec<(String, crate::columns::ContainerResources)> {
+    let mut out = Vec::new();
+    for key in ["containers", "initContainers", "ephemeralContainers"] {
+        let Some(arr) = obj
+            .data
+            .pointer(&format!("/spec/{key}"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        for c in arr {
+            if let Some(name) = c.get("name").and_then(Value::as_str) {
+                out.push((name.to_string(), single_container_resources(c)));
+            }
+        }
+    }
+    out
+}
+
+/// Kubernetes QoS class for a pod. Prefers the authoritative
+/// `status.qosClass` set by the API server; when absent (e.g. a not-yet-
+/// scheduled pod), derives it from regular-container requests and limits.
+/// Returns an empty string only when there is no pod spec to reason about.
+pub(super) fn qos_class(obj: &DynamicObject) -> String {
+    if let Some(q) = obj
+        .data
+        .pointer("/status/qosClass")
+        .and_then(Value::as_str)
+        .filter(|q| !q.is_empty())
+    {
+        return q.to_string();
+    }
+
+    let Some(containers) = obj
+        .data
+        .pointer("/spec/containers")
+        .and_then(Value::as_array)
+    else {
+        return String::new();
+    };
+    if containers.is_empty() {
+        return String::new();
+    }
+
+    let mut any_set = false;
+    let mut guaranteed = true;
+    for c in containers {
+        use crate::columns::ContainerResources;
+        let ContainerResources {
+            cpu_request,
+            cpu_limit,
+            mem_request,
+            mem_limit,
+        } = single_container_resources(c);
+        if cpu_request.is_some()
+            || cpu_limit.is_some()
+            || mem_request.is_some()
+            || mem_limit.is_some()
+        {
+            any_set = true;
+        }
+        // Guaranteed requires every resource to have request == limit > 0.
+        let matched = |req: Option<i64>, lim: Option<i64>| matches!((req, lim), (Some(r), Some(l)) if r == l && r > 0);
+        if !(matched(cpu_request, cpu_limit) && matched(mem_request, mem_limit)) {
+            guaranteed = false;
+        }
+    }
+
+    if !any_set {
+        "BestEffort".into()
+    } else if guaranteed {
+        "Guaranteed".into()
+    } else {
+        "Burstable".into()
+    }
+}
+
+/// Parse one container's `resources` block. Shared by [`qos_class`]'s fallback
+/// computation.
+fn single_container_resources(c: &Value) -> crate::columns::ContainerResources {
+    use crate::columns::{ContainerResources, parse_cpu_milli, parse_mem_bytes};
+    let q = |section: &str, resource: &str, parse: fn(&str) -> i64| {
+        c.pointer(&format!("/resources/{section}/{resource}"))
+            .and_then(Value::as_str)
+            .map(parse)
+    };
+    ContainerResources {
+        cpu_request: q("requests", "cpu", parse_cpu_milli),
+        cpu_limit: q("limits", "cpu", parse_cpu_milli),
+        mem_request: q("requests", "memory", parse_mem_bytes),
+        mem_limit: q("limits", "memory", parse_mem_bytes),
+    }
+}

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -64,6 +64,8 @@ impl App {
         let name = obj.metadata.name.clone().unwrap_or_default();
         self.container_pod = Some((ns, name));
         self.container_list = names;
+        self.container_resources = container_resources_of(obj).into_iter().collect();
+        self.container_qos = qos_class(obj);
         self.container_state.select(Some(0));
         self.mode = Mode::Containers;
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -581,6 +581,11 @@ pub struct App {
     pub container_list: Vec<String>,
     pub container_state: ListState,
     container_pod: Option<(String, String)>, // (ns, name)
+    /// Declared requests/limits for the pod shown by the container picker,
+    /// keyed by container name. Drives the request/limit percentage columns.
+    pub container_resources: HashMap<String, crate::columns::ContainerResources>,
+    /// QoS class of the pod shown by the container picker (empty if unknown).
+    pub container_qos: String,
 
     /// Cursor into [`FLUX_MENU_ITEMS`] for the Flux suspend/resume menu.
     pub flux_menu_state: ListState,
@@ -719,6 +724,8 @@ impl App {
             container_list: Vec::new(),
             container_state: ListState::default(),
             container_pod: None,
+            container_resources: HashMap::new(),
+            container_qos: String::new(),
             flux_menu_state: ListState::default(),
             port_forwards: Vec::new(),
             pf_state: ListState::default(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1280,6 +1280,161 @@ async fn container_picker_reads_latest_metrics_snapshot() {
     assert_eq!(app.selected_pod_container_metrics("missing"), None);
 }
 
+#[test]
+fn container_resources_extracted_per_container() {
+    use crate::columns::ContainerResources;
+    let pod = obj(json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "api", "namespace": "default"},
+        "spec": {"containers": [
+            {"name": "app", "resources": {
+                "requests": {"cpu": "250m", "memory": "64Mi"},
+                "limits": {"cpu": "500m", "memory": "128Mi"}
+            }},
+            // sidecar declares only a request, no limits -> those stay None.
+            {"name": "sidecar", "resources": {"requests": {"cpu": "50m"}}}
+        ]}
+    }));
+
+    let res: std::collections::HashMap<_, _> = container_resources_of(&pod).into_iter().collect();
+    assert_eq!(
+        res["app"],
+        ContainerResources {
+            cpu_request: Some(250),
+            cpu_limit: Some(500),
+            mem_request: Some(64 * 1024 * 1024),
+            mem_limit: Some(128 * 1024 * 1024),
+        }
+    );
+    assert_eq!(
+        res["sidecar"],
+        ContainerResources {
+            cpu_request: Some(50),
+            cpu_limit: None,
+            mem_request: None,
+            mem_limit: None,
+        }
+    );
+}
+
+#[test]
+fn qos_class_prefers_status_then_computes() {
+    // The API server's status.qosClass is authoritative when present.
+    let with_status = obj(json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "api"},
+        "spec": {"containers": [{"name": "app"}]},
+        "status": {"qosClass": "Burstable"}
+    }));
+    assert_eq!(qos_class(&with_status), "Burstable");
+
+    // No status: derive Guaranteed when every resource has request == limit.
+    let guaranteed = obj(json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "api"},
+        "spec": {"containers": [{"name": "app", "resources": {
+            "requests": {"cpu": "500m", "memory": "128Mi"},
+            "limits": {"cpu": "500m", "memory": "128Mi"}
+        }}]}
+    }));
+    assert_eq!(qos_class(&guaranteed), "Guaranteed");
+
+    // Requests below limits -> Burstable.
+    let burstable = obj(json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "api"},
+        "spec": {"containers": [{"name": "app", "resources": {
+            "requests": {"cpu": "250m"},
+            "limits": {"cpu": "500m"}
+        }}]}
+    }));
+    assert_eq!(qos_class(&burstable), "Burstable");
+
+    // No requests or limits at all -> BestEffort.
+    let besteffort = obj(json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "api"},
+        "spec": {"containers": [{"name": "app"}]}
+    }));
+    assert_eq!(qos_class(&besteffort), "BestEffort");
+}
+
+#[tokio::test]
+async fn container_picker_populates_resources_and_qos() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "api", "namespace": "default"},
+            "spec": {"containers": [{"name": "app", "resources": {
+                "requests": {"cpu": "250m", "memory": "64Mi"},
+                "limits": {"cpu": "500m", "memory": "128Mi"}
+            }}]},
+            "status": {"qosClass": "Burstable"}
+        }),
+    );
+
+    let pod = app.selected().unwrap();
+    app.open_containers(&pod);
+    assert_eq!(app.container_qos, "Burstable");
+    assert_eq!(app.container_resources["app"].cpu_request, Some(250));
+    assert_eq!(
+        app.container_resources["app"].mem_limit,
+        Some(128 * 1024 * 1024)
+    );
+}
+
+#[tokio::test]
+async fn container_picker_renders_qos_and_utilization() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "api", "namespace": "default"},
+            "spec": {"containers": [{"name": "app", "resources": {
+                "requests": {"cpu": "250m", "memory": "128Mi"},
+                "limits": {"cpu": "500m", "memory": "256Mi"}
+            }}]},
+            "status": {"qosClass": "Burstable"}
+        }),
+    );
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::from([("default/api".into(), (125, 64 * 1024 * 1024))]),
+        containers: HashMap::from([("default/api/app".into(), (125, 64 * 1024 * 1024))]),
+    });
+
+    let pod = app.selected().unwrap();
+    app.open_containers(&pod);
+
+    let mut term = Terminal::new(TestBackend::new(120, 32)).unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let buffer = term.backend().buffer().clone();
+    let screen: String = (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // QoS is surfaced in the popup title.
+    assert!(screen.contains("Burstable"), "missing QoS in:\n{screen}");
+    // 125m of a 250m request / 500m limit, and 64Mi of 128Mi / 256Mi.
+    assert!(
+        screen.contains("50%/25%"),
+        "missing utilization percentages in:\n{screen}"
+    );
+}
+
 #[tokio::test]
 async fn logs_keep_view_and_restore_selection() {
     let (mut app, _rx) = test_app();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1397,18 +1397,29 @@ async fn container_picker_renders_qos_and_utilization() {
         &mut app,
         json!({
             "apiVersion": "v1", "kind": "Pod",
-            "metadata": {"name": "api", "namespace": "default"},
-            "spec": {"containers": [{"name": "app", "resources": {
-                "requests": {"cpu": "250m", "memory": "128Mi"},
-                "limits": {"cpu": "500m", "memory": "256Mi"}
-            }}]},
+            "metadata": {"name": "mailerlite-app-horizon-mail-7dbdf476f8", "namespace": "default"},
+            "spec": {"containers": [
+                {"name": "mailerlite-mailerlite-app-horizon-mail", "resources": {
+                    "requests": {"cpu": "250m", "memory": "128Mi"},
+                    "limits": {"cpu": "500m", "memory": "256Mi"}
+                }},
+                // istio-proxy declares a request but no memory limit -> "-".
+                {"name": "istio-proxy", "resources": {"requests": {"cpu": "100m", "memory": "128Mi"}}}
+            ]},
             "status": {"qosClass": "Burstable"}
         }),
     );
+    let key = "default/mailerlite-app-horizon-mail-7dbdf476f8";
     app.handle_msg(Msg::Metrics {
         generation: app.generation,
-        data: HashMap::from([("default/api".into(), (125, 64 * 1024 * 1024))]),
-        containers: HashMap::from([("default/api/app".into(), (125, 64 * 1024 * 1024))]),
+        data: HashMap::from([(key.into(), (175, 80 * 1024 * 1024))]),
+        containers: HashMap::from([
+            (
+                format!("{key}/mailerlite-mailerlite-app-horizon-mail"),
+                (125, 64 * 1024 * 1024),
+            ),
+            (format!("{key}/istio-proxy"), (50, 16 * 1024 * 1024)),
+        ]),
     });
 
     let pod = app.selected().unwrap();
@@ -1426,12 +1437,22 @@ async fn container_picker_renders_qos_and_utilization() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    // QoS is surfaced in the popup title.
+    // QoS is surfaced in the popup title, and the table has a labeled header.
     assert!(screen.contains("Burstable"), "missing QoS in:\n{screen}");
+    assert!(
+        screen.contains("NAME") && screen.contains("CPU") && screen.contains("MEM"),
+        "missing column header in:\n{screen}"
+    );
     // 125m of a 250m request / 500m limit, and 64Mi of 128Mi / 256Mi.
     assert!(
         screen.contains("50%/25%"),
         "missing utilization percentages in:\n{screen}"
+    );
+    // The istio-proxy's unset memory limit renders as a "-" in its pair
+    // (16Mi of a 128Mi request, no limit).
+    assert!(
+        screen.contains("13%/-"),
+        "missing missing-limit indicator in:\n{screen}"
     );
 }
 

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1482,6 +1482,36 @@ pub fn fmt_mem(bytes: i64) -> String {
     }
 }
 
+/// A container's declared CPU/memory requests and limits, in millicores and
+/// bytes. `None` marks an unset request or limit so callers can tell a missing
+/// declaration apart from an explicit zero.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ContainerResources {
+    pub cpu_request: Option<i64>,
+    pub cpu_limit: Option<i64>,
+    pub mem_request: Option<i64>,
+    pub mem_limit: Option<i64>,
+}
+
+/// Usage as an integer percentage of `base` (a request or limit). `None` when
+/// the base is unset or non-positive, so the UI distinguishes a missing
+/// request/limit from a real 0%.
+pub fn usage_pct(usage: i64, base: Option<i64>) -> Option<i64> {
+    match base {
+        Some(b) if b > 0 => Some(((usage as f64 / b as f64) * 100.0).round() as i64),
+        _ => None,
+    }
+}
+
+/// Render a percentage from [`usage_pct`]; `None` (missing request/limit) shows
+/// as `-`.
+pub fn fmt_pct(pct: Option<i64>) -> String {
+    match pct {
+        Some(p) => format!("{p}%"),
+        None => "-".into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1501,6 +1531,19 @@ mod tests {
         assert_eq!(parse_mem_bytes("1Mi"), 1024 * 1024);
         assert_eq!(parse_mem_bytes("1Gi"), 1024 * 1024 * 1024);
         assert_eq!(fmt_mem(parse_mem_bytes("512Mi")), "512Mi");
+    }
+
+    #[test]
+    fn usage_percent_distinguishes_missing_base_from_zero() {
+        // Half of a 250m request rounds to 50%.
+        assert_eq!(usage_pct(125, Some(250)), Some(50));
+        // A measured zero against a real request is 0%, not "missing".
+        assert_eq!(usage_pct(0, Some(250)), Some(0));
+        // No request/limit declared -> None, so the UI shows "-".
+        assert_eq!(usage_pct(125, None), None);
+        assert_eq!(usage_pct(125, Some(0)), None);
+        assert_eq!(fmt_pct(usage_pct(125, Some(250))), "50%");
+        assert_eq!(fmt_pct(usage_pct(125, None)), "-");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1739,6 +1739,32 @@ fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+/// Color a resource utilization percentage: close to the base (a request or,
+/// more importantly, a limit) is dangerous. A missing base dims to a muted
+/// tone so it reads as "not set" rather than "healthy".
+fn util_color(pct: Option<i64>) -> Color {
+    match pct {
+        Some(p) if p >= 90 => theme::red(),
+        Some(p) if p >= 75 => theme::yellow(),
+        Some(_) => theme::green(),
+        None => theme::overlay1(),
+    }
+}
+
+/// Build the `%req/%lim` utilization cell for one resource, plus the color that
+/// reflects the worse (limit-first) utilization. `usage` is `None` when Metrics
+/// Server data is unavailable, in which case percentages cannot be computed.
+fn util_cell(usage: Option<i64>, request: Option<i64>, limit: Option<i64>) -> (String, Color) {
+    use crate::columns::{fmt_pct, usage_pct};
+    let Some(usage) = usage else {
+        return ("-/-".into(), theme::overlay1());
+    };
+    let req_pct = usage_pct(usage, request);
+    let lim_pct = usage_pct(usage, limit);
+    let text = format!("{}/{}", fmt_pct(req_pct), fmt_pct(lim_pct));
+    (text, util_color(lim_pct.or(req_pct)))
+}
+
 fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     let name_width = app
         .container_list
@@ -1751,8 +1777,8 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         .container_list
         .iter()
         .map(|container| {
-            let (cpu, memory) = app
-                .selected_pod_container_metrics(container)
+            let usage = app.selected_pod_container_metrics(container);
+            let (cpu, memory) = usage
                 .map(|(cpu, memory)| {
                     (
                         crate::columns::fmt_cpu(cpu),
@@ -1760,6 +1786,15 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
                     )
                 })
                 .unwrap_or_else(|| ("-".into(), "-".into()));
+            let res = app
+                .container_resources
+                .get(container)
+                .cloned()
+                .unwrap_or_default();
+            let (cpu_pct, cpu_pct_color) =
+                util_cell(usage.map(|(c, _)| c), res.cpu_request, res.cpu_limit);
+            let (mem_pct, mem_pct_color) =
+                util_cell(usage.map(|(_, m)| m), res.mem_request, res.mem_limit);
             ListItem::new(Line::from(vec![
                 Span::styled(
                     format!("{container:<name_width$}"),
@@ -1767,20 +1802,33 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
                 ),
                 Span::styled(format!("  {cpu:>8}"), Style::default().fg(theme::yellow())),
                 Span::styled(
+                    format!("  {cpu_pct:>9}"),
+                    Style::default().fg(cpu_pct_color),
+                ),
+                Span::styled(
                     format!("  {memory:>10}"),
                     Style::default().fg(theme::teal()),
+                ),
+                Span::styled(
+                    format!("  {mem_pct:>9}"),
+                    Style::default().fg(mem_pct_color),
                 ),
             ]))
         })
         .collect();
+    let qos = if app.container_qos.is_empty() {
+        String::new()
+    } else {
+        format!(" · {}", app.container_qos)
+    };
     render_popup_list(
         frame,
         area,
-        64,
+        72,
         60,
         items,
         Span::styled(
-            " Containers · CPU · MEMORY (⏎ logs · p previous · s shell) ",
+            format!(" Containers{qos} · CPU %R/L · MEM %R/L (⏎ logs · p previous · s shell) "),
             theme::title(),
         ),
         &mut app.container_state,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1765,14 +1765,54 @@ fn util_cell(usage: Option<i64>, request: Option<i64>, limit: Option<i64>) -> (S
     (text, util_color(lim_pct.or(req_pct)))
 }
 
+// Numeric column widths for the container table, shared by the header and the
+// data rows so they line up exactly. `CPU%`/`MEM%` hold a `%req/%lim` pair.
+const C_CPU: usize = 7;
+const C_CPU_PCT: usize = 9;
+const C_MEM: usize = 8;
+const C_MEM_PCT: usize = 9;
+const C_GAP: usize = 2;
+
+/// Truncate to `max` display columns with a trailing ellipsis (character-based;
+/// container names are ASCII in practice).
+fn truncate_cols(s: &str, max: usize) -> String {
+    let n = s.chars().count();
+    if n <= max {
+        return s.to_string();
+    }
+    match max {
+        0 => String::new(),
+        _ => {
+            let mut t: String = s.chars().take(max - 1).collect();
+            t.push('…');
+            t
+        }
+    }
+}
+
 fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
+    let gap = " ".repeat(C_GAP);
+    // Keep the name column readable but bounded so long names can't push the
+    // numeric columns off the right edge; anything longer is ellipsized.
+    let name_cap = (area.width as usize).saturating_sub(40).max(8);
     let name_width = app
         .container_list
         .iter()
         .map(|name| name.chars().count())
         .max()
         .unwrap_or(4)
-        .max(4);
+        .clamp(4, name_cap);
+
+    let header = Line::from(format!(
+        "{name:<name_width$}{gap}{cpu:>C_CPU$}{gap}{cpu_pct:>C_CPU_PCT$}{gap}{mem:>C_MEM$}{gap}{mem_pct:>C_MEM_PCT$}",
+        name = "NAME",
+        cpu = "CPU",
+        cpu_pct = "%R/L",
+        mem = "MEM",
+        mem_pct = "%R/L",
+    ))
+    .style(theme::dim());
+
     let items: Vec<ListItem> = app
         .container_list
         .iter()
@@ -1795,44 +1835,85 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
                 util_cell(usage.map(|(c, _)| c), res.cpu_request, res.cpu_limit);
             let (mem_pct, mem_pct_color) =
                 util_cell(usage.map(|(_, m)| m), res.mem_request, res.mem_limit);
+            let name = truncate_cols(container, name_width);
             ListItem::new(Line::from(vec![
                 Span::styled(
-                    format!("{container:<name_width$}"),
+                    format!("{name:<name_width$}"),
                     Style::default().fg(theme::text()),
                 ),
-                Span::styled(format!("  {cpu:>8}"), Style::default().fg(theme::yellow())),
                 Span::styled(
-                    format!("  {cpu_pct:>9}"),
+                    format!("{gap}{cpu:>C_CPU$}"),
+                    Style::default().fg(theme::yellow()),
+                ),
+                Span::styled(
+                    format!("{gap}{cpu_pct:>C_CPU_PCT$}"),
                     Style::default().fg(cpu_pct_color),
                 ),
                 Span::styled(
-                    format!("  {memory:>10}"),
+                    format!("{gap}{memory:>C_MEM$}"),
                     Style::default().fg(theme::teal()),
                 ),
                 Span::styled(
-                    format!("  {mem_pct:>9}"),
+                    format!("{gap}{mem_pct:>C_MEM_PCT$}"),
                     Style::default().fg(mem_pct_color),
                 ),
             ]))
         })
         .collect();
+
     let qos = if app.container_qos.is_empty() {
         String::new()
     } else {
         format!(" · {}", app.container_qos)
     };
-    render_popup_list(
-        frame,
-        area,
-        72,
-        60,
-        items,
-        Span::styled(
-            format!(" Containers{qos} · CPU %R/L · MEM %R/L (⏎ logs · p previous · s shell) "),
-            theme::title(),
-        ),
-        &mut app.container_state,
+    let title = format!(" Containers{qos} ");
+    let footer = " ⏎ logs · p previous · s shell ";
+
+    // Size the box to its contents: header + rows + borders, and wide enough
+    // for the columns, the title, or the footer — whichever needs the most.
+    let content_w = 2 // list highlight symbol ("▌ ")
+        + name_width
+        + C_GAP + C_CPU
+        + C_GAP + C_CPU_PCT
+        + C_GAP + C_MEM
+        + C_GAP + C_MEM_PCT;
+    let inner_w = content_w
+        .max(title.chars().count())
+        .max(footer.chars().count());
+    // +2 borders, +1 so the last column doesn't touch the right border.
+    let popup_w = (inner_w as u16 + 3).min(area.width);
+    let rows = app.container_list.len() as u16;
+    let popup_h = (rows + 3).clamp(5, area.height); // header + rows + 2 borders
+
+    let popup = centered_rect_exact(popup_w, popup_h, area);
+    clear_region(frame, popup);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(theme::border_focused())
+        .title(Span::styled(title, theme::title()))
+        .title_bottom(Line::from(Span::styled(footer, theme::dim())).right_aligned());
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let [header_area, list_area] =
+        Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(inner);
+    // Indent the header past the 2-column highlight gutter so it lines up with
+    // the rows underneath it.
+    frame.render_widget(
+        Paragraph::new(header),
+        Rect {
+            x: header_area.x + 2,
+            width: header_area.width.saturating_sub(2),
+            ..header_area
+        },
     );
+    let list = List::new(items)
+        .highlight_style(theme::selected_row())
+        .highlight_symbol("▌ ")
+        .highlight_spacing(HighlightSpacing::Always);
+    frame.render_stateful_widget(list, list_area, &mut app.container_state);
 }
 
 fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {
@@ -2333,6 +2414,19 @@ fn render_framed_list<'a, T>(
                 .title(title.into()),
         );
     frame.render_stateful_widget(list, area, state);
+}
+
+/// Center a fixed-size rectangle within `r`, clamped to `r`'s bounds. Used by
+/// popups that size themselves to their content rather than a percentage.
+fn centered_rect_exact(width: u16, height: u16, r: Rect) -> Rect {
+    let width = width.min(r.width);
+    let height = height.min(r.height);
+    Rect {
+        x: r.x + (r.width - width) / 2,
+        y: r.y + (r.height - height) / 2,
+        width,
+        height,
+    }
 }
 
 fn centered_rect_with_min(


### PR DESCRIPTION
## Summary

Extends the per-container metrics view (added in #42) to answer "is this container close to its request/limit?" without leaving Sofka.

- **Utilization percentages** — each container's CPU and memory usage shown as a percentage of its request and its limit (`%R/%L`), colored by proximity to the limit: green `<75%`, yellow `≥75%`, red `≥90%`.
- **Missing request/limit indicators** — an unset request or limit renders as `-` (e.g. `50%/-`), so a missing declaration is distinct from a real `0%`.
- **QoS class** — the pod's QoS (`Guaranteed`/`Burstable`/`BestEffort`) shown in the popup title. Prefers the authoritative `status.qosClass`; falls back to computing it from container requests/limits when the status is absent.
- Requests/limits are parsed through the existing shared quantity parsers and cover regular, init, and ephemeral containers.
- The whole view still degrades gracefully when Metrics Server is unavailable (`-/-`).

Advances Milestone 2 ("actionable health") in the roadmap.

## Test plan

- [x] `cargo test` — 220 passing, incl. new unit tests for `usage_pct`/`fmt_pct`, `container_resources_of`, `qos_class` (status + computed Guaranteed/Burstable/BestEffort), and an end-to-end render test asserting the QoS title and `50%/25%` cells appear in the drawn buffer.
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt`