### PR TITLE
feat: configurable warning/critical coloring thresholds

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -871,6 +871,13 @@ impl App {
         let mut warnings = resolved.warnings;
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
+        // Thresholds only change cell coloring (never the column layout), so —
+        // unlike custom views — they're safe to re-apply live without yanking
+        // the current view.
+        let (thresholds, threshold_warnings) =
+            crate::thresholds::compile(&resolved.config.thresholds);
+        self.thresholds = thresholds;
+        warnings.extend(threshold_warnings);
         let (log_provider, provider_warnings) =
             crate::providers::compile(resolved.config.providers.logs.as_ref());
         self.log_provider = log_provider;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -676,6 +676,9 @@ pub struct App {
     pub log_provider: Option<crate::providers::LogProvider>,
     /// Compiled custom views from config, re-resolved on context switch.
     pub user_views: HashMap<String, crate::views::View>,
+    /// Compiled warning/critical coloring thresholds from config, re-resolved
+    /// on context switch and `:reload`.
+    pub thresholds: crate::thresholds::Compiled,
     /// CRD printer-column fallbacks fetched per plural for this cluster
     /// (`None` = fetched, nothing usable). Cleared on context switch.
     crd_views: HashMap<String, Option<crate::views::View>>,
@@ -787,6 +790,7 @@ impl App {
             }),
             log_provider: None,
             user_views: HashMap::new(),
+            thresholds: crate::thresholds::Compiled::default(),
             crd_views: HashMap::new(),
             wide: false,
             spec: crate::columns::build_spec("", None, None, false),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -269,6 +269,9 @@ impl App {
         self.plugins = resolved.config.plugins;
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
+        let (thresholds, threshold_warnings) =
+            crate::thresholds::compile(&resolved.config.thresholds);
+        self.thresholds = thresholds;
         let (log_provider, provider_warnings) =
             crate::providers::compile(resolved.config.providers.logs.as_ref());
         self.log_provider = log_provider;
@@ -307,12 +310,14 @@ impl App {
             .warnings
             .first()
             .or(view_warnings.first())
+            .or(threshold_warnings.first())
             .or(provider_warnings.first())
         {
             self.flash_warn(w);
         }
         // Keep `:config` in sync with the layers just resolved for this context.
         self.config_warnings = resolved.warnings;
+        self.config_warnings.extend(threshold_warnings);
         let kind = resolved
             .config
             .default_resource

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -280,6 +280,17 @@ impl App {
         &self.spec
     }
 
+    /// The coloring thresholds in effect for the current view: the current
+    /// kind's per-resource overrides layered over the global defaults, or the
+    /// bare defaults when the kind is unknown (synthetic helm views, an
+    /// unconnected cluster).
+    pub(crate) fn resolved_thresholds(&self) -> crate::thresholds::Thresholds {
+        match self.kind.as_ref() {
+            Some(k) => self.thresholds.resolve(&k.ar),
+            None => self.thresholds.defaults(),
+        }
+    }
+
     /// Rebuild the active column layout from the current kind, user views,
     /// printer-column fallback, and wide mode. An active sort stays pinned to
     /// its column *header* — indices shift when columns appear/disappear (wide

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,70 @@ pub struct Config {
     /// Optional external observability backends — see [`Providers`]. Compiled
     /// and validated by [`crate::providers::compile`].
     pub providers: Providers,
+    /// Warning/critical thresholds for value-based cell coloring — see
+    /// [`Thresholds`]. Compiled and validated by [`crate::thresholds::compile`].
+    pub thresholds: Thresholds,
+}
+
+/// Warning/critical thresholds that decide when a RESTARTS/CPU/MEM cell (or the
+/// container picker's request/limit utilization) turns a warning or critical
+/// tint. Global `[thresholds]` values apply everywhere; `[thresholds.resources.
+/// <key>]` overrides them for one resource kind, keyed like `[views]`
+/// (`apiVersion/plural`, `group/plural`, plural, or lowercased kind). Anything
+/// left unset keeps sofka's built-in defaults, so an empty config colors
+/// exactly as before. Compiled by [`crate::thresholds::compile`].
+///
+/// ```toml
+/// [thresholds]
+/// restarts = { warn = 3, critical = 10 }
+/// cpu = { warn = "200m", critical = "1" }     # absolute usage
+/// memory = { warn = "256Mi", critical = "1Gi" }
+/// utilization = { warn = 75, critical = 90 }  # percent of request/limit
+///
+/// [thresholds.resources.pods]                 # per-kind override
+/// restarts = { warn = 5, critical = 20 }
+/// ```
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct Thresholds {
+    /// Global defaults, applied to every resource.
+    #[serde(flatten)]
+    pub defaults: ThresholdSet,
+    /// Per-resource overrides layered over [`Self::defaults`].
+    pub resources: HashMap<String, ThresholdSet>,
+}
+
+/// One layer of thresholds: each metric is optional so a partial override only
+/// touches the bounds it names.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct ThresholdSet {
+    /// Summed container restart count (RESTARTS cell).
+    pub restarts: Option<CountBand>,
+    /// Absolute CPU usage as a Kubernetes quantity (`200m`, `1`).
+    pub cpu: Option<QuantityBand>,
+    /// Absolute memory usage as a Kubernetes quantity (`256Mi`, `1Gi`).
+    pub memory: Option<QuantityBand>,
+    /// Usage as a percentage of a container's request/limit.
+    pub utilization: Option<CountBand>,
+}
+
+/// A numeric warn/critical band (counts, percentages). Either bound may be
+/// omitted to disable that level.
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(default)]
+pub struct CountBand {
+    pub warn: Option<i64>,
+    pub critical: Option<i64>,
+}
+
+/// A Kubernetes-quantity warn/critical band (CPU/memory), parsed at compile
+/// time. Either bound may be omitted to disable that level.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct QuantityBand {
+    pub warn: Option<String>,
+    pub critical: Option<String>,
 }
 
 /// External provider integrations. Sofka stays fully usable without any of
