### PR TITLE
feat: initial session-local timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,19 @@ per resource kind.
   rows, errors, pending, completed all read as one color), _plus_ a
   distinct STATUS badge and outlier coloring on RESTARTS/CPU/MEM so a
   crash-looping or resource-hungry pod still pops out of an otherwise
-  uniform row.
+  uniform row. The RESTARTS/CPU/MEM (and container request/limit) warning
+  and critical thresholds are **configurable** per resource and per context.
+- **It explains _why_ something is broken.** `X` opens a deterministic,
+  evidence-backed incident view for the selection: rollout state, degraded
+  conditions, the blocking pods and their container failure reasons
+  (ImagePullBackOff, CrashLoopBackOff, OOMKilled, unschedulable, failing
+  probes), and recent Warning events — no AI, no external service. `⏎`/`E`/`l`
+  jump straight from a finding to the offending pod, its events, or its logs.
+- **A session-local timeline.** `T` shows the state changes sofka has
+  observed for an object while watching — generation bumps, replica/readiness
+  shifts, pod phase/restart/waiting-reason changes, condition transitions —
+  as a causal, timestamped log, derived from the watch stream with nothing
+  stored on disk.
 
 ## Why it's faster
 
@@ -113,11 +125,24 @@ Not a marketing number - these are specific, checkable design choices:
   memory, each container's usage as a percentage of its request and limit
   (`-` marks an unset request/limit), and the pod's QoS class; all of it
   degrades gracefully when metrics-server is absent.
+- **Configurable thresholds** (`[thresholds]`) — the warning/critical cutoffs
+  for RESTARTS, CPU, memory, and container request/limit utilization coloring,
+  with global defaults plus per-resource and per-context overrides.
+- **Explain-unhealthy view** (`X` / `:explain`) — a deterministic,
+  evidence-backed explanation of why the selected object is unhealthy
+  (rollout state, degraded conditions, blocking pods and their container
+  failure reasons, recent Warning events), with `⏎`/`E`/`l` to jump to the
+  resource, its events, or its logs.
+- **Session-local timeline** (`T` / `:timeline`) — a per-object, timestamped
+  log of the state changes sofka has observed while watching (generation
+  bumps, readiness shifts, phase/restart/condition changes), bounded and
+  kept only in memory.
 - **Drill-down navigation** with a breadcrumb stack: workload/service →
   pods, node → its pods, pod → containers, namespace → re-scope, CRD → its
   custom resources. `esc` pops back.
 - **Command palette** (`:`) - fuzzy over the full resource catalog _and_
-  built-in commands (`ctx`, `pulse`, `xray`, `diff`, `events`, `pf`) together, plus
+  built-in commands (`ctx`, `pulse`, `xray`, `explain`, `timeline`, `diff`,
+  `events`, `pf`) together, plus
   row **filtering** (`/`) with matched-character highlighting: fuzzy text,
   `!text` inverse match, `-l`/`-f` label & field selectors (evaluated by the
   API server on ⏎), and typed column comparisons (`status=CrashLoopBackOff`,
@@ -154,7 +179,8 @@ Not a marketing number - these are specific, checkable design choices:
   Tokyo Night, One Dark, Rosé Pine, and Monokai palettes, auto-detected
   dark/light default, plus per-swatch overrides in config.
 - **Config file** (TOML): aliases, default namespace/resource, plugins,
-  views, log provider, skin.
+  views, thresholds, log provider, skin — with per-cluster/per-context
+  overrides and live `:reload`.
 
 ## Installation
 
@@ -267,6 +293,30 @@ take the TUI down.
 Custom resources without an explicit view automatically use their CRD's
 `additionalPrinterColumns` (columns with `priority > 0` become wide-only),
 so most CRs get useful columns with zero configuration.
+
+### Thresholds
+
+The warning/critical cutoffs behind RESTARTS/CPU/MEM cell coloring (and the
+container picker's request/limit utilization) are configurable. Anything left
+unset keeps sofka's built-in defaults, so an empty config colors exactly as
+before. Global `[thresholds]` apply everywhere; `[thresholds.resources.<key>]`
+overrides them per resource (keyed like `[views]`), and — like every section —
+a per-cluster/per-context override file can retune them for one context.
+Thresholds also re-apply live on `:reload`.
+
+```toml
+[thresholds]
+restarts    = { warn = 3, critical = 10 }      # count
+cpu         = { warn = "200m", critical = "1" } # absolute usage
+memory      = { warn = "256Mi", critical = "1Gi" }
+utilization = { warn = 75, critical = 90 }     # percent of request/limit
+
+[thresholds.resources.pods]                    # per-kind override
+restarts = { warn = 5, critical = 20 }
+```
+
+Either bound of a band may be omitted to disable that level; `warn` is peach,
+`critical` is red.
 
 ### Log provider (VictoriaLogs)
 
@@ -383,6 +433,7 @@ header) and switching away restores write mode.
 | `o`                       | show the node hosting the selected pod                                                                                                |
 | `ctrl-r`                  | refresh the watch                                                                                                                     |
 | `y` / `d` / `E`           | view YAML / describe (`kubectl`) / live events                                                                                        |
+| `X` / `T`                 | explain why the selection is unhealthy / session-local state-change timeline                                                          |
 | `:ctx` / `:ctx <name>`    | context switcher popup / switch directly (the name tab-completes)                                                                     |
 | `:skin`                   | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
 | `l` / `p`                 | logs (workload = all matching pods) / previous-container logs                                                                         |
@@ -403,6 +454,10 @@ header) and switching away restores write mode.
 timestamps · `x` stop/resume stream · `c` copy buffer · `ctrl-s` save to file
 · `esc` back. The newest line anchors to the bottom of the viewport.
 
