### PR TITLE
ci: run the Nix build matrix only on push to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,10 @@ jobs:
         run: cargo test
 
   nix:
+    # The multi-platform Nix build is slow and expensive; skip it on pull
+    # requests (the `rust` job still runs fmt/clippy/test there) and run the
+    # full matrix only on pushes to main, after merge.
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

The four-system Nix matrix (linux/darwin × x86_64/aarch64, each doing
`nix flake check` + build + smoke) dominates PR CI time. This gates that
`nix` job to **push events on `main`** only. Pull requests keep the fast
native `rust` job (fmt + clippy + test on ubuntu), which is what catches
compile/lint/test regressions; multi-platform and Nix-packaging breaks now
surface on the post-merge push to `main` instead.

```yaml
nix:
  if: github.event_name == 'push'
```

## Trade-off

- PRs no longer verify the Nix build or the non-ubuntu targets — those are
  checked when the branch lands on `main`.
- **Branch protection:** if the `nix` matrix jobs are currently *required*
  status checks, they'll show as skipped on PRs and may block merges. Drop
  them from the required set (keep the `rust` job required) after this merges.