@@ -530,6 +594,39 @@ mod tests {
         );
         assert_eq!(logs.fields.pod.as_deref(), Some("pod_name"));
         assert!(logs.fields.namespace.is_none());
+    }
+
+    #[test]
+    fn parses_thresholds_section() {
+        let toml = r#"
+            [thresholds]
+            restarts = { warn = 3, critical = 10 }
+            cpu = { warn = "200m", critical = "1" }
+            memory = { warn = "256Mi", critical = "1Gi" }
+            utilization = { critical = 95 }
+
+            [thresholds.resources.pods]
+            restarts = { warn = 5, critical = 20 }
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        let t = &cfg.thresholds;
+        let d = &t.defaults;
+        assert_eq!(d.restarts.unwrap().warn, Some(3));
+        assert_eq!(d.restarts.unwrap().critical, Some(10));
+        assert_eq!(d.cpu.as_ref().unwrap().warn.as_deref(), Some("200m"));
+        assert_eq!(d.memory.as_ref().unwrap().critical.as_deref(), Some("1Gi"));
+        assert_eq!(d.utilization.unwrap().warn, None);
+        assert_eq!(d.utilization.unwrap().critical, Some(95));
+        let pods = t.resources.get("pods").unwrap();
+        assert_eq!(pods.restarts.unwrap().warn, Some(5));
+        assert_eq!(pods.restarts.unwrap().critical, Some(20));
+    }
+
+    #[test]
+    fn empty_config_has_default_thresholds() {
+        let cfg: Config = toml::from_str("").unwrap();
+        assert!(cfg.thresholds.defaults.restarts.is_none());
+        assert!(cfg.thresholds.resources.is_empty());
     }
 
     fn val(s: &str) -> toml::Value {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod k8s;
 mod providers;
 mod store;
 mod theme;
+mod thresholds;
 mod ui;
 mod views;
 
@@ -153,6 +154,11 @@ async fn main() -> Result<()> {
         eprintln!("warning: {w}");
     }
     app.user_views = user_views;
+    let (thresholds, threshold_warnings) = thresholds::compile(&cfg.thresholds);
+    for w in &threshold_warnings {
+        eprintln!("warning: {w}");
+    }
+    app.thresholds = thresholds;
     let (log_provider, provider_warnings) = providers::compile(cfg.providers.logs.as_ref());
     for w in &provider_warnings {
         eprintln!("warning: {w}");
@@ -164,6 +170,7 @@ async fn main() -> Result<()> {
     app.active_skin = Some(initial_skin);
     // Keep initial-load validation problems visible in-app (`:config`), not
     // just on the stderr that the alternate screen is about to cover.
+    config_warnings.extend(threshold_warnings);
     app.config_warnings = config_warnings;
     // CLI flags pin the mode for the whole session; otherwise config decides,
     // re-resolved per context on every `:ctx` switch.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -482,39 +482,13 @@ pub fn row_color(s: &str) -> Color {
     }
 }
 
-/// Restart-count severity: `None` for a clean 0 (falls back to the row
-/// color), a warning tint for a handful, red for a pod that's actively
-/// crash-looping. Absolute thresholds, mirroring k9s' restart colorer.
-pub fn restarts_severity(count: i64) -> Option<Color> {
-    if count >= 5 {
-        Some(red())
-    } else if count >= 1 {
-        Some(peach())
-    } else {
-        None
-    }
-}
-
-/// CPU-usage severity in millicores. `None` for unremarkable usage.
-pub fn cpu_severity(millicores: i64) -> Option<Color> {
-    if millicores >= 1000 {
-        Some(red())
-    } else if millicores >= 200 {
-        Some(peach())
-    } else {
-        None
-    }
-}
-
-/// Memory-usage severity in bytes. `None` for unremarkable usage.
-pub fn mem_severity(bytes: i64) -> Option<Color> {
-    let mi = bytes as f64 / (1024.0 * 1024.0);
-    if mi >= 1024.0 {
-        Some(red())
-    } else if mi >= 256.0 {
-        Some(peach())
-    } else {
-        None
+/// Foreground tint for a threshold [`Severity`](crate::thresholds::Severity):
+/// a warning stands out in peach, critical in red. The cutoffs themselves are
+/// user-configurable — see [`crate::thresholds`].
+pub fn severity_fg(sev: crate::thresholds::Severity) -> Color {
+    match sev {
+        crate::thresholds::Severity::Warn => peach(),
+        crate::thresholds::Severity::Critical => red(),
     }
 }
 
@@ -599,18 +573,10 @@ mod tests {
     }
 
     #[test]
-    fn resource_severity_thresholds() {
-        assert_eq!(restarts_severity(0), None);
-        assert_eq!(restarts_severity(1), Some(peach()));
-        assert_eq!(restarts_severity(5), Some(red()));
-
-        assert_eq!(cpu_severity(50), None);
-        assert_eq!(cpu_severity(200), Some(peach()));
-        assert_eq!(cpu_severity(1000), Some(red()));
-
-        assert_eq!(mem_severity(100 * 1024 * 1024), None); // 100Mi
-        assert_eq!(mem_severity(300 * 1024 * 1024), Some(peach())); // 300Mi
-        assert_eq!(mem_severity(2048 * 1024 * 1024), Some(red())); // 2Gi
+    fn severity_maps_to_warn_and_critical_tints() {
+        use crate::thresholds::Severity;
+        assert_eq!(severity_fg(Severity::Warn), peach());
+        assert_eq!(severity_fg(Severity::Critical), red());
     }
 
     #[test]

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -1,0 +1,387 @@
+//! User-configurable warning/critical thresholds for value-based cell
+//! coloring. These decide when a RESTARTS/CPU/MEM cell (and the container
+//! picker's request/limit utilization) stops reading as healthy and turns a
+//! warning or critical tint.
+//!
+//! Thresholds come from config (see [`crate::config::Thresholds`]) with three
+//! layers of precedence, low to high:
+//!
+//! 1. Built-in defaults ([`Thresholds::default`]) — the historical hardcoded
+//!    values, so an empty config behaves exactly as before.
+//! 2. Global `[thresholds]` overrides.
+//! 3. Per-resource `[thresholds.resources.<key>]` overrides, keyed like
+//!    `[views]` (`apiVersion/plural`, `group/plural`, plural, or lowercased
+//!    kind — most specific wins).
+//!
+//! Per-context overrides come for free: config override files merge before we
+//! compile, exactly like the rest of the configuration.
+//!
+//! ```toml
+//! [thresholds]
+//! restarts = { warn = 3, critical = 10 }
+//! cpu = { warn = "200m", critical = "1" }
+//! memory = { warn = "256Mi", critical = "1Gi" }
+//! utilization = { warn = 75, critical = 90 }
+//!
+//! [thresholds.resources.pods]
+//! restarts = { warn = 5, critical = 20 }
+//! ```
+
+use std::collections::HashMap;
+
+use kube::discovery::ApiResource;
+
+use crate::columns::{parse_cpu_milli, parse_mem_bytes};
+use crate::config;
+
+/// Which side of the thresholds a measured value falls on. `None` (from
+/// [`Band::severity`]) means "below the warning line" — healthy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Warn,
+    Critical,
+}
+
+/// A warn/critical band over an ordered `i64` metric (restart counts,
+/// millicores, bytes, percentages). Both bounds are inclusive lower limits;
+/// either can be `None` to disable that level entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Band {
+    pub warn: Option<i64>,
+    pub critical: Option<i64>,
+}
+
+impl Band {
+    const fn new(warn: i64, critical: i64) -> Self {
+        Band {
+            warn: Some(warn),
+            critical: Some(critical),
+        }
+    }
+
+    /// Severity of `value`: `Critical` at or above the critical bound, else
+    /// `Warn` at or above the warn bound, else `None` (healthy). Critical is
+    /// checked first so an out-of-order config (`critical < warn`) still
+    /// escalates rather than capping at warn.
+    pub fn severity(&self, value: i64) -> Option<Severity> {
+        if let Some(c) = self.critical
+            && value >= c
+        {
+            return Some(Severity::Critical);
+        }
+        if let Some(w) = self.warn
+            && value >= w
+        {
+            return Some(Severity::Warn);
+        }
+        None
+    }
+
+    /// Overlay individually-set bounds from a config band, keeping the base
+    /// value where the override omits one.
+    fn overlaid_num(self, o: &config::CountBand) -> Self {
+        Band {
+            warn: o.warn.or(self.warn),
+            critical: o.critical.or(self.critical),
+        }
+    }
+
+    /// As [`Self::overlaid_num`] but for quantity strings (CPU/memory),
+    /// parsing each present bound with `parse`. Unparseable values are left as
+    /// the base and reported through `warn_sink`.
+    fn overlaid_qty(
+        self,
+        o: &config::QuantityBand,
+        metric: &str,
+        parse: impl Fn(&str) -> i64,
+        warn_sink: &mut Vec<String>,
+    ) -> Self {
+        let parse_bound = |field: &str, raw: &Option<String>, sink: &mut Vec<String>| match raw {
+            None => None,
+            Some(s) => {
+                let v = parse(s);
+                if v > 0 {
+                    Some(v)
+                } else {
+                    sink.push(format!(
+                        "thresholds.{metric}.{field}: invalid quantity '{s}' (ignored)"
+                    ));
+                    None
+                }
+            }
+        };
+        Band {
+            warn: parse_bound("warn", &o.warn, warn_sink).or(self.warn),
+            critical: parse_bound("critical", &o.critical, warn_sink).or(self.critical),
+        }
+    }
+}
+
+/// A fully-resolved set of thresholds for one resource view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Thresholds {
+    /// Summed container restart count (RESTARTS cell).
+    pub restarts: Band,
+    /// Absolute CPU usage in millicores (CPU cell).
+    pub cpu: Band,
+    /// Absolute memory usage in bytes (MEM cell).
+    pub memory: Band,
+    /// Usage as a percentage of a container's request/limit (container picker).
+    pub utilization: Band,
+}
+
+impl Default for Thresholds {
+    fn default() -> Self {
+        Thresholds {
+            restarts: Band::new(1, 5),
+            cpu: Band::new(200, 1000),
+            memory: Band::new(256 * 1024 * 1024, 1024 * 1024 * 1024),
+            utilization: Band::new(75, 90),
+        }
+    }
+}
+
+impl Thresholds {
+    /// Overlay a config threshold set onto these bands, parsing CPU/memory
+    /// quantities and collecting any parse warnings.
+    fn overlaid(self, set: &config::ThresholdSet, warnings: &mut Vec<String>) -> Self {
+        Thresholds {
+            restarts: set
+                .restarts
+                .map_or(self.restarts, |b| self.restarts.overlaid_num(&b)),
+            cpu: set.cpu.as_ref().map_or(self.cpu, |b| {
+                self.cpu.overlaid_qty(b, "cpu", parse_cpu_milli, warnings)
+            }),
+            memory: set.memory.as_ref().map_or(self.memory, |b| {
+                self.memory
+                    .overlaid_qty(b, "memory", parse_mem_bytes, warnings)
+            }),
+            utilization: set
+                .utilization
+                .map_or(self.utilization, |b| self.utilization.overlaid_num(&b)),
+        }
+    }
+}
+
+/// Compiled thresholds: resolved global defaults plus per-resource overrides,
+/// resolved against a resource kind on demand (mirrors [`crate::views`]).
+#[derive(Debug, Clone, Default)]
+pub struct Compiled {
+    default: Thresholds,
+    resources: HashMap<String, Thresholds>,
+}
+
+impl Compiled {
+    /// The thresholds that apply to `ar`, most specific key first:
+    /// `apiVersion/plural`, `group/plural`, plural, then lowercased kind.
+    /// Falls back to the resolved global defaults.
+    pub fn resolve(&self, ar: &ApiResource) -> Thresholds {
+        if self.resources.is_empty() {
+            return self.default;
+        }
+        let plural = ar.plural.to_lowercase();
+        let mut keys = vec![format!("{}/{plural}", ar.api_version.to_lowercase())];
+        if !ar.group.is_empty() {
+            keys.push(format!("{}/{plural}", ar.group.to_lowercase()));
+        }
+        keys.push(plural);
+        keys.push(ar.kind.to_lowercase());
+        keys.iter()
+            .find_map(|k| self.resources.get(k))
+            .copied()
+            .unwrap_or(self.default)
+    }
+
+    /// The resolved global defaults, for callers without a resource kind.
+    pub fn defaults(&self) -> Thresholds {
+        self.default
+    }
+}
+
+/// Compile the raw `[thresholds]` config into resolved bands. Invalid quantity
+/// values are skipped with an actionable warning instead of dropping the whole
+/// config.
+pub fn compile(cfg: &config::Thresholds) -> (Compiled, Vec<String>) {
+    let mut warnings = Vec::new();
+    let default = Thresholds::default().overlaid(&cfg.defaults, &mut warnings);
+    let resources =
+        cfg.resources
+            .iter()
+            .map(|(key, set)| {
+                let mut per = Vec::new();
+                let resolved = default.overlaid(set, &mut per);
+                // Attribute per-resource parse errors to their subtable.
+                warnings.extend(per.into_iter().map(|w| {
+                    w.replacen("thresholds.", &format!("thresholds.resources.{key}."), 1)
+                }));
+                (key.to_lowercase(), resolved)
+            })
+            .collect();
+    (Compiled { default, resources }, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CountBand, QuantityBand, ThresholdSet, Thresholds as Cfg};
+
+    fn ar(group: &str, version: &str, kind: &str, plural: &str) -> ApiResource {
+        ApiResource {
+            group: group.into(),
+            version: version.into(),
+            api_version: if group.is_empty() {
+                version.into()
+            } else {
+                format!("{group}/{version}")
+            },
+            kind: kind.into(),
+            plural: plural.into(),
+        }
+    }
+
+    #[test]
+    fn band_severity_bounds_are_inclusive_and_critical_wins() {
+        let b = Band::new(1, 5);
+        assert_eq!(b.severity(0), None);
+        assert_eq!(b.severity(1), Some(Severity::Warn));
+        assert_eq!(b.severity(4), Some(Severity::Warn));
+        assert_eq!(b.severity(5), Some(Severity::Critical));
+        assert_eq!(b.severity(99), Some(Severity::Critical));
+    }
+
+    #[test]
+    fn disabled_bound_is_skipped() {
+        let warn_only = Band {
+            warn: Some(3),
+            critical: None,
+        };
+        assert_eq!(warn_only.severity(100), Some(Severity::Warn));
+        let none = Band::default();
+        assert_eq!(none.severity(i64::MAX), None);
+    }
+
+    #[test]
+    fn empty_config_keeps_builtin_defaults() {
+        let (c, warns) = compile(&Cfg::default());
+        assert!(warns.is_empty());
+        assert_eq!(c.defaults(), Thresholds::default());
+        // Unknown kind still resolves to defaults.
+        assert_eq!(
+            c.resolve(&ar("", "v1", "Pod", "pods")),
+            Thresholds::default()
+        );
+    }
+
+    #[test]
+    fn global_overrides_merge_per_bound_and_parse_quantities() {
+        let cfg = Cfg {
+            defaults: ThresholdSet {
+                restarts: Some(CountBand {
+                    warn: Some(3),
+                    critical: None, // keep built-in 5
+                }),
+                cpu: Some(QuantityBand {
+                    warn: Some("500m".into()),
+                    critical: Some("2".into()),
+                }),
+                memory: Some(QuantityBand {
+                    warn: Some("1Gi".into()),
+                    critical: None,
+                }),
+                utilization: None,
+            },
+            resources: Default::default(),
+        };
+        let (c, warns) = compile(&cfg);
+        assert!(warns.is_empty(), "{warns:?}");
+        let t = c.defaults();
+        assert_eq!(t.restarts, Band::new(3, 5));
+        assert_eq!(t.cpu, Band::new(500, 2000));
+        assert_eq!(t.memory.warn, Some(1024 * 1024 * 1024));
+        assert_eq!(t.memory.critical, Some(1024 * 1024 * 1024)); // built-in kept
+        assert_eq!(t.utilization, Thresholds::default().utilization);
+    }
+
+    #[test]
+    fn per_resource_overlays_over_globals() {
+        let mut resources = HashMap::new();
+        resources.insert(
+            "pods".to_string(),
+            ThresholdSet {
+                restarts: Some(CountBand {
+                    warn: Some(10),
+                    critical: Some(50),
+                }),
+                ..Default::default()
+            },
+        );
+        let cfg = Cfg {
+            defaults: ThresholdSet {
+                cpu: Some(QuantityBand {
+                    warn: Some("100m".into()),
+                    critical: Some("500m".into()),
+                }),
+                ..Default::default()
+            },
+            resources,
+        };
+        let (c, warns) = compile(&cfg);
+        assert!(warns.is_empty());
+        let pods = c.resolve(&ar("", "v1", "Pod", "pods"));
+        // Per-resource restart band applied...
+        assert_eq!(pods.restarts, Band::new(10, 50));
+        // ...global CPU override inherited by the per-resource set.
+        assert_eq!(pods.cpu, Band::new(100, 500));
+        // A different kind gets only the globals.
+        let deploy = c.resolve(&ar("apps", "v1", "Deployment", "deployments"));
+        assert_eq!(deploy.restarts, Thresholds::default().restarts);
+        assert_eq!(deploy.cpu, Band::new(100, 500));
+    }
+
+    #[test]
+    fn invalid_quantity_warns_and_keeps_default() {
+        let cfg = Cfg {
+            defaults: ThresholdSet {
+                cpu: Some(QuantityBand {
+                    warn: Some("banana".into()),
+                    critical: Some("1".into()),
+                }),
+                ..Default::default()
+            },
+            resources: Default::default(),
+        };
+        let (c, warns) = compile(&cfg);
+        assert_eq!(warns.len(), 1);
+        assert!(
+            warns[0].contains("cpu.warn") && warns[0].contains("banana"),
+            "{warns:?}"
+        );
+        // The bad warn bound falls back to the built-in; the good one applies.
+        assert_eq!(c.defaults().cpu, Band::new(200, 1000));
+    }
+
+    #[test]
+    fn per_resource_parse_warning_is_attributed_to_subtable() {
+        let mut resources = HashMap::new();
+        resources.insert(
+            "pods".to_string(),
+            ThresholdSet {
+                memory: Some(QuantityBand {
+                    warn: Some("nope".into()),
+                    critical: None,
+                }),
+                ..Default::default()
+            },
+        );
+        let cfg = Cfg {
+            resources,
+            ..Default::default()
+        };
+        let (_c, warns) = compile(&cfg);
+        assert_eq!(warns.len(), 1);
+        assert!(
+            warns[0].contains("thresholds.resources.pods.memory.warn"),
+            "{warns:?}"
+        );
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -433,6 +433,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     app.ensure_table_cell_cache(&visible_objects);
     let cell_cache = app.table_cell_cache();
     let spec = app.view_spec();
+    let thresholds = app.resolved_thresholds();
 
     let rows: Vec<Row> = visible_objects
         .iter()
@@ -520,16 +521,22 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                         c.into_cell_aligned(align).style(theme::dim())
                     } else if Some(i) == restarts_idx {
                         let n: i64 = c.as_str().trim().parse().unwrap_or(0);
-                        let color = theme::restarts_severity(n).unwrap_or(row_color);
+                        let color = thresholds
+                            .restarts
+                            .severity(n)
+                            .map(theme::severity_fg)
+                            .unwrap_or(row_color);
                         c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else if Some(i) == cpu_idx {
                         let color = metrics_raw
-                            .and_then(|(cpu, _)| theme::cpu_severity(cpu))
+                            .and_then(|(cpu, _)| thresholds.cpu.severity(cpu))
+                            .map(theme::severity_fg)
                             .unwrap_or(row_color);
                         c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else if Some(i) == mem_idx {
                         let color = metrics_raw
-                            .and_then(|(_, mem)| theme::mem_severity(mem))
+                            .and_then(|(_, mem)| thresholds.memory.severity(mem))
+                            .map(theme::severity_fg)
                             .unwrap_or(row_color);
                         c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else {
@@ -1749,22 +1756,31 @@ fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
-/// Color a resource utilization percentage: close to the base (a request or,
-/// more importantly, a limit) is dangerous. A missing base dims to a muted
-/// tone so it reads as "not set" rather than "healthy".
-fn util_color(pct: Option<i64>) -> Color {
+/// Color a resource utilization percentage against the configured band: close
+/// to the base (a request or, more importantly, a limit) is dangerous. A
+/// missing base dims to a muted tone so it reads as "not set" rather than
+/// "healthy"; a present percentage below the warning line reads green.
+fn util_color(pct: Option<i64>, band: crate::thresholds::Band) -> Color {
+    use crate::thresholds::Severity;
     match pct {
-        Some(p) if p >= 90 => theme::red(),
-        Some(p) if p >= 75 => theme::yellow(),
-        Some(_) => theme::green(),
         None => theme::overlay1(),
+        Some(p) => match band.severity(p) {
+            Some(Severity::Critical) => theme::red(),
+            Some(Severity::Warn) => theme::yellow(),
+            None => theme::green(),
+        },
     }
 }
 
 /// Build the `%req/%lim` utilization cell for one resource, plus the color that
 /// reflects the worse (limit-first) utilization. `usage` is `None` when Metrics
 /// Server data is unavailable, in which case percentages cannot be computed.
-fn util_cell(usage: Option<i64>, request: Option<i64>, limit: Option<i64>) -> (String, Color) {
+fn util_cell(
+    usage: Option<i64>,
+    request: Option<i64>,
+    limit: Option<i64>,
+    band: crate::thresholds::Band,
+) -> (String, Color) {
     use crate::columns::{fmt_pct, usage_pct};
     let Some(usage) = usage else {
         return ("-/-".into(), theme::overlay1());
@@ -1772,7 +1788,7 @@ fn util_cell(usage: Option<i64>, request: Option<i64>, limit: Option<i64>) -> (S
     let req_pct = usage_pct(usage, request);
     let lim_pct = usage_pct(usage, limit);
     let text = format!("{}/{}", fmt_pct(req_pct), fmt_pct(lim_pct));
-    (text, util_color(lim_pct.or(req_pct)))
+    (text, util_color(lim_pct.or(req_pct), band))
 }
 
 // Numeric column widths for the container table, shared by the header and the
@@ -1805,6 +1821,7 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     // Keep the name column readable but bounded so long names can't push the
     // numeric columns off the right edge; anything longer is ellipsized.
     let name_cap = (area.width as usize).saturating_sub(40).max(8);
+    let util_band = app.resolved_thresholds().utilization;
     let name_width = app
         .container_list
         .iter()
@@ -1841,10 +1858,18 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
                 .get(container)
                 .cloned()
                 .unwrap_or_default();
-            let (cpu_pct, cpu_pct_color) =
-                util_cell(usage.map(|(c, _)| c), res.cpu_request, res.cpu_limit);
-            let (mem_pct, mem_pct_color) =
-                util_cell(usage.map(|(_, m)| m), res.mem_request, res.mem_limit);
+            let (cpu_pct, cpu_pct_color) = util_cell(
+                usage.map(|(c, _)| c),
+                res.cpu_request,
+                res.cpu_limit,
+                util_band,
+            );
+            let (mem_pct, mem_pct_color) = util_cell(
+                usage.map(|(_, m)| m),
+                res.mem_request,
+                res.mem_limit,
+                util_band,
+            );
             let name = truncate_cols(container, name_width);
             ListItem::new(Line::from(vec![
                 Span::styled(


### PR DESCRIPTION
## Summary

Milestone 2 item: **Configurable thresholds**.

The restart/CPU/memory/utilization coloring cutoffs were hardcoded in
`theme.rs`. This makes them user-configurable via a new `[thresholds]`
config section, without changing default behavior.

- New `[thresholds]` config: `restarts`, `cpu`, `memory` (Kubernetes
  quantities), and `utilization` (percent of request/limit) — each a
  `{ warn, critical }` band. Any bound left unset keeps sofka's built-in
  default, so an empty config colors exactly as before.
- Three precedence layers: built-in defaults → global `[thresholds]` →
  per-resource `[thresholds.resources.<key>]`, keyed like `[views]`
  (`apiVersion/plural`, `group/plural`, plural, or lowercased kind).
  Per-context overrides come for free through the existing override-file
  merge.
- New `src/thresholds.rs` compiles + validates the config (bad quantity
  values become actionable warnings shown in `:config`, never a panic).
- Thresholds recompile on `:reload`, context switch, and startup. Unlike
  custom views, they hot-reload live since they only affect coloring,
  never the column layout.
- `theme.rs` now exposes `severity_fg(Severity)` instead of the three
  hardcoded `*_severity` helpers; `ui.rs` resolves the active view's
  thresholds once per frame.

Example:

\`\`\`toml
[thresholds]
restarts = { warn = 3, critical = 10 }
cpu = { warn = "200m", critical = "1" }
memory = { warn = "256Mi", critical = "1Gi" }
utilization = { warn = 75, critical = 90 }

[thresholds.resources.pods]
restarts = { warn = 5, critical = 20 }
\`\`\`

## Test plan

- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green (pre-commit hooks).
- [x] New unit tests: band severity bounds, per-bound/per-resource overlay, quantity parsing + warnings, config `[thresholds]` parsing (incl. `[serde(flatten)]` under TOML).
- [x] Ran `--snapshot` against a live cluster with a per-resource `[thresholds.resources.pods]` config — parses and applies with no panic.

Note: the roadmap also lists *age* and *readiness* thresholds. Age cells
are deliberately dimmed ("rarely the interesting signal") and readiness
is expressed through pod-status reclassification today; adding coloring
bands for those would be new behavior, deferred as follow-up rather than
bundled here.