### PR TITLE
feat: rich plugin execution and output modes

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -871,7 +871,7 @@ impl App {
         let mut warnings = resolved.warnings;
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
-        warnings.extend(crate::config::plugin_key_warnings(&self.plugins));
+        warnings.extend(crate::config::plugin_warnings(&self.plugins));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -210,9 +210,16 @@ impl App {
         true
     }
 
-    /// Substitute placeholders and queue the plugin's shell-out.
+    /// Resolve placeholders, then run the plugin — after a confirmation prompt
+    /// when it's marked `confirm`/`dangerous`.
     fn run_plugin(&mut self, plugin: crate::config::Plugin) {
-        if self.deny_readonly() {
+        // A mutating plugin (the default) is blocked in read-only mode; one
+        // explicitly declared read-only stays available.
+        if plugin.mutating.unwrap_or(true) && self.readonly {
+            self.flash_warn(&format!(
+                "read-only mode — plugin '{}' may mutate (set mutating = false to allow)",
+                plugin.name
+            ));
             return;
         }
         let Some(obj) = self.selected_ref() else {
@@ -222,19 +229,126 @@ impl App {
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let ctx = self.cluster.context.clone();
+        let cluster = self.cluster.cluster_name.clone();
         let res = self.kind_plural.clone();
+        let filter = self.filter.clone();
+        let (group, version, kind) = self
+            .kind
+            .as_ref()
+            .map(|k| (k.ar.group.clone(), k.ar.version.clone(), k.ar.kind.clone()))
+            .unwrap_or_default();
+        // Substitute each placeholder as one whole argument — never spliced
+        // into a shell string. `$NAMESPACE` before `$NS`/`$NAME` so the longer
+        // token wins.
         let subst = |s: &str| {
             s.replace("$NAMESPACE", &ns)
                 .replace("$NS", &ns)
                 .replace("$NAME", &name)
                 .replace("$CONTEXT", &ctx)
+                .replace("$CLUSTER", &cluster)
                 .replace("$RESOURCE", &res)
+                .replace("$GROUP", &group)
+                .replace("$VERSION", &version)
+                .replace("$KIND", &kind)
+                .replace("$FILTER", &filter)
         };
-        let mut argv = vec![subst(&plugin.command)];
+
+        // argv-by-default; `shell = true` opts into `sh -c`, still passing the
+        // substituted args as positional parameters ($1, $2, …) rather than
+        // interpolating them into the script.
+        let mut argv = if plugin.shell {
+            vec![
+                "sh".into(),
+                "-c".into(),
+                subst(&plugin.command),
+                "sofka".into(),
+            ]
+        } else {
+            vec![subst(&plugin.command)]
+        };
         argv.extend(plugin.args.iter().map(|a| subst(a)));
-        self.flash = format!("plugin: {}", plugin.name);
-        self.flash_err = false;
-        self.pending = Some(Suspend::Shell(argv));
+
+        let mode = match plugin.output.as_deref() {
+            Some("popup") => PluginMode::Popup,
+            Some("background") => PluginMode::Background,
+            _ => PluginMode::Terminal,
+        };
+        let timeout = plugin
+            .timeout
+            .as_deref()
+            .and_then(|t| crate::providers::parse_lookback(t).ok())
+            .unwrap_or(30)
+            .max(1) as u64;
+
+        if plugin.confirm || plugin.dangerous {
+            let cmd = truncate_cmd(&argv);
+            self.confirm_label = if plugin.dangerous {
+                format!("⚠ Run dangerous plugin '{}'?  {cmd}", plugin.name)
+            } else {
+                format!("Run plugin '{}'?  {cmd}", plugin.name)
+            };
+            self.confirm_action = Some(ConfirmAction::Plugin {
+                argv,
+                name: plugin.name.clone(),
+                mode,
+                timeout,
+            });
+            self.mode = Mode::Confirm;
+            return;
+        }
+        self.launch_plugin(argv, plugin.name.clone(), mode, timeout);
+    }
+
+    /// Dispatch a resolved plugin invocation by its output mode.
+    pub(super) fn launch_plugin(
+        &mut self,
+        argv: Vec<String>,
+        name: String,
+        mode: PluginMode,
+        timeout: u64,
+    ) {
+        if argv.is_empty() {
+            return;
+        }
+        match mode {
+            PluginMode::Terminal => {
+                self.flash = format!("plugin: {name}");
+                self.flash_err = false;
+                self.pending = Some(Suspend::Shell(argv));
+            }
+            PluginMode::Popup => {
+                // Mirror describe: stay put, swap to the doc view when output
+                // lands, so a view switch mid-run cleanly drops the result.
+                self.set_return_mode();
+                self.flash = format!("plugin: {name}…");
+                self.flash_err = false;
+                self.spawn_plugin(argv, format!("{name} — output"), mode, timeout);
+            }
+            PluginMode::Background => {
+                self.flash = format!("plugin: {name} (background)…");
+                self.flash_err = false;
+                self.spawn_plugin(argv, name, mode, timeout);
+            }
+        }
+    }
+
+    /// Run a plugin off-thread with a timeout and bounded output capture, then
+    /// report back via [`Msg`]. A hung command can't freeze the UI: the timeout
+    /// aborts it and the result is generation-gated like every other stream.
+    fn spawn_plugin(&mut self, argv: Vec<String>, title: String, mode: PluginMode, timeout: u64) {
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let run = tokio::process::Command::new(&argv[0])
+                .args(&argv[1..])
+                .output();
+            let outcome = tokio::time::timeout(Duration::from_secs(timeout), run).await;
+            let msg = match mode {
+                PluginMode::Popup => plugin_popup_msg(genr, title, timeout, outcome),
+                _ => plugin_done_msg(genr, title, timeout, outcome),
+            };
+            let _ = tx.send(msg).await;
+        });
     }
 
     pub(super) fn key_command(&mut self, key: KeyEvent) {
@@ -800,4 +914,120 @@ fn is_ctx_command(head: &str) -> bool {
     PALETTE_COMMANDS
         .iter()
         .any(|c| matches!(c.action, PaletteAction::Ctx) && c.names.contains(&head))
+}
+
+/// Bound the number of captured output lines and total bytes from a
+/// popup/background plugin, so a chatty command can't balloon memory or the
+/// redraw. Mirrors the log view's tail-buffer discipline.
+const PLUGIN_MAX_LINES: usize = 5_000;
+const PLUGIN_MAX_BYTES: usize = 1 << 20; // 1 MiB
+
+/// A short, single-line preview of an argv for the confirmation dialog.
+fn truncate_cmd(argv: &[String]) -> String {
+    let joined = argv.join(" ");
+    if joined.chars().count() > 120 {
+        let mut s: String = joined.chars().take(119).collect();
+        s.push('…');
+        s
+    } else {
+        joined
+    }
+}
+
+type SpawnOutcome = Result<std::io::Result<std::process::Output>, tokio::time::error::Elapsed>;
+
+/// Split captured bytes into bounded display lines.
+fn bounded_lines(bytes: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(&bytes[..bytes.len().min(PLUGIN_MAX_BYTES)]);
+    let mut lines: Vec<String> = text
+        .lines()
+        .take(PLUGIN_MAX_LINES)
+        .map(str::to_string)
+        .collect();
+    if text.lines().count() > PLUGIN_MAX_LINES {
+        lines.push(format!("… output truncated at {PLUGIN_MAX_LINES} lines"));
+    }
+    lines
+}
+
+/// First non-empty line of stderr, for a compact failure summary.
+fn stderr_summary(stderr: &[u8]) -> String {
+    String::from_utf8_lossy(stderr)
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("failed")
+        .chars()
+        .take(160)
+        .collect()
+}
+
+/// Build the [`Msg::PluginOutput`] for a finished popup run.
+fn plugin_popup_msg(generation: u64, title: String, timeout: u64, outcome: SpawnOutcome) -> Msg {
+    match outcome {
+        Err(_) => Msg::PluginOutput {
+            generation,
+            title,
+            lines: vec![format!("timed out after {timeout}s")],
+            warn: Some(format!("plugin timed out after {timeout}s")),
+        },
+        Ok(Err(e)) => Msg::PluginOutput {
+            generation,
+            title,
+            lines: vec![format!("failed to run: {e}")],
+            warn: Some(format!("plugin failed to start: {e}")),
+        },
+        Ok(Ok(out)) => {
+            let mut lines = bounded_lines(&out.stdout);
+            let warn = if out.status.success() {
+                if lines.is_empty() {
+                    lines.push("(no output)".into());
+                }
+                None
+            } else {
+                let err = stderr_summary(&out.stderr);
+                if !err.is_empty() {
+                    lines.push(String::new());
+                    lines.push(format!("[stderr] {err}"));
+                }
+                Some(format!("plugin exited {}", exit_label(&out.status)))
+            };
+            Msg::PluginOutput {
+                generation,
+                title,
+                lines,
+                warn,
+            }
+        }
+    }
+}
+
+/// Build the [`Msg::PluginDone`] notification for a finished background run.
+fn plugin_done_msg(generation: u64, name: String, timeout: u64, outcome: SpawnOutcome) -> Msg {
+    let (ok, summary) = match outcome {
+        Err(_) => (false, format!("timed out after {timeout}s")),
+        Ok(Err(e)) => (false, format!("failed to start: {e}")),
+        Ok(Ok(out)) if out.status.success() => (true, "done".into()),
+        Ok(Ok(out)) => (
+            false,
+            format!(
+                "exited {} — {}",
+                exit_label(&out.status),
+                stderr_summary(&out.stderr)
+            ),
+        ),
+    };
+    Msg::PluginDone {
+        generation,
+        name,
+        ok,
+        summary,
+    }
+}
+
+fn exit_label(status: &std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(c) => format!("code {c}"),
+        None => "by signal".into(),
+    }
 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -600,6 +600,39 @@ impl App {
                     .select((!self.explain_items.is_empty()).then_some(first));
                 self.mode = Mode::Explain;
             }
+            Msg::PluginOutput {
+                generation,
+                title,
+                lines,
+                warn,
+            } if generation == self.generation => {
+                self.detail = Scrollable {
+                    title,
+                    lines: lines.into(),
+                    ..Default::default()
+                };
+                self.mode = Mode::Detail;
+                match warn {
+                    Some(w) => self.flash_warn(&w),
+                    None => {
+                        self.flash = "plugin done".into();
+                        self.flash_err = false;
+                    }
+                }
+            }
+            Msg::PluginDone {
+                generation,
+                name,
+                ok,
+                summary,
+            } if generation == self.generation => {
+                if ok {
+                    self.flash = format!("plugin {name}: {summary}");
+                    self.flash_err = false;
+                } else {
+                    self.flash_warn(&format!("plugin {name}: {summary}"));
+                }
+            }
             Msg::Detail {
                 generation,
                 title,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -186,6 +186,24 @@ enum ConfirmAction {
     /// Uninstall one or more Helm releases (`helm uninstall`), `(name, ns)`
     /// per release — bulk when marked, like [`ConfirmAction::Delete`].
     HelmUninstall { targets: Vec<(String, String)> },
+    /// Run a confirmed plugin (`confirm`/`dangerous`) once accepted.
+    Plugin {
+        argv: Vec<String>,
+        name: String,
+        mode: PluginMode,
+        timeout: u64,
+    },
+}
+
+/// How a plugin's output is delivered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginMode {
+    /// Interactive, inheriting the terminal (default) — suspends the TUI.
+    Terminal,
+    /// Captured off-thread into a scrollable document view.
+    Popup,
+    /// Detached; a notification flashes on completion.
+    Background,
 }
 
 /// What the logs view is currently streaming, so it can be re-streamed when

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -83,6 +83,14 @@ impl App {
                             self.do_helm_uninstall(targets);
                             self.marked.clear();
                         }
+                        ConfirmAction::Plugin {
+                            argv,
+                            name,
+                            mode,
+                            timeout,
+                        } => {
+                            self.launch_plugin(argv, name, mode, timeout);
+                        }
                     }
                 }
                 self.mode = Mode::Table;

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -267,7 +267,7 @@ impl App {
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
-        let plugin_warnings = crate::config::plugin_key_warnings(&self.plugins);
+        let plugin_warnings = crate::config::plugin_warnings(&self.plugins);
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2289,8 +2289,7 @@ async fn readonly_blocks_mutating_actions() {
         key: "g".into(),
         name: "argocd-sync".into(),
         command: "argocd".into(),
-        args: vec![],
-        scopes: vec![],
+        ..Default::default()
     }];
     app.flash.clear();
     assert!(
@@ -2321,8 +2320,7 @@ async fn modifier_plugin_chord_does_not_trigger_plain_key_builtin() {
         key: "ctrl-g".into(),
         name: "gen".into(),
         command: "true".into(),
-        args: vec![],
-        scopes: vec![],
+        ..Default::default()
     }];
     app.table_state.select(Some(2));
 
@@ -2345,6 +2343,101 @@ async fn modifier_plugin_chord_does_not_trigger_plain_key_builtin() {
     app.handle_key(press(KeyCode::Char('g'))).unwrap();
     assert_eq!(app.table_state.selected(), Some(0), "plain g goes to top");
     assert!(app.pending.is_none(), "plain g is not the plugin");
+}
+
+/// Set up a one-pod table with the cursor on it, for plugin dispatch tests.
+fn app_with_pod() -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "a", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    (app, rx)
+}
+
+#[tokio::test]
+async fn readonly_gates_mutating_plugins_only() {
+    let (mut app, _rx) = app_with_pod();
+    app.readonly = true;
+
+    // The default (mutating) plugin is blocked in read-only mode.
+    app.plugins = vec![crate::config::Plugin {
+        key: "g".into(),
+        name: "mut".into(),
+        command: "true".into(),
+        ..Default::default()
+    }];
+    assert!(app.try_plugin_key(press(KeyCode::Char('g'))));
+    assert!(app.pending.is_none(), "mutating plugin blocked");
+    assert!(app.flash.contains("read-only"));
+
+    // An explicitly read-only plugin runs even with --readonly.
+    app.plugins = vec![crate::config::Plugin {
+        key: "h".into(),
+        name: "ro".into(),
+        command: "true".into(),
+        mutating: Some(false),
+        ..Default::default()
+    }];
+    app.flash.clear();
+    assert!(app.try_plugin_key(press(KeyCode::Char('h'))));
+    assert!(
+        matches!(app.pending, Some(Suspend::Shell(_))),
+        "read-only plugin runs"
+    );
+}
+
+#[tokio::test]
+async fn dangerous_plugin_confirms_before_running() {
+    let (mut app, _rx) = app_with_pod();
+    app.plugins = vec![crate::config::Plugin {
+        key: "g".into(),
+        name: "danger".into(),
+        command: "true".into(),
+        dangerous: true,
+        ..Default::default()
+    }];
+    app.try_plugin_key(press(KeyCode::Char('g')));
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(app.pending.is_none(), "must not run before confirmation");
+    assert!(app.confirm_label.contains("danger") && app.confirm_label.contains('⚠'));
+
+    // Accepting runs it.
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(
+        matches!(app.pending, Some(Suspend::Shell(_))),
+        "runs after y"
+    );
+}
+
+#[tokio::test]
+async fn plugin_placeholders_substitute_as_separate_args() {
+    let (mut app, _rx) = app_with_pod();
+    app.plugins = vec![crate::config::Plugin {
+        key: "g".into(),
+        name: "p".into(),
+        command: "echo".into(),
+        args: vec!["$RESOURCE".into(), "$NAMESPACE".into(), "$NAME".into()],
+        ..Default::default()
+    }];
+    app.try_plugin_key(press(KeyCode::Char('g')));
+    let Some(Suspend::Shell(argv)) = &app.pending else {
+        panic!("plugin did not run");
+    };
+    // Each placeholder is one whole argv entry (boundaries preserved).
+    assert_eq!(
+        argv,
+        &vec![
+            "echo".to_string(),
+            "pods".into(),
+            "default".into(),
+            "a".into()
+        ]
+    );
 }
 
 #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,14 +274,18 @@ pub struct Skin {
 }
 
 /// A shell-out plugin (k9s-style). Bound to `key` on resources matching
