### PR TITLE
fix: vim-style in-place search for document views (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,12 @@ header) and switching away restores write mode.
 timestamps · `x` stop/resume stream · `c` copy buffer · `ctrl-s` save to file
 · `esc` back. The newest line anchors to the bottom of the viewport.
 
+**Document views** (YAML, describe, diff, events): `/` searches vim-style —
+the whole document stays on screen with every match highlighted, and `n` / `N`
+jump to the next / previous match. `w` wraps, `c` copies the document, `esc`
+backs out (first press clears an active search). The `?` help panel's `/`
+filters instead, narrowing to matching keybinds.
+
 **Explain view** (`X`): `j`/`k` move · `⏎` jump to the resource behind a
 finding (a blocking pod) · `E` its events · `l` its logs · `r` re-gather ·
 `esc` back. Findings that can be jumped into are marked with a trailing `→`.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -462,10 +462,11 @@ impl App {
     }
 
     /// Copy the current single-document view (YAML/describe/diff/events) to
-    /// the clipboard (k9s `c` in those views). Mirrors [`Self::copy_logs`]:
-    /// with a `/` search active, only the matching lines are copied.
+    /// the clipboard (k9s `c` in those views). Copies the whole document — the
+    /// `/` search highlights in place, it doesn't filter, so there is no
+    /// "matching subset" to copy.
     pub(super) fn copy_doc(&mut self) {
-        let text = self.filtered_doc_text();
+        let text = self.doc_text();
         if text.is_empty() {
             self.flash_warn("nothing to copy");
             return;
@@ -478,12 +479,10 @@ impl App {
         );
     }
 
-    pub(super) fn filtered_doc_text(&self) -> String {
-        let f = self.detail.filter.to_lowercase();
+    pub(super) fn doc_text(&self) -> String {
         self.detail
             .lines
             .iter()
-            .filter(|l| f.is_empty() || l.to_lowercase().contains(&f))
             .cloned()
             .collect::<Vec<_>>()
             .join("\n")

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -815,11 +815,17 @@ impl App {
                     self.restore_selection();
                 }
             }
-            // Search within the document (k9s `/` in YAML/describe views).
+            // Search within the document (k9s `/` in YAML/describe views):
+            // matches are highlighted in place while the full document stays
+            // rendered, vim-style, and `n`/`N` step between them.
             KeyCode::Char('/') if detail => {
                 self.doc_filter_return = self.mode;
                 self.mode = Mode::DocFilter;
             }
+            // Jump to the next / previous search match (vim `n`/`N`). No-op
+            // when no search is active.
+            KeyCode::Char('n') if detail => target.step_match(true),
+            KeyCode::Char('N') if detail => target.step_match(false),
             // Copy the document to the clipboard (k9s `c`), same as the logs
             // view: an active search copies only the matching lines.
             KeyCode::Char('c') if detail => {
@@ -1013,17 +1019,21 @@ impl App {
         match key.code {
             KeyCode::Esc => {
                 self.doc_filter_mut().clear();
-                self.reset_doc_scroll();
                 self.mode = self.doc_filter_return;
             }
-            KeyCode::Enter => self.mode = self.doc_filter_return,
+            KeyCode::Enter => {
+                // Finalize: on a document view, jump to the first match so the
+                // hit is on screen; help filters in place and needs no jump.
+                if self.doc_filter_return != Mode::Help {
+                    self.detail.focus_first_match();
+                }
+                self.mode = self.doc_filter_return;
+            }
             KeyCode::Backspace => {
                 self.doc_filter_mut().pop();
-                self.reset_doc_scroll();
             }
             KeyCode::Char(c) => {
                 self.doc_filter_mut().push(c);
-                self.reset_doc_scroll();
             }
             _ => {}
         }
@@ -1036,14 +1046,6 @@ impl App {
             &mut self.help_filter
         } else {
             &mut self.detail.filter
-        }
-    }
-
-    /// Snap back to the top when the query changes, so the first match is
-    /// visible instead of a stale offset past the (now shorter) filtered list.
-    fn reset_doc_scroll(&mut self) {
-        if self.doc_filter_return != Mode::Help {
-            self.detail.scroll = 0;
         }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -293,10 +293,14 @@ pub struct Scrollable {
     /// Word-wrap toggle. When on, long lines fold instead of being clipped, and
     /// horizontal scrolling is disabled.
     pub wrap: bool,
-    /// Case-insensitive substring search (`/`): only matching lines are shown,
-    /// with matches highlighted — same behavior as the logs filter. Reset
-    /// whenever a fresh document replaces the view.
+    /// Case-insensitive substring search (`/`), vim-style: the full document
+    /// stays rendered with every match highlighted, and `n`/`N` step between
+    /// them. Reset whenever a fresh document replaces the view. (The help view
+    /// keeps its own filtering search in `help_filter`.)
     pub filter: String,
+    /// Which match `n`/`N` last landed on (0-based into [`Self::match_lines`]),
+    /// for the `[cur/total]` counter and relative stepping.
+    pub match_idx: usize,
 }
 
 /// One command-palette suggestion — a built-in command (`:ctx`, `:pulse`), a
@@ -454,6 +458,51 @@ impl Scrollable {
             self.hscroll = 0;
         }
         self.wrap
+    }
+
+    /// Line indices (0-based) containing the active search query, matched
+    /// case-insensitively as a substring. Empty when no search is active.
+    pub fn match_lines(&self) -> Vec<usize> {
+        if self.filter.is_empty() {
+            return Vec::new();
+        }
+        let needle = self.filter.to_lowercase();
+        self.lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.to_lowercase().contains(&needle))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Finalize a search: scroll to the first match at or after the current
+    /// position (wrapping to the first if none follow), so `⏎` lands on a hit
+    /// without disturbing the rest of the document. No-op with no matches.
+    pub fn focus_first_match(&mut self) {
+        let matches = self.match_lines();
+        if matches.is_empty() {
+            return;
+        }
+        let pos = matches.iter().position(|&i| i >= self.scroll).unwrap_or(0);
+        self.match_idx = pos;
+        self.scroll = matches[pos];
+    }
+
+    /// Step to the next (`forward`) or previous match, wrapping around, and
+    /// scroll it into view. No-op with no matches.
+    pub fn step_match(&mut self, forward: bool) {
+        let matches = self.match_lines();
+        let n = matches.len();
+        if n == 0 {
+            return;
+        }
+        let cur = self.match_idx.min(n - 1);
+        self.match_idx = if forward {
+            (cur + 1) % n
+        } else {
+            (cur + n - 1) % n
+        };
+        self.scroll = matches[self.match_idx];
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2868,7 +2868,7 @@ async fn failed_switch_while_disconnected_reopens_picker() {
 }
 
 #[tokio::test]
-async fn doc_search_filters_detail_view() {
+async fn doc_search_highlights_without_filtering() {
     let (mut app, _rx) = test_app();
     apply(
         &mut app,
@@ -2878,6 +2878,7 @@ async fn doc_search_filters_detail_view() {
     app.table_state.select(Some(0));
     app.handle_key(press(KeyCode::Char('y'))).unwrap();
     assert_eq!(app.mode, Mode::Detail);
+    let total = app.detail.lines.len();
 
     // `/` opens the search prompt for the detail view; typing builds the query.
     app.handle_key(press(KeyCode::Char('/'))).unwrap();
@@ -2888,10 +2889,19 @@ async fn doc_search_filters_detail_view() {
     }
     assert_eq!(app.detail.filter, "kind");
 
-    // Enter keeps the query and returns to the view.
+    // Enter keeps the query, returns to the view, and jumps to the first match
+    // — the full document stays rendered (no lines removed).
     app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Detail);
     assert_eq!(app.detail.filter, "kind");
+    assert_eq!(
+        app.detail.lines.len(),
+        total,
+        "search must not filter lines"
+    );
+    let matches = app.detail.match_lines();
+    assert_eq!(matches.len(), 1, "one `kind:` line");
+    assert_eq!(app.detail.scroll, matches[0], "jumped to the match");
 
     // First esc clears the search (stays), second esc leaves the view.
     app.handle_key(press(KeyCode::Esc)).unwrap();
@@ -2902,7 +2912,48 @@ async fn doc_search_filters_detail_view() {
 }
 
 #[tokio::test]
-async fn doc_search_esc_clears_and_scroll_resets() {
+async fn doc_search_n_and_capital_n_step_between_matches() {
+    let (mut app, _rx) = test_app();
+    app.detail = Scrollable {
+        title: "x — YAML".into(),
+        // Matches on lines 1, 3, 5.
+        lines: vec![
+            "alpha".into(),
+            "needle one".into(),
+            "beta".into(),
+            "needle two".into(),
+            "gamma".into(),
+            "needle three".into(),
+        ]
+        .into(),
+        ..Default::default()
+    };
+    app.mode = Mode::Detail;
+
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "needle".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    // Finalized on the first match.
+    assert_eq!(app.detail.scroll, 1);
+    assert_eq!(app.detail.match_idx, 0);
+
+    // `n` walks forward, then wraps back to the first.
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.detail.scroll, 3);
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.detail.scroll, 5);
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.detail.scroll, 1, "wrapped to the first match");
+
+    // `N` walks backward (wrapping to the last).
+    app.handle_key(press(KeyCode::Char('N'))).unwrap();
+    assert_eq!(app.detail.scroll, 5);
+}
+
+#[tokio::test]
+async fn doc_search_esc_in_prompt_clears_query() {
     let (mut app, _rx) = test_app();
     app.detail = Scrollable {
         title: "x — YAML".into(),
@@ -2914,8 +2965,8 @@ async fn doc_search_esc_clears_and_scroll_resets() {
 
     app.handle_key(press(KeyCode::Char('/'))).unwrap();
     app.handle_key(press(KeyCode::Char('9'))).unwrap();
-    // Typing snaps the view back to the top so the first match is visible.
-    assert_eq!(app.detail.scroll, 0);
+    // Typing does not move the document — the search highlights in place.
+    assert_eq!(app.detail.scroll, 50);
     // Esc in the prompt aborts the search entirely.
     app.handle_key(press(KeyCode::Esc)).unwrap();
     assert_eq!(app.mode, Mode::Detail);
@@ -2954,7 +3005,7 @@ async fn help_search_uses_own_buffer() {
 }
 
 #[tokio::test]
-async fn copy_doc_respects_active_search() {
+async fn copy_doc_copies_the_whole_document() {
     let (mut app, _rx) = test_app();
     app.detail = Scrollable {
         title: "web — YAML".into(),
@@ -2968,15 +3019,13 @@ async fn copy_doc_respects_active_search() {
         ..Default::default()
     };
 
-    // No search: the whole document.
-    assert_eq!(
-        app.filtered_doc_text(),
-        "apiVersion: v1\nkind: Pod\nmetadata:\n  name: web"
-    );
+    let whole = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: web";
+    assert_eq!(app.doc_text(), whole);
 
-    // Active search: only the matching lines (case-insensitive).
+    // An active search highlights in place; it does not filter, so copy still
+    // returns the whole document.
     app.detail.filter = "KIND".into();
-    assert_eq!(app.filtered_doc_text(), "kind: Pod");
+    assert_eq!(app.doc_text(), whole);
 }
 
 #[tokio::test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -709,20 +709,20 @@ fn draw_scrollable(
     accent: ratatui::style::Color,
 ) {
     let inner_h = area.height.saturating_sub(2) as usize;
-    let shown = doc_filtered_lines(view);
-    // The scroll offset is clamped against the unfiltered length by the key
-    // handlers; re-clamp against the (shorter) filtered list.
-    let scroll = view.scroll.min(shown.len().saturating_sub(1));
-    let (start, end) = visible_line_window(shown.len(), scroll, inner_h);
-    let text: Vec<Line> = shown[start..end]
+    let scroll = view.scroll.min(view.lines.len().saturating_sub(1));
+    let (start, end) = visible_line_window(view.lines.len(), scroll, inner_h);
+    let text: Vec<Line> = view
+        .lines
         .iter()
+        .skip(start)
+        .take(end - start)
         .map(|l| highlight_matches(Line::from(highlight_yaml(l)), &view.filter))
         .collect();
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(accent))
-        .title(Span::styled(doc_title(view, shown.len()), theme::title()));
+        .title(Span::styled(doc_title(view), theme::title()));
     let p = Paragraph::new(text).block(block);
     // Wrap folds long lines; otherwise honor the horizontal offset so content
     // past the right edge can be scrolled into view.
@@ -1345,18 +1345,20 @@ fn klog_level(l: &str, level: char) -> bool {
 /// Unified-diff view with +/- line coloring.
 fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
     let inner_h = area.height.saturating_sub(2) as usize;
-    let shown = doc_filtered_lines(view);
-    let scroll = view.scroll.min(shown.len().saturating_sub(1));
-    let (start, end) = visible_line_window(shown.len(), scroll, inner_h);
-    let lines: Vec<Line> = shown[start..end]
+    let scroll = view.scroll.min(view.lines.len().saturating_sub(1));
+    let (start, end) = visible_line_window(view.lines.len(), scroll, inner_h);
+    let lines: Vec<Line> = view
+        .lines
         .iter()
+        .skip(start)
+        .take(end - start)
         .map(|l| {
             let color = match l.chars().next() {
                 Some('+') => theme::green(),
                 Some('-') => theme::red(),
                 _ => theme::overlay1(),
             };
-            let line = Line::from(Span::styled((*l).clone(), Style::default().fg(color)));
+            let line = Line::from(Span::styled(l.clone(), Style::default().fg(color)));
             highlight_matches(line, &view.filter)
         })
         .collect();
@@ -1364,7 +1366,7 @@ fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme::peach()))
-        .title(Span::styled(doc_title(view, shown.len()), theme::title()));
+        .title(Span::styled(doc_title(view), theme::title()));
     let p = Paragraph::new(lines).block(block);
     let p = if view.wrap {
         p.wrap(Wrap { trim: false })
@@ -1380,23 +1382,24 @@ fn visible_line_window(len: usize, scroll: usize, height: usize) -> (usize, usiz
     (start, end)
 }
 
-/// The lines a doc view shows: all of them, or only those matching the active
-/// `/` search (case-insensitive substring, like the logs filter).
-fn doc_filtered_lines(view: &crate::app::Scrollable) -> Vec<&String> {
-    let filter = view.filter.to_lowercase();
-    view.lines
-        .iter()
-        .filter(|l| filter.is_empty() || l.to_lowercase().contains(&filter))
-        .collect()
-}
-
-/// Doc-view title, extended with the active search query and its match count
-/// (` title · /query [n] `), mirroring the logs title.
-fn doc_title(view: &crate::app::Scrollable, shown: usize) -> String {
+/// Doc-view title, extended with the active search query and the current
+/// match position (` title · /query [2/5] `, or `[no matches]`), vim-style.
+fn doc_title(view: &crate::app::Scrollable) -> String {
     if view.filter.is_empty() {
-        format!(" {} ", view.title)
+        return format!(" {} ", view.title);
+    }
+    let matches = view.match_lines();
+    if matches.is_empty() {
+        format!(" {} · /{} [no matches] ", view.title, view.filter)
     } else {
-        format!(" {} · /{} [{}] ", view.title, view.filter, shown)
+        let cur = view.match_idx.min(matches.len() - 1) + 1;
+        format!(
+            " {} · /{} [{}/{}] ",
+            view.title,
+            view.filter,
+            cur,
+            matches.len()
+        )
     }
 }
 
@@ -1558,7 +1561,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "VictoriaLogs history (autodiscovered or [providers.logs]) — pods/workloads/ns",
         ),
         bind("c", "copy resource name · in doc views: copy the document"),
-        bind("/", "search within YAML/describe/diff/events/help"),
+        bind(
+            "/ · n/N",
+            "search within YAML/describe/diff/events (highlight in place, n/N to jump); filters help",
+        ),
         bind("x", "secrets: show data base64-decoded"),
         bind(
             "shift-x · :explain",
@@ -2570,7 +2576,7 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Detail | Mode::Events | Mode::Diff => {
-            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  w:wrap  c:copy  esc:back";
+            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  esc:back";
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),


### PR DESCRIPTION
## Summary
Reworks `/` search in single-document views (YAML, describe, diff, events) to work like vim, per [@fhoekstra's follow-up on #31](https://github.com/nklmilojevic/sofka/issues/31#issuecomment-4958060820).

Previously the search **filtered** the document to only matching lines, hiding the surrounding context. Now:

- The **full document stays rendered** with every match highlighted as you type.
- **`⏎`** finalizes the query and jumps to the first match at/after the current position.
- **`n` / `N`** step to the next / previous match (wrapping around).
- The title shows a **`[cur/total]`** match counter (or `[no matches]`).
- **`esc`** in the view clears an active search first, then backs out.

The **`?` help panel keeps its filtering search** — the reporter said they liked it there.

`c` (copy) now copies the whole document, since search no longer produces a "matching subset".

## Implementation
- `Scrollable` gains `match_lines()`, `focus_first_match()`, `step_match()` and a `match_idx` cursor.
- `key_scroll` binds `n`/`N`; `key_doc_filter` jumps to the first match on `⏎` and no longer resets scroll while typing.
- `draw_scrollable` / `draw_diff` render all lines (highlighted) instead of the filtered subset; `doc_title` shows the match counter.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 314 pass (reworked `doc_search_*` tests, added `doc_search_n_and_capital_n_step_between_matches`)
- [x] Live-verified against a real pod's YAML on the home cluster: typing highlights in place (`[1/30]`), full doc stays rendered, `⏎` jumps to first match, `n`/`N` step forward/back with wrap, `esc` clears