### PR TITLE
feat: managed-resource mutation warnings

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -19,13 +19,50 @@ impl App {
             return;
         }
         let cascade = Cascade::Background;
-        self.confirm_label = delete_confirm_label(&self.kind_plural, &targets, force, cascade);
+        let managed = self.recreated_note();
+        self.confirm_label = delete_confirm_label(
+            &self.kind_plural,
+            &targets,
+            force,
+            cascade,
+            managed.as_deref(),
+        );
         self.confirm_action = Some(ConfirmAction::Delete {
             targets,
             force,
             cascade,
+            managed,
         });
         self.mode = Mode::Confirm;
+    }
+
+    /// A short "managed by X — recreated on delete" warning when any object in
+    /// the current delete selection is owned by Flux or a controller (so the
+    /// user knows deletion won't stick). `None` when nothing is managed.
+    fn recreated_note(&self) -> Option<String> {
+        let objs = self.action_target_objects();
+        let managed: Vec<String> = objs.iter().filter_map(managed_by).collect();
+        let (mine, total) = (managed.len(), objs.len());
+        let first = managed.into_iter().next()?;
+        Some(if total == 1 {
+            format!("⚠ managed by {first} — recreated on delete")
+        } else {
+            format!("⚠ {mine}/{total} managed (e.g. {first}) — recreated on delete")
+        })
+    }
+
+    /// The objects targeted by a bulk-or-single action (marked rows, else the
+    /// selection), as owned clones.
+    fn action_target_objects(&self) -> Vec<DynamicObject> {
+        if self.marked.is_empty() {
+            self.selected_ref().cloned().into_iter().collect()
+        } else {
+            self.rows()
+                .into_iter()
+                .filter(|o| self.marked.contains(&row_key(o)))
+                .cloned()
+                .collect()
+        }
     }
 
     pub(super) fn spawn_patch_action<F>(
@@ -624,13 +661,25 @@ impl App {
             return;
         };
         let name = obj.metadata.name.clone().unwrap_or_default();
+        // A Flux-managed object gets its spec reverted on the next reconcile —
+        // warn (and confirm) before opening the editor.
+        let flux = flux_managed_by(obj);
         let mut argv = self.kubectl_base();
         argv.extend(["edit".into(), self.kind_plural.clone(), name]);
         if let Some(ns) = &obj.metadata.namespace {
             argv.push("-n".into());
             argv.push(ns.clone());
         }
-        self.pending = Some(Suspend::Shell(argv));
+        match flux {
+            Some(owner) => {
+                self.confirm_label = format!(
+                    "⚠ Managed by {owner} — your edit will be reverted on the next reconcile. Edit anyway?"
+                );
+                self.confirm_action = Some(ConfirmAction::Edit { argv });
+                self.mode = Mode::Confirm;
+            }
+            None => self.pending = Some(Suspend::Shell(argv)),
+        }
     }
 
     pub(super) fn request_exec(&mut self) {

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -43,11 +43,33 @@ pub(super) fn node_unschedulable_patch(unschedulable: bool) -> Value {
     json!({ "spec": { "unschedulable": unschedulable } })
 }
 
+/// What manages `obj`, if anything: its Flux owner (from the toolkit labels)
+/// preferred, else its controller/owner reference. Used to warn that a delete
+/// will be recreated.
+pub(super) fn managed_by(obj: &DynamicObject) -> Option<String> {
+    if let Some(f) = flux_managed_by(obj) {
+        return Some(f);
+    }
+    let owners = obj.metadata.owner_references.as_ref()?;
+    let owner = owners
+        .iter()
+        .find(|o| o.controller == Some(true))
+        .or_else(|| owners.first())?;
+    Some(format!("{}/{}", owner.kind, owner.name))
+}
+
+/// The Flux Kustomization/HelmRelease managing `obj`, from its toolkit labels.
+/// Used to warn that an edit will be reverted on the next reconcile.
+pub(super) fn flux_managed_by(obj: &DynamicObject) -> Option<String> {
+    crate::gitops::owner_ref(obj).map(|r| format!("Flux {}/{}", r.kind, r.name))
+}
+
 pub(super) fn delete_confirm_label(
     kind_plural: &str,
     targets: &[(String, String)],
     force: bool,
     cascade: Cascade,
+    managed: Option<&str>,
 ) -> String {
     let verb = if force { "Force delete" } else { "Delete" };
     // Background is the kubectl default, so only surface the unusual modes.
@@ -56,6 +78,8 @@ pub(super) fn delete_confirm_label(
         Cascade::Foreground => " (cascade: foreground)",
         Cascade::Orphan => " (orphan dependents)",
     };
+    // A managed target gets recreated straight after deletion — say so.
+    let managed = managed.map(|m| format!("  {m}")).unwrap_or_default();
     if targets.len() == 1 {
         let (name, ns) = &targets[0];
         let where_ns = if ns.is_empty() {
@@ -63,9 +87,12 @@ pub(super) fn delete_confirm_label(
         } else {
             format!(" in {ns}")
         };
-        format!("{verb} {} {name}{where_ns}{suffix}?", trim_s(kind_plural))
+        format!(
+            "{verb} {} {name}{where_ns}{suffix}?{managed}",
+            trim_s(kind_plural)
+        )
     } else {
-        format!("{verb} {} {}{suffix}?", targets.len(), kind_plural)
+        format!("{verb} {} {}{suffix}?{managed}", targets.len(), kind_plural)
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -174,7 +174,13 @@ enum ConfirmAction {
         targets: Vec<(String, String)>,
         force: bool,
         cascade: Cascade,
+        /// A "managed — will be recreated" warning when any target is owned by
+        /// Flux or a controller (shown in the dialog).
+        managed: Option<String>,
     },
+    /// Edit a Flux-managed object (`kubectl edit`) after warning that the edit
+    /// will be reverted on the next reconcile.
+    Edit { argv: Vec<String> },
     /// One or more node names to cordon and drain.
     Drain { targets: Vec<String> },
     /// Roll a Helm release back to an earlier revision (`helm rollback`) —

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -68,9 +68,13 @@ impl App {
                             targets,
                             force,
                             cascade,
+                            ..
                         } => {
                             self.do_delete(targets, force, cascade);
                             self.marked.clear();
+                        }
+                        ConfirmAction::Edit { argv } => {
+                            self.pending = Some(Suspend::Shell(argv));
                         }
                         ConfirmAction::Drain { targets } => {
                             self.do_drain_nodes(targets);
@@ -101,15 +105,21 @@ impl App {
                         targets,
                         force,
                         cascade,
+                        managed,
                     }) => {
                         *force = !*force;
-                        Some((targets.clone(), *force, *cascade))
+                        Some((targets.clone(), *force, *cascade, managed.clone()))
                     }
                     _ => None,
                 };
-                if let Some((targets, force, cascade)) = update {
-                    self.confirm_label =
-                        delete_confirm_label(&self.kind_plural, &targets, force, cascade);
+                if let Some((targets, force, cascade, managed)) = update {
+                    self.confirm_label = delete_confirm_label(
+                        &self.kind_plural,
+                        &targets,
+                        force,
+                        cascade,
+                        managed.as_deref(),
+                    );
                 }
             }
             KeyCode::Char('c') | KeyCode::Char('C') => {
@@ -118,15 +128,21 @@ impl App {
                         targets,
                         force,
                         cascade,
+                        managed,
                     }) => {
                         *cascade = cascade.next();
-                        Some((targets.clone(), *force, *cascade))
+                        Some((targets.clone(), *force, *cascade, managed.clone()))
                     }
                     _ => None,
                 };
-                if let Some((targets, force, cascade)) = update {
-                    self.confirm_label =
-                        delete_confirm_label(&self.kind_plural, &targets, force, cascade);
+                if let Some((targets, force, cascade, managed)) = update {
+                    self.confirm_label = delete_confirm_label(
+                        &self.kind_plural,
+                        &targets,
+                        force,
+                        cascade,
+                        managed.as_deref(),
+                    );
                 }
             }
             _ => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2358,6 +2358,57 @@ fn app_with_pod() -> (App, Receiver<Msg>) {
     (app, rx)
 }
 
+/// A pod carrying Flux kustomize toolkit labels (so it reads as managed).
+fn flux_managed_pod(app: &mut App) {
+    app.switch_kind("pods");
+    apply(
+        app,
+        json!({"apiVersion":"v1","kind":"Pod","metadata":{
+            "name":"a","namespace":"default","labels":{
+                "kustomize.toolkit.fluxcd.io/name":"apps",
+                "kustomize.toolkit.fluxcd.io/namespace":"flux-system"}}}),
+    );
+    app.table_state.select(Some(0));
+}
+
+#[tokio::test]
+async fn editing_flux_managed_object_confirms_with_revert_warning() {
+    let (mut app, _rx) = test_app();
+    flux_managed_pod(&mut app);
+    app.request_edit();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(app.pending.is_none(), "must not edit before confirming");
+    assert!(
+        app.confirm_label.contains("Managed by Flux") && app.confirm_label.contains("reverted"),
+        "{}",
+        app.confirm_label
+    );
+    // Confirming opens the editor.
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert!(matches!(app.pending, Some(Suspend::Shell(_))));
+}
+
+#[tokio::test]
+async fn editing_unmanaged_object_skips_the_warning() {
+    let (mut app, _rx) = app_with_pod(); // plain pod, no toolkit labels
+    app.request_edit();
+    assert_ne!(app.mode, Mode::Confirm, "unmanaged edit needs no confirm");
+    assert!(matches!(app.pending, Some(Suspend::Shell(_))));
+}
+
+#[tokio::test]
+async fn deleting_managed_object_warns_it_will_be_recreated() {
+    let (mut app, _rx) = test_app();
+    flux_managed_pod(&mut app);
+    app.request_delete(false);
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("managed by Flux") && app.confirm_label.contains("recreated"),
+        "{}",
+        app.confirm_label
+    );
+}
+
 #[tokio::test]
 async fn readonly_gates_mutating_plugins_only() {
     let (mut app, _rx) = app_with_pod();


### PR DESCRIPTION
## Summary

Milestone 4 item: **managed-resource mutation warnings** — warn before mutating
an object a controller will simply undo.

- **Delete**: the confirm dialog now appends `⚠ managed by <owner> — recreated
  on delete` when any target is owned by **Flux** (kustomize/helm toolkit
  labels) or a **controller** (`ownerReferences`). Bulk shows how many of the
  set are managed (`⚠ 3/5 managed (e.g. Flux Kustomization/apps) — …`).
- **Edit**: editing a **Flux-managed** object first pops a confirm — `⚠ Managed
  by Flux <owner> — your edit will be reverted on the next reconcile. Edit
  anyway?` — since Flux reverts spec drift on reconcile. Unmanaged edits open
  the editor directly, as before.

New `managed_by` / `flux_managed_by` helpers (Flux label preferred, else the
controller owner ref); `ConfirmAction` gains an `Edit` variant and a `managed`
note on `Delete` (preserved across the force/cascade toggles).

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (302 tests; new: edit-managed confirms with revert warning, unmanaged edit skips it, delete-managed warns "recreated").
- [x] Drove the real Flux cluster: `ctrl-d` on a HelmRelease-managed Deployment showed `Delete deployment … ⚠ managed by Flux HelmRelease…`; `e` showed `⚠ Managed by Flux HelmRelease/… — your edit will be reverted …`. Both cancelled — no mutation.