### PR TITLE
feat: declarative guardrails

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -18,22 +18,30 @@ impl App {
         if targets.is_empty() {
             return;
         }
+        let action = if force { "force-delete" } else { "delete" };
+        let plural = self.kind_plural.clone();
+        let Some(level) = self.guard(action, &plural, &targets, ConfirmLevel::Plain) else {
+            return;
+        };
         let cascade = Cascade::Background;
         let managed = self.recreated_note();
-        self.confirm_label = delete_confirm_label(
-            &self.kind_plural,
-            &targets,
-            force,
-            cascade,
-            managed.as_deref(),
+        let label = delete_confirm_label(&plural, &targets, force, cascade, managed.as_deref());
+        let name_hint = if targets.len() == 1 {
+            targets[0].0.clone()
+        } else {
+            targets.len().to_string()
+        };
+        self.begin_guarded(
+            ConfirmAction::Delete {
+                targets,
+                force,
+                cascade,
+                managed,
+            },
+            label,
+            level,
+            name_hint,
         );
-        self.confirm_action = Some(ConfirmAction::Delete {
-            targets,
-            force,
-            cascade,
-            managed,
-        });
-        self.mode = Mode::Confirm;
     }
 
     /// A short "managed by X — recreated on delete" warning when any object in
@@ -194,7 +202,13 @@ impl App {
         if targets.is_empty() {
             return;
         }
-        self.confirm_label = if targets.len() == 1 {
+        // Guardrails match on (name, namespace); nodes are cluster-scoped.
+        let pairs: Vec<(String, String)> =
+            targets.iter().map(|n| (n.clone(), String::new())).collect();
+        let Some(level) = self.guard("drain", "nodes", &pairs, ConfirmLevel::Plain) else {
+            return;
+        };
+        let label = if targets.len() == 1 {
             format!("Drain node {}? Cordon and evict eligible pods.", targets[0])
         } else {
             format!(
@@ -202,8 +216,12 @@ impl App {
                 targets.len()
             )
         };
-        self.confirm_action = Some(ConfirmAction::Drain { targets });
-        self.mode = Mode::Confirm;
+        let name_hint = if targets.len() == 1 {
+            targets[0].clone()
+        } else {
+            targets.len().to_string()
+        };
+        self.begin_guarded(ConfirmAction::Drain { targets }, label, level, name_hint);
     }
 
     pub(super) fn do_drain_nodes(&mut self, targets: Vec<String>) {
@@ -695,7 +713,21 @@ impl App {
         };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
-        self.exec_into(ns, name, None);
+        // Shell is gated by guardrails (deny / confirm) but has no default
+        // confirmation, so an unguarded shell opens straight away.
+        let targets = [(name.clone(), ns.clone())];
+        let Some(level) = self.guard("shell", "pods", &targets, ConfirmLevel::None) else {
+            return;
+        };
+        self.begin_guarded(
+            ConfirmAction::Exec {
+                ns,
+                name: name.clone(),
+            },
+            format!("Shell into {name}?"),
+            level,
+            name,
+        );
     }
 
     /// Shell into `pod`, optionally pinned to `container` (k9s-style `-c`).
@@ -923,9 +955,11 @@ impl App {
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;
+        self.guardrails = resolved.config.guardrails;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         warnings.extend(crate::config::workspace_warnings(&self.workspaces));
+        warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.

--- a/src/app/guardrails.rs
+++ b/src/app/guardrails.rs
@@ -1,0 +1,194 @@
+use super::*;
+
+/// How much confirmation an action needs, ordered weakest → strongest so the
+/// strongest matching guardrail wins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ConfirmLevel {
+    /// Run immediately, no confirmation (an action's default when nothing
+    /// forces a prompt).
+    None,
+    /// The ordinary y/n confirm dialog.
+    Plain,
+    /// Type the resource name (or the target count for a bulk action).
+    TypeName,
+    /// Type the current context name.
+    TypeContext,
+}
+
+impl App {
+    /// Evaluate the guardrails matching `action` on `targets` (a `(name, ns)`
+    /// list). Returns the confirmation level to require — escalated from
+    /// `base` — or `None` when a guardrail blocks the action outright (a
+    /// `deny`, or a `max_bulk` the selection exceeds), having flashed why.
+    pub(super) fn guard(
+        &mut self,
+        action: &str,
+        plural: &str,
+        targets: &[(String, String)],
+        base: ConfirmLevel,
+    ) -> Option<ConfirmLevel> {
+        let ctx = self.cluster.context.clone();
+        let mut level = base;
+        let mut deny: Option<String> = None;
+        let mut cap: Option<usize> = None;
+
+        for g in &self.guardrails {
+            if !list_matches(&g.contexts, &ctx)
+                || !list_matches(&g.actions, action)
+                || !list_matches(&g.resources, plural)
+            {
+                continue;
+            }
+            // A namespace filter matches if any target is in a listed namespace.
+            if !g.namespaces.is_empty()
+                && !targets
+                    .iter()
+                    .any(|(_, ns)| list_matches(&g.namespaces, ns))
+            {
+                continue;
+            }
+            if g.deny {
+                deny = Some(g.reason.clone().unwrap_or_default());
+            }
+            if let Some(m) = g.max_bulk {
+                cap = Some(cap.map_or(m, |c| c.min(m)));
+            }
+            if let Some(c) = &g.confirmation {
+                level = level.max(parse_level(c));
+            }
+        }
+
+        if let Some(reason) = deny {
+            let tail = if reason.is_empty() {
+                String::new()
+            } else {
+                format!(" — {reason}")
+            };
+            self.flash_warn(&format!("blocked by guardrail: {action} {plural}{tail}"));
+            return None;
+        }
+        if let Some(max) = cap
+            && targets.len() > max
+        {
+            self.flash_warn(&format!(
+                "guardrail: {} exceeds the max of {max} for {action} — mark fewer",
+                targets.len()
+            ));
+            return None;
+        }
+        Some(level)
+    }
+
+    /// Route an about-to-run action through its required confirmation. `Plain`
+    /// uses the y/n dialog; the typed levels use a prompt that must match a
+    /// resource name (`name_hint`) or the context; `None` runs immediately.
+    pub(super) fn begin_guarded(
+        &mut self,
+        action: ConfirmAction,
+        label: String,
+        level: ConfirmLevel,
+        name_hint: String,
+    ) {
+        match level {
+            ConfirmLevel::None => self.run_confirm_action(action),
+            ConfirmLevel::Plain => {
+                self.confirm_label = label;
+                self.confirm_action = Some(action);
+                self.mode = Mode::Confirm;
+            }
+            ConfirmLevel::TypeName | ConfirmLevel::TypeContext => {
+                let expected = if level == ConfirmLevel::TypeContext {
+                    self.cluster.context.clone()
+                } else {
+                    name_hint
+                };
+                self.prompt_label = format!("⚠ guardrail — type '{expected}' to confirm:");
+                self.prompt_input.clear();
+                self.prompt_kind = Some(PromptKind::GuardConfirm {
+                    expected,
+                    action: Box::new(action),
+                });
+                self.mode = Mode::Prompt;
+            }
+        }
+    }
+}
+
+fn parse_level(s: &str) -> ConfirmLevel {
+    match s {
+        "type-resource-name" => ConfirmLevel::TypeName,
+        "type-context-name" => ConfirmLevel::TypeContext,
+        _ => ConfirmLevel::Plain,
+    }
+}
+
+/// Whether `value` matches any pattern (glob), or the list is empty ("any").
+fn list_matches(patterns: &[String], value: &str) -> bool {
+    patterns.is_empty() || patterns.iter().any(|p| glob(p, value))
+}
+
+/// Minimal glob: `*` matches any run of characters; every other char is
+/// literal. Supports the `prod-*`, `*-system`, `*payments*` shapes guardrails
+/// use.
+fn glob(pattern: &str, value: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == value;
+    }
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut pos = 0;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // Leading segment must anchor at the start.
+            if !value[pos..].starts_with(part) {
+                return false;
+            }
+            pos += part.len();
+        } else if i == parts.len() - 1 {
+            // Trailing segment must anchor at the end.
+            return value[pos..].ends_with(part);
+        } else {
+            match value[pos..].find(part) {
+                Some(at) => pos += at + part.len(),
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_shapes() {
+        assert!(glob("prod-*", "prod-eu"));
+        assert!(!glob("prod-*", "staging-eu"));
+        assert!(glob("*-system", "kube-system"));
+        assert!(glob("*payments*", "acme-payments-prod"));
+        assert!(glob("*", "anything"));
+        assert!(glob("exact", "exact"));
+        assert!(!glob("exact", "exactly"));
+    }
+
+    #[test]
+    fn list_matches_treats_empty_as_any() {
+        assert!(list_matches(&[], "whatever"));
+        assert!(list_matches(&["a".into(), "b*".into()], "bee"));
+        assert!(!list_matches(&["a".into(), "b*".into()], "cee"));
+    }
+
+    #[test]
+    fn parse_level_maps_confirmation_strings() {
+        assert_eq!(parse_level("confirm"), ConfirmLevel::Plain);
+        assert_eq!(parse_level("type-resource-name"), ConfirmLevel::TypeName);
+        assert_eq!(parse_level("type-context-name"), ConfirmLevel::TypeContext);
+        assert_eq!(parse_level("bogus"), ConfirmLevel::Plain);
+        // Ordering: context is the strongest.
+        assert!(ConfirmLevel::TypeContext > ConfirmLevel::TypeName);
+        assert!(ConfirmLevel::TypeName > ConfirmLevel::Plain);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -31,6 +31,8 @@ use tokio::task::JoinHandle;
 use crate::k8s::{Cluster, Kind};
 use crate::store::{Msg, Pulse, Store, XrayItem, row_key};
 
+pub(crate) use guardrails::ConfirmLevel;
+
 /// Maximum number of buffered log lines while following. A chatty pod would
 /// otherwise grow the buffer (and the unbounded channel feeding it) without
 /// limit; we keep the most recent lines, like k9s' tail buffer.
@@ -181,6 +183,8 @@ enum ConfirmAction {
     /// Edit a Flux-managed object (`kubectl edit`) after warning that the edit
     /// will be reverted on the next reconcile.
     Edit { argv: Vec<String> },
+    /// Shell into a pod, once a guardrail confirmation is satisfied.
+    Exec { ns: String, name: String },
     /// One or more node names to cordon and drain.
     Drain { targets: Vec<String> },
     /// Roll a Helm release back to an earlier revision (`helm rollback`) —
@@ -267,6 +271,12 @@ enum PromptKind {
     /// New lookback period for the provider logs view (`T`) — the only
     /// prompt opened from (and returning to) [`Mode::Logs`].
     ProviderLookback,
+    /// A guardrail typed-confirmation: the action runs only if the input
+    /// matches `expected` (a resource or context name).
+    GuardConfirm {
+        expected: String,
+        action: Box<ConfirmAction>,
+    },
 }
 
 #[derive(Default)]
@@ -664,6 +674,9 @@ pub struct App {
     /// Saved workspaces (`[[workspaces]]`), re-applied on context switch and
     /// `:reload`.
     pub workspaces: Vec<crate::config::Workspace>,
+    /// Declarative guardrails (`[[guardrails]]`), re-applied on context switch
+    /// and `:reload`.
+    pub guardrails: Vec<crate::config::Guardrail>,
     /// A workspace waiting for an in-flight context switch before it opens.
     pub pending_workspace: Option<crate::config::Workspace>,
     /// The workspace currently being cycled with `Tab`/`Shift-Tab`, if any.
@@ -844,6 +857,7 @@ impl App {
             workspaces: Vec::new(),
             pending_workspace: None,
             active_workspace: None,
+            guardrails: Vec::new(),
             rbac_allowed: None,
             last_rbac_ns: None,
             container_list: Vec::new(),
@@ -937,6 +951,7 @@ mod dashboards;
 mod details;
 mod explain;
 mod gitops;
+mod guardrails;
 mod helpers;
 mod input;
 mod lifecycle;

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -59,43 +59,52 @@ impl App {
         }
     }
 
+    /// Execute a confirmed action. Shared by the y/n confirm dialog and the
+    /// guardrail typed-confirmation prompt.
+    pub(super) fn run_confirm_action(&mut self, action: ConfirmAction) {
+        match action {
+            ConfirmAction::Delete {
+                targets,
+                force,
+                cascade,
+                ..
+            } => {
+                self.do_delete(targets, force, cascade);
+                self.marked.clear();
+            }
+            ConfirmAction::Edit { argv } => {
+                self.pending = Some(Suspend::Shell(argv));
+            }
+            ConfirmAction::Exec { ns, name } => {
+                self.exec_into(ns, name, None);
+            }
+            ConfirmAction::Drain { targets } => {
+                self.do_drain_nodes(targets);
+                self.marked.clear();
+            }
+            ConfirmAction::HelmRollback { ns, name, revision } => {
+                self.do_helm_rollback(ns, name, revision);
+            }
+            ConfirmAction::HelmUninstall { targets } => {
+                self.do_helm_uninstall(targets);
+                self.marked.clear();
+            }
+            ConfirmAction::Plugin {
+                jobs,
+                name,
+                mode,
+                timeout,
+            } => {
+                self.launch_plugin(jobs, name, mode, timeout);
+            }
+        }
+    }
+
     pub(super) fn key_confirm(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
                 if let Some(action) = self.confirm_action.take() {
-                    match action {
-                        ConfirmAction::Delete {
-                            targets,
-                            force,
-                            cascade,
-                            ..
-                        } => {
-                            self.do_delete(targets, force, cascade);
-                            self.marked.clear();
-                        }
-                        ConfirmAction::Edit { argv } => {
-                            self.pending = Some(Suspend::Shell(argv));
-                        }
-                        ConfirmAction::Drain { targets } => {
-                            self.do_drain_nodes(targets);
-                            self.marked.clear();
-                        }
-                        ConfirmAction::HelmRollback { ns, name, revision } => {
-                            self.do_helm_rollback(ns, name, revision);
-                        }
-                        ConfirmAction::HelmUninstall { targets } => {
-                            self.do_helm_uninstall(targets);
-                            self.marked.clear();
-                        }
-                        ConfirmAction::Plugin {
-                            jobs,
-                            name,
-                            mode,
-                            timeout,
-                        } => {
-                            self.launch_plugin(jobs, name, mode, timeout);
-                        }
-                    }
+                    self.run_confirm_action(action);
                 }
                 self.mode = Mode::Table;
             }
@@ -205,6 +214,13 @@ impl App {
                         self.apply_provider_lookback(&input)
                     }
                     Some(PromptKind::ProviderLookback) => {}
+                    Some(PromptKind::GuardConfirm { expected, action }) => {
+                        if input == expected {
+                            self.run_confirm_action(*action);
+                        } else {
+                            self.flash_warn("guardrail: input did not match — cancelled");
+                        }
+                    }
                     None => {}
                 }
             }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -335,9 +335,11 @@ impl App {
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;
+        self.guardrails = resolved.config.guardrails;
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);
         plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));
+        plugin_warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2410,6 +2410,61 @@ async fn deleting_managed_object_warns_it_will_be_recreated() {
 }
 
 #[tokio::test]
+async fn guardrail_denies_an_action() {
+    let (mut app, _rx) = app_with_pod();
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["delete".into()],
+        deny: true,
+        reason: Some("prod is locked".into()),
+        ..Default::default()
+    }];
+    app.request_delete(false);
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(app.confirm_action.is_none(), "denied — nothing to confirm");
+    assert!(
+        app.flash.contains("blocked by guardrail") && app.flash.contains("prod is locked"),
+        "{}",
+        app.flash
+    );
+}
+
+#[tokio::test]
+async fn guardrail_caps_bulk_delete() {
+    let (mut app, _rx) = app_with_two_marked_pods();
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["delete".into()],
+        max_bulk: Some(1),
+        ..Default::default()
+    }];
+    app.request_delete(false);
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(app.flash.contains("exceeds the max"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn guardrail_type_resource_name_confirmation() {
+    let (mut app, _rx) = app_with_pod(); // single pod "a"
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["delete".into()],
+        confirmation: Some("type-resource-name".into()),
+        ..Default::default()
+    }];
+    app.request_delete(false);
+    assert_eq!(app.mode, Mode::Prompt, "typed confirmation opens a prompt");
+
+    // A wrong name cancels without deleting.
+    app.prompt_input = "wrong".into();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("did not match"), "{}", app.flash);
+
+    // The exact name proceeds.
+    app.request_delete(false);
+    app.prompt_input = "a".into();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("deleting"), "{}", app.flash);
+}
+
+#[tokio::test]
 async fn readonly_gates_mutating_plugins_only() {
     let (mut app, _rx) = app_with_pod();
     app.readonly = true;

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,9 @@ pub struct Config {
     /// Task-oriented collections of views — see [`Workspace`]. Validated by
     /// [`workspace_warnings`].
     pub workspaces: Vec<Workspace>,
+    /// Declarative safety policies gating dangerous actions — see
+    /// [`Guardrail`]. Validated by [`guardrail_warnings`].
+    pub guardrails: Vec<Guardrail>,
     /// Custom table views keyed by resource — see [`ViewConfig`]. Compiled
     /// and validated by [`crate::views::compile`].
     pub views: HashMap<String, ViewConfig>,
@@ -480,6 +483,70 @@ pub fn workspace_warnings(workspaces: &[Workspace]) -> Vec<String> {
                     "workspace {label:?}: unknown view {kind:?} (expected xray/pulse) — ignored"
                 ));
             }