-/// `scopes` (plural names; empty = all). Placeholders `$NAME`, `$NAMESPACE`,
-/// `$NS`, `$CONTEXT`, `$RESOURCE` are substituted in `command`/`args`.
+/// `scopes` (plural names; empty = all).
 ///
 /// `key` is a [key chord](crate::keys::KeyChord): a single character (`"g"`),
 /// or a modifier combination (`"ctrl-g"`, `"alt-x"`, `"shift-b"`), or a
 /// function/named key (`"f5"`, `"ctrl-f2"`). A single lowercase char keeps the
 /// original single-key behaviour, so existing configs are unchanged. Built-in
 /// keys win over a plugin bound to the same chord.
+///
+/// Placeholders are substituted in `command`/`args`, each as one argument (no
+/// implicit shell): `$NAME`, `$NAMESPACE`/`$NS`, `$CONTEXT`, `$CLUSTER`,
+/// `$RESOURCE` (plural), `$GROUP`, `$VERSION`, `$KIND`, and `$FILTER` (the
+/// active row filter).
 ///
 /// ```toml
 /// [[plugins]]
@@ -290,8 +294,17 @@ pub struct Skin {
 /// command = "argocd"
 /// args = ["app", "sync", "$NAME"]
 /// scopes = ["deployments"]
+/// dangerous = true          # confirm (showing the command) before running
+///
+/// [[plugins]]
+/// key = "shift-y"
+/// name = "yaml-summary"
+/// command = "kubectl"
+/// args = ["get", "$RESOURCE", "$NAME", "-n", "$NAMESPACE", "-o", "yaml"]
+/// mutating = false          # read-only: allowed even in --readonly mode
+/// output = "popup"          # capture into a scrollable view (not the terminal)
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Plugin {
     /// Key chord that triggers the plugin (see [`crate::keys::KeyChord`]).
     pub key: String,
@@ -301,20 +314,57 @@ pub struct Plugin {
     pub args: Vec<String>,
     #[serde(default)]
     pub scopes: Vec<String>,
+    /// Whether the plugin can modify the cluster. `None`/absent defaults to
+    /// `true` — blocked in read-only mode. Set `false` for a known read-only
+    /// plugin so it stays available with `--readonly`.
+    pub mutating: Option<bool>,
+    /// Confirm (showing the exact command) before running.
+    #[serde(default)]
+    pub confirm: bool,
+    /// Mark the plugin dangerous: implies `confirm` and is highlighted red in
+    /// the confirmation dialog.
+    #[serde(default)]
+    pub dangerous: bool,
+    /// Run the command through `sh -c` instead of executing the argv directly.
+    /// An explicit opt-in into shell interpretation; placeholders are still
+    /// passed as separate positional arguments (`$1`, `$2`, …), never spliced
+    /// into the script string.
+    #[serde(default)]
+    pub shell: bool,
+    /// Output mode: `terminal` (default; interactive, inherits the terminal),
+    /// `popup` (captured into a scrollable view), or `background` (detached,
+    /// notifies on completion).
+    pub output: Option<String>,
+    /// Timeout for `popup`/`background` runs (`"30s"`, `"2m"`). Default 30s.
+    /// Ignored for `terminal` (interactive) plugins.
+    pub timeout: Option<String>,
 }
 
-/// Validation warnings for plugin key chords that don't parse (see
-/// [`crate::keys::KeyChord::parse`]). A bad chord disables just that plugin —
-/// it can never match a keypress — so it's reported, not fatal.
-pub fn plugin_key_warnings(plugins: &[Plugin]) -> Vec<String> {
-    plugins
-        .iter()
-        .filter_map(|p| {
-            crate::keys::KeyChord::parse(&p.key)
-                .err()
-                .map(|e| format!("plugin {:?}: invalid key — {e}", p.name))
-        })
-        .collect()
+/// Validation warnings for plugins: an unparseable key chord (see
+/// [`crate::keys::KeyChord::parse`]), an unknown `output` mode, or a malformed
+/// `timeout`. A bad chord disables just that plugin; a bad output/timeout
+/// falls back to the default. Reported, never fatal.
+pub fn plugin_warnings(plugins: &[Plugin]) -> Vec<String> {
+    let mut warns = Vec::new();
+    for p in plugins {
+        if let Err(e) = crate::keys::KeyChord::parse(&p.key) {
+            warns.push(format!("plugin {:?}: invalid key — {e}", p.name));
+        }
+        if let Some(o) = &p.output
+            && !matches!(o.as_str(), "terminal" | "popup" | "background")
+        {
+            warns.push(format!(
+                "plugin {:?}: unknown output {o:?} (expected terminal/popup/background) — using terminal",
+                p.name
+            ));
+        }
+        if let Some(t) = &p.timeout
+            && let Err(e) = crate::providers::parse_lookback(t)
+        {
+            warns.push(format!("plugin {:?}: timeout: {e} — using 30s", p.name));
+        }
+    }
+    warns
 }
 
 /// Config resolved for one (cluster, context) pair: the base config with any
@@ -577,6 +627,56 @@ mod tests {
         assert_eq!(p.key, "g");
         assert_eq!(p.args, vec!["app", "sync", "$NAME"]);
         assert_eq!(p.scopes, vec!["deployments"]);
+    }
+
+    #[test]
+    fn parses_rich_plugin_fields() {
+        let toml = r#"
+            [[plugins]]
+            key = "shift-y"
+            name = "yaml"
+            command = "kubectl"
+            args = ["get", "$RESOURCE", "$NAME"]
+            mutating = false
+            dangerous = true
+            shell = true
+            output = "popup"
+            timeout = "45s"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        let p = &cfg.plugins[0];
+        assert_eq!(p.mutating, Some(false));
+        assert!(p.dangerous && p.shell);
+        assert_eq!(p.output.as_deref(), Some("popup"));
+        assert_eq!(p.timeout.as_deref(), Some("45s"));
+        assert!(plugin_warnings(&cfg.plugins).is_empty());
+
+        // Legacy minimal plugin still parses; new fields default off.
+        let cfg: Config =
+            toml::from_str("[[plugins]]\nkey = \"g\"\nname = \"x\"\ncommand = \"true\"").unwrap();
+        let p = &cfg.plugins[0];
+        assert_eq!(p.mutating, None);
+        assert!(!p.confirm && !p.dangerous && !p.shell);
+        assert!(p.output.is_none());
+    }
+
+    #[test]
+    fn plugin_warnings_flag_bad_output_and_timeout() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [[plugins]]
+            key = "ctrl-x"
+            name = "bad"
+            command = "true"
+            output = "sidebar"
+            timeout = "soon"
+        "#,
+        )
+        .unwrap();
+        let w = plugin_warnings(&cfg.plugins);
+        assert_eq!(w.len(), 2, "{w:?}");
+        assert!(w.iter().any(|s| s.contains("unknown output")));
+        assert!(w.iter().any(|s| s.contains("timeout")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> Result<()> {
     app.all_contexts = Cluster::list_contexts();
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
-    for w in config::plugin_key_warnings(&app.plugins) {
+    for w in config::plugin_warnings(&app.plugins) {
         eprintln!("warning: {w}");
         config_warnings.push(w);
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -55,6 +55,21 @@ pub enum Msg {
         title: String,
         findings: Vec<crate::explain::Finding>,
     },
+    /// Captured output of an `output = "popup"` plugin run.
+    PluginOutput {
+        generation: u64,
+        title: String,
+        lines: Vec<String>,
+        /// Set when the plugin failed or timed out (a nonzero exit, stderr).
+        warn: Option<String>,
+    },
+    /// Completion notice for an `output = "background"` plugin run.
+    PluginDone {
+        generation: u64,
+        name: String,
+        ok: bool,
+        summary: String,
+    },
     /// Result of an off-thread `kubectl describe` (or its YAML fallback).
     Detail {
         generation: u64,


### PR DESCRIPTION
## Summary

Milestone 3 item: **rich plugin execution and output modes**. Extends plugins
beyond a single foreground shell-out.

- **`mutating`** — declare a plugin read-only (`mutating = false`) so it stays
  usable in `--readonly` mode; the default (mutating) is still blocked there.
- **`confirm` / `dangerous`** — prompt before running, showing the exact
  executable and substituted arguments; `dangerous` is flagged with ⚠.
- **`output`** — `terminal` (default, interactive, inherits the terminal),
  `popup` (captured off-thread into a scrollable view), or `background`
  (detached, flashes on completion). `popup`/`background` run with a **timeout
  and bounded output capture**, so a slow or hung command can't freeze the UI.
- **`shell`** — explicit opt-in to `sh -c`; placeholders are still passed as
  separate positional parameters (`$1`, `$2`, …), never spliced into the script
  string (preserves argument boundaries — the security requirement).
- **Richer placeholders** — `$CLUSTER`, `$GROUP`, `$VERSION`, `$KIND`, `$FILTER`
  alongside the existing `$NAME`/`$NAMESPACE`/`$NS`/`$CONTEXT`/`$RESOURCE`, each
  substituted as one whole argument.
- **`timeout`** — per-plugin (`s`/`m`/`h`) for popup/background runs.

Invalid `output`/`timeout` values degrade to defaults with a `:config` warning.
**Existing plugin configs are unchanged** — every new field is optional and
defaults off / `terminal`.

Deferred to follow-ups: bulk invocation over marked rows (next PR), and typed
inputs (string/number/bool/secret/dropdown).

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (281 tests; new: rich-field parsing, output/timeout validation warnings, read-only gating by `mutating`, dangerous-confirm flow, and placeholder→argv boundary preservation).
- [x] Drove the real TUI against a live cluster:
  - A `popup` `kubectl get $RESOURCE $NAME -n $NAMESPACE` plugin captured its output into a scrollable "— output" view.
  - A `dangerous` plugin bound to `ctrl-x` opened a confirm dialog reading `⚠ Run dangerous plugin 'danger'? echo boom <pod>` (placeholders substituted), running only after `y`.

Note: docs (README) for the expanded plugin config can follow in a milestone-3 README pass; the config rustdoc covers the new fields.