### PR TITLE
feat: ephemeral debug container workflow (:debug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Not a marketing number - these are specific, checkable design choices:
   it - the same answer `kubectl auth can-i` gives, without leaving the TUI.
 - **Declarative guardrails** (`[[guardrails]]`) - config-defined rules that
   match on context/namespace/resource/action globs to **deny** a destructive
-  action outright (`delete`/`force-delete`/`drain`/`shell`), force
+  action outright (`delete`/`force-delete`/`drain`/`shell`/`debug`), force
   **type-to-confirm** (resource name or `context/name`), or cap **bulk**
   operations - so "never delete in prod", "always confirm a prod shell", and
   "no more than one at once" are enforced, not remembered.
@@ -198,6 +198,11 @@ Not a marketing number - these are specific, checkable design choices:
   of every mutating action you've taken (what, target, context, when),
   newest-first. Identifiers only - never secret input or decoded values - and
   never written to disk.
+- **Ephemeral debug containers** (`:debug`) - attach a throwaway debug
+  container to the selected pod via `kubectl debug`, prompting for the image
+  (prefilled with the `[debug]` default). `d` in the container picker targets
+  a specific container's process namespace (`--target`). Gated by read-only
+  mode and the `debug` guardrail; recorded in the journal.
 - **RBAC-aware palette** - hides resource kinds you can't `list`.
 - **Namespace switcher** (`n`) with pinned **favourites** (`favorite_namespaces`,
   ★) and per-context session **recents** (·) above the rest, and **context
@@ -469,8 +474,8 @@ remember. Each rule matches on `contexts`, `namespaces`, `resources`, and
 the strictest of: `deny` (block outright), `confirmation` (type to confirm),
 and `max_bulk` (cap how many rows one action may touch). The gated `actions`
 are the destructive verbs sofka takes directly — `delete`, `force-delete`,
-`drain`, and `shell` (exec). The first matching rule wins; `reason` is shown
-when it fires.
+`drain`, `shell` (exec), and `debug`. The first matching rule wins; `reason`
+is shown when it fires.
 
 ```toml
 [[guardrails]]
@@ -491,6 +496,25 @@ namespaces = ["kube-system"]
 actions = ["delete"]
 max_bulk = 1                     # no bulk deletes in kube-system
 ```
+
+### Ephemeral debug containers
+
+`:debug` attaches a throwaway debug container to the selected pod through
+`kubectl debug`, prompting for the image (prefilled with the default below).
+Leaving `command` empty launches an interactive shell (bash if the image ships
+it, else sh), mirroring the pod shell. `d` in the container picker pins
+`--target=<container>` so the debug container shares that container's process
+namespace. The ephemeral container persists on the pod until it's recreated —
+Kubernetes can't remove it — so there's nothing for sofka to clean up.
+
+```toml
+[debug]
+image = "nicolaka/netshoot:latest"   # default image the prompt is prefilled with
+command = ["bash"]                   # entrypoint; omit for an interactive shell
+```
+
+Debug creation is disabled in read-only mode and gated by the `debug`
+guardrail action.
 
 ### Log provider (VictoriaLogs)
 
@@ -619,6 +643,7 @@ header) and switching away restores write mode.
 | `e`                                        | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |
 | `s`                                        | shell into pod / scale a workload (context-dependent)                                                                                 |
 | `a`                                        | attach to pod                                                                                                                         |
+| `:debug`                                   | attach an ephemeral debug container to the pod (`kubectl debug`; `d` in the container picker targets one)                             |
 | `i`                                        | set container image                                                                                                                   |
 | `r`                                        | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
 | `f` / `shift-f`                            | port-forward (pods/services) - runs in the background                                                                                 |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Interactive-shell entrypoint for `exec`/`debug`: prefer bash when the image
