### PR TITLE
feat: session-local action journal (:journal)

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -113,6 +113,8 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        let label = self.action_label(&targets);
+        self.note_action(if force { "force-delete" } else { "delete" }, label);
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
@@ -167,6 +169,10 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        self.note_action(
+            if unschedulable { "cordon" } else { "uncordon" },
+            node_targets_label(&targets),
+        );
         let verb = if unschedulable {
             "cordoning"
         } else {
@@ -228,6 +234,7 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        self.note_action("drain", node_targets_label(&targets));
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
@@ -552,6 +559,7 @@ impl App {
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
+        self.note_action("restart", format!("{name} in {ns}"));
         self.flash = format!("restarting {name}…");
         self.flash_err = false;
         self.spawn_patch_action(
@@ -661,6 +669,10 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        self.note_action(
+            format!("set-image {container}={image}"),
+            format!("{name} in {ns}"),
+        );
         self.flash = format!("setting image: {container} → {image}");
         self.flash_err = false;
         self.spawn_patch_action(
@@ -679,14 +691,20 @@ impl App {
             return;
         };
         let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        let edit_label = if ns.is_empty() {
+            name.clone()
+        } else {
+            format!("{name} in {ns}")
+        };
         // A Flux-managed object gets its spec reverted on the next reconcile —
         // warn (and confirm) before opening the editor.
         let flux = flux_managed_by(obj);
         let mut argv = self.kubectl_base();
         argv.extend(["edit".into(), self.kind_plural.clone(), name]);
-        if let Some(ns) = &obj.metadata.namespace {
+        if !ns.is_empty() {
             argv.push("-n".into());
-            argv.push(ns.clone());
+            argv.push(ns);
         }
         match flux {
             Some(owner) => {
@@ -696,7 +714,10 @@ impl App {
                 self.confirm_action = Some(ConfirmAction::Edit { argv });
                 self.mode = Mode::Confirm;
             }
-            None => self.pending = Some(Suspend::Shell(argv)),
+            None => {
+                self.note_action("edit", edit_label);
+                self.pending = Some(Suspend::Shell(argv));
+            }
         }
     }
 
@@ -736,6 +757,7 @@ impl App {
         if self.deny_readonly() {
             return;
         }
+        self.note_action("shell", format!("{pod} in {ns}"));
         let mut argv = self.kubectl_base();
         argv.extend(["exec".into(), "-it".into(), "-n".into(), ns, pod]);
         if let Some(c) = container {
@@ -1082,6 +1104,7 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        self.note_action(format!("scale to {replicas}"), format!("{name} in {ns}"));
         self.flash = format!("scaling {name} → {replicas}");
         self.flash_err = false;
         self.spawn_patch_action(
@@ -1148,6 +1171,8 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        let label = self.action_label(&targets);
+        self.note_action(if suspend { "suspend" } else { "resume" }, label);
         let verb = if suspend { "suspending" } else { "resuming" };
         self.flash = if targets.len() == 1 {
             format!("{verb} {}…", targets[0].0)
@@ -1172,6 +1197,8 @@ impl App {
             return;
         };
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
+        let label = self.action_label(&targets);
+        self.note_action("reconcile", label);
         self.flash = if targets.len() == 1 {
             format!("reconciling {}…", targets[0].0)
         } else {
@@ -1214,6 +1241,8 @@ impl App {
             return;
         };
         let now = k8s_openapi::jiff::Timestamp::now().as_second().to_string();
+        let label = self.action_label(&targets);
+        self.note_action("refresh", label);
         self.flash = if targets.len() == 1 {
             format!("refreshing {}…", targets[0].0)
         } else {
@@ -1301,6 +1330,10 @@ impl App {
     }
 
     pub(super) fn do_helm_rollback(&mut self, ns: String, name: String, revision: String) {
+        self.note_action(
+            format!("helm rollback to {revision}"),
+            format!("{name} in {ns}"),
+        );
         let mut argv = self.helm_base();
         argv.extend([
             "rollback".to_string(),
@@ -1353,6 +1386,11 @@ impl App {
     }
 
     pub(super) fn do_helm_uninstall(&mut self, targets: Vec<(String, String)>) {
+        let label = match targets.as_slice() {
+            [(name, ns)] => format!("{name} in {ns}"),
+            many => format!("{} Helm releases", many.len()),
+        };
+        self.note_action("helm uninstall", label);
         self.flash = if targets.len() == 1 {
             format!("uninstalling {}…", targets[0].0)
         } else {

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -43,6 +43,15 @@ pub(super) fn node_unschedulable_patch(unschedulable: bool) -> Value {
     json!({ "spec": { "unschedulable": unschedulable } })
 }
 
+/// A compact journal label for a set of node names.
+pub(super) fn node_targets_label(targets: &[String]) -> String {
+    match targets {
+        [] => "—".into(),
+        [one] => one.clone(),
+        many => format!("{} nodes", many.len()),
+    }
+}
+
 /// What manages `obj`, if anything: its Flux owner (from the toolkit labels)
 /// preferred, else its controller/owner reference. Used to warn that a delete
 /// will be recreated.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -345,6 +345,14 @@ impl App {
             return;
         }
         let n = jobs.len();
+        self.note_action(
+            format!("plugin: {name}"),
+            if n == 1 {
+                "1 target".to_string()
+            } else {
+                format!("{n} targets")
+            },
+        );
         match mode {
             PluginMode::Terminal => {
                 // Terminal runs are single (enforced in run_plugin).
@@ -508,6 +516,7 @@ impl App {
             PaletteAction::Timeline => self.open_timeline(),
             PaletteAction::Gitops => self.open_gitops(),
             PaletteAction::CanI => self.open_can_i(),
+            PaletteAction::Journal => self.open_journal(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+impl App {
+    /// Record a mutating action in the session journal. Pass identifiers only
+    /// (verbs, names) — never secret input or decoded Secret values.
+    pub(super) fn note_action(&mut self, action: impl Into<String>, target: impl Into<String>) {
+        let ctx = self.cluster.context.clone();
+        self.journal.record(&ctx, action, target);
+    }
+
+    /// A compact "name" / "N kind" target label for a bulk-or-single action.
+    pub(super) fn action_label(&self, targets: &[(String, String)]) -> String {
+        match targets {
+            [] => "—".into(),
+            [(name, ns)] if ns.is_empty() => name.clone(),
+            [(name, ns)] => format!("{name} in {ns}"),
+            many => format!("{} {}", many.len(), self.kind_plural),
+        }
+    }
+
+    /// `:journal` — the session's action log as a scrollable document.
+    pub(super) fn open_journal(&mut self) {
+        self.set_return_mode();
+        let title = if self.journal.is_empty() {
+            "action journal (empty)".to_string()
+        } else {
+            format!("action journal ({} entries)", self.journal.len())
+        };
+        self.detail = Scrollable {
+            title,
+            lines: self.journal.lines().into(),
+            ..Default::default()
+        };
+        self.mode = Mode::Detail;
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -341,6 +341,7 @@ enum PaletteAction {
     Timeline,
     Gitops,
     CanI,
+    Journal,
     Diff,
     Events,
     PortForwards,
@@ -383,6 +384,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::CanI,
         names: &["can-i", "cani", "can"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Journal,
+        names: &["journal", "audit", "actions"],
     },
     PaletteCommand {
         action: PaletteAction::Diff,
@@ -677,6 +682,8 @@ pub struct App {
     /// Declarative guardrails (`[[guardrails]]`), re-applied on context switch
     /// and `:reload`.
     pub guardrails: Vec<crate::config::Guardrail>,
+    /// Session-local log of mutating actions taken (`:journal`).
+    pub journal: crate::journal::Journal,
     /// A workspace waiting for an in-flight context switch before it opens.
     pub pending_workspace: Option<crate::config::Workspace>,
     /// The workspace currently being cycled with `Tab`/`Shift-Tab`, if any.
@@ -858,6 +865,7 @@ impl App {
             pending_workspace: None,
             active_workspace: None,
             guardrails: Vec::new(),
+            journal: crate::journal::Journal::default(),
             rbac_allowed: None,
             last_rbac_ns: None,
             container_list: Vec::new(),
@@ -954,6 +962,7 @@ mod gitops;
 mod guardrails;
 mod helpers;
 mod input;
+mod journal;
 mod lifecycle;
 mod logs;
 mod navigation;

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -73,6 +73,21 @@ impl App {
                 self.marked.clear();
             }
             ConfirmAction::Edit { argv } => {
+                // argv is `<kubectl> edit <kind> <name> [-n <ns>]`; recover the
+                // name (and namespace) that follow `edit` for the journal entry.
+                let label = argv
+                    .iter()
+                    .position(|a| a == "edit")
+                    .and_then(|i| argv.get(i + 2))
+                    .map(|name| match argv.iter().position(|a| a == "-n") {
+                        Some(j) => match argv.get(j + 1) {
+                            Some(ns) => format!("{name} in {ns}"),
+                            None => name.clone(),
+                        },
+                        None => name.clone(),
+                    })
+                    .unwrap_or_default();
+                self.note_action("edit", label);
                 self.pending = Some(Suspend::Shell(argv));
             }
             ConfirmAction::Exec { ns, name } => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2397,6 +2397,29 @@ async fn editing_unmanaged_object_skips_the_warning() {
 }
 
 #[tokio::test]
+async fn mutating_action_is_recorded_in_the_journal() {
+    let (mut app, _rx) = app_with_pod();
+    assert!(app.journal.is_empty(), "journal starts empty");
+    app.request_edit(); // unmanaged edit records straight away
+    assert_eq!(app.journal.len(), 1);
+    // The palette command opens it as a scrollable document.
+    app.open_journal();
+    assert_eq!(app.mode, Mode::Detail);
+    let body = app
+        .detail
+        .lines
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(body.contains("edit"), "{body}");
+    assert!(
+        body.contains(&app.cluster.context),
+        "context column: {body}"
+    );
+}
+
+#[tokio::test]
 async fn deleting_managed_object_warns_it_will_be_recreated() {
     let (mut app, _rx) = test_app();
     flux_managed_pod(&mut app);

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,0 +1,130 @@
+//! Session-local action journal.
+//!
+//! A bounded, in-memory log of the mutating actions taken this session — what,
+//! against which target, in which context, and when — for a quick audit trail
+//! (`:journal`). It records identifiers only (names, verbs), never secret
+//! inputs or decoded Secret values, and is never written to disk.
+
+use std::collections::VecDeque;
+
+use k8s_openapi::jiff::Timestamp;
+
+/// How many entries to keep before dropping the oldest.
+const MAX_ENTRIES: usize = 500;
+
+/// One recorded action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    /// Epoch seconds when the action was taken.
+    pub at: i64,
+    pub context: String,
+    /// The verb (`delete`, `scale to 3`, `shell`, `plugin: argocd-sync`, …).
+    pub action: String,
+    /// The object(s) acted on (`pods/api in prod`, `3 deployments`, …).
+    pub target: String,
+}
+
+/// The session's action log, newest last.
+#[derive(Default)]
+pub struct Journal {
+    entries: VecDeque<Entry>,
+}
+
+impl Journal {
+    /// Record an action. Callers pass only identifiers — never secret input or
+    /// decoded Secret values.
+    pub fn record(&mut self, context: &str, action: impl Into<String>, target: impl Into<String>) {
+        self.entries.push_back(Entry {
+            at: Timestamp::now().as_second(),
+            context: context.to_string(),
+            action: action.into(),
+            target: target.into(),
+        });
+        while self.entries.len() > MAX_ENTRIES {
+            self.entries.pop_front();
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The journal as display lines, newest first, with a header.
+    pub fn lines(&self) -> Vec<String> {
+        let mut out = vec![format!(
+            "{:<19}  {:<24}  {:<18}  TARGET",
+            "WHEN", "ACTION", "CONTEXT"
+        )];
+        if self.entries.is_empty() {
+            out.push("(no actions recorded this session)".into());
+            return out;
+        }
+        for e in self.entries.iter().rev() {
+            out.push(format!(
+                "{:<19}  {:<24}  {:<18}  {}",
+                clock(e.at),
+                e.action,
+                e.context,
+                e.target
+            ));
+        }
+        out
+    }
+}
+
+/// Format an epoch second as `MM-DD HH:MM:SS` (UTC, like the events view).
+fn clock(at: i64) -> String {
+    match Timestamp::from_second(at) {
+        Ok(ts) => {
+            let s = ts.to_string(); // 2026-07-13T08:45:12Z
+            let date = s.split('T').next().unwrap_or("");
+            let day = date.get(5..).unwrap_or(date); // MM-DD
+            let time = s
+                .split_once('T')
+                .map(|(_, t)| t.split(['.', 'Z']).next().unwrap_or(t))
+                .unwrap_or("");
+            format!("{day} {time}")
+        }
+        Err(_) => at.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_and_formats_newest_first() {
+        let mut j = Journal::default();
+        assert!(j.is_empty());
+        j.record("prod", "delete", "pods/a in default");
+        j.record("prod", "scale to 3", "deployments/api in prod");
+        assert_eq!(j.len(), 2);
+        let lines = j.lines();
+        // Header, then newest first.
+        assert!(lines[0].contains("ACTION"));
+        assert!(lines[1].contains("scale to 3"), "{:?}", lines);
+        assert!(lines[2].contains("delete"), "{:?}", lines);
+    }
+
+    #[test]
+    fn bounded_to_the_cap() {
+        let mut j = Journal::default();
+        for i in 0..(MAX_ENTRIES + 25) {
+            j.record("c", "delete", format!("pods/p{i}"));
+        }
+        assert_eq!(j.len(), MAX_ENTRIES);
+        // Oldest dropped: the newest is p<max+24>.
+        assert!(j.lines()[1].contains(&format!("p{}", MAX_ENTRIES + 24)));
+    }
+
+    #[test]
+    fn empty_journal_says_so() {
+        let j = Journal::default();
+        assert!(j.lines().iter().any(|l| l.contains("no actions recorded")));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod explain;
 mod filter;
 mod gitops;
 mod helm;
+mod journal;
 mod k8s;
 mod keys;
 mod providers;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1572,6 +1572,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             ":gitops · :flux",
             "Flux owner, source, revisions & reconciliation chain (⏎ to jump)",
         ),
+        bind(
+            ":journal · :audit",
+            "session-local log of the mutating actions you've taken",
+        ),
         Line::from(""),
         Line::from(Span::styled("  Act", theme::title())),
         bind("e", "edit in $EDITOR (kubectl edit)"),


### PR DESCRIPTION
## Summary
- Adds a bounded, in-memory **action journal** surfaced as a scrollable `:journal` (aka `:audit` / `:actions`) document — what mutating action was taken, against which target, in which context, and when.
- Records **identifiers only** (verbs, names, counts) — never secret input or decoded Secret values — and is **never written to disk**. Cleared when the process exits.
- Capped at 500 entries (oldest dropped), shown newest-first with a `WHEN / ACTION / CONTEXT / TARGET` header.

## What gets recorded
Every mutating executor now notes its action:
- delete / force-delete, cordon / uncordon, drain
- scale, restart, set-image
- Flux suspend / resume / reconcile
- External Secrets refresh
- Helm rollback / uninstall
- shell (exec), edit (managed + unmanaged), plugin launches

## Implementation
- `src/journal.rs` — pure `Journal` type (`record` / `lines` / `len` / `is_empty`), `MM-DD HH:MM:SS` clock, 3 unit tests.
- `src/app/journal.rs` — `note_action`, `action_label`, `open_journal`.
- `App.journal` field + `PaletteAction::Journal` + palette command + help entry.

## Test plan
- [x] `cargo fmt` / `cargo clippy --all-targets -D warnings` clean
- [x] `cargo test` — 313 pass (added `mutating_action_is_recorded_in_the_journal` + 3 journal unit tests)
- [x] Live-verified against home Flux cluster: reconciled a Kustomization, opened `:journal`, confirmed the entry (`reconcile · admin@home-kubernetes · ha-mcp in ai`) with timestamp