### PR TITLE
feat: bulk plugin invocation over marked rows

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,4 +1,5 @@
 use super::*;
+use futures_util::StreamExt;
 
 impl App {
     // ----- key handling --------------------------------------------------
@@ -222,52 +223,6 @@ impl App {
             ));
             return;
         }
-        let Some(obj) = self.selected_ref() else {
-            self.flash_warn("no selection for plugin");
-            return;
-        };
-        let name = obj.metadata.name.clone().unwrap_or_default();
-        let ns = obj.metadata.namespace.clone().unwrap_or_default();
-        let ctx = self.cluster.context.clone();
-        let cluster = self.cluster.cluster_name.clone();
-        let res = self.kind_plural.clone();
-        let filter = self.filter.clone();
-        let (group, version, kind) = self
-            .kind
-            .as_ref()
-            .map(|k| (k.ar.group.clone(), k.ar.version.clone(), k.ar.kind.clone()))
-            .unwrap_or_default();
-        // Substitute each placeholder as one whole argument — never spliced
-        // into a shell string. `$NAMESPACE` before `$NS`/`$NAME` so the longer
-        // token wins.
-        let subst = |s: &str| {
-            s.replace("$NAMESPACE", &ns)
-                .replace("$NS", &ns)
-                .replace("$NAME", &name)
-                .replace("$CONTEXT", &ctx)
-                .replace("$CLUSTER", &cluster)
-                .replace("$RESOURCE", &res)
-                .replace("$GROUP", &group)
-                .replace("$VERSION", &version)
-                .replace("$KIND", &kind)
-                .replace("$FILTER", &filter)
-        };
-
-        // argv-by-default; `shell = true` opts into `sh -c`, still passing the
-        // substituted args as positional parameters ($1, $2, …) rather than
-        // interpolating them into the script.
-        let mut argv = if plugin.shell {
-            vec![
-                "sh".into(),
-                "-c".into(),
-                subst(&plugin.command),
-                "sofka".into(),
-            ]
-        } else {
-            vec![subst(&plugin.command)]
-        };
-        argv.extend(plugin.args.iter().map(|a| subst(a)));
-
         let mode = match plugin.output.as_deref() {
             Some("popup") => PluginMode::Popup,
             Some("background") => PluginMode::Background,
@@ -280,15 +235,81 @@ impl App {
             .unwrap_or(30)
             .max(1) as u64;
 
+        // Marked rows drive a bulk run; otherwise the single selection.
+        let targets = self.action_targets();
+        if targets.is_empty() {
+            self.flash_warn("no selection for plugin");
+            return;
+        }
+        // An interactive terminal command can't compose over a marked set:
+        // refuse rather than surprise the user by running on just one row.
+        if mode == PluginMode::Terminal && targets.len() > 1 {
+            self.flash_warn(&format!(
+                "'{}': a marked set needs output = popup or background",
+                plugin.name
+            ));
+            return;
+        }
+
+        let ctx = self.cluster.context.clone();
+        let cluster = self.cluster.cluster_name.clone();
+        let res = self.kind_plural.clone();
+        let filter = self.filter.clone();
+        let (group, version, kind) = self
+            .kind
+            .as_ref()
+            .map(|k| (k.ar.group.clone(), k.ar.version.clone(), k.ar.kind.clone()))
+            .unwrap_or_default();
+
+        // One (label, argv) job per target. Placeholders are substituted as
+        // whole arguments — never spliced into a shell string. `$NAMESPACE`
+        // before `$NS`/`$NAME` so the longer token wins.
+        let jobs: Vec<(String, Vec<String>)> = targets
+            .iter()
+            .map(|(name, ns)| {
+                let subst = |s: &str| {
+                    s.replace("$NAMESPACE", ns)
+                        .replace("$NS", ns)
+                        .replace("$NAME", name)
+                        .replace("$CONTEXT", &ctx)
+                        .replace("$CLUSTER", &cluster)
+                        .replace("$RESOURCE", &res)
+                        .replace("$GROUP", &group)
+                        .replace("$VERSION", &version)
+                        .replace("$KIND", &kind)
+                        .replace("$FILTER", &filter)
+                };
+                // `shell = true` opts into `sh -c`, still passing the args as
+                // positional parameters ($1, $2, …), not interpolated.
+                let mut argv = if plugin.shell {
+                    vec![
+                        "sh".into(),
+                        "-c".into(),
+                        subst(&plugin.command),
+                        "sofka".into(),
+                    ]
+                } else {
+                    vec![subst(&plugin.command)]
+                };
+                argv.extend(plugin.args.iter().map(|a| subst(a)));
+                (name.clone(), argv)
+            })
+            .collect();
+
         if plugin.confirm || plugin.dangerous {
-            let cmd = truncate_cmd(&argv);
-            self.confirm_label = if plugin.dangerous {
-                format!("⚠ Run dangerous plugin '{}'?  {cmd}", plugin.name)
+            let cmd = truncate_cmd(&jobs[0].1);
+            let head = if jobs.len() > 1 {
+                format!("Run plugin '{}' on {} resources?", plugin.name, jobs.len())
             } else {
-                format!("Run plugin '{}'?  {cmd}", plugin.name)
+                format!("Run plugin '{}'?", plugin.name)
+            };
+            self.confirm_label = if plugin.dangerous {
+                format!("⚠ {head} (dangerous)  {cmd}")
+            } else {
+                format!("{head}  {cmd}")
             };
             self.confirm_action = Some(ConfirmAction::Plugin {
-                argv,
+                jobs,
                 name: plugin.name.clone(),
                 mode,
                 timeout,
@@ -296,22 +317,28 @@ impl App {
             self.mode = Mode::Confirm;
             return;
         }
-        self.launch_plugin(argv, plugin.name.clone(), mode, timeout);
+        self.launch_plugin(jobs, plugin.name.clone(), mode, timeout);
     }
 
-    /// Dispatch a resolved plugin invocation by its output mode.
+    /// Dispatch resolved plugin jobs (one per target) by output mode.
     pub(super) fn launch_plugin(
         &mut self,
-        argv: Vec<String>,
+        jobs: Vec<(String, Vec<String>)>,
         name: String,
         mode: PluginMode,
         timeout: u64,
     ) {
-        if argv.is_empty() {
+        if jobs.is_empty() {
             return;
         }
+        let n = jobs.len();
         match mode {
             PluginMode::Terminal => {
+                // Terminal runs are single (enforced in run_plugin).
+                let argv = jobs.into_iter().next().map(|(_, a)| a).unwrap_or_default();
+                if argv.is_empty() {
+                    return;
+                }
                 self.flash = format!("plugin: {name}");
                 self.flash_err = false;
                 self.pending = Some(Suspend::Shell(argv));
@@ -320,32 +347,52 @@ impl App {
                 // Mirror describe: stay put, swap to the doc view when output
                 // lands, so a view switch mid-run cleanly drops the result.
                 self.set_return_mode();
-                self.flash = format!("plugin: {name}…");
+                self.flash = plugin_flash(&name, n, "");
                 self.flash_err = false;
-                self.spawn_plugin(argv, format!("{name} — output"), mode, timeout);
+                self.spawn_plugin(jobs, format!("{name} — output"), mode, timeout);
             }
             PluginMode::Background => {
-                self.flash = format!("plugin: {name} (background)…");
+                self.flash = plugin_flash(&name, n, " (background)");
                 self.flash_err = false;
-                self.spawn_plugin(argv, name, mode, timeout);
+                self.spawn_plugin(jobs, name, mode, timeout);
             }
         }
     }
 
-    /// Run a plugin off-thread with a timeout and bounded output capture, then
-    /// report back via [`Msg`]. A hung command can't freeze the UI: the timeout
-    /// aborts it and the result is generation-gated like every other stream.
-    fn spawn_plugin(&mut self, argv: Vec<String>, title: String, mode: PluginMode, timeout: u64) {
+    /// Run every job off-thread with a per-job timeout, bounded output capture,
+    /// and bounded concurrency, then report back via [`Msg`]. A hung command
+    /// can't freeze the UI — the timeout aborts it — and the aggregated result
+    /// is generation-gated like every other stream. For a bulk run this is
+    /// where partial failures are counted.
+    fn spawn_plugin(
+        &mut self,
+        jobs: Vec<(String, Vec<String>)>,
+        title: String,
+        mode: PluginMode,
+        timeout: u64,
+    ) {
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
-            let run = tokio::process::Command::new(&argv[0])
-                .args(&argv[1..])
-                .output();
-            let outcome = tokio::time::timeout(Duration::from_secs(timeout), run).await;
+            let dur = Duration::from_secs(timeout);
+            // Bounded concurrency, results in the marked order.
+            let results: Vec<(String, SpawnOutcome)> =
+                futures_util::stream::iter(jobs.into_iter().map(|(label, argv)| async move {
+                    let out = tokio::time::timeout(
+                        dur,
+                        tokio::process::Command::new(&argv[0])
+                            .args(&argv[1..])
+                            .output(),
+                    )
+                    .await;
+                    (label, out)
+                }))
+                .buffered(8)
+                .collect()
+                .await;
             let msg = match mode {
-                PluginMode::Popup => plugin_popup_msg(genr, title, timeout, outcome),
-                _ => plugin_done_msg(genr, title, timeout, outcome),
+                PluginMode::Popup => plugin_popup_msg(genr, title, timeout, results),
+                _ => plugin_bulk_msg(genr, title, timeout, results),
             };
             let _ = tx.send(msg).await;
         });
@@ -962,66 +1009,96 @@ fn stderr_summary(stderr: &[u8]) -> String {
         .collect()
 }
 
-/// Build the [`Msg::PluginOutput`] for a finished popup run.
-fn plugin_popup_msg(generation: u64, title: String, timeout: u64, outcome: SpawnOutcome) -> Msg {
+/// Reduce one job's outcome to `(ok, stdout lines, short failure reason)`.
+fn reduce_outcome(timeout: u64, outcome: SpawnOutcome) -> (bool, Vec<String>, String) {
     match outcome {
-        Err(_) => Msg::PluginOutput {
-            generation,
-            title,
-            lines: vec![format!("timed out after {timeout}s")],
-            warn: Some(format!("plugin timed out after {timeout}s")),
-        },
-        Ok(Err(e)) => Msg::PluginOutput {
-            generation,
-            title,
-            lines: vec![format!("failed to run: {e}")],
-            warn: Some(format!("plugin failed to start: {e}")),
-        },
+        Err(_) => {
+            let r = format!("timed out after {timeout}s");
+            (false, vec![r.clone()], r)
+        }
+        Ok(Err(e)) => {
+            let r = format!("failed to start: {e}");
+            (false, vec![format!("failed to run: {e}")], r)
+        }
         Ok(Ok(out)) => {
             let mut lines = bounded_lines(&out.stdout);
-            let warn = if out.status.success() {
+            if out.status.success() {
                 if lines.is_empty() {
                     lines.push("(no output)".into());
                 }
-                None
+                (true, lines, String::new())
             } else {
                 let err = stderr_summary(&out.stderr);
-                if !err.is_empty() {
+                let reason = if err.is_empty() {
+                    format!("exited {}", exit_label(&out.status))
+                } else {
                     lines.push(String::new());
                     lines.push(format!("[stderr] {err}"));
-                }
-                Some(format!("plugin exited {}", exit_label(&out.status)))
-            };
-            Msg::PluginOutput {
-                generation,
-                title,
-                lines,
-                warn,
+                    format!("exited {} — {err}", exit_label(&out.status))
+                };
+                (false, lines, reason)
             }
         }
     }
 }
 
-/// Build the [`Msg::PluginDone`] notification for a finished background run.
-fn plugin_done_msg(generation: u64, name: String, timeout: u64, outcome: SpawnOutcome) -> Msg {
-    let (ok, summary) = match outcome {
-        Err(_) => (false, format!("timed out after {timeout}s")),
-        Ok(Err(e)) => (false, format!("failed to start: {e}")),
-        Ok(Ok(out)) if out.status.success() => (true, "done".into()),
-        Ok(Ok(out)) => (
-            false,
-            format!(
-                "exited {} — {}",
-                exit_label(&out.status),
-                stderr_summary(&out.stderr)
-            ),
-        ),
-    };
-    Msg::PluginDone {
+/// Build [`Msg::PluginOutput`] for a finished popup run, aggregating one block
+/// per job (with a `== label ==` header when there's more than one).
+fn plugin_popup_msg(
+    generation: u64,
+    title: String,
+    timeout: u64,
+    results: Vec<(String, SpawnOutcome)>,
+) -> Msg {
+    let total = results.len();
+    let multi = total > 1;
+    let mut lines = Vec::new();
+    let mut failed = 0;
+    for (i, (label, outcome)) in results.into_iter().enumerate() {
+        let (ok, block, _) = reduce_outcome(timeout, outcome);
+        if !ok {
+            failed += 1;
+        }
+        if multi {
+            if i > 0 {
+                lines.push(String::new());
+            }
+            lines.push(format!("== {label} =="));
+        }
+        lines.extend(block);
+    }
+    let warn = (failed > 0).then(|| format!("{failed} of {total} failed"));
+    Msg::PluginOutput {
+        generation,
+        title,
+        lines,
+        warn,
+    }
+}
+
+/// Build [`Msg::PluginBulkDone`] for a finished background run, counting
+/// successes and listing the failures (target label + reason).
+fn plugin_bulk_msg(
+    generation: u64,
+    name: String,
+    timeout: u64,
+    results: Vec<(String, SpawnOutcome)>,
+) -> Msg {
+    let mut ok = 0;
+    let mut failed = Vec::new();
+    for (label, outcome) in results {
+        let (success, _, reason) = reduce_outcome(timeout, outcome);
+        if success {
+            ok += 1;
+        } else {
+            failed.push(format!("{label}: {reason}"));
+        }
+    }
+    Msg::PluginBulkDone {
         generation,
         name,
         ok,
-        summary,
+        failed,
     }
 }
 
@@ -1029,5 +1106,15 @@ fn exit_label(status: &std::process::ExitStatus) -> String {
     match status.code() {
         Some(c) => format!("code {c}"),
         None => "by signal".into(),
+    }
+}
+
+/// Flash text for a launched popup/background run, noting the count on a bulk
+/// run.
+fn plugin_flash(name: &str, n: usize, suffix: &str) -> String {
+    if n > 1 {
+        format!("plugin: {name} ×{n}{suffix}…")
+    } else {
+        format!("plugin: {name}{suffix}…")
     }
 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -620,17 +620,28 @@ impl App {
                     }
                 }
             }
-            Msg::PluginDone {
+            Msg::PluginBulkDone {
                 generation,
                 name,
                 ok,
-                summary,
+                failed,
             } if generation == self.generation => {
-                if ok {
-                    self.flash = format!("plugin {name}: {summary}");
+                if failed.is_empty() {
+                    self.flash = format!("plugin {name}: {ok} ok");
                     self.flash_err = false;
                 } else {
-                    self.flash_warn(&format!("plugin {name}: {summary}"));
+                    let shown: Vec<&str> = failed.iter().take(3).map(String::as_str).collect();
+                    let more = failed.len().saturating_sub(shown.len());
+                    let tail = if more > 0 {
+                        format!(" (+{more} more)")
+                    } else {
+                        String::new()
+                    };
+                    self.flash_warn(&format!(
+                        "plugin {name}: {ok} ok, {} failed — {}{tail}",
+                        failed.len(),
+                        shown.join("; ")
+                    ));
                 }
             }
             Msg::Detail {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -186,9 +186,10 @@ enum ConfirmAction {
     /// Uninstall one or more Helm releases (`helm uninstall`), `(name, ns)`
     /// per release — bulk when marked, like [`ConfirmAction::Delete`].
     HelmUninstall { targets: Vec<(String, String)> },
-    /// Run a confirmed plugin (`confirm`/`dangerous`) once accepted.
+    /// Run a confirmed plugin (`confirm`/`dangerous`) once accepted — one job
+    /// (label, argv) per target, so a bulk run confirms once.
     Plugin {
-        argv: Vec<String>,
+        jobs: Vec<(String, Vec<String>)>,
         name: String,
         mode: PluginMode,
         timeout: u64,

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -84,12 +84,12 @@ impl App {
                             self.marked.clear();
                         }
                         ConfirmAction::Plugin {
-                            argv,
+                            jobs,
                             name,
                             mode,
                             timeout,
                         } => {
-                            self.launch_plugin(argv, name, mode, timeout);
+                            self.launch_plugin(jobs, name, mode, timeout);
                         }
                     }
                 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2440,6 +2440,60 @@ async fn plugin_placeholders_substitute_as_separate_args() {
     );
 }
 
+/// Two marked pods, cursor on the first.
+fn app_with_two_marked_pods() -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["a", "b"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+    let keys: Vec<String> = app.rows().iter().map(|o| row_key(o)).collect();
+    for k in keys {
+        app.marked.insert(k);
+    }
+    app.table_state.select(Some(0));
+    (app, rx)
+}
+
+#[tokio::test]
+async fn bulk_terminal_plugin_is_refused() {
+    let (mut app, _rx) = app_with_two_marked_pods();
+    app.plugins = vec![crate::config::Plugin {
+        key: "g".into(),
+        name: "t".into(),
+        command: "echo".into(),
+        args: vec!["$NAME".into()],
+        ..Default::default() // terminal output — can't run over a marked set
+    }];
+    app.try_plugin_key(press(KeyCode::Char('g')));
+    assert!(
+        app.flash.contains("marked set") && app.flash_err,
+        "flash: {}",
+        app.flash
+    );
+    assert!(app.pending.is_none(), "terminal bulk must not run");
+}
+
+#[tokio::test]
+async fn bulk_background_plugin_runs_over_all_marked() {
+    let (mut app, _rx) = app_with_two_marked_pods();
+    app.plugins = vec![crate::config::Plugin {
+        key: "g".into(),
+        name: "bg".into(),
+        command: "true".into(),
+        output: Some("background".into()),
+        ..Default::default()
+    }];
+    app.try_plugin_key(press(KeyCode::Char('g')));
+    // Bulk dispatch over the two marked rows; background never suspends.
+    assert!(app.flash.contains("×2"), "flash: {}", app.flash);
+    assert!(app.pending.is_none(), "background must not suspend the TUI");
+}
+
 #[tokio::test]
 async fn context_switch_resolves_readonly_and_cli_pin_wins() {
     let dir = std::env::temp_dir().join(format!("sofka-readonly-test-{}", std::process::id()));

--- a/src/store.rs
+++ b/src/store.rs
@@ -63,12 +63,13 @@ pub enum Msg {
         /// Set when the plugin failed or timed out (a nonzero exit, stderr).
         warn: Option<String>,
     },
-    /// Completion notice for an `output = "background"` plugin run.
-    PluginDone {
+    /// Completion notice for an `output = "background"` plugin run (single or
+    /// bulk): how many jobs succeeded and the failures (label + reason).
+    PluginBulkDone {
         generation: u64,
         name: String,
-        ok: bool,
-        summary: String,
+        ok: usize,
+        failed: Vec<String>,
     },
     /// Result of an off-thread `kubectl describe` (or its YAML fallback).
     Detail {


### PR DESCRIPTION
## Summary

Milestone 3 item: **bulk plugins**. A plugin with `output = popup` or
`background` now runs over **every marked row** (falling back to the single
selection when nothing is marked), building one job per target with its own
`$NAME`/`$NAMESPACE` substitution.

- **background**: jobs run off-thread with bounded concurrency and a per-job
  timeout; the completion notice counts successes and **clearly lists partial
  failures** (target label + reason) —
  `plugin x: 3 ok, 2 failed — a: exited code 1; b: timed out (+1 more)`.
- **popup**: each job's output is aggregated into one scrollable, headed by
  `== <target> ==` when there's more than one, with a trailing warning noting
  how many failed.
- **terminal** (interactive) plugins can't compose over a set, so a marked run
  is **refused** with a clear message rather than silently acting on one row.

Confirmation for `confirm`/`dangerous` plugins happens **once** for the whole
set, noting the resource count. `Msg::PluginDone` → `PluginBulkDone`.

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (283 tests; new: terminal-bulk refusal, and background bulk dispatching over all marked rows).
- [x] Drove the real TUI: marked two pods, then
  - `popup` plugin (`kubectl get pod $NAME -n $NAMESPACE`) aggregated both pods' output under `== <pod> ==` headers in one scrollable;
  - `background` plugin flashed `plugin byname: 2 ok`.