### PR TITLE
feat: operational workspaces

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -872,8 +872,10 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
+        self.workspaces = resolved.config.workspaces;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
+        warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -35,7 +35,7 @@ impl App {
             && (key.modifiers.contains(KeyModifiers::CONTROL)
                 || key.modifiers.contains(KeyModifiers::ALT))
         {
-            if !self.try_bookmark_key(key) {
+            if !self.try_bookmark_key(key) && !self.try_workspace_key(key) {
                 self.try_plugin_key(key);
             }
             return Ok(());
@@ -150,6 +150,13 @@ impl App {
             // Browser-style view history: [ back, ] forward.
             KeyCode::Char('[') => self.history_back(),
             KeyCode::Char(']') => self.history_forward(),
+            // Cycle the active workspace's views (no-op when none is open).
+            KeyCode::Tab => {
+                self.cycle_workspace(true);
+            }
+            KeyCode::BackTab => {
+                self.cycle_workspace(false);
+            }
             // k9s: 0 = all namespaces.
             KeyCode::Char('0') => {
                 self.namespace.clear();
@@ -188,7 +195,7 @@ impl App {
             // are routed earlier, in `handle_key`, before the plain-key
             // bindings above can claim them.
             _ => {
-                if !self.try_bookmark_key(key) {
+                if !self.try_bookmark_key(key) && !self.try_workspace_key(key) {
                     self.try_plugin_key(key);
                 }
             }
@@ -449,6 +456,11 @@ impl App {
                             self.apply_bookmark_named(&s.label);
                         }
                     }
+                    Some(SuggestKind::Workspace) => {
+                        if let Some(s) = picked {
+                            self.open_workspace_named(&s.label);
+                        }
+                    }
                     // An exact typed built-in wins (stable muscle memory), then
                     // the highlighted suggestion, then the raw text as a resource.
                     _ => {
@@ -463,7 +475,8 @@ impl App {
                                 // Handled by the outer match arms above.
                                 SuggestKind::Namespace
                                 | SuggestKind::Context
-                                | SuggestKind::Bookmark => {}
+                                | SuggestKind::Bookmark
+                                | SuggestKind::Workspace => {}
                             }
                         } else if !head.is_empty() {
                             self.switch_kind_ns(&head, ns_arg);
@@ -600,6 +613,24 @@ impl App {
                     Suggestion {
                         label: b.name.clone(),
                         kind: SuggestKind::Bookmark,
+                    },
+                ));
+            }
+        }
+
+        // Saved workspaces, matched by name, ranked alongside bookmarks.
+        for w in &self.workspaces {
+            let score = if q.is_empty() {
+                Some(i64::MAX)
+            } else {
+                self.matcher.fuzzy_match(&w.name, q).map(|s| s + 1_000)
+            };
+            if let Some(score) = score {
+                scored.push((
+                    score,
+                    Suggestion {
+                        label: w.name.clone(),
+                        kind: SuggestKind::Workspace,
                     },
                 ));
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -196,6 +196,13 @@ enum ConfirmAction {
     },
 }
 
+/// The workspace being cycled: its views and where in them we are.
+pub struct ActiveWorkspace {
+    pub name: String,
+    pub views: Vec<crate::config::WorkspaceView>,
+    pub index: usize,
+}
+
 /// How a plugin's output is delivered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PluginMode {
@@ -293,6 +300,8 @@ pub enum SuggestKind {
     Context,
     /// A saved bookmark — Enter applies its full navigation command.
     Bookmark,
+    /// A saved workspace — Enter opens it (lands on its first view).
+    Workspace,
 }
 
 /// A built-in palette action, plus the names/aliases that select it. The first
@@ -629,6 +638,13 @@ pub struct App {
     /// A bookmark waiting for an in-flight context switch to land before its
     /// resource/namespace/filter/sort are applied.
     pub pending_bookmark: Option<crate::config::Bookmark>,
+    /// Saved workspaces (`[[workspaces]]`), re-applied on context switch and
+    /// `:reload`.
+    pub workspaces: Vec<crate::config::Workspace>,
+    /// A workspace waiting for an in-flight context switch before it opens.
+    pub pending_workspace: Option<crate::config::Workspace>,
+    /// The workspace currently being cycled with `Tab`/`Shift-Tab`, if any.
+    pub active_workspace: Option<ActiveWorkspace>,
     /// Resource plurals the user may list (None = unknown/all). "*" = all.
     rbac_allowed: Option<HashSet<String>>,
     last_rbac_ns: Option<String>,
@@ -794,6 +810,9 @@ impl App {
             plugins: Vec::new(),
             bookmarks: Vec::new(),
             pending_bookmark: None,
+            workspaces: Vec::new(),
+            pending_workspace: None,
+            active_workspace: None,
             rbac_allowed: None,
             last_rbac_ns: None,
             container_list: Vec::new(),
@@ -890,6 +909,7 @@ mod overlays;
 mod pickers;
 mod rows;
 mod timeline;
+mod workspaces;
 
 use helpers::*;
 

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -268,8 +268,10 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
+        self.workspaces = resolved.config.workspaces;
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);
         plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
+        plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =
@@ -325,9 +327,11 @@ impl App {
         self.config_warnings = resolved.warnings;
         self.config_warnings.extend(plugin_warnings);
         self.config_warnings.extend(threshold_warnings);
-        // A bookmark that requested this context lands on its own view; a plain
-        // switch lands on the context's default resource.
-        if self.pending_bookmark.is_some() {
+        // A bookmark/workspace that requested this context lands on its own
+        // view(s); a plain switch lands on the context's default resource.
+        if self.pending_workspace.is_some() {
+            self.apply_pending_workspace();
+        } else if self.pending_bookmark.is_some() {
             self.apply_pending_bookmark();
         } else {
             let kind = resolved

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2503,6 +2503,53 @@ async fn bookmark_applies_resource_namespace_filter_and_sort() {
 }
 
 #[tokio::test]
+async fn workspace_opens_first_view_and_tab_cycles() {
+    let (mut app, _rx) = test_app();
+    app.workspaces = vec![crate::config::Workspace {
+        key: Some("ctrl-w".into()),
+        name: "ops".into(),
+        context: None,
+        views: vec![
+            crate::config::WorkspaceView {
+                name: "pods".into(),
+                resource: "pods".into(),
+                namespace: Some("checkout".into()),
+                ..Default::default()
+            },
+            crate::config::WorkspaceView {
+                name: "deploys".into(),
+                resource: "deployments".into(),
+                ..Default::default()
+            },
+        ],
+    }];
+    assert!(app.open_workspace_named("ops"));
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.namespace, "checkout");
+    assert!(app.flash.contains("[1/2]"));
+
+    // Tab advances to the second view; wraps back on the third press.
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    assert!(app.flash.contains("[2/2]"));
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert!(app.flash.contains("[1/2]"));
+
+    // Shift-Tab goes back.
+    app.handle_key(press(KeyCode::BackTab)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+}
+
+#[tokio::test]
+async fn tab_is_a_noop_without_an_active_workspace() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    assert!(!app.cycle_workspace(true));
+    assert_eq!(app.kind_plural, "pods");
+}
+
+#[tokio::test]
 async fn bookmark_key_chord_triggers_it() {
     let (mut app, _rx) = test_app();
     app.bookmarks = vec![crate::config::Bookmark {

--- a/src/app/workspaces.rs
+++ b/src/app/workspaces.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+impl App {
+    /// Trigger a workspace bound to `key`. Returns whether one matched.
+    pub(super) fn try_workspace_key(&mut self, key: KeyEvent) -> bool {
+        let Some(ws) = self
+            .workspaces
+            .iter()
+            .find(|w| {
+                w.key
+                    .as_deref()
+                    .and_then(|k| crate::keys::KeyChord::parse(k).ok())
+                    .is_some_and(|chord| chord.matches(&key))
+            })
+            .cloned()
+        else {
+            return false;
+        };
+        self.open_workspace(ws);
+        true
+    }
+
+    /// Open a workspace by name (from the command palette).
+    pub(super) fn open_workspace_named(&mut self, name: &str) -> bool {
+        let Some(ws) = self.workspaces.iter().find(|w| w.name == name).cloned() else {
+            return false;
+        };
+        self.open_workspace(ws);
+        true
+    }
+
+    /// Open a workspace: switch its context first (deferred, if it differs),
+    /// then land on the first view and start cycling.
+    pub(super) fn open_workspace(&mut self, ws: crate::config::Workspace) {
+        if ws.views.is_empty() {
+            self.flash_warn(&format!("workspace '{}' has no views", ws.name));
+            return;
+        }
+        if let Some(ctx) = ws.context.clone()
+            && ctx != self.cluster.context
+        {
+            self.pending_workspace = Some(ws);
+            self.switch_context(ctx);
+            return;
+        }
+        self.start_workspace(ws);
+    }
+
+    /// Land on a workspace's first view and make it the active workspace.
+    fn start_workspace(&mut self, ws: crate::config::Workspace) {
+        self.active_workspace = Some(ActiveWorkspace {
+            name: ws.name,
+            views: ws.views,
+            index: 0,
+        });
+        self.apply_active_view();
+    }
+
+    /// Open a workspace stashed across a context switch, once it lands.
+    pub(super) fn apply_pending_workspace(&mut self) {
+        if let Some(ws) = self.pending_workspace.take() {
+            self.start_workspace(ws);
+        }
+    }
+
+    /// `Tab`/`Shift-Tab`: move to the next/previous view of the active
+    /// workspace (wrapping). No-op when no workspace is active.
+    pub(super) fn cycle_workspace(&mut self, forward: bool) -> bool {
+        let Some(ws) = &self.active_workspace else {
+            return false;
+        };
+        let len = ws.views.len();
+        if len == 0 {
+            return false;
+        }
+        let next = if forward {
+            (ws.index + 1) % len
+        } else {
+            (ws.index + len - 1) % len
+        };
+        if let Some(ws) = self.active_workspace.as_mut() {
+            ws.index = next;
+        }
+        self.apply_active_view();
+        true
+    }
+
+    /// Apply the active workspace's current view and set the status line.
+    fn apply_active_view(&mut self) {
+        let Some(ws) = &self.active_workspace else {
+            return;
+        };
+        let Some(view) = ws.views.get(ws.index) else {
+            return;
+        };
+        let (name, i, n, vname) = (
+            ws.name.clone(),
+            ws.index + 1,
+            ws.views.len(),
+            view.name.clone(),
+        );
+        let bookmark = view.as_bookmark();
+        // Reuse the bookmark application path (resource/ns/filter/sort/view),
+        // then relabel the status line for the workspace.
+        self.apply_bookmark_local(bookmark);
+        if self.kind.is_some() {
+            self.flash = format!("workspace {name} [{i}/{n}]: {vname}");
+            self.flash_err = false;
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,9 @@ pub struct Config {
     /// Saved navigation commands bound to keys and the palette — see
     /// [`Bookmark`]. Validated by [`bookmark_warnings`].
     pub bookmarks: Vec<Bookmark>,
+    /// Task-oriented collections of views — see [`Workspace`]. Validated by
+    /// [`workspace_warnings`].
+    pub workspaces: Vec<Workspace>,
     /// Custom table views keyed by resource — see [`ViewConfig`]. Compiled
     /// and validated by [`crate::views::compile`].
     pub views: HashMap<String, ViewConfig>,
@@ -377,6 +380,106 @@ pub struct Bookmark {
     pub sort: Option<String>,
     /// A view to open after landing: `xray` or `pulse`.
     pub view: Option<String>,
+}
+
+/// A task-oriented collection of views — checkout operations, a cluster
+/// upgrade, certificate renewal — saved as plain config a team can share.
+/// Opening a workspace switches to its (optional) context and lands on its
+/// first view; `Tab`/`Shift-Tab` cycle through the rest without leaving it.
+///
+/// ```toml
+/// [[workspaces]]
+/// key = "ctrl-w"
+/// name = "Checkout ops"
+/// context = "prod-eu"          # optional: switched once on open
+///
+/// [[workspaces.views]]
+/// name = "API pods"
+/// resource = "pods"
+/// namespace = "checkout"
+/// filter = "-l app=api"
+/// sort = "RESTARTS:desc"
+///
+/// [[workspaces.views]]
+/// name = "Ingress"
+/// resource = "ingresses"
+/// namespace = "checkout"
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct Workspace {
+    /// Optional key chord (see [`crate::keys::KeyChord`]) to open it.
+    pub key: Option<String>,
+    pub name: String,
+    /// Kubeconfig context, switched to once when the workspace opens.
+    pub context: Option<String>,
+    pub views: Vec<WorkspaceView>,
+}
+
+/// One view within a [`Workspace`]: like a [`Bookmark`] without its own key or
+/// context (the workspace owns those).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct WorkspaceView {
+    pub name: String,
+    pub resource: String,
+    pub namespace: Option<String>,
+    pub filter: Option<String>,
+    pub sort: Option<String>,
+    pub view: Option<String>,
+}
+
+impl WorkspaceView {
+    /// The equivalent [`Bookmark`] (no key/context), so the app can apply a
+    /// workspace view through the same path as a bookmark.
+    pub fn as_bookmark(&self) -> Bookmark {
+        Bookmark {
+            key: None,
+            name: self.name.clone(),
+            resource: self.resource.clone(),
+            namespace: self.namespace.clone(),
+            context: None,
+            filter: self.filter.clone(),
+            sort: self.sort.clone(),
+            view: self.view.clone(),
+        }
+    }
+}
+
+/// Validation warnings for workspaces: an unparseable key chord, a missing
+/// name, no views, or a bad view (missing resource / unknown view kind).
+pub fn workspace_warnings(workspaces: &[Workspace]) -> Vec<String> {
+    let mut warns = Vec::new();
+    for w in workspaces {
+        let label = if w.name.is_empty() {
+            "<unnamed>"
+        } else {
+            &w.name
+        };
+        if w.name.trim().is_empty() {
+            warns.push("workspace: missing `name`".into());
+        }
+        if let Some(k) = &w.key
+            && let Err(e) = crate::keys::KeyChord::parse(k)
+        {
+            warns.push(format!("workspace {label:?}: invalid key — {e}"));
+        }
+        if w.views.is_empty() {
+            warns.push(format!("workspace {label:?}: no [[workspaces.views]]"));
+        }
+        for v in &w.views {
+            if v.resource.trim().is_empty() {
+                warns.push(format!("workspace {label:?}: a view is missing `resource`"));
+            }
+            if let Some(kind) = &v.view
+                && !matches!(kind.as_str(), "xray" | "pulse")
+            {
+                warns.push(format!(
+                    "workspace {label:?}: unknown view {kind:?} (expected xray/pulse) — ignored"
+                ));
+            }
+        }
+    }
+    warns
 }
 
 /// Validation warnings for bookmarks: an unparseable key chord, a missing
@@ -771,6 +874,55 @@ mod tests {
         assert!(w.iter().any(|s| s.contains("missing `resource`")), "{w:?}");
         assert!(w.iter().any(|s| s.contains("invalid key")), "{w:?}");
         assert!(w.iter().any(|s| s.contains("unknown view")), "{w:?}");
+    }
+
+    #[test]
+    fn parses_workspaces_and_flags_problems() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [[workspaces]]
+            key = "ctrl-w"
+            name = "Checkout ops"
+            context = "prod-eu"
+
+            [[workspaces.views]]
+            name = "API pods"
+            resource = "pods"
+            namespace = "checkout"
+            filter = "-l app=api"
+            sort = "RESTARTS:desc"
+
+            [[workspaces.views]]
+            name = "Ingress"
+            resource = "ingresses"
+        "#,
+        )
+        .unwrap();
+        let w = &cfg.workspaces[0];
+        assert_eq!(w.name, "Checkout ops");
+        assert_eq!(w.context.as_deref(), Some("prod-eu"));
+        assert_eq!(w.views.len(), 2);
+        assert_eq!(w.views[0].resource, "pods");
+        assert!(workspace_warnings(&cfg.workspaces).is_empty());
+
+        let bad: Config = toml::from_str(
+            r#"
+            [[workspaces]]
+            name = ""
+            key = "hyper-x"
+        "#,
+        )
+        .unwrap();
+        let warns = workspace_warnings(&bad.workspaces);
+        assert!(
+            warns.iter().any(|s| s.contains("missing `name`")),
+            "{warns:?}"
+        );
+        assert!(warns.iter().any(|s| s.contains("invalid key")), "{warns:?}");
+        assert!(
+            warns.iter().any(|s| s.contains("no [[workspaces.views]]")),
+            "{warns:?}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,9 +153,11 @@ async fn main() -> Result<()> {
     app.user_aliases = cfg.aliases.clone();
     app.plugins = cfg.plugins.clone();
     app.bookmarks = cfg.bookmarks.clone();
+    app.workspaces = cfg.workspaces.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))
+        .chain(config::workspace_warnings(&app.workspaces))
     {
         eprintln!("warning: {w}");
         config_warnings.push(w);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1631,6 +1631,26 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             lines.push(bind(&key, &format!("★ {}", b.name)));
         }
     }
+    // Saved workspaces: their chord (if any), view count, and Tab hint.
+    if !app.workspaces.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("  Workspaces", theme::title())));
+        for w in &app.workspaces {
+            let key = w
+                .key
+                .as_deref()
+                .map(|k| {
+                    crate::keys::KeyChord::parse(k)
+                        .map(|c| c.label())
+                        .unwrap_or_else(|_| format!("{k}?"))
+                })
+                .unwrap_or_else(|| ":".to_string());
+            lines.push(bind(
+                &key,
+                &format!("▦ {} ({} views · Tab to cycle)", w.name, w.views.len()),
+            ));
+        }
+    }
     // `/` search: keep only matching binding lines (section headers and
     // spacers match like any other text), highlighting the matched runs.
     let needle = app.help_filter.to_lowercase();
@@ -2124,6 +2144,10 @@ fn draw_palette(frame: &mut Frame, app: &mut App, area: Rect) {
                     Style::default().fg(theme::yellow()),
                 ),
                 Span::styled("  bookmark", theme::dim()),
+            ])),
+            SuggestKind::Workspace => ListItem::new(Line::from(vec![
+                Span::styled(format!("▦ {}", s.label), Style::default().fg(theme::sky())),
+                Span::styled("  workspace", theme::dim()),
             ])),
         })
         .collect();


### PR DESCRIPTION
## Summary

Milestone 3 item: **operational workspaces**. `[[workspaces]]` are named,
task-oriented collections of resource views (checkout ops, a cluster upgrade,
cert renewal) saved as plain, shareable config.

```toml
[[workspaces]]
key = "ctrl-w"
name = "Checkout ops"
context = "prod-eu"          # optional: switched once on open

[[workspaces.views]]
name = "API pods"
resource = "pods"
namespace = "checkout"
filter = "-l app=api"
sort = "RESTARTS:desc"

[[workspaces.views]]
name = "Ingress"
resource = "ingresses"
namespace = "checkout"
```

- Open via key chord or the command palette (`▦` tag): switches the optional
  context once, then lands on the first view.
- **`Tab` / `Shift-Tab`** cycle through the views without leaving the
  workspace; the status line shows `workspace <name> [i/n]: <view>`.
- Each view is resource + namespace + filter + sort + optional view
  (xray/pulse), applied through the same path as a bookmark.
- A context change defers opening until the switch lands.
- Listed in help; invalid workspaces (bad chord, missing name, no views, a
  view without a resource, unknown view kind) warn in `:config`. Re-applied on
  context switch and `:reload`.

New `src/app/workspaces.rs`; `config::Workspace`/`WorkspaceView`;
`SuggestKind::Workspace`.

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (290 tests; new: config parse + validation, open-first-view, Tab/Shift-Tab cycling with wraparound, and Tab as a no-op with no active workspace).
- [x] Drove the real TUI: `ctrl-w` opened `monitoring ops [1/3]: pods`; Tab advanced through `[2/3]: deployments` and `[3/3]: services`, each landing on the right resource in the `monitoring` namespace.