### PR TITLE
feat: bookmarks and saved queries

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -871,7 +871,9 @@ impl App {
         let mut warnings = resolved.warnings;
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
+        self.bookmarks = resolved.config.bookmarks;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
+        warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.

--- a/src/app/bookmarks.rs
+++ b/src/app/bookmarks.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+impl App {
+    /// Try to trigger a bookmark bound to `key`. Returns whether one matched.
+    pub(super) fn try_bookmark_key(&mut self, key: KeyEvent) -> bool {
+        let Some(bm) = self
+            .bookmarks
+            .iter()
+            .find(|b| {
+                b.key
+                    .as_deref()
+                    .and_then(|k| crate::keys::KeyChord::parse(k).ok())
+                    .is_some_and(|chord| chord.matches(&key))
+            })
+            .cloned()
+        else {
+            return false;
+        };
+        self.apply_bookmark(bm);
+        true
+    }
+
+    /// Apply a bookmark by name (from the command palette). Returns whether a
+    /// bookmark with that name exists.
+    pub(super) fn apply_bookmark_named(&mut self, name: &str) -> bool {
+        let Some(bm) = self.bookmarks.iter().find(|b| b.name == name).cloned() else {
+            return false;
+        };
+        self.apply_bookmark(bm);
+        true
+    }
+
+    /// Apply a bookmark. A context change is asynchronous, so the rest of the
+    /// bookmark is stashed and applied once the switch lands
+    /// ([`Self::apply_pending_bookmark`]).
+    pub(super) fn apply_bookmark(&mut self, bm: crate::config::Bookmark) {
+        if let Some(ctx) = bm.context.clone()
+            && ctx != self.cluster.context
+        {
+            self.pending_bookmark = Some(bm);
+            self.switch_context(ctx);
+            return;
+        }
+        self.apply_bookmark_local(bm);
+    }
+
+    /// Apply a bookmark against the current cluster: namespace, resource,
+    /// filter, sort, then an optional view.
+    pub(super) fn apply_bookmark_local(&mut self, bm: crate::config::Bookmark) {
+        if bm.resource.trim().is_empty() {
+            self.flash_warn("bookmark has no resource");
+            return;
+        }
+        // Namespace + kind in one move (also starts the watch and builds the
+        // view spec, so headers are ready for the sort below).
+        let ns = bm.namespace.as_deref();
+        self.switch_kind_ns(bm.resource.trim(), ns);
+        // If the kind didn't resolve, switch_kind_ns already flashed an error
+        // and left the view unchanged — don't layer a filter/sort on top.
+        if self.kind.is_none() {
+            return;
+        }
+
+        if let Some(filter) = &bm.filter {
+            self.filter = filter.clone();
+            self.sync_filter_selectors();
+            self.invalidate_rows();
+            self.table_state.select(Some(0));
+        }
+        if let Some(sort) = &bm.sort {
+            self.apply_sort_spec(sort);
+        }
+        match bm.view.as_deref() {
+            Some("xray") => self.open_xray(),
+            Some("pulse") => self.open_pulse(),
+            _ => {}
+        }
+        self.flash = format!("bookmark: {}", bm.name);
+        self.flash_err = false;
+    }
+
+    /// Apply a stashed bookmark once its context switch has connected.
+    pub(super) fn apply_pending_bookmark(&mut self) {
+        if let Some(bm) = self.pending_bookmark.take() {
+            self.apply_bookmark_local(bm);
+        }
+    }
+
+    /// Set the active sort from a `COLUMN[:asc|:desc]` spec (bookmark sort).
+    fn apply_sort_spec(&mut self, spec: &str) {
+        let (name, desc) = match spec.rsplit_once(':') {
+            Some((col, "desc")) => (col.trim(), true),
+            Some((col, "asc")) => (col.trim(), false),
+            _ => (spec.trim(), false),
+        };
+        let header = name.to_uppercase();
+        match self.display_headers().iter().position(|h| *h == header) {
+            Some(i) => {
+                self.sort_column = Some(i);
+                self.sort_desc = desc;
+                self.invalidate_rows();
+            }
+            None => self.flash_warn(&format!("bookmark sort column '{header}' not found")),
+        }
+    }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -35,7 +35,9 @@ impl App {
             && (key.modifiers.contains(KeyModifiers::CONTROL)
                 || key.modifiers.contains(KeyModifiers::ALT))
         {
-            self.try_plugin_key(key);
+            if !self.try_bookmark_key(key) {
+                self.try_plugin_key(key);
+            }
             return Ok(());
         }
 
@@ -180,12 +182,15 @@ impl App {
                 self.help_filter.clear();
                 self.mode = Mode::Help;
             }
-            // User-defined plugins fall through here (built-ins take priority).
-            // Any unhandled key — a bare char, a function key — is offered to
-            // the plugin chords. Ctrl/alt combos are routed earlier, in
-            // `handle_key`, before the plain-key bindings above can claim them.
+            // User-defined bindings fall through here (built-ins take
+            // priority): bookmarks first, then plugins. Any unhandled key — a
+            // bare char, a function key — is offered to them. Ctrl/alt combos
+            // are routed earlier, in `handle_key`, before the plain-key
+            // bindings above can claim them.
             _ => {
-                self.try_plugin_key(key);
+                if !self.try_bookmark_key(key) {
+                    self.try_plugin_key(key);
+                }
             }
         }
     }
@@ -439,6 +444,11 @@ impl App {
                             self.switch_context(s.label);
                         }
                     }