+        }
+    }
+    warns
+}
+
+/// A declarative safety policy: match dangerous actions by context, namespace,
+/// resource, and action, then require extra confirmation, deny them, or cap a
+/// bulk selection. Gates `delete`, `force-delete`, `drain`, and `shell` today.
+/// Empty match lists mean "any"; glob `*` is supported in the patterns.
+///
+/// ```toml
+/// [[guardrails]]
+/// contexts = ["prod-*"]
+/// namespaces = ["kube-system", "payments"]
+/// actions = ["delete", "force-delete", "drain"]
+/// confirmation = "type-resource-name"   # confirm | type-resource-name | type-context-name
+///
+/// [[guardrails]]
+/// contexts = ["prod-*"]
+/// actions = ["force-delete", "drain", "shell"]
+/// deny = true
+/// reason = "not allowed on prod — use a break-glass context"
+///
+/// [[guardrails]]
+/// actions = ["delete"]
+/// max_bulk = 10          # refuse a marked delete of more than 10 at once
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct Guardrail {
+    /// Kubeconfig contexts this applies to (globs). Empty = any.
+    pub contexts: Vec<String>,
+    /// Namespaces this applies to (globs). Empty = any.
+    pub namespaces: Vec<String>,
+    /// Resource plurals/kinds this applies to (globs). Empty = any.
+    pub resources: Vec<String>,
+    /// Actions this applies to: `delete`, `force-delete`, `drain`, `shell`.
+    /// Empty = any.
+    pub actions: Vec<String>,
+    /// Block the action outright.
+    pub deny: bool,
+    /// Extra confirmation required: `confirm`, `type-resource-name`, or
+    /// `type-context-name`.
+    pub confirmation: Option<String>,
+    /// Maximum number of targets a single (bulk) action may touch.
+    pub max_bulk: Option<usize>,
+    /// Human note shown when the guardrail blocks or confirms.
+    pub reason: Option<String>,
+}
+
+/// Validation warnings for guardrails: an unknown `confirmation` mode.
+pub fn guardrail_warnings(guardrails: &[Guardrail]) -> Vec<String> {
+    let mut warns = Vec::new();
+    for (i, g) in guardrails.iter().enumerate() {
+        if let Some(c) = &g.confirmation
+            && !matches!(
+                c.as_str(),
+                "confirm" | "type-resource-name" | "type-context-name"
+            )
+        {
+            warns.push(format!(
+                "guardrail #{}: unknown confirmation {c:?} (expected confirm/type-resource-name/type-context-name) — treated as confirm",
+                i + 1
+            ));
         }
     }
     warns

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,10 +156,12 @@ async fn main() -> Result<()> {
     app.plugins = cfg.plugins.clone();
     app.bookmarks = cfg.bookmarks.clone();
     app.workspaces = cfg.workspaces.clone();
+    app.guardrails = cfg.guardrails.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))
         .chain(config::workspace_warnings(&app.workspaces))