+**Explain view** (`X`): `j`/`k` move · `⏎` jump to the resource behind a
+finding (a blocking pod) · `E` its events · `l` its logs · `r` re-gather ·
+`esc` back. Findings that can be jumped into are marked with a trailing `→`.
+
 Interactive actions (`e`, `s`-shell, `a`) suspend the TUI and shell out to
 `kubectl`; delete/scale/restart/set-image/suspend/resume/reconcile/
 port-forward go through the kube API (or a backgrounded process) directly.
@@ -422,6 +477,12 @@ store.rs     In-memory resource store + the Msg enum that watch tasks send to
              the UI (generation-tagged so stale streams are dropped).
 columns.rs   Per-kind column definitions and cell extraction from
              DynamicObjects (the "render" layer), with unit tests.
+thresholds.rs Configurable RESTARTS/CPU/MEM/utilization coloring bands
+             (global + per-resource), compiled from config, with unit tests.
+explain.rs   Deterministic "why is this unhealthy?" analysis — pure, turns
+             an object + its pods + events into ranked findings, unit-tested.
+timeline.rs  Session-local per-object state-change history diffed from the
+             watch stream (pure transition logic, unit-tested).
 ui.rs        All ratatui rendering: header, table, scrollable views, popups,
              status bar.
 theme.rs     Palette + semantic styles, skin resolution.
@@ -471,10 +532,10 @@ platform binaries, publishes crates.io, and warms the Nix cache.
 
 - [x] Container metrics.
 - [x] Request/limit percentages and QoS.
-- [ ] Configurable thresholds.
-- [ ] Explain-unhealthy view.
-- [ ] Direct evidence navigation.
-- [ ] Initial session-local timeline.
+- [x] Configurable thresholds.
+- [x] Explain-unhealthy view.
+- [x] Direct evidence navigation.
+- [x] Initial session-local timeline.
 
 ### Milestone 3: extensibility and repeatable workflows
 
@@ -507,7 +568,8 @@ platform binaries, publishes crates.io, and warms the Nix cache.
 
 - [ ] Opt-in cross-context health dashboard.
 - [ ] Historical metrics provider interface.
