### PR TITLE
feat: modifier-aware hotkeys for plugins

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -871,6 +871,7 @@ impl App {
         let mut warnings = resolved.warnings;
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
+        warnings.extend(crate::config::plugin_key_warnings(&self.plugins));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -26,6 +26,18 @@ impl App {
             }
         }
 
+        // Ctrl/alt combos in the table are user plugin chords (the reserved
+        // built-in ctrl keys above already returned). Route them here so they
+        // never fall through to the plain-key table bindings — `ctrl-g` must
+        // not trigger `g`. Unmatched combos are swallowed rather than misfiring.
+        if self.mode == Mode::Table
+            && (key.modifiers.contains(KeyModifiers::CONTROL)
+                || key.modifiers.contains(KeyModifiers::ALT))
+        {
+            self.try_plugin_key(key);
+            return Ok(());
+        }
+
         match self.mode {
             Mode::Table => self.key_table(key),
             Mode::Command => self.key_command(key),
@@ -168,26 +180,38 @@ impl App {
                 self.mode = Mode::Help;
             }
             // User-defined plugins fall through here (built-ins take priority).
-            KeyCode::Char(c) => self.try_plugin(c),
-            _ => {}
+            // Any unhandled key — a bare char, a function key — is offered to
+            // the plugin chords. Ctrl/alt combos are routed earlier, in
+            // `handle_key`, before the plain-key bindings above can claim them.
+            _ => {
+                self.try_plugin_key(key);
+            }
         }
     }
 
     /// Run a config-defined plugin bound to `c` if it applies to the current
     /// kind. Blocked in read-only mode: plugins shell out to arbitrary