+/// ships it, otherwise fall back to sh, in a single `sh -c` invocation.
+const SHELL_FALLBACK: &str = "command -v bash >/dev/null 2>&1 && exec bash || exec sh";
+
 impl App {
     // ----- actions -------------------------------------------------------
 
@@ -763,12 +767,85 @@ impl App {
             argv.push("-c".into());
             argv.push(c);
         }
+        argv.extend(["--".into(), "sh".into(), "-c".into(), SHELL_FALLBACK.into()]);
+        self.pending = Some(Suspend::Shell(argv));
+    }
+
+    /// `:debug` — attach an ephemeral debug container to the selected pod via
+    /// `kubectl debug`, prompting for the image (prefilled with the configured
+    /// default). `target` pins `--target=<container>` when launched from the
+    /// container picker. Gated by read-only mode and the `debug` guardrail.
+    pub(super) fn request_debug(&mut self, target: Option<String>) {
+        if self.deny_readonly() {
+            return;
+        }
+        if self.kind_plural != "pods" {
+            self.flash_warn("debug attaches an ephemeral container to a pod");
+            return;
+        }
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        // A debug container is a mutation of the pod — let guardrails gate it,
+        // with no default confirmation (like shell).
+        let targets = [(name.clone(), ns.clone())];
+        if self
+            .guard("debug", "pods", &targets, ConfirmLevel::None)
+            .is_none()
+        {
+            return;
+        }
+        self.prompt_label = match &target {
+            Some(c) => format!("Debug image for {name} (--target {c}, ⏎ to accept):"),
+            None => format!("Debug image for {name} (⏎ to accept):"),
+        };
+        self.prompt_input = self.debug.image.clone();
+        self.prompt_kind = Some(PromptKind::Debug {
+            ns,
+            pod: name,
+            target,
+        });
+        self.mode = Mode::Prompt;
+    }
+
+    /// Launch `kubectl debug` for the ephemeral container: suspends the TUI and
+    /// shells out interactively, exactly like exec/attach. The ephemeral
+    /// container persists on the pod (Kubernetes can't remove it) until the pod
+    /// is recreated — so there's nothing for sofka to clean up afterwards.
+    pub(super) fn do_debug(
+        &mut self,
+        ns: String,
+        pod: String,
+        target: Option<String>,
+        image: String,
+    ) {
+        let tgt = target
+            .as_deref()
+            .map(|c| format!(" --target {c}"))
+            .unwrap_or_default();
+        self.note_action(format!("debug ({image}){tgt}"), format!("{pod} in {ns}"));
+        let mut argv = self.kubectl_base();
         argv.extend([
-            "--".into(),
-            "sh".into(),
-            "-c".into(),
-            "command -v bash >/dev/null 2>&1 && exec bash || exec sh".into(),
+            "debug".into(),
+            "-it".into(),
+            "-n".into(),
+            ns,
+            pod,
+            format!("--image={image}"),
         ]);
+        if let Some(c) = target {
+            argv.push(format!("--target={c}"));
+        }
+        // No configured command = an interactive shell (bash if the image has
+        // it, else sh), mirroring the pod shell; otherwise the configured argv.
+        if self.debug.command.is_empty() {
+            argv.extend(["--".into(), "sh".into(), "-c".into(), SHELL_FALLBACK.into()]);
+        } else {
+            argv.push("--".into());
+            argv.extend(self.debug.command.clone());
+        }
         self.pending = Some(Suspend::Shell(argv));
     }
 