+        .chain(config::guardrail_warnings(&app.guardrails))
     {
         eprintln!("warning: {w}");
         config_warnings.push(w);


### PR DESCRIPTION
## Summary

Milestone 4 item: **declarative guardrails** — safety policies beyond the
session-wide read-only switch.

```toml
[[guardrails]]
contexts = ["prod-*"]
namespaces = ["kube-system", "payments"]
actions = ["delete", "force-delete", "drain"]
confirmation = "type-resource-name"

[[guardrails]]
actions = ["force-delete", "drain", "shell"]
deny = true
reason = "not allowed here"

[[guardrails]]
actions = ["delete"]
max_bulk = 10
```

- **Match** by context, namespace, resource, and action (glob patterns; empty
  list = any). Gated actions: `delete`, `force-delete`, `drain`, `shell`.
- **Outcomes**: `deny` (block, with a reason), `max_bulk` (refuse a marked
  action over N targets), and confirmation escalation — `confirm` (y/n),
  `type-resource-name`, or `type-context-name` (type the exact name into a
  prompt to proceed). The strongest matching level wins.

New `src/app/guardrails.rs` (matching + a small glob, unit-tested) plus a
generic `guard()` / `begin_guarded()` the destructive-action requesters route
through. `ConfirmAction` gains an `Exec` variant and `PromptKind` a typed
`GuardConfirm`; `key_confirm`'s dispatch is extracted into `run_confirm_action`
so the y/n dialog and the typed prompt share it. Re-applied on context switch
and `:reload`; invalid `confirmation` modes warn in `:config`.

Editing/scaling and other actions can be gated later through the same `guard()`
helper.

## Test plan

- [x] `cargo fmt`/`clippy -D warnings`/`cargo test` green (310 tests; new: glob shapes, empty-list-is-any, confirmation parsing/ordering, and app-level deny / max-bulk-cap / type-resource-name flows).
- [x] Drove the real cluster: a `type-resource-name` guardrail on `monitoring` deletes prompted `⚠ guardrail — type 'blackbox-exporter' to confirm:` (cancelled); a `deny` guardrail on `drain` blocked with `blocked by guardrail: drain nodes — drains disabled on this cluster`.