-    /// commands, so we can't know they won't mutate the cluster.
-    pub(super) fn try_plugin(&mut self, c: char) {
+    /// commands, so we can't know they won't mutate the cluster. Returns
+    /// whether a plugin matched (so the caller can stop treating the event as
+    /// an unhandled key).
+    pub(super) fn try_plugin_key(&mut self, key: KeyEvent) -> bool {
         let Some(plugin) = self
             .plugins
             .iter()
             .find(|p| {
-                p.key == c
+                crate::keys::KeyChord::parse(&p.key).is_ok_and(|chord| chord.matches(&key))
                     && (p.scopes.is_empty() || p.scopes.iter().any(|s| s == &self.kind_plural))
             })
             .cloned()
         else {
-            return;
+            return false;
         };
+        self.run_plugin(plugin);
+        true
+    }
+
+    /// Substitute placeholders and queue the plugin's shell-out.
+    fn run_plugin(&mut self, plugin: crate::config::Plugin) {
         if self.deny_readonly() {
             return;
         }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -267,6 +267,7 @@ impl App {
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
+        let plugin_warnings = crate::config::plugin_key_warnings(&self.plugins);
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =
@@ -312,6 +313,7 @@ impl App {
             .warnings
             .first()
             .or(view_warnings.first())
+            .or(plugin_warnings.first())
             .or(threshold_warnings.first())
             .or(provider_warnings.first())
         {
@@ -319,6 +321,7 @@ impl App {
         }
         // Keep `:config` in sync with the layers just resolved for this context.
         self.config_warnings = resolved.warnings;
+        self.config_warnings.extend(plugin_warnings);
         self.config_warnings.extend(threshold_warnings);
         let kind = resolved
             .config

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2286,14 +2286,17 @@ async fn readonly_blocks_mutating_actions() {
     assert!(app.flash.contains("read-only"));
 
     app.plugins = vec![crate::config::Plugin {
-        key: 'g',
+        key: "g".into(),
         name: "argocd-sync".into(),
         command: "argocd".into(),
         args: vec![],
         scopes: vec![],
     }];
     app.flash.clear();
-    app.try_plugin('g');
+    assert!(
+        app.try_plugin_key(press(KeyCode::Char('g'))),
+        "plugin chord matched"
+    );
     assert!(app.pending.is_none(), "plugin must not run");
     assert!(app.flash.contains("read-only"));
 
@@ -2301,6 +2304,47 @@ async fn readonly_blocks_mutating_actions() {
     app.flash.clear();
     app.handle_key(press(KeyCode::Char('d'))).unwrap();
     assert!(!app.flash.contains("read-only"));
+}
+
+#[tokio::test]
+async fn modifier_plugin_chord_does_not_trigger_plain_key_builtin() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["a", "b", "c"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+    app.plugins = vec![crate::config::Plugin {
+        key: "ctrl-g".into(),
+        name: "gen".into(),
+        command: "true".into(),
+        args: vec![],
+        scopes: vec![],
+    }];
+    app.table_state.select(Some(2));
+
+    // ctrl-g runs the plugin (write mode) — and must NOT fire the built-in `g`
+    // (go to top), which would move the cursor to row 0.
+    let ctrl_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL);
+    app.handle_key(ctrl_g).unwrap();
+    assert_eq!(
+        app.table_state.selected(),
+        Some(2),
+        "ctrl-g must not jump to top"
+    );
+    assert!(
+        matches!(app.pending, Some(Suspend::Shell(_))),
+        "ctrl-g should run the plugin"
+    );
+    app.pending = None;
+
+    // Plain `g` still triggers the built-in go-to-top.
+    app.handle_key(press(KeyCode::Char('g'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(0), "plain g goes to top");
+    assert!(app.pending.is_none(), "plain g is not the plugin");
 }
 
 #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -277,9 +277,15 @@ pub struct Skin {
 /// `scopes` (plural names; empty = all). Placeholders `$NAME`, `$NAMESPACE`,
 /// `$NS`, `$CONTEXT`, `$RESOURCE` are substituted in `command`/`args`.
 ///
+/// `key` is a [key chord](crate::keys::KeyChord): a single character (`"g"`),
+/// or a modifier combination (`"ctrl-g"`, `"alt-x"`, `"shift-b"`), or a
+/// function/named key (`"f5"`, `"ctrl-f2"`). A single lowercase char keeps the
+/// original single-key behaviour, so existing configs are unchanged. Built-in
+/// keys win over a plugin bound to the same chord.
+///
 /// ```toml
 /// [[plugins]]
-/// key = "g"
+/// key = "ctrl-g"
 /// name = "argocd-sync"
 /// command = "argocd"
 /// args = ["app", "sync", "$NAME"]
@@ -287,13 +293,28 @@ pub struct Skin {
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct Plugin {
-    pub key: char,
+    /// Key chord that triggers the plugin (see [`crate::keys::KeyChord`]).
+    pub key: String,
     pub name: String,
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
     #[serde(default)]
     pub scopes: Vec<String>,
+}
+
+/// Validation warnings for plugin key chords that don't parse (see
+/// [`crate::keys::KeyChord::parse`]). A bad chord disables just that plugin —
+/// it can never match a keypress — so it's reported, not fatal.
+pub fn plugin_key_warnings(plugins: &[Plugin]) -> Vec<String> {
+    plugins
+        .iter()
+        .filter_map(|p| {
+            crate::keys::KeyChord::parse(&p.key)
+                .err()
+                .map(|e| format!("plugin {:?}: invalid key — {e}", p.name))
+        })
+        .collect()
 }
 
 /// Config resolved for one (cluster, context) pair: the base config with any
@@ -553,7 +574,7 @@ mod tests {
         );
         assert_eq!(cfg.plugins.len(), 1);
         let p = &cfg.plugins[0];
-        assert_eq!(p.key, 'g');
+        assert_eq!(p.key, "g");
         assert_eq!(p.args, vec!["app", "sync", "$NAME"]);
         assert_eq!(p.scopes, vec!["deployments"]);
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,292 @@
+//! Key chords for user-bindable actions (plugins today, bookmarks next).
+//!
+//! A chord is parsed from a small, forgiving string syntax — a key, optionally
+//! prefixed with `ctrl-`/`alt-`/`shift-` modifiers joined by `-`:
+//!
+//! ```text
+//! g          ctrl-g       alt-x        shift-b
+//! f5         ctrl-f5      shift-f5     ctrl-alt-delete
+//! enter      space        pageup
+//! ```
+//!
+//! Matching is deliberately lenient about `shift` on letters (an uppercase
+//! char already encodes it, exactly like the built-in `G`/`S`/`E` bindings)
+//! and about the case of a `ctrl-`ed letter (terminals deliver `ctrl-g` as a
+//! lowercase `g`). Modifiers `ctrl`/`alt` must match exactly, so a plain `g`
+//! binding never fires on `ctrl-g` and vice-versa.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// A parsed key binding: a base key plus the modifiers that must accompany it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyChord {
+    pub code: KeyCode,
+    pub ctrl: bool,
+    pub alt: bool,
+    /// Only enforced for non-`Char` keys (function keys, Enter, …). For a
+    /// letter, shift is folded into the char's case at parse time.
+    pub shift: bool,
+}
+
+impl KeyChord {
+    /// Parse a chord string. Returns a human-readable error naming the problem.
+    pub fn parse(s: &str) -> Result<KeyChord, String> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err("empty key binding".into());
+        }
+        // A lone single character is the key itself (covers "-", "?", "g").
+        if trimmed.chars().count() == 1 {
+            let c = trimmed.chars().next().unwrap();
+            return Ok(KeyChord {
+                code: KeyCode::Char(c),
+                ctrl: false,
+                alt: false,
+                shift: false,
+            });
+        }
+
+        let parts: Vec<&str> = trimmed.split('-').collect();
+        let (mods, key) = parts.split_at(parts.len() - 1);
+        let key = key[0];
+
+        let (mut ctrl, mut alt, mut shift) = (false, false, false);
+        for m in mods {
+            match m.to_ascii_lowercase().as_str() {
+                "ctrl" | "control" | "c" => ctrl = true,
+                "alt" | "option" | "opt" | "meta" | "a" | "m" => alt = true,
+                "shift" | "s" => shift = true,
+                "" => return Err(format!("{s:?}: empty modifier (stray '-'?)")),
+                other => return Err(format!("{s:?}: unknown modifier {other:?}")),
+            }
+        }
+
+        let mut code = parse_key(key).ok_or_else(|| format!("{s:?}: unknown key {key:?}"))?;
+
+        // Fold shift into a letter's case so matching stays case-based (like the
+        // built-in bindings); keep it as a flag for function/named keys.
+        if let (true, KeyCode::Char(c)) = (shift, code)
+            && c.is_ascii_alphabetic()
+        {
+            code = KeyCode::Char(c.to_ascii_uppercase());
+            shift = false;
+        }
+
+        Ok(KeyChord {
+            code,
+            ctrl,
+            alt,
+            shift,
+        })
+    }
+
+    /// Whether `event` triggers this chord.
+    pub fn matches(&self, event: &KeyEvent) -> bool {
+        let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = event.modifiers.contains(KeyModifiers::ALT);
+        if ctrl != self.ctrl || alt != self.alt {
+            return false;
+        }
+        match (self.code, event.code) {
+            (KeyCode::Char(a), KeyCode::Char(b)) => {
+                // ctrl-letter arrives lowercase regardless of shift; otherwise
+                // the char's case is significant (uppercase = shift).
+                if self.ctrl {
+                    a.eq_ignore_ascii_case(&b)
+                } else {
+                    a == b
+                }
+            }
+            (a, b) => a == b && self.shift == event.modifiers.contains(KeyModifiers::SHIFT),
+        }
+    }
+
+    /// Render the chord back to its canonical string, for help/error text.
+    pub fn label(&self) -> String {
+        let mut out = String::new();
+        if self.ctrl {
+            out.push_str("ctrl-");
+        }
+        if self.alt {
+            out.push_str("alt-");
+        }
+        if self.shift {
+            out.push_str("shift-");
+        }
+        out.push_str(&key_label(self.code));
+        out
+    }
+}
+
+/// Parse the key token (already modifier-stripped): a single char, a function
+/// key `f1`..`f24`, or a named special key.
+fn parse_key(token: &str) -> Option<KeyCode> {
+    if token.chars().count() == 1 {
+        return Some(KeyCode::Char(token.chars().next().unwrap()));
+    }
+    let lower = token.to_ascii_lowercase();
+    if let Some(n) = lower.strip_prefix('f')
+        && let Ok(n) = n.parse::<u8>()
+        && (1..=24).contains(&n)
+    {
+        return Some(KeyCode::F(n));
+    }
+    Some(match lower.as_str() {
+        "enter" | "return" | "ret" => KeyCode::Enter,
+        "tab" => KeyCode::Tab,
+        "esc" | "escape" => KeyCode::Esc,
+        "space" => KeyCode::Char(' '),
+        "backspace" | "bs" => KeyCode::Backspace,
+        "delete" | "del" => KeyCode::Delete,
+        "insert" | "ins" => KeyCode::Insert,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pageup" | "pgup" => KeyCode::PageUp,
+        "pagedown" | "pgdn" | "pgdown" => KeyCode::PageDown,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        _ => return None,
+    })
+}
+
+fn key_label(code: KeyCode) -> String {
+    match code {
+        KeyCode::Char(' ') => "space".into(),
+        KeyCode::Char(c) => c.to_string(),
+        KeyCode::F(n) => format!("f{n}"),
+        KeyCode::Enter => "enter".into(),
+        KeyCode::Tab => "tab".into(),
+        KeyCode::Esc => "esc".into(),
+        KeyCode::Backspace => "backspace".into(),
+        KeyCode::Delete => "delete".into(),
+        KeyCode::Insert => "insert".into(),
+        KeyCode::Home => "home".into(),
+        KeyCode::End => "end".into(),
+        KeyCode::PageUp => "pageup".into(),
+        KeyCode::PageDown => "pagedown".into(),
+        KeyCode::Up => "up".into(),
+        KeyCode::Down => "down".into(),
+        KeyCode::Left => "left".into(),
+        KeyCode::Right => "right".into(),
+        other => format!("{other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    #[test]
+    fn parses_plain_char() {
+        let c = KeyChord::parse("g").unwrap();
+        assert_eq!(c.code, KeyCode::Char('g'));
+        assert!(!c.ctrl && !c.alt && !c.shift);
+        assert_eq!(c.label(), "g");
+    }
+
+    #[test]
+    fn parses_ctrl_and_alt() {
+        let c = KeyChord::parse("ctrl-g").unwrap();
+        assert_eq!(c.code, KeyCode::Char('g'));
+        assert!(c.ctrl && !c.alt);
+        assert_eq!(c.label(), "ctrl-g");
+
+        let c = KeyChord::parse("alt-x").unwrap();
+        assert!(c.alt && !c.ctrl);
+        assert_eq!(c.label(), "alt-x");
+
+        // Aliases.
+        assert_eq!(
+            KeyChord::parse("control-g").unwrap(),
+            KeyChord::parse("ctrl-g").unwrap()
+        );
+        assert_eq!(
+            KeyChord::parse("option-x").unwrap(),
+            KeyChord::parse("alt-x").unwrap()
+        );
+    }
+
+    #[test]
+    fn shift_letter_folds_into_uppercase() {
+        let c = KeyChord::parse("shift-b").unwrap();
+        assert_eq!(c.code, KeyCode::Char('B'));
+        assert!(!c.shift, "shift folded into the char");
+        // Equivalent to writing the uppercase letter directly.
+        assert_eq!(c, KeyChord::parse("B").unwrap());
+        assert_eq!(c.label(), "B");
+    }
+
+    #[test]
+    fn parses_function_and_named_keys() {
+        assert_eq!(KeyChord::parse("f5").unwrap().code, KeyCode::F(5));
+        let c = KeyChord::parse("shift-f5").unwrap();
+        assert_eq!(c.code, KeyCode::F(5));
+        assert!(c.shift);
+        assert_eq!(c.label(), "shift-f5");
+        assert_eq!(KeyChord::parse("enter").unwrap().code, KeyCode::Enter);
+        assert_eq!(KeyChord::parse("pageup").unwrap().code, KeyCode::PageUp);
+        assert_eq!(KeyChord::parse("space").unwrap().code, KeyCode::Char(' '));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(KeyChord::parse("").is_err());
+        assert!(
+            KeyChord::parse("hyper-g")
+                .unwrap_err()
+                .contains("unknown modifier")
+        );
+        assert!(
+            KeyChord::parse("ctrl-nope")
+                .unwrap_err()
+                .contains("unknown key")
+        );
+        assert!(
+            KeyChord::parse("ctrl-")
+                .unwrap_err()
+                .contains("unknown key")
+        );
+    }
+
+    #[test]
+    fn matches_respects_modifiers() {
+        let plain = KeyChord::parse("g").unwrap();
+        assert!(plain.matches(&ev(KeyCode::Char('g'), KeyModifiers::NONE)));
+        // A plain binding must NOT fire on ctrl-g.
+        assert!(!plain.matches(&ev(KeyCode::Char('g'), KeyModifiers::CONTROL)));
+
+        let ctrl_g = KeyChord::parse("ctrl-g").unwrap();
+        assert!(ctrl_g.matches(&ev(KeyCode::Char('g'), KeyModifiers::CONTROL)));
+        assert!(!ctrl_g.matches(&ev(KeyCode::Char('g'), KeyModifiers::NONE)));
+        // ctrl-letter comparison is case-insensitive (terminals send lowercase).
+        assert!(
+            KeyChord::parse("ctrl-G")
+                .unwrap()
+                .matches(&ev(KeyCode::Char('g'), KeyModifiers::CONTROL))
+        );
+    }
+
+    #[test]
+    fn matches_uppercase_char_ignoring_shift_modifier() {
+        let upper = KeyChord::parse("B").unwrap();
+        // Some terminals set SHIFT alongside the uppercase char, some don't.
+        assert!(upper.matches(&ev(KeyCode::Char('B'), KeyModifiers::SHIFT)));
+        assert!(upper.matches(&ev(KeyCode::Char('B'), KeyModifiers::NONE)));
+        // But not the lowercase.
+        assert!(!upper.matches(&ev(KeyCode::Char('b'), KeyModifiers::NONE)));
+    }
+
+    #[test]
+    fn matches_function_key_with_shift() {
+        let c = KeyChord::parse("shift-f5").unwrap();
+        assert!(c.matches(&ev(KeyCode::F(5), KeyModifiers::SHIFT)));
+        assert!(!c.matches(&ev(KeyCode::F(5), KeyModifiers::NONE)));
+        assert!(!c.matches(&ev(KeyCode::F(6), KeyModifiers::SHIFT)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod explain;
 mod filter;
 mod helm;
 mod k8s;
+mod keys;
 mod providers;
 mod store;
 mod theme;
@@ -151,6 +152,10 @@ async fn main() -> Result<()> {
     app.all_contexts = Cluster::list_contexts();
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
+    for w in config::plugin_key_warnings(&app.plugins) {
+        eprintln!("warning: {w}");
+        config_warnings.push(w);
+    }
     let (user_views, view_warnings) = views::compile(&cfg.views);
     for w in &view_warnings {
         eprintln!("warning: {w}");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1504,7 +1504,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(d.to_string(), theme::dim()),
         ])
     };
-    let lines = vec![
+    let mut lines = vec![
         Line::from(Span::styled("  Navigation", theme::title())),
         bind(
             ":<resource>",
@@ -1598,6 +1598,22 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind(":q / ctrl-c", "quit"),
         bind("?", "toggle help"),
     ];
+    // Config-defined plugins, with their (possibly modified) key chords.
+    if !app.plugins.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("  Plugins", theme::title())));
+        for p in &app.plugins {
+            let key = crate::keys::KeyChord::parse(&p.key)
+                .map(|c| c.label())
+                .unwrap_or_else(|_| format!("{}?", p.key));
+            let scope = if p.scopes.is_empty() {
+                "all resources".to_string()
+            } else {
+                p.scopes.join(", ")
+            };
+            lines.push(bind(&key, &format!("{} ({scope})", p.name)));
+        }
+    }
     // `/` search: keep only matching binding lines (section headers and
     // spacers match like any other text), highlighting the matched runs.
     let needle = app.help_filter.to_lowercase();


### PR DESCRIPTION
## Summary

Milestone 3 item: **modifier-aware hotkeys** — the foundation for richer
plugins and (next) bookmarks.

Generalizes plugin key bindings from a single character to a **key chord**:
`ctrl-`/`alt-`/`shift-` modifiers, function keys (`f1`..`f24`), and named keys
(`enter`, `space`, `pageup`, …). New `src/keys.rs` parses and matches chords.

- Plugin `key` is now a chord string — `"ctrl-g"`, `"alt-x"`, `"shift-b"`,
  `"f5"`. A single lowercase char is unchanged, so **existing configs keep
  working** (the field is a TOML string either way).
- `handle_key` routes `ctrl`/`alt` combos in the table straight to plugin
  chords, so `ctrl-g` no longer falls through to the built-in `g` (go-to-top).
  The reserved built-in ctrl keys (`ctrl-c/d/k/r`) still win.
- Matching folds `shift` into a letter's case (`shift-b` ≡ `B`, like the
  built-in `G`/`S`/`E` bindings) and compares `ctrl`-letters case-insensitively
  (terminals deliver them lowercase). `ctrl`/`alt` must match exactly, so a
  plain `g` binding never fires on `ctrl-g`.
- Invalid chords disable just that plugin, with an actionable warning shown in
  `:config`; validated at load, `:ctx` switch, and `:reload`.
- **Help now lists configured plugins** with their chord, scope, and name.

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (276 tests; 8 new in `keys::tests`, plus a dispatch test proving `ctrl-g` runs the plugin and does *not* trigger the plain-`g` built-in).
- [x] Drove the real TUI: a `ctrl-g` (scoped to deployments), an `f5`, and a deliberately-broken `bogus-key` plugin. Help showed the Plugins section (`ctrl-g → argocd-sync (deployments)`, `f5 → refresh-thing`, `bogus-key?` for the unparseable one), and `:config` reported `plugin "broken": invalid key — "bogus-key": unknown modifier "bogus"`.

Backward compatibility: `key = "g"` continues to behave exactly as before.