@@ -977,6 +1054,7 @@ impl App {
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;
         self.guardrails = resolved.config.guardrails;
+        self.debug = resolved.config.debug;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         warnings.extend(crate::config::workspace_warnings(&self.workspaces));

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -517,6 +517,7 @@ impl App {
             PaletteAction::Gitops => self.open_gitops(),
             PaletteAction::CanI => self.open_can_i(),
             PaletteAction::Journal => self.open_journal(),
+            PaletteAction::Debug => self.request_debug(None),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -268,6 +268,14 @@ enum PromptKind {
         plural: String,
         container: String,
     },
+    /// Debug image for an ephemeral debug container (`:debug`), prefilled with
+    /// the configured default. `target` pins `--target=<container>` when the
+    /// workflow was launched from the container picker.
+    Debug {
+        ns: String,
+        pod: String,
+        target: Option<String>,
+    },
     /// New lookback period for the provider logs view (`T`) — the only
     /// prompt opened from (and returning to) [`Mode::Logs`].
     ProviderLookback,
@@ -346,6 +354,7 @@ enum PaletteAction {
     Gitops,
     CanI,
     Journal,
+    Debug,
     Diff,
     Events,
     PortForwards,
@@ -392,6 +401,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Journal,
         names: &["journal", "audit", "actions"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Debug,
+        names: &["debug", "ephemeral", "dbg"],
     },
     PaletteCommand {
         action: PaletteAction::Diff,
@@ -731,6 +744,9 @@ pub struct App {
     /// Declarative guardrails (`[[guardrails]]`), re-applied on context switch
     /// and `:reload`.
     pub guardrails: Vec<crate::config::Guardrail>,
+    /// Ephemeral-debug-container defaults (`[debug]`) for `:debug`, re-applied
+    /// on context switch and `:reload`.
+    pub debug: crate::config::DebugConfig,
     /// Session-local log of mutating actions taken (`:journal`).
     pub journal: crate::journal::Journal,
     /// A workspace waiting for an in-flight context switch before it opens.
@@ -914,6 +930,7 @@ impl App {
             pending_workspace: None,
             active_workspace: None,
             guardrails: Vec::new(),
+            debug: crate::config::DebugConfig::default(),
             journal: crate::journal::Journal::default(),
             rbac_allowed: None,
             last_rbac_ns: None,

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -55,6 +55,17 @@ impl App {
                     self.launch_provider_container_logs(ns, name, c);
                 }
             }
+            // Debug an ephemeral container targeting this container's namespace
+            // (`kubectl debug --target`). The picker's pod is the selected row,
+            // so request_debug reads it back from the table selection.
+            KeyCode::Char('d') => {
+                if let Some(i) = self.container_state.selected()
+                    && let Some(c) = self.container_list.get(i).cloned()
+                {
+                    self.mode = Mode::Table;
+                    self.request_debug(Some(c));
+                }
+            }
             _ => {}
         }
     }
@@ -222,6 +233,13 @@ impl App {
                             self.flash_warn("no image given");
                         } else {
                             self.do_set_image(ns, name, plural, container, input);
+                        }
+                    }
+                    Some(PromptKind::Debug { ns, pod, target }) => {
+                        if input.is_empty() {
+                            self.flash_warn("no debug image given");
+                        } else {
+                            self.do_debug(ns, pod, target, input);
                         }
                     }
                     // Empty input = cancel, keep the current period.

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -336,6 +336,7 @@ impl App {
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;
         self.guardrails = resolved.config.guardrails;
+        self.debug = resolved.config.debug;
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);
         plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2488,6 +2488,74 @@ async fn guardrail_type_resource_name_confirmation() {
 }
 
 #[tokio::test]
+async fn debug_prompt_prefills_image_then_shells_out_to_kubectl_debug() {
+    let (mut app, _rx) = app_with_pod();
+    app.debug = crate::config::DebugConfig {
+        image: "nicolaka/netshoot:latest".into(),
+        command: Vec::new(),
+    };
+    app.request_debug(None);
+    assert_eq!(app.mode, Mode::Prompt);
+    // The prompt is prefilled with the configured default image.
+    assert_eq!(app.prompt_input, "nicolaka/netshoot:latest");
+    assert!(matches!(app.prompt_kind, Some(PromptKind::Debug { .. })));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("debug should suspend into a kubectl debug shell");
+    };
+    assert!(argv.iter().any(|a| a == "debug"));
+    assert!(argv.iter().any(|a| a == "-it"));
+    assert!(
+        argv.iter().any(|a| a == "--image=nicolaka/netshoot:latest"),
+        "{argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|a| a.starts_with("--target")),
+        "no target when launched from the pod row: {argv:?}"
+    );
+    // Recorded in the journal as a debug action.
+    assert!(app.journal.lines().iter().any(|l| l.contains("debug")));
+}
+
+#[tokio::test]
+async fn debug_from_container_picker_pins_target() {
+    let (mut app, _rx) = app_with_pod();
+    app.do_debug(
+        "default".into(),
+        "a".into(),
+        Some("app".into()),
+        "busybox:latest".into(),
+    );
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("expected a debug shell");
+    };
+    assert!(argv.iter().any(|a| a == "--target=app"), "{argv:?}");
+}
+
+#[tokio::test]
+async fn debug_is_blocked_in_readonly_and_by_guardrail() {
+    // Read-only mode.
+    let (mut app, _rx) = app_with_pod();
+    app.readonly = true;
+    app.request_debug(None);
+    assert_ne!(app.mode, Mode::Prompt, "read-only blocks debug");
+    assert!(app.flash.contains("read-only"));
+
+    // A guardrail denying the `debug` action.
+    let (mut app, _rx) = app_with_pod();
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["debug".into()],
+        deny: true,
+        reason: Some("no debug on prod".into()),
+        ..Default::default()
+    }];
+    app.request_debug(None);
+    assert_ne!(app.mode, Mode::Prompt);
+    assert!(app.flash.contains("blocked by guardrail"), "{}", app.flash);
+}
+
+#[tokio::test]
 async fn readonly_gates_mutating_plugins_only() {
     let (mut app, _rx) = app_with_pod();
     app.readonly = true;

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,38 @@ pub struct Config {
     /// Warning/critical thresholds for value-based cell coloring — see
     /// [`Thresholds`]. Compiled and validated by [`crate::thresholds::compile`].
     pub thresholds: Thresholds,
+    /// Defaults for the ephemeral-debug-container workflow (`:debug`) — see
+    /// [`DebugConfig`].
+    pub debug: DebugConfig,
+}
+
+/// Defaults for `:debug`, which attaches an ephemeral debug container to the
+/// selected pod via `kubectl debug`. The image prompt is prefilled with
+/// [`Self::image`]; leaving [`Self::command`] empty launches an interactive
+/// shell (bash if the debug image has it, else sh), mirroring the pod shell.
+///
+/// ```toml
+/// [debug]
+/// image = "nicolaka/netshoot:latest"   # default debug image
+/// command = ["bash"]                   # entrypoint; omit for a shell
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct DebugConfig {
+    /// Image the `:debug` prompt is prefilled with.
+    pub image: String,
+    /// Entrypoint for the ephemeral container. Empty = an interactive shell.
+    pub command: Vec<String>,
+}
+
+impl Default for DebugConfig {
+    fn default() -> Self {
+        // busybox is tiny and always pulls; a good least-surprise default.
+        Self {
+            image: "busybox:latest".into(),
+            command: Vec::new(),
+        }
+    }
 }
 
 /// Warning/critical thresholds that decide when a RESTARTS/CPU/MEM cell (or the
@@ -490,8 +522,8 @@ pub fn workspace_warnings(workspaces: &[Workspace]) -> Vec<String> {
 
 /// A declarative safety policy: match dangerous actions by context, namespace,
 /// resource, and action, then require extra confirmation, deny them, or cap a
-/// bulk selection. Gates `delete`, `force-delete`, `drain`, and `shell` today.
-/// Empty match lists mean "any"; glob `*` is supported in the patterns.
+/// bulk selection. Gates `delete`, `force-delete`, `drain`, `shell`, and
+/// `debug` today. Empty match lists mean "any"; glob `*` supported in patterns.
 ///
 /// ```toml
 /// [[guardrails]]
@@ -519,8 +551,8 @@ pub struct Guardrail {
     pub namespaces: Vec<String>,
     /// Resource plurals/kinds this applies to (globs). Empty = any.
     pub resources: Vec<String>,
-    /// Actions this applies to: `delete`, `force-delete`, `drain`, `shell`.
-    /// Empty = any.
+    /// Actions this applies to: `delete`, `force-delete`, `drain`, `shell`,
+    /// `debug`. Empty = any.
     pub actions: Vec<String>,
     /// Block the action outright.
     pub deny: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,7 @@ async fn main() -> Result<()> {
     app.bookmarks = cfg.bookmarks.clone();
     app.workspaces = cfg.workspaces.clone();
     app.guardrails = cfg.guardrails.clone();
+    app.debug = cfg.debug.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1587,6 +1587,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("e", "edit in $EDITOR (kubectl edit)"),
         bind("s", "shell into pod / scale workload"),
         bind("a", "attach to pod"),
+        bind(
+            ":debug",
+            "attach an ephemeral debug container to the pod (kubectl debug; d in the container picker targets one)",
+        ),
         bind("i", "set container image"),
         bind(
             "r",
@@ -2000,7 +2004,7 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         format!(" · {}", app.container_qos)
     };
     let title = format!(" Containers{qos} ");
-    let footer = " ⏎ logs · p previous · s shell · L provider ";
+    let footer = " ⏎ logs · p previous · s shell · d debug · L provider ";
 
     // Size the box to its contents: header + rows + borders, and wide enough
     // for the columns, the title, or the footer — whichever needs the most.


### PR DESCRIPTION
## Summary
First item of **Milestone 5 (debugging & collaboration)**: attach a throwaway debug container to the selected pod via `kubectl debug`.

- **`:debug`** (palette; aliases `ephemeral`, `dbg`) prompts for the image — prefilled with the `[debug]` default — then suspends into an interactive shell, exactly like exec/attach.
- **`d`** in the container picker pins `--target=<container>` so the debug container shares that container's process namespace.
- New **`[debug]`** config: `image` (prompt default) and `command` (entrypoint; empty = a bash/sh interactive shell, mirroring the pod shell).
- **Disabled in read-only mode** and gated by a new **`debug` guardrail action**; **recorded in the action journal**.
- The ephemeral container persists on the pod until it's recreated (Kubernetes can't remove it), so there's nothing for sofka to clean up — noted in the docs.

## Config
```toml
[debug]
image = "nicolaka/netshoot:latest"   # default image the prompt is prefilled with
command = ["bash"]                   # entrypoint; omit for an interactive shell
```

## Implementation
- `config::DebugConfig` (+ `Config.debug`), wired at all three config-application sites (startup, context switch, `:reload`).
- `request_debug(target)` / `do_debug(...)` in `actions.rs`; `PromptKind::Debug`; palette action + container-picker `d` key.
- Extracted the `exec`/`debug` shared shell-fallback into a `SHELL_FALLBACK` const.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 317 pass (added prompt-prefill, `--target`, and readonly/guardrail-gating tests)
- [x] Live-verified against the home cluster: `:debug` prefilled `busybox:latest`, launched `kubectl debug -it -n ai ha-mcp-0 --image=busybox:latest -- sh -c …`, dropped into a shell on the target pod (`hostname` → `ha-mcp-0`), TUI resumed cleanly on exit, and the journal recorded `debug (busybox:latest) · ha-mcp-0 in ai`