### PR TITLE
feat: direct evidence navigation from the explain view

### DIFF
--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -6,10 +6,12 @@ impl App {
     /// Remember which view a transient sub-view (logs/detail/diff) was opened
     /// from, so `esc` returns there (e.g. back to the xray tree, not the table).
     pub(super) fn set_return_mode(&mut self) {
-        self.return_mode = if self.mode == Mode::Xray {
-            Mode::Xray
-        } else {
-            Mode::Table
+        // A transient sub-view (logs/detail/events) opened from a list-style
+        // view returns to that view, not the table underneath it.
+        self.return_mode = match self.mode {
+            Mode::Xray => Mode::Xray,
+            Mode::Explain => Mode::Explain,
+            _ => Mode::Table,
         };
         // Remember the selected row so we can land back on it.
         self.return_selection = self.selected_ref().map(row_key);
@@ -248,27 +250,34 @@ impl App {
     /// available. Uses the discovered `events` resource, so core/v1 Events are
     /// preferred but events.k8s.io clusters still work.
     pub(super) fn open_events(&mut self) {
-        self.set_return_mode();
         let Some(obj) = self.selected_ref() else {
             self.flash_warn("no selection for events");
             return;
         };
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        let uid = obj.metadata.uid.clone().filter(|u| !u.is_empty());
+        self.open_events_for(name, ns, uid);
+    }
+
+    /// Live Events for an object identified by coordinates (rather than the
+    /// current table selection), so the explain view can open the event stream
+    /// for a blocking pod. `uid` scopes precisely when known; otherwise we fall
+    /// back to a name(+namespace) selector.
+    pub(super) fn open_events_for(&mut self, name: String, ns: String, uid: Option<String>) {
+        self.set_return_mode();
         let Some(kind) = self.cluster.resolve("events") else {
             self.flash_warn("events kind unavailable");
             return;
         };
 
-        let name = obj.metadata.name.clone().unwrap_or_default();
-        let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let title = format!("{name} — events");
         let field = if kind.ar.group == "events.k8s.io" {
             "regarding"
         } else {
             "involvedObject"
         };
-        let selector = obj
-            .metadata
-            .uid
+        let selector = uid
             .as_ref()
             .filter(|uid| !uid.is_empty())
             .map(|uid| format!("{field}.uid={uid}"))

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -130,7 +130,68 @@ impl App {
                 }
             }
             KeyCode::Char('r') => self.refresh_explain(),
+            // Direct evidence navigation: jump to the resource behind the
+            // selected finding (⏎), or open its events (E) / logs (l). With no
+            // target on the current line, E/l fall back to the object being
+            // explained — so the whole evidence trail is one keystroke away.
+            KeyCode::Enter => self.explain_goto(),
+            KeyCode::Char('E') => self.explain_events(),
+            KeyCode::Char('l') => self.explain_logs(),
             _ => {}
+        }
+    }
+
+    /// The navigation target of the highlighted finding, if any.
+    fn selected_target(&self) -> Option<crate::explain::Target> {
+        self.explain_state
+            .selected()
+            .and_then(|i| self.explain_items.get(i))
+            .and_then(|f| f.target.clone())
+    }
+
+    /// ⏎ — land on the resource behind the selected finding (a blocking pod),
+    /// as a name-filtered table view. Everything you'd do next (logs, events,
+    /// containers) is then a single keystroke away.
+    fn explain_goto(&mut self) {
+        let Some(t) = self.selected_target() else {
+            self.flash_warn("no resource to jump to on this line");
+            return;
+        };
+        if t.plural != "pods" {
+            self.flash_warn("can only jump to pods here");
+            return;
+        }
+        self.drill_to_pods(
+            t.namespace.unwrap_or_default(),
+            None,
+            Some(format!("metadata.name={}", t.name)),
+            format!("pod/{}", t.name),
+        );
+        self.mode = Mode::Table;
+    }
+
+    /// `E` — open the event stream for the selected finding's target, or (no
+    /// target) the object being explained.
+    fn explain_events(&mut self) {
+        match self.selected_target() {
+            Some(t) => self.open_events_for(t.name, t.namespace.unwrap_or_default(), None),
+            None => self.open_events(),
+        }
+    }
+
+    /// `l` — stream logs for the selected finding's target pod, or (no target)
+    /// the object being explained.
+    fn explain_logs(&mut self) {
+        match self.selected_target() {
+            Some(t) if t.plural == "pods" => self.launch_logs(
+                LogSource::Pod {
+                    ns: t.namespace.unwrap_or_default(),
+                    name: t.name.clone(),
+                    containers: vec![],
+                },
+                format!("{} — logs", t.name),
+            ),
+            _ => self.open_logs(),
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2188,7 +2188,7 @@ fn draw_explain(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
 
     let title = format!(
-        " {}  ({} findings · r refresh · esc back) ",
+        " {}  ({} findings · ⏎/E/l evidence · r refresh) ",
         app.explain_title,
         app.explain_items.len()
     );
@@ -2402,7 +2402,7 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         }
         Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),
         Mode::Explain => Line::from(Span::styled(
-            "  j/k: move   r: refresh   esc: back",
+            "  j/k: move   ⏎: go to resource   E: events   l: logs   r: refresh   esc: back",
             theme::dim(),
         )),
         Mode::FluxMenu => Line::from(Span::styled(


### PR DESCRIPTION
## Summary

Milestone 2 item: **Direct evidence navigation**.

Makes the explain-unhealthy view's findings actionable — from a finding you
can jump straight to the resource, event stream, or logs behind it, so the
incident view leads into the evidence instead of dead-ending at a summary.

- **`⏎`** on a finding with a target (a blocking pod) drills the table to that
  pod (name-filtered, count 1), so its logs/events/containers are one keystroke
  away. Lines with no target flash a hint.
- **`E`** opens the event stream for the selected finding's target pod, or —
  when the line has no target — the object being explained.
- **`l`** streams logs for the selected finding's target pod, else the object
  being explained.

`set_return_mode` now remembers the explain view, so events/logs opened from it
return to the **explanation** on `esc` (not the table underneath). `open_events`
is refactored into a coordinate-based `open_events_for` so it can target a pod
that isn't the current table selection — no behavior change for the existing
`E`/`:events` path.

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (259 tests).
- [x] Drove the real TUI against a live cluster with a broken deployment:
  - `⏎` on a blocking pod landed on a pods table scoped to exactly that pod (`pods ‹ pod/broken-…`, count 1).
  - `E` opened that pod's event stream (BackOff/Failed/Pulling…); `esc` returned to the explanation.
  - `⏎` on a non-target line (evidence/heading) is a no-op with a hint.