-- [ ] Log and trace provider interfaces.
+- [x] Log provider interface (VictoriaLogs: autodiscovery or configured URL).
+- [ ] Trace provider interface.
 - [ ] Extended relationship graph.
 - [ ] Vulnerability scanner integration.
 - [ ] Historical right-sizing recommendations.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -44,6 +44,7 @@ impl App {
             Mode::Pulse => self.key_pulse(key),
             Mode::Xray => self.key_xray(key),
             Mode::Explain => self.key_explain(key),
+            Mode::Timeline => self.key_timeline(key),
             Mode::FluxMenu => self.key_flux_menu(key),
             Mode::PortForwards => self.key_port_forwards(key),
             Mode::Skins => self.key_skins(key),
@@ -118,6 +119,8 @@ impl App {
             KeyCode::Char('J') => self.jump_owner(),
             // `X` — explain why the selection is unhealthy (evidence-backed).
             KeyCode::Char('X') => self.open_explain(),
+            // `T` — session-local state-change timeline for the selection.
+            KeyCode::Char('T') => self.open_timeline(),
             KeyCode::Char('C') => self.request_cordon(true),
             KeyCode::Char('U') => self.request_cordon(false),
             KeyCode::Char('D') => self.request_drain(),
@@ -290,6 +293,7 @@ impl App {
             PaletteAction::Pulse => self.open_pulse(),
             PaletteAction::Xray => self.open_xray(),
             PaletteAction::Explain => self.open_explain(),
+            PaletteAction::Timeline => self.open_timeline(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -503,10 +503,15 @@ impl App {
                 key,
                 obj,
             } if generation == self.generation => {
+                // Record state changes against the previous version before it's
+                // overwritten (session-local timeline).
+                self.timeline
+                    .observe(&self.kind_plural, &key, self.store.get(&key), &obj);
                 self.store.apply(key.clone(), *obj);
                 self.invalidate_row(&key);
             }
             Msg::Deleted { generation, key } if generation == self.generation => {
+                self.timeline.observe_delete(&self.kind_plural, &key);
                 self.store.remove(&key);
                 self.invalidate_row(&key);
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -100,6 +100,8 @@ pub enum Mode {
     Xray,
     /// Deterministic "why is this unhealthy?" explanation for the selection.
     Explain,
+    /// Session-local state-change history for the selection.
+    Timeline,
     Diff,
     Events,
     FluxMenu,
@@ -288,6 +290,7 @@ enum PaletteAction {
     Pulse,
     Xray,
     Explain,
+    Timeline,
     Diff,
     Events,
     PortForwards,
@@ -318,6 +321,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Explain,
         names: &["explain", "why", "diagnose"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Timeline,
+        names: &["timeline", "tl", "history"],
     },
     PaletteCommand {
         action: PaletteAction::Diff,
@@ -659,6 +666,11 @@ pub struct App {
     pub explain_title: String,
     /// The object the explain view is investigating, kept so `r` can re-gather.
     pub explain_source: Option<DynamicObject>,
+    /// Session-local per-object state-change history, fed by the table watch.
+    pub timeline: crate::timeline::Timeline,
+    /// The `(plural, row_key)` the timeline view is showing, and its cursor.
+    pub timeline_target: Option<(String, String)>,
+    pub timeline_state: ListState,
 
     pub confirm_label: String,
     confirm_action: Option<ConfirmAction>,
@@ -786,6 +798,9 @@ impl App {
             explain_state: ListState::default(),
             explain_title: String::new(),
             explain_source: None,
+            timeline: crate::timeline::Timeline::default(),
+            timeline_target: None,
+            timeline_state: ListState::default(),
             confirm_label: String::new(),
             confirm_action: None,
             prompt_label: String::new(),
@@ -844,6 +859,7 @@ mod navigation;
 mod overlays;
 mod pickers;
 mod rows;
+mod timeline;
 
 use helpers::*;
 

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -277,6 +277,8 @@ impl App {
         self.log_provider = log_provider;
         // Printer-column fallbacks came from the old cluster's CRDs.
         self.crd_views.clear();
+        // The timeline recorded the old cluster's objects.
+        self.timeline.clear();
         self.skin_colors = resolved.config.skin.colors;
         self.readonly = self.readonly_override.unwrap_or(resolved.config.readonly);
         cluster.add_aliases(&self.user_aliases);

--- a/src/app/timeline.rs
+++ b/src/app/timeline.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+impl App {
+    /// Open the session-local timeline for the selected object: the state
+    /// changes sofka has observed while watching this kind. The history keeps
+    /// accruing underneath (the table watch stays live), so the view updates as
+    /// new changes arrive.
+    pub(super) fn open_timeline(&mut self) {
+        if self.kind.is_none() {
+            self.flash_warn("select a resource first");
+            return;
+        }
+        let Some(obj) = self.selected_ref() else {
+            self.flash_warn("no selection for timeline");
+            return;
+        };
+        let rk = row_key(obj);
+        let plural = self.kind_plural.clone();
+        self.set_return_mode();
+        let n = self
+            .timeline
+            .entries(&plural, &rk)
+            .map(|e| e.len())
+            .unwrap_or(0);
+        // Land on the newest entry (bottom).
+        self.timeline_state.select(n.checked_sub(1));
+        self.timeline_target = Some((plural, rk));
+        self.mode = Mode::Timeline;
+    }
+
+    pub(super) fn key_timeline(&mut self, key: KeyEvent) {
+        let len = self
+            .timeline_target
+            .as_ref()
+            .and_then(|(p, rk)| self.timeline.entries(p, rk))
+            .map(|e| e.len())
+            .unwrap_or(0);
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = self.return_mode;
+                if self.return_mode == Mode::Table {
+                    self.restore_selection();
+                }
+            }
+            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.timeline_state, len, true),
+            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.timeline_state, len, false),
+            KeyCode::Char('g') | KeyCode::Home => {
+                if len > 0 {
+                    self.timeline_state.select(Some(0));
+                }
+            }
+            KeyCode::Char('G') | KeyCode::End => {
+                if len > 0 {
+                    self.timeline_state.select(Some(len - 1));
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/app/timeline.rs
+++ b/src/app/timeline.rs
@@ -44,15 +44,9 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.timeline_state, len, true),
             KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.timeline_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home => {
-                if len > 0 {
-                    self.timeline_state.select(Some(0));
-                }
-            }
-            KeyCode::Char('G') | KeyCode::End => {
-                if len > 0 {
-                    self.timeline_state.select(Some(len - 1));
-                }
+            KeyCode::Char('g') | KeyCode::Home if len > 0 => self.timeline_state.select(Some(0)),
+            KeyCode::Char('G') | KeyCode::End if len > 0 => {
+                self.timeline_state.select(Some(len - 1))
             }
             _ => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod providers;
 mod store;
 mod theme;
 mod thresholds;
+mod timeline;
 mod ui;
 mod views;
 

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -1,0 +1,524 @@
+//! Session-local resource timeline.
+//!
+//! As the table watch streams object versions, [`Timeline::observe`] diffs each
+//! new version against the previous one and records the meaningful state
+//! changes — generation bumps, replica/readiness shifts, pod phase and restart
+//! changes, and condition transitions — into a bounded, per-object history.
+//! The explain/timeline view then presents them as a causal, chronological log.
+//!
+//! This is deliberately session-local: it observes only what happens while
+//! sofka is watching, cannot reconstruct anything from before it started, and
+//! keeps nothing on disk. The transition logic is pure and unit-tested; the app
+//! layer feeds it watch events and renders the history.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use k8s_openapi::jiff::Timestamp;
+use kube::core::DynamicObject;
+use serde_json::Value;
+
+/// How many entries to keep per object before dropping the oldest.
+const MAX_PER_OBJECT: usize = 200;
+/// How many distinct objects to keep history for before evicting the
+/// least-recently-touched one.
+const MAX_OBJECTS: usize = 2000;
+
+/// Coloring/severity of a timeline entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Level {
+    Info,
+    Good,
+    Warn,
+    Bad,
+}
+
+/// One recorded state change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    /// Epoch seconds when sofka observed the change.
+    pub at: i64,
+    pub level: Level,
+    pub text: String,
+}
+
+/// Per-object session-local history, keyed by `plural/namespace/name`.
+pub struct Timeline {
+    /// Epoch seconds when this timeline started observing.
+    started: i64,
+    history: HashMap<String, VecDeque<Entry>>,
+    /// Touch order for [`MAX_OBJECTS`] eviction (front = oldest).
+    order: VecDeque<String>,
+    /// Keys observed at least once, so "created" fires only on genuine first
+    /// sight (not on a watcher relist, which re-applies everything).
+    seen: HashSet<String>,
+}
+
+impl Default for Timeline {
+    fn default() -> Self {
+        Timeline {
+            started: Self::now(),
+            history: HashMap::new(),
+            order: VecDeque::new(),
+            seen: HashSet::new(),
+        }
+    }
+}
+
+impl Timeline {
+    /// Wipe all history (e.g. on a context switch — a new cluster's objects are
+    /// unrelated). Keeps `started` so creation detection stays anchored.
+    pub fn clear(&mut self) {
+        self.history.clear();
+        self.order.clear();
+        self.seen.clear();
+    }
+
+    /// Record the transitions from `prev` to `new` for one object. `prev` is
+    /// `None` on first sight (initial list / post-relist): nothing is recorded
+    /// except a genuine creation (first sight *and* born after we started
+    /// watching), so a relisted fleet doesn't flood the log with phantom
+    /// "created" lines.
+    pub fn observe(
+        &mut self,
+        plural: &str,
+        rk: &str,
+        prev: Option<&DynamicObject>,
+        new: &DynamicObject,
+    ) {
+        let now = Self::now();
+        let key = tkey(plural, rk);
+        let first_ever = self.seen.insert(key.clone());
+        match prev {
+            // First sight (initial list / post-relist). Record a creation only
+            // for an object genuinely born after we started watching, and only
+            // once — so a relisted fleet doesn't flood the log.
+            None => {
+                if first_ever && created_after(new, self.started) {
+                    self.push(
+                        &key,
+                        now,
+                        Level::Good,
+                        format!("{} created", singular(plural)),
+                    );
+                }
+            }
+            Some(prev) => {
+                for (level, text) in transitions(prev, new, plural) {
+                    self.push(&key, now, level, text);
+                }
+            }
+        }
+    }
+
+    /// Record a deletion.
+    pub fn observe_delete(&mut self, plural: &str, rk: &str) {
+        let now = Self::now();
+        self.push(
+            &tkey(plural, rk),
+            now,
+            Level::Bad,
+            format!("{} deleted", singular(plural)),
+        );
+    }
+
+    /// The recorded history for one object, oldest first.
+    pub fn entries(&self, plural: &str, rk: &str) -> Option<&VecDeque<Entry>> {
+        self.history.get(&tkey(plural, rk))
+    }
+
+    fn push(&mut self, key: &str, at: i64, level: Level, text: String) {
+        let entry = Entry { at, level, text };
+        let dq = match self.history.get_mut(key) {
+            Some(dq) => dq,
+            None => {
+                if self.order.len() >= MAX_OBJECTS
+                    && let Some(evict) = self.order.pop_front()
+                {
+                    self.history.remove(&evict);
+                }
+                self.order.push_back(key.to_string());
+                self.history.entry(key.to_string()).or_default()
+            }
+        };
+        dq.push_back(entry);
+        while dq.len() > MAX_PER_OBJECT {
+            dq.pop_front();
+        }
+    }
+
+    fn now() -> i64 {
+        Timestamp::now().as_second()
+    }
+}
+
+fn tkey(plural: &str, rk: &str) -> String {
+    format!("{plural}/{rk}")
+}
+
+/// A rough singular for display ("deployments" -> "Deployment").
+fn singular(plural: &str) -> String {
+    let base = plural.strip_suffix('s').unwrap_or(plural);
+    let mut c = base.chars();
+    match c.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + c.as_str(),
+        None => base.to_string(),
+    }
+}
+
+/// Whether the object was created at or after `since` (epoch seconds).
+fn created_after(obj: &DynamicObject, since: i64) -> bool {
+    obj.metadata
+        .creation_timestamp
+        .as_ref()
+        .map(|ts| ts.0.as_second() >= since)
+        .unwrap_or(false)
+}
+
+/// Format an entry timestamp as `HH:MM:SS` (UTC, matching the events view).
+pub fn clock(at: i64) -> String {
+    match Timestamp::from_second(at) {
+        Ok(ts) => {
+            let s = ts.to_string();
+            s.split_once('T')
+                .map(|(_, t)| t.split(['.', 'Z']).next().unwrap_or(t).to_string())
+                .unwrap_or(s)
+        }
+        Err(_) => at.to_string(),
+    }
+}
+
+// ----- transition detection (pure) ----------------------------------------
+
+fn transitions(prev: &DynamicObject, new: &DynamicObject, plural: &str) -> Vec<(Level, String)> {
+    let mut out = Vec::new();
+
+    // Spec (generation) change — the rollout trigger.
+    if let (Some(a), Some(b)) = (prev.metadata.generation, new.metadata.generation)
+        && a != b
+    {
+        out.push((Level::Info, format!("spec changed: generation {a} → {b}")));
+    }
+
+    match plural {
+        "pods" => pod_transitions(prev, new, &mut out),
+        "deployments" | "statefulsets" | "daemonsets" | "replicasets" => {
+            workload_transitions(prev, new, plural, &mut out)
+        }
+        _ => ready_transition(prev, new, &mut out),
+    }
+    out
+}
+
+fn pod_transitions(prev: &DynamicObject, new: &DynamicObject, out: &mut Vec<(Level, String)>) {
+    // Phase.
+    let (p0, p1) = (str_at(prev, "/status/phase"), str_at(new, "/status/phase"));
+    if p0 != p1 && !p1.is_empty() {
+        let level = match p1.as_str() {
+            "Running" | "Succeeded" => Level::Good,
+            "Failed" => Level::Bad,
+            _ => Level::Info,
+        };
+        out.push((level, format!("phase {} → {}", or_none(&p0), p1)));
+    }
+
+    // Restarts (summed across containers).
+    let (r0, r1) = (restarts_sum(prev), restarts_sum(new));
+    if r1 > r0 {
+        out.push((
+            Level::Warn,
+            format!("container restart ({r0} → {r1} total)"),
+        ));
+    }
+
+    // Waiting reason (CrashLoopBackOff, ImagePullBackOff, …).
+    let (w0, w1) = (waiting_reason(prev), waiting_reason(new));
+    if w0 != w1 {
+        match &w1 {
+            Some(r) => out.push((Level::Bad, format!("container waiting: {r}"))),
+            None => {
+                if w0.is_some() {
+                    out.push((Level::Good, "container no longer waiting".into()));
+                }
+            }
+        }
+    }
+
+    ready_transition(prev, new, out);
+}
+
+fn workload_transitions(
+    prev: &DynamicObject,
+    new: &DynamicObject,
+    plural: &str,
+    out: &mut Vec<(Level, String)>,
+) {
+    let (ready_ptr, total_ptr) = if plural == "daemonsets" {
+        ("/status/numberReady", "/status/desiredNumberScheduled")
+    } else {
+        ("/status/readyReplicas", "/status/replicas")
+    };
+    let (a, b) = (i_at(prev, ready_ptr), i_at(new, ready_ptr));
+    if a != b {
+        let total = i_at(new, total_ptr);
+        let level = if b < a { Level::Warn } else { Level::Good };
+        out.push((level, format!("ready replicas {a} → {b} (of {total})")));
+    }
+
+    // Available / Progressing conditions.
+    for ty in ["Available", "Progressing"] {
+        if let Some(t) = cond_transition(prev, new, ty) {
+            out.push(t);
+        }
+    }
+}
+
+/// Ready-condition transition (pods, Flux objects, most condition-based CRDs).
+fn ready_transition(prev: &DynamicObject, new: &DynamicObject, out: &mut Vec<(Level, String)>) {
+    if let Some(t) = cond_transition(prev, new, "Ready") {
+        out.push(t);
+    }
+}
+
+/// A `(status, reason)` change on condition `ty`, rendered with a sensible
+/// severity. `None` when the status didn't change.
+fn cond_transition(prev: &DynamicObject, new: &DynamicObject, ty: &str) -> Option<(Level, String)> {
+    let (s0, _) = condition(prev, ty)?;
+    let (s1, reason) = condition(new, ty)?;
+    if s0 == s1 {
+        return None;
+    }
+    // For Progressing/Available/Ready, True is the healthy state.
+    let level = match s1.as_str() {
+        "True" => Level::Good,
+        "False" => Level::Bad,
+        _ => Level::Warn,
+    };
+    let suffix = if reason.is_empty() {
+        String::new()
+    } else {
+        format!(" ({reason})")
+    };
+    Some((level, format!("{ty}: {s0} → {s1}{suffix}")))
+}
+
+// ----- accessors -----------------------------------------------------------
+
+fn str_at(obj: &DynamicObject, ptr: &str) -> String {
+    obj.data
+        .pointer(ptr)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn i_at(obj: &DynamicObject, ptr: &str) -> i64 {
+    obj.data.pointer(ptr).and_then(Value::as_i64).unwrap_or(0)
+}
+
+fn restarts_sum(obj: &DynamicObject) -> i64 {
+    obj.data
+        .pointer("/status/containerStatuses")
+        .and_then(Value::as_array)
+        .map(|cs| {
+            cs.iter()
+                .filter_map(|c| c.get("restartCount").and_then(Value::as_i64))
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+fn waiting_reason(obj: &DynamicObject) -> Option<String> {
+    let cs = obj
+        .data
+        .pointer("/status/containerStatuses")
+        .and_then(Value::as_array)?;
+    cs.iter().find_map(|c| {
+        c.pointer("/state/waiting/reason")
+            .and_then(Value::as_str)
+            .filter(|r| *r != "ContainerCreating" && *r != "PodInitializing")
+            .map(String::from)
+    })
+}
+
+/// `(status, reason)` of condition `ty`, if present.
+fn condition(obj: &DynamicObject, ty: &str) -> Option<(String, String)> {
+    obj.data
+        .pointer("/status/conditions")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|c| c.get("type").and_then(Value::as_str) == Some(ty))
+        .map(|c| {
+            (
+                c.get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                c.get("reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            )
+        })
+}
+
+fn or_none(s: &str) -> String {
+    if s.is_empty() {
+        "<none>".into()
+    } else {
+        s.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn obj(v: Value) -> DynamicObject {
+        serde_json::from_value(v).unwrap()
+    }
+
+    fn kinds(t: &[(Level, String)]) -> Vec<&str> {
+        t.iter().map(|(_, s)| s.as_str()).collect()
+    }
+
+    #[test]
+    fn deployment_generation_and_ready_changes() {
+        let a = obj(json!({
+            "apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api","generation":17},
+            "status":{"readyReplicas":3,"replicas":3}
+        }));
+        let b = obj(json!({
+            "apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api","generation":18},
+            "status":{"readyReplicas":1,"replicas":3}
+        }));
+        let t = transitions(&a, &b, "deployments");
+        let all = kinds(&t).join("|");
+        assert!(all.contains("generation 17 → 18"), "{all}");
+        assert!(all.contains("ready replicas 3 → 1 (of 3)"), "{all}");
+        // A drop is a warning.
+        assert!(
+            t.iter()
+                .any(|(l, s)| *l == Level::Warn && s.contains("ready replicas"))
+        );
+    }
+
+    #[test]
+    fn pod_phase_restart_and_waiting_transitions() {
+        let a = obj(json!({
+            "apiVersion":"v1","kind":"Pod","metadata":{"name":"p"},
+            "status":{"phase":"Pending","containerStatuses":[
+                {"name":"c","restartCount":2,"state":{"running":{}}}
+            ]}
+        }));
+        let b = obj(json!({
+            "apiVersion":"v1","kind":"Pod","metadata":{"name":"p"},
+            "status":{"phase":"Running","containerStatuses":[
+                {"name":"c","restartCount":3,"state":{"waiting":{"reason":"CrashLoopBackOff"}}}
+            ]}
+        }));
+        let t = transitions(&a, &b, "pods");
+        let all = kinds(&t).join("|");
+        assert!(all.contains("phase Pending → Running"), "{all}");
+        assert!(all.contains("container restart (2 → 3 total)"), "{all}");
+        assert!(all.contains("container waiting: CrashLoopBackOff"), "{all}");
+    }
+
+    #[test]
+    fn ready_condition_transition_records_reason() {
+        let a = obj(json!({
+            "apiVersion":"cert-manager.io/v1","kind":"Certificate","metadata":{"name":"tls"},
+            "status":{"conditions":[{"type":"Ready","status":"True"}]}
+        }));
+        let b = obj(json!({
+            "apiVersion":"cert-manager.io/v1","kind":"Certificate","metadata":{"name":"tls"},
+            "status":{"conditions":[{"type":"Ready","status":"False","reason":"Expired"}]}
+        }));
+        let t = transitions(&a, &b, "certificates");
+        assert_eq!(t.len(), 1);
+        assert_eq!(t[0].0, Level::Bad);
+        assert!(
+            t[0].1.contains("Ready: True → False (Expired)"),
+            "{}",
+            t[0].1
+        );
+    }
+
+    #[test]
+    fn no_change_yields_nothing() {
+        let a = obj(json!({
+            "apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api","generation":5},
+            "status":{"readyReplicas":3,"replicas":3,
+                "conditions":[{"type":"Available","status":"True"}]}
+        }));
+        assert!(transitions(&a, &a, "deployments").is_empty());
+    }
+
+    #[test]
+    fn observe_baselines_first_sight_without_created_for_old_objects() {
+        let mut tl = Timeline::default();
+        // An object created long ago (epoch 1000s) — no "created" on first sight.
+        let old = obj(json!({
+            "apiVersion":"v1","kind":"Pod",
+            "metadata":{"name":"p","creationTimestamp":"1970-01-01T00:16:40Z"},
+            "status":{"phase":"Running"}
+        }));
+        tl.observe("pods", "ns/p", None, &old);
+        assert!(tl.entries("pods", "ns/p").is_none());
+        // A later phase change records.
+        let changed = obj(json!({
+            "apiVersion":"v1","kind":"Pod",
+            "metadata":{"name":"p","creationTimestamp":"1970-01-01T00:16:40Z"},
+            "status":{"phase":"Failed"}
+        }));
+        tl.observe("pods", "ns/p", Some(&old), &changed);
+        let e = tl.entries("pods", "ns/p").unwrap();
+        assert_eq!(e.len(), 1);
+        assert!(e[0].text.contains("phase Running → Failed"));
+    }
+
+    #[test]
+    fn created_fires_once_for_session_born_objects_only() {
+        let mut tl = Timeline::default();
+        // Born far in the future → unambiguously after `started`.
+        let born = obj(json!({
+            "apiVersion":"v1","kind":"Pod",
+            "metadata":{"name":"new","creationTimestamp":"2999-01-01T00:00:00Z"},
+            "status":{"phase":"Pending"}
+        }));
+        tl.observe("pods", "ns/new", None, &born);
+        let e = tl.entries("pods", "ns/new").unwrap();
+        assert_eq!(e.len(), 1);
+        assert!(e[0].text.contains("Pod created"));
+        // A relist (prev=None again) must not record a second creation.
+        tl.observe("pods", "ns/new", None, &born);
+        assert_eq!(tl.entries("pods", "ns/new").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn per_object_history_is_bounded() {
+        let mut tl = Timeline::default();
+        let mk = |n: i64| {
+            obj(json!({
+                "apiVersion":"apps/v1","kind":"Deployment",
+                "metadata":{"name":"api","generation":n},"status":{}
+            }))
+        };
+        let mut prev = mk(0);
+        for g in 1..(MAX_PER_OBJECT as i64 + 50) {
+            let cur = mk(g);
+            tl.observe("deployments", "ns/api", Some(&prev), &cur);
+            prev = cur;
+        }
+        assert_eq!(
+            tl.entries("deployments", "ns/api").unwrap().len(),
+            MAX_PER_OBJECT
+        );
+    }
+
+    #[test]
+    fn clock_formats_hms() {
+        // 08:45:12 UTC on 2026-07-13 → 1_752_396_312.
+        assert_eq!(clock(1_752_396_312), "08:45:12");
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -97,6 +97,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Pulse => draw_pulse(frame, app, chunks[1]),
         Mode::Xray => draw_xray(frame, app, chunks[1]),
         Mode::Explain => draw_explain(frame, app, chunks[1]),
+        Mode::Timeline => draw_timeline(frame, app, chunks[1]),
         Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
         _ => draw_table(frame, app, chunks[1]),
     }
@@ -265,6 +266,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             | Mode::Pulse
             | Mode::Xray
             | Mode::Explain
+            | Mode::Timeline
             | Mode::PortForwards
     ) {
         return Vec::new();
@@ -275,13 +277,13 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             hint_line(&[("s", "shell"), ("a", "attach"), ("f", "port-fwd")]),
             hint_line(&[("y", "yaml"), ("d", "describe"), ("E", "events")]),
             hint_line(&[("e", "edit"), ("o", "node"), ("J", "owner")]),
-            hint_line(&[("X", "explain"), ("^d", "delete"), ("^k", "kill")]),
+            hint_line(&[("X", "explain"), ("T", "timeline"), ("^d", "delete")]),
         ],
         "deployments" | "statefulsets" => vec![
             hint_line(&[("⏎", "pods"), ("l", "logs"), ("E", "events")]),
             hint_line(&[("s", "scale"), ("r", "restart"), ("i", "image")]),
             hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
-            hint_line(&[("X", "explain"), ("f", "port-fwd"), ("^d", "delete")]),
+            hint_line(&[("X", "explain"), ("T", "timeline"), ("f", "port-fwd")]),
         ],
         "daemonsets" => vec![
             hint_line(&[("⏎", "pods"), ("l", "logs"), ("E", "events")]),
@@ -1556,6 +1558,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "shift-x · :explain",
             "explain why the selection is unhealthy (evidence-backed)",
         ),
+        bind(
+            "shift-t · :timeline",
+            "session-local state-change history for the selection",
+        ),
         Line::from(""),
         Line::from(Span::styled("  Act", theme::title())),
         bind("e", "edit in $EDITOR (kubectl edit)"),
@@ -2201,6 +2207,51 @@ fn draw_explain(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+/// Session-local timeline: the state changes observed for one object while
+/// sofka has been watching, oldest first.
+fn draw_timeline(frame: &mut Frame, app: &mut App, area: Rect) {
+    use crate::timeline::Level;
+    let color = |level: Level| match level {
+        Level::Info => theme::text(),
+        Level::Good => theme::green(),
+        Level::Warn => theme::peach(),
+        Level::Bad => theme::red(),
+    };
+    let (target, entries) = match &app.timeline_target {
+        Some((plural, rk)) => (rk.clone(), app.timeline.entries(plural, rk)),
+        None => (String::new(), None),
+    };
+    let count = entries.map(|e| e.len()).unwrap_or(0);
+
+    let items: Vec<ListItem> = match entries {
+        Some(e) if !e.is_empty() => e
+            .iter()
+            .map(|entry| {
+                ListItem::new(Line::from(vec![
+                    Span::styled(
+                        format!("{}  ", crate::timeline::clock(entry.at)),
+                        theme::dim(),
+                    ),
+                    Span::styled(entry.text.clone(), Style::default().fg(color(entry.level))),
+                ]))
+            })
+            .collect(),
+        _ => vec![ListItem::new(Line::from(Span::styled(
+            "no changes observed yet — the timeline records what happens while sofka watches",
+            theme::dim(),
+        )))],
+    };
+
+    let title = format!(" {target} — timeline  ({count} events · session-local) ");
+    render_framed_list(
+        frame,
+        area,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.timeline_state,
+    );
+}
+
 /// Pulse dashboard: cluster-health tiles.
 fn draw_pulse(frame: &mut Frame, app: &App, area: Rect) {
     let p = &app.pulse;
@@ -2403,6 +2454,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),
         Mode::Explain => Line::from(Span::styled(
             "  j/k: move   ⏎: go to resource   E: events   l: logs   r: refresh   esc: back",
+            theme::dim(),
+        )),
+        Mode::Timeline => Line::from(Span::styled(
+            "  j/k: move   g/G: top/bottom   esc: back",
             theme::dim(),
         )),
         Mode::FluxMenu => Line::from(Span::styled(


### PR DESCRIPTION
## Summary

Milestone 2 item: **Initial session-local timeline** (roadmap P2 "resource timeline", initial version) — the last item in milestone 2.

Adds a per-object state-change timeline, opened with **`T`** or **`:timeline`**
(aliases `:tl`, `:history`). As the table watch streams each object version,
the new `src/timeline.rs` diffs it against the previous version and records the
meaningful changes into a bounded, session-local history.

**Recorded transitions:**
- generation (spec) bumps — the rollout trigger
- workloads: ready-replica shifts, `Available`/`Progressing` condition changes
- pods: phase changes, container restart increments, waiting-reason changes
  (CrashLoopBackOff/ImagePullBackOff…), `Ready`-condition changes
- condition-based CRDs / Flux: `Ready` transitions with reason
- creations (only for objects born while sofka was watching — once each, so a
  relist doesn't flood the log) and deletions

**Session-local by design**, exactly as the roadmap prescribes: it observes
only what happens while sofka is watching, can't reconstruct anything from
before it started, keeps nothing on disk, is bounded (per-object and
total-object caps), clears on context switch, and the view is labelled
"session-local". The diff logic is pure and unit-tested (8 tests).

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (267 tests; 8 new in `timeline::tests`).
- [x] Drove the real TUI against a live cluster:
  - Watched a Deployment, scaled it twice → timeline showed `spec changed: generation 1 → 2` and `2 → 3` with wall-clock timestamps, chronological, cursor on newest.
  - Watched Pods, scaled up → a new pod's timeline recorded `container waiting: ErrImagePull` → `ImagePullBackOff`.

## Screenshot

\`\`\`
 sofka-explain-test/broken — timeline  (2 events · session-local)
   10:47:42  spec changed: generation 1 → 2
   10:47:47  spec changed: generation 2 → 3
\`\`\`

---

This is the final milestone-2 feature; the roadmap's "actionable health"
milestone is now complete (container metrics, request/limit % + QoS,
configurable thresholds, explain-unhealthy, evidence navigation, timeline).