+                    Some(SuggestKind::Bookmark) => {
+                        if let Some(s) = picked {
+                            self.apply_bookmark_named(&s.label);
+                        }
+                    }
                     // An exact typed built-in wins (stable muscle memory), then
                     // the highlighted suggestion, then the raw text as a resource.
                     _ => {
@@ -450,7 +460,10 @@ impl App {
                                     self.run_palette_command(&s.label);
                                 }
                                 SuggestKind::Resource => self.switch_kind_ns(&s.label, ns_arg),
-                                SuggestKind::Namespace | SuggestKind::Context => {}
+                                // Handled by the outer match arms above.
+                                SuggestKind::Namespace
+                                | SuggestKind::Context
+                                | SuggestKind::Bookmark => {}
                             }
                         } else if !head.is_empty() {
                             self.switch_kind_ns(&head, ns_arg);
@@ -569,6 +582,26 @@ impl App {
                         },
                     ));
                 }
+            }
+        }
+
+        // Saved bookmarks, matched by name. They rank above resources so a
+        // curated jump wins over an incidental catalog match, and they show on
+        // an empty `:` so they're discoverable.
+        for b in &self.bookmarks {
+            let score = if q.is_empty() {
+                Some(i64::MAX)
+            } else {
+                self.matcher.fuzzy_match(&b.name, q).map(|s| s + 1_000)
+            };
+            if let Some(score) = score {
+                scored.push((
+                    score,
+                    Suggestion {
+                        label: b.name.clone(),
+                        kind: SuggestKind::Bookmark,
+                    },
+                ));
             }
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -291,6 +291,8 @@ pub enum SuggestKind {
     Namespace,
     /// Context argument for `:ctx <name>` — Enter switches context.
     Context,
+    /// A saved bookmark — Enter applies its full navigation command.
+    Bookmark,
 }
 
 /// A built-in palette action, plus the names/aliases that select it. The first
@@ -621,6 +623,12 @@ pub struct App {
     pub user_aliases: HashMap<String, String>,
     /// User-defined shell-out plugins.
     pub plugins: Vec<crate::config::Plugin>,
+    /// Saved navigation commands (`[[bookmarks]]`), re-applied on context
+    /// switch and `:reload`.
+    pub bookmarks: Vec<crate::config::Bookmark>,
+    /// A bookmark waiting for an in-flight context switch to land before its
+    /// resource/namespace/filter/sort are applied.
+    pub pending_bookmark: Option<crate::config::Bookmark>,
     /// Resource plurals the user may list (None = unknown/all). "*" = all.
     rbac_allowed: Option<HashSet<String>>,
     last_rbac_ns: Option<String>,
@@ -784,6 +792,8 @@ impl App {
             all_contexts: Vec::new(),
             user_aliases: HashMap::new(),
             plugins: Vec::new(),
+            bookmarks: Vec::new(),
+            pending_bookmark: None,
             rbac_allowed: None,
             last_rbac_ns: None,
             container_list: Vec::new(),
@@ -867,6 +877,7 @@ impl App {
 }
 
 mod actions;
+mod bookmarks;
 mod dashboards;
 mod details;
 mod explain;

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -267,7 +267,9 @@ impl App {
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
-        let plugin_warnings = crate::config::plugin_warnings(&self.plugins);
+        self.bookmarks = resolved.config.bookmarks;
+        let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);
+        plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =
@@ -323,10 +325,16 @@ impl App {
         self.config_warnings = resolved.warnings;
         self.config_warnings.extend(plugin_warnings);
         self.config_warnings.extend(threshold_warnings);
-        let kind = resolved
-            .config
-            .default_resource
-            .unwrap_or_else(|| "pods".into());
-        self.switch_kind(&kind);
+        // A bookmark that requested this context lands on its own view; a plain
+        // switch lands on the context's default resource.
+        if self.pending_bookmark.is_some() {
+            self.apply_pending_bookmark();
+        } else {
+            let kind = resolved
+                .config
+                .default_resource
+                .unwrap_or_else(|| "pods".into());
+            self.switch_kind(&kind);
+        }
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2479,6 +2479,63 @@ async fn bulk_terminal_plugin_is_refused() {
 }
 
 #[tokio::test]
+async fn bookmark_applies_resource_namespace_filter_and_sort() {
+    let (mut app, _rx) = test_app();
+    app.bookmarks = vec![crate::config::Bookmark {
+        name: "api fails".into(),
+        resource: "pods".into(),
+        namespace: Some("prod".into()),
+        filter: Some("status!=Running".into()),
+        sort: Some("NAME:desc".into()),
+        ..Default::default()
+    }];
+    assert!(app.apply_bookmark_named("api fails"));
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.namespace, "prod");
+    assert_eq!(app.filter, "status!=Running");
+    // NAME is the first column; sort landed on it, descending.
+    assert_eq!(app.sort_column, Some(0));
+    assert!(app.sort_desc);
+    assert!(app.flash.contains("api fails"));
+
+    // Unknown bookmark name is a no-op.
+    assert!(!app.apply_bookmark_named("nope"));
+}
+
+#[tokio::test]
+async fn bookmark_key_chord_triggers_it() {
+    let (mut app, _rx) = test_app();
+    app.bookmarks = vec![crate::config::Bookmark {
+        key: Some("z".into()),
+        name: "go pods".into(),
+        resource: "pods".into(),
+        ..Default::default()
+    }];
+    assert!(app.try_bookmark_key(press(KeyCode::Char('z'))));
+    assert_eq!(app.kind_plural, "pods");
+    // A key with no bookmark bound is not claimed.
+    assert!(!app.try_bookmark_key(press(KeyCode::Char('q'))));
+}
+
+#[tokio::test]
+async fn bookmarks_appear_in_command_palette() {
+    let (mut app, _rx) = test_app();
+    app.bookmarks = vec![crate::config::Bookmark {
+        name: "Prod API".into(),
+        resource: "pods".into(),
+        ..Default::default()
+    }];
+    app.command = "prod".into();
+    app.update_suggestions();
+    assert!(
+        app.cmd_suggestions
+            .iter()
+            .any(|s| s.kind == SuggestKind::Bookmark && s.label == "Prod API"),
+        "bookmark missing from palette suggestions"
+    );
+}
+
+#[tokio::test]
 async fn bulk_background_plugin_runs_over_all_marked() {
     let (mut app, _rx) = app_with_two_marked_pods();
     app.plugins = vec![crate::config::Plugin {

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,9 @@ pub struct Config {
     pub aliases: HashMap<String, String>,
     /// User-defined shell-out plugins bound to keys.
     pub plugins: Vec<Plugin>,
+    /// Saved navigation commands bound to keys and the palette — see
+    /// [`Bookmark`]. Validated by [`bookmark_warnings`].
+    pub bookmarks: Vec<Bookmark>,
     /// Custom table views keyed by resource — see [`ViewConfig`]. Compiled
     /// and validated by [`crate::views::compile`].
     pub views: HashMap<String, ViewConfig>,
@@ -338,6 +341,74 @@ pub struct Plugin {
     /// Timeout for `popup`/`background` runs (`"30s"`, `"2m"`). Default 30s.
     /// Ignored for `terminal` (interactive) plugins.
     pub timeout: Option<String>,
+}
+
+/// A saved navigation command: jump to a resource (optionally in another
+/// context/namespace) with a filter, sort, and view applied in one keystroke.
+/// Bound to an optional key chord and always available in the command palette.
+///
+/// ```toml
+/// [[bookmarks]]
+/// key = "shift-1"
+/// name = "Prod API failures"
+/// resource = "pods"
+/// context = "prod-eu"          # optional: switch context first
+/// namespace = "checkout"       # optional; "all"/"*" = all namespaces
+/// filter = "status!=Running -l app=api"   # optional: same syntax as `/`
+/// sort = "RESTARTS:desc"       # optional: COLUMN[:asc|:desc]
+/// view = "xray"                # optional: xray | pulse
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Bookmark {
+    /// Optional key chord (see [`crate::keys::KeyChord`]) to trigger it.
+    pub key: Option<String>,
+    /// Display name, shown in the palette and help, and used by `:` selection.
+    pub name: String,
+    /// Resource to open (alias/plural/kind).
+    pub resource: String,
+    /// Namespace to scope to, or `all`/`*` for all namespaces. Absent keeps
+    /// the current namespace.
+    pub namespace: Option<String>,
+    /// Kubeconfig context to switch to first. Absent stays on the current one.
+    pub context: Option<String>,
+    /// Row filter to apply, same syntax as the interactive `/` filter.
+    pub filter: Option<String>,
+    /// Initial sort: a column header, optionally suffixed `:asc`/`:desc`.
+    pub sort: Option<String>,
+    /// A view to open after landing: `xray` or `pulse`.
+    pub view: Option<String>,
+}
+
+/// Validation warnings for bookmarks: an unparseable key chord, a missing
+/// name/resource, or an unknown `view`. A broken bookmark is skipped, not fatal.
+pub fn bookmark_warnings(bookmarks: &[Bookmark]) -> Vec<String> {
+    let mut warns = Vec::new();
+    for b in bookmarks {
+        let label = if b.name.is_empty() {
+            "<unnamed>"
+        } else {
+            &b.name
+        };
+        if b.name.trim().is_empty() {
+            warns.push("bookmark: missing `name`".into());
+        }
+        if b.resource.trim().is_empty() {
+            warns.push(format!("bookmark {label:?}: missing `resource`"));
+        }
+        if let Some(k) = &b.key
+            && let Err(e) = crate::keys::KeyChord::parse(k)
+        {
+            warns.push(format!("bookmark {label:?}: invalid key — {e}"));
+        }
+        if let Some(v) = &b.view
+            && !matches!(v.as_str(), "xray" | "pulse")
+        {
+            warns.push(format!(
+                "bookmark {label:?}: unknown view {v:?} (expected xray/pulse) — ignored"
+            ));
+        }
+    }
+    warns
 }
 
 /// Validation warnings for plugins: an unparseable key chord (see
@@ -658,6 +729,48 @@ mod tests {
         assert_eq!(p.mutating, None);
         assert!(!p.confirm && !p.dangerous && !p.shell);
         assert!(p.output.is_none());
+    }
+
+    #[test]
+    fn parses_bookmarks_and_flags_problems() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [[bookmarks]]
+            key = "shift-1"
+            name = "Prod API failures"
+            resource = "pods"
+            context = "prod-eu"
+            namespace = "checkout"
+            filter = "status!=Running -l app=api"
+            sort = "RESTARTS:desc"
+            view = "xray"
+        "#,
+        )
+        .unwrap();
+        let b = &cfg.bookmarks[0];
+        assert_eq!(b.name, "Prod API failures");
+        assert_eq!(b.resource, "pods");
+        assert_eq!(b.context.as_deref(), Some("prod-eu"));
+        assert_eq!(b.namespace.as_deref(), Some("checkout"));
+        assert_eq!(b.sort.as_deref(), Some("RESTARTS:desc"));
+        assert_eq!(b.view.as_deref(), Some("xray"));
+        assert!(bookmark_warnings(&cfg.bookmarks).is_empty());
+
+        let bad: Config = toml::from_str(
+            r#"
+            [[bookmarks]]
+            name = ""
+            resource = ""
+            key = "hyper-x"
+            view = "sidebar"
+        "#,
+        )
+        .unwrap();
+        let w = bookmark_warnings(&bad.bookmarks);
+        assert!(w.iter().any(|s| s.contains("missing `name`")), "{w:?}");
+        assert!(w.iter().any(|s| s.contains("missing `resource`")), "{w:?}");
+        assert!(w.iter().any(|s| s.contains("invalid key")), "{w:?}");
+        assert!(w.iter().any(|s| s.contains("unknown view")), "{w:?}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,11 @@ async fn main() -> Result<()> {
     app.all_contexts = Cluster::list_contexts();
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
-    for w in config::plugin_warnings(&app.plugins) {
+    app.bookmarks = cfg.bookmarks.clone();
+    for w in config::plugin_warnings(&app.plugins)
+        .into_iter()
+        .chain(config::bookmark_warnings(&app.bookmarks))
+    {
         eprintln!("warning: {w}");
         config_warnings.push(w);
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1614,6 +1614,23 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             lines.push(bind(&key, &format!("{} ({scope})", p.name)));
         }
     }
+    // Saved bookmarks: their chord (if any) and where they jump.
+    if !app.bookmarks.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("  Bookmarks", theme::title())));
+        for b in &app.bookmarks {
+            let key = b
+                .key
+                .as_deref()
+                .map(|k| {
+                    crate::keys::KeyChord::parse(k)
+                        .map(|c| c.label())
+                        .unwrap_or_else(|_| format!("{k}?"))
+                })
+                .unwrap_or_else(|| ":".to_string());
+            lines.push(bind(&key, &format!("★ {}", b.name)));
+        }
+    }
     // `/` search: keep only matching binding lines (section headers and
     // spacers match like any other text), highlighting the matched runs.
     let needle = app.help_filter.to_lowercase();
@@ -2099,6 +2116,14 @@ fn draw_palette(frame: &mut Frame, app: &mut App, area: Rect) {
             SuggestKind::Context => ListItem::new(Line::from(vec![
                 Span::styled(s.label.clone(), Style::default().fg(theme::mauve())),
                 Span::styled("  ctx", theme::dim()),
+            ])),
+            // Saved bookmarks read as a distinct, high-value jump (a ★ tag).
+            SuggestKind::Bookmark => ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("★ {}", s.label),
+                    Style::default().fg(theme::yellow()),
+                ),
+                Span::styled("  bookmark", theme::dim()),
             ])),
         })
         .collect();


