### PR TITLE
feat: namespace favourites and recents

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -870,6 +870,7 @@ impl App {
             .resolve(&self.cluster.context, &self.cluster.cluster_name);
         let mut warnings = resolved.warnings;
         self.user_aliases = resolved.config.aliases;
+        self.namespace_favorites = resolved.config.favorite_namespaces;
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -16,6 +16,7 @@ impl App {
             Some(kind) => {
                 if let Some(ns) = ns {
                     self.namespace = normalize_ns(ns);
+                    self.note_recent_namespace(ns);
                 }
                 let title = kind.title();
                 self.set_root_view(kind);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -616,6 +616,11 @@ pub struct App {
 
     pub ns_list: Vec<String>,
     pub ns_state: ListState,
+    /// Namespaces pinned to the top of the switcher (config `favorite_namespaces`),
+    /// re-applied on context switch and `:reload`.
+    pub namespace_favorites: Vec<String>,
+    /// Session-local recently-selected namespaces, newest first, per context.
+    pub recent_namespaces: HashMap<String, VecDeque<String>>,
     /// Type-to-filter buffer for the namespace switcher; also accepted verbatim
     /// (freeform) so you can switch to a namespace that isn't listed (e.g. when
     /// cluster-wide namespace listing is restricted).
@@ -801,6 +806,8 @@ impl App {
             logs: LogsView::default(),
             ns_list: Vec::new(),
             ns_state: ListState::default(),
+            namespace_favorites: Vec::new(),
+            recent_namespaces: HashMap::new(),
             ns_filter: String::new(),
             ctx_list: Vec::new(),
             ctx_state: ListState::default(),

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -207,6 +207,7 @@ impl App {
             self.table_state.select(Some(0));
         }
         self.namespace = ns;
+        self.note_recent_namespace(name);
         self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
         self.record_history();

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+/// How many recent namespaces to keep per context in the switcher.
+const MAX_RECENT_NAMESPACES: usize = 8;
+
 impl App {
     /// Open the namespace switcher immediately with a loading placeholder, then
     /// fetch the list off-thread (it arrives as `Msg::Namespaces`).
@@ -55,21 +58,82 @@ impl App {
         }
     }
 
-    /// Namespaces for the switcher: `<all>` is always pinned first, the rest
-    /// fuzzy-matched against the type-to-filter buffer.
+    /// Namespaces for the switcher: `<all>` is always pinned first. When
+    /// browsing (no filter), configured favourites lead, then session recents,
+    /// then the remaining namespaces alphabetically. With a filter active,
+    /// everything is fuzzy-matched (favourites/recents lose their pinning so
+    /// the best textual match wins).
     pub fn filtered_namespaces(&self) -> Vec<String> {
         let mut out = vec!["<all>".to_string()];
         let rest = self.ns_list.iter().filter(|n| n.as_str() != "<all>");
-        if self.ns_filter.is_empty() {
-            out.extend(rest.cloned());
-        } else {
+        if !self.ns_filter.is_empty() {
             let mut scored: Vec<(i64, &String)> = rest
                 .filter_map(|n| self.matcher.fuzzy_match(n, &self.ns_filter).map(|s| (s, n)))
                 .collect();
             scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(b.1)));
             out.extend(scored.into_iter().map(|(_, n)| n.clone()));
+            return out;
+        }
+
+        let available: std::collections::HashSet<&str> = rest.map(String::as_str).collect();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Favourites first, in configured order (pinned even if not currently
+        // listable — the switcher still accepts a verbatim pick).
+        for f in &self.namespace_favorites {
+            if !f.is_empty() && seen.insert(f.clone()) {
+                out.push(f.clone());
+            }
+        }
+        // Then session recents that still exist and aren't already favourites.
+        for r in self.recent_namespaces_for_context() {
+            if available.contains(r.as_str()) && seen.insert(r.clone()) {
+                out.push(r);
+            }
+        }
+        // Then everything else (ns_list is already sorted).
+        for n in self.ns_list.iter().filter(|n| n.as_str() != "<all>") {
+            if seen.insert(n.clone()) {
+                out.push(n.clone());
+            }
         }
         out
+    }
+
+    /// The recent namespaces for the current context, newest first.
+    fn recent_namespaces_for_context(&self) -> Vec<String> {
+        self.recent_namespaces
+            .get(&self.cluster.context)
+            .map(|dq| dq.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Whether `n` is a configured favourite namespace.
+    pub fn is_favorite_namespace(&self, n: &str) -> bool {
+        self.namespace_favorites.iter().any(|f| f == n)
+    }
+
+    /// Whether `n` is a session-recent namespace for the current context.
+    pub fn is_recent_namespace(&self, n: &str) -> bool {
+        self.recent_namespaces
+            .get(&self.cluster.context)
+            .is_some_and(|dq| dq.iter().any(|r| r == n))
+    }
+
+    /// Record a real namespace selection into the current context's recents
+    /// (newest first, deduped, bounded). `<all>`/empty are not recorded.
+    pub(super) fn note_recent_namespace(&mut self, ns: &str) {
+        if ns.is_empty() || ns == "<all>" {
+            return;
+        }
+        let dq = self
+            .recent_namespaces
+            .entry(self.cluster.context.clone())
+            .or_default();
+        dq.retain(|r| r != ns);
+        dq.push_front(ns.to_string());
+        while dq.len() > MAX_RECENT_NAMESPACES {
+            dq.pop_back();
+        }
     }
 
     pub(super) fn key_namespaces(&mut self, key: KeyEvent) {
@@ -131,6 +195,7 @@ impl App {
 
     pub(super) fn set_namespace(&mut self, sel: String) {
         self.namespace = normalize_ns(&sel);
+        self.note_recent_namespace(&sel);
         self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
         self.ns_filter.clear();
@@ -266,6 +331,7 @@ impl App {
     pub(super) fn apply_context_switch(&mut self, name: String, mut cluster: Box<Cluster>) {
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
+        self.namespace_favorites = resolved.config.favorite_namespaces;
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2503,6 +2503,66 @@ async fn bookmark_applies_resource_namespace_filter_and_sort() {
 }
 
 #[tokio::test]
+async fn namespace_switcher_pins_favorites_then_recents() {
+    let (mut app, _rx) = test_app();
+    app.ns_list = ["<all>", "alpha", "beta", "checkout", "monitoring"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    app.namespace_favorites = vec!["monitoring".into()];
+    // Recents, oldest→newest (newest ends up first).
+    app.note_recent_namespace("checkout");
+    app.note_recent_namespace("alpha");
+
+    // Browsing: <all>, favourite, recents (newest first), then the rest.
+    assert_eq!(
+        app.filtered_namespaces(),
+        vec!["<all>", "monitoring", "alpha", "checkout", "beta"]
+    );
+    assert!(app.is_favorite_namespace("monitoring"));
+    assert!(app.is_recent_namespace("alpha") && !app.is_recent_namespace("beta"));
+
+    // A filter falls back to pure fuzzy ranking (no pinning).
+    app.ns_filter = "beta".into();
+    assert_eq!(app.filtered_namespaces(), vec!["<all>", "beta"]);
+}
+
+#[tokio::test]
+async fn recent_namespaces_dedupe_and_bound() {
+    let (mut app, _rx) = test_app();
+    for n in ["a", "b", "c", "a"] {
+        app.note_recent_namespace(n);
+    }
+    // `a` moved to the front, no duplicate.
+    let recents: Vec<String> = app
+        .recent_namespaces
+        .get(&app.cluster.context)
+        .unwrap()
+        .iter()
+        .cloned()
+        .collect();
+    assert_eq!(recents, vec!["a", "c", "b"]);
+
+    // Bounded to 8, newest kept.
+    for i in 0..12 {
+        app.note_recent_namespace(&format!("ns{i}"));
+    }
+    let dq = app.recent_namespaces.get(&app.cluster.context).unwrap();
+    assert_eq!(dq.len(), 8);
+    assert_eq!(dq.front().unwrap(), "ns11");
+    // `<all>` and empty are never recorded.
+    app.note_recent_namespace("<all>");
+    app.note_recent_namespace("");
+    assert_eq!(
+        app.recent_namespaces
+            .get(&app.cluster.context)
+            .unwrap()
+            .len(),
+        8
+    );
+}
+
+#[tokio::test]
 async fn workspace_opens_first_view_and_tab_cycles() {
     let (mut app, _rx) = test_app();
     app.workspaces = vec![crate::config::Workspace {

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,9 @@ pub struct Config {
     pub readonly: bool,
     /// Custom alias -> canonical resource (plural/kind) mappings.
     pub aliases: HashMap<String, String>,
+    /// Namespaces pinned to the top of the switcher (a curated team list, in
+    /// the given order). Session-local recents follow them.
+    pub favorite_namespaces: Vec<String>,
     /// User-defined shell-out plugins bound to keys.
     pub plugins: Vec<Plugin>,
     /// Saved navigation commands bound to keys and the palette — see
@@ -942,6 +945,15 @@ mod tests {
         assert_eq!(w.len(), 2, "{w:?}");
         assert!(w.iter().any(|s| s.contains("unknown output")));
         assert!(w.iter().any(|s| s.contains("timeout")));
+    }
+
+    #[test]
+    fn parses_favorite_namespaces() {
+        let cfg: Config =
+            toml::from_str("favorite_namespaces = [\"kube-system\", \"monitoring\"]").unwrap();
+        assert_eq!(cfg.favorite_namespaces, vec!["kube-system", "monitoring"]);
+        let empty: Config = toml::from_str("").unwrap();
+        assert!(empty.favorite_namespaces.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,7 @@ async fn main() -> Result<()> {
     // palette can complete `:ctx <name>` without re-reading the file per keystroke.
     app.all_contexts = Cluster::list_contexts();
     app.user_aliases = cfg.aliases.clone();
+    app.namespace_favorites = cfg.favorite_namespaces.clone();
     app.plugins = cfg.plugins.clone();
     app.bookmarks = cfg.bookmarks.clone();
     app.workspaces = cfg.workspaces.clone();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1679,20 +1679,33 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
 
 fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
     let names = app.filtered_namespaces();
+    let browsing = app.ns_filter.is_empty();
     let items: Vec<ListItem> = names
         .iter()
         .map(|n| {
-            let color = if n == "<all>" {
-                theme::teal()
+            if n == "<all>" {
+                return ListItem::new(Span::styled(n.clone(), Style::default().fg(theme::teal())));
+            }
+            // Only tag favourites/recents while browsing (the pinned ordering);
+            // a filtered list is ranked by match, so a tag there would mislead.
+            let (tag, color) = if !browsing {
+                ("", theme::text())
+            } else if app.is_favorite_namespace(n) {
+                ("★ ", theme::yellow())
+            } else if app.is_recent_namespace(n) {
+                ("· ", theme::sky())
             } else {
-                theme::text()
+                ("", theme::text())
             };
-            ListItem::new(Span::styled(n.clone(), Style::default().fg(color)))
+            ListItem::new(Line::from(vec![
+                Span::styled(tag.to_string(), theme::dim()),
+                Span::styled(n.clone(), Style::default().fg(color)),
+            ]))
         })
         .collect();
     // Show the type-to-filter buffer in the title so it reads like an input.
     let title = if app.ns_filter.is_empty() {
-        " Namespaces (type to filter · ⏎ switch) ".to_string()
+        " Namespaces (★ fav · recent · ⏎ switch) ".to_string()
     } else {
         format!(" Namespaces · /{}_ ", app.ns_filter)
     };


### PR DESCRIPTION
## Summary

Final milestone-3 item: **namespace favourites and recents**. The namespace
switcher now pins a curated team list and a session-local recent list above the
rest.

- **`favorite_namespaces`** (config): namespaces pinned to the top of the
  switcher, in the given order, tagged ★. Re-applied on context switch and
  `:reload`.

  ```toml
  favorite_namespaces = ["kube-system", "monitoring"]
  ```
- **Session recents**: the namespaces you've switched to, newest first, per
  context (bounded to 8, deduped), shown next and tagged `·`. Recorded from the
  switcher, `:<kind> <ns>`, and namespace drill-down.
- **Ordering** (unfiltered browse): `<all>`, favourites, recents, then the rest
  alphabetically. A filter falls back to pure fuzzy ranking, so typing still
  finds the best textual match (no misleading tags while filtering).

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (293 tests; new: config parse, switcher ordering (favourites→recents→rest + fuzzy fallback), and recents dedupe/bound/`<all>`-exclusion).
- [x] Drove the real TUI: with `favorite_namespaces = ["monitoring", "kube-system"]`, the switcher showed `<all>`, `★ monitoring`, `★ kube-system`; after switching to `cert-manager`, reopening showed `· cert-manager` as a recent below the favourites.