### PR DESCRIPTION
## Summary

Milestone 3 item: **bookmarks and saved queries**. `[[bookmarks]]` are saved
navigation commands that jump to a resource — optionally in another
context/namespace, with a filter, sort, and view applied — in one keystroke.

```toml
[[bookmarks]]
key = "shift-1"                # optional key chord (modifier-aware)
name = "Prod API failures"
resource = "pods"
context = "prod-eu"            # optional: switch context first
namespace = "checkout"        # optional; all/* = all namespaces
filter = "status!=Running -l app=api"   # optional, same syntax as `/`
sort = "RESTARTS:desc"         # optional: COLUMN[:asc|:desc]
view = "xray"                  # optional: xray | pulse
```

- Triggered by their key chord (reusing the modifier-aware chord parser) **or**
  from the command palette, where they rank above resources and show on an
  empty `:` for discoverability (`★ name  bookmark`).
- A **context change** is applied first; the rest of the bookmark is stashed
  and applied once the async switch lands.
- Listed in **help** with their chord. Invalid bookmarks (bad chord, missing
  `name`/`resource`, unknown `view`) warn in `:config` and are skipped.
- Re-applied on context switch and `:reload`.

New `src/app/bookmarks.rs`; `SuggestKind::Bookmark` in the palette.

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (287 tests; new: config parse + validation, apply resource/ns/filter/sort, key-chord trigger, palette-suggestion presence).
- [x] Drove the real TUI: a `ctrl-p` bookmark jumped to `pods` in `monitoring` sorted by RESTARTS desc; `:flux` surfaced `★ flux kustomizations` and Enter jumped to kustomizations across all namespaces.

Context-switching bookmarks (the deferred-apply path) are covered by unit logic; the live cluster has a single context so that path wasn't exercised interactively.