### PR TITLE
feat: node debug pod workflow (:debug on a node)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Not a marketing number - these are specific, checkable design choices:
   it - the same answer `kubectl auth can-i` gives, without leaving the TUI.
 - **Declarative guardrails** (`[[guardrails]]`) - config-defined rules that
   match on context/namespace/resource/action globs to **deny** a destructive
-  action outright (`delete`/`force-delete`/`drain`/`shell`/`debug`), force
+  action outright (`delete`/`force-delete`/`drain`/`shell`/`debug`/`node-debug`), force
   **type-to-confirm** (resource name or `context/name`), or cap **bulk**
   operations - so "never delete in prod", "always confirm a prod shell", and
   "no more than one at once" are enforced, not remembered.
@@ -203,6 +203,12 @@ Not a marketing number - these are specific, checkable design choices:
   (prefilled with the `[debug]` default). `d` in the container picker targets
   a specific container's process namespace (`--target`). Gated by read-only
   mode and the `debug` guardrail; recorded in the journal.
+- **Node debug pods** (`:debug` on a node) - launch a privileged diagnostic
+  pod on the selected node (`kubectl debug node/…`) that mounts the host
+  filesystem at `/host` and joins the host namespaces. sofka previews exactly
+  that access and requires confirmation before creating it, gates it behind
+  read-only mode and the `node-debug` guardrail, and tracks what it launched
+  so `:debug-clean` can remove the debugger pods afterwards.
 - **RBAC-aware palette** - hides resource kinds you can't `list`.
 - **Namespace switcher** (`n`) with pinned **favourites** (`favorite_namespaces`,
   ★) and per-context session **recents** (·) above the rest, and **context
@@ -474,8 +480,8 @@ remember. Each rule matches on `contexts`, `namespaces`, `resources`, and
 the strictest of: `deny` (block outright), `confirmation` (type to confirm),
 and `max_bulk` (cap how many rows one action may touch). The gated `actions`
 are the destructive verbs sofka takes directly — `delete`, `force-delete`,
-`drain`, `shell` (exec), and `debug`. The first matching rule wins; `reason`
-is shown when it fires.
+`drain`, `shell` (exec), `debug`, and `node-debug`. The first matching rule
+wins; `reason` is shown when it fires.
 
 ```toml
 [[guardrails]]
@@ -497,24 +503,36 @@ actions = ["delete"]
 max_bulk = 1                     # no bulk deletes in kube-system
 ```
 
-### Ephemeral debug containers
+### Debug containers and pods
 
-`:debug` attaches a throwaway debug container to the selected pod through
-`kubectl debug`, prompting for the image (prefilled with the default below).
+`:debug` on a **pod** attaches a throwaway ephemeral debug container through
+`kubectl debug`, prompting for the image (prefilled with `image` below).
 Leaving `command` empty launches an interactive shell (bash if the image ships
 it, else sh), mirroring the pod shell. `d` in the container picker pins
 `--target=<container>` so the debug container shares that container's process
 namespace. The ephemeral container persists on the pod until it's recreated —
 Kubernetes can't remove it — so there's nothing for sofka to clean up.
 
+`:debug` on a **node** launches a privileged diagnostic pod on it
+(`kubectl debug node/<node>`, image `node_image` in `node_namespace`, optional
+`node_profile`). Because that pod mounts the host filesystem at `/host` and
+joins the host PID/network/IPC namespaces, sofka previews exactly that access
+and makes you confirm before creating it. sofka tracks the node debuggers it
+launches this session; `:debug-clean` deletes them (matched by the
+`node-debugger-*` name and the node they run on). kubectl leaves the pod
+running after you exit, so clean up when you're done.
+
 ```toml
 [debug]
-image = "nicolaka/netshoot:latest"   # default image the prompt is prefilled with
-command = ["bash"]                   # entrypoint; omit for an interactive shell
+image = "nicolaka/netshoot:latest"       # ephemeral (in-pod) debug image
+command = ["bash"]                       # entrypoint; omit for an interactive shell
+node_image = "nicolaka/netshoot:latest"  # node debug pod image
+node_namespace = "default"               # namespace the node debugger lands in
+node_profile = "sysadmin"                # kubectl debug --profile (optional)
 ```
 
-Debug creation is disabled in read-only mode and gated by the `debug`
-guardrail action.
+Both are disabled in read-only mode and gated by guardrails — the `debug`
+action for pods, `node-debug` for nodes.
 
 ### Log provider (VictoriaLogs)
 
@@ -643,7 +661,8 @@ header) and switching away restores write mode.
 | `e`                                        | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |
 | `s`                                        | shell into pod / scale a workload (context-dependent)                                                                                 |
 | `a`                                        | attach to pod                                                                                                                         |
-| `:debug`                                   | attach an ephemeral debug container to the pod (`kubectl debug`; `d` in the container picker targets one)                             |
+| `:debug`                                   | pod: ephemeral debug container (`d` in the picker targets one) · node: privileged debug pod (previewed + confirmed)                   |
+| `:debug-clean`                             | delete the node debugger pods launched this session                                                                                   |
 | `i`                                        | set container image                                                                                                                   |
 | `r`                                        | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
 | `f` / `shift-f`                            | port-forward (pods/services) - runs in the background                                                                                 |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -779,8 +779,14 @@ impl App {
         if self.deny_readonly() {
             return;
         }
+        // On a node, `:debug` launches a privileged node debug pod instead of
+        // an in-pod ephemeral container.
+        if self.kind_plural == "nodes" {
+            self.request_node_debug();
+            return;
+        }
         if self.kind_plural != "pods" {
-            self.flash_warn("debug attaches an ephemeral container to a pod");
+            self.flash_warn("debug: select a pod (ephemeral container) or node (debug pod)");
             return;
         }
         let Some(obj) = self.selected_ref() else {
@@ -847,6 +853,145 @@ impl App {
             argv.extend(self.debug.command.clone());
         }
         self.pending = Some(Suspend::Shell(argv));
+    }
+
+    /// `:debug` on a node — preview and confirm the host access a node debug
+    /// pod grants, then launch it. A node debugger is privileged by design
+    /// (host filesystem at `/host`, host PID/network/IPC), so this always
+    /// confirms, on top of any `node-debug` guardrail.
+    pub(super) fn request_node_debug(&mut self) {
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
+        let node = obj.metadata.name.clone().unwrap_or_default();
+        let targets = [(node.clone(), String::new())];
+        let Some(level) = self.guard("node-debug", "nodes", &targets, ConfirmLevel::Plain) else {
+            return;
+        };
+        let image = self.debug.node_image.clone();
+        let namespace = self.debug.node_namespace.clone();
+        let profile = self.debug.node_profile.clone();
+        let profile_note = profile
+            .as_deref()
+            .map(|p| format!(", profile {p}"))
+            .unwrap_or_default();
+        let label = format!(
+            "⚠ Node debug pod on {node} (image {image} in {namespace}{profile_note}) — \
+             grants the host filesystem (/host) and host PID/network/IPC namespaces. Launch?"
+        );
+        self.begin_guarded(
+            ConfirmAction::NodeDebug {
+                node: node.clone(),
+                image,
+                namespace,
+                profile,
+            },
+            label,
+            level,
+            node,
+        );
+    }
+
+    /// Launch `kubectl debug node/<node>` and suspend into it, tracking the
+    /// `(namespace, node)` so `:debug-clean` can delete the debugger pod later
+    /// (kubectl leaves it running after the session).
+    pub(super) fn do_node_debug(
+        &mut self,
+        node: String,
+        image: String,
+        namespace: String,
+        profile: Option<String>,
+    ) {
+        self.note_action(format!("node-debug ({image})"), format!("node/{node}"));
+        let entry = (namespace.clone(), node.clone());
+        if !self.launched_node_debuggers.contains(&entry) {
+            self.launched_node_debuggers.push(entry);
+        }
+        let mut argv = self.kubectl_base();
+        argv.extend([
+            "debug".into(),
+            format!("node/{node}"),
+            "-it".into(),
+            "-n".into(),
+            namespace,
+            format!("--image={image}"),
+        ]);
+        if let Some(p) = profile {
+            argv.push(format!("--profile={p}"));
+        }
+        argv.extend(["--".into(), "sh".into(), "-c".into(), SHELL_FALLBACK.into()]);
+        self.pending = Some(Suspend::Shell(argv));
+    }
+
+    /// `:debug-clean` — delete the node debugger pods sofka launched this
+    /// session (after a confirm). No-op with a flash when none were launched.
+    pub(super) fn request_debug_cleanup(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
+        if self.launched_node_debuggers.is_empty() {
+            self.flash_warn("no node debuggers launched this session");
+            return;
+        }
+        let nodes: Vec<&str> = self
+            .launched_node_debuggers
+            .iter()
+            .map(|(_, node)| node.as_str())
+            .collect();
+        self.confirm_label = format!(
+            "Delete node debugger pod(s) on {} launched this session?",
+            nodes.join(", ")
+        );
+        self.confirm_action = Some(ConfirmAction::CleanupDebuggers);
+        self.mode = Mode::Confirm;
+    }
+
+    /// Delete every `node-debugger-*` pod scheduled on a tracked node, in its
+    /// tracked namespace — the pods `kubectl debug node` creates. Matching on
+    /// the name prefix *and* `spec.nodeName` avoids touching unrelated pods.
+    pub(super) fn do_cleanup_debuggers(&mut self) {
+        let targets = std::mem::take(&mut self.launched_node_debuggers);
+        self.flash = format!("cleaning up {} node debugger(s)…", targets.len());
+        self.flash_err = false;
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let mut deleted = 0usize;
+            let mut failed: Vec<String> = Vec::new();
+            for (ns, node) in targets {
+                let pods: Api<Pod> = Api::namespaced(client.clone(), &ns);
+                let listed = pods
+                    .list(&ListParams::default().fields(&format!("spec.nodeName={node}")))
+                    .await;
+                let list = match listed {
+                    Ok(l) => l,
+                    Err(e) => {
+                        failed.push(format!("{ns} (node {node}): list failed: {e}"));
+                        continue;
+                    }
+                };
+                for pod in list.items {
+                    let Some(name) = pod.metadata.name.as_deref() else {
+                        continue;
+                    };
+                    if !name.starts_with("node-debugger-") {
+                        continue;
+                    }
+                    match pods.delete(name, &DeleteParams::default()).await {
+                        Ok(_) => deleted += 1,
+                        Err(e) => failed.push(format!("{ns}/{name}: {e}")),
+                    }
+                }
+            }
+            let _ = tx
+                .send(Msg::DebuggersCleaned {
+                    generation: genr,
+                    deleted,
+                    failed,
+                })
+                .await;
+        });
     }
 
     pub(super) fn request_scale(&mut self) {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -518,6 +518,7 @@ impl App {
             PaletteAction::CanI => self.open_can_i(),
             PaletteAction::Journal => self.open_journal(),
             PaletteAction::Debug => self.request_debug(None),
+            PaletteAction::DebugClean => self.request_debug_cleanup(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -669,6 +669,23 @@ impl App {
                     ));
                 }
             }
+            Msg::DebuggersCleaned {
+                generation,
+                deleted,
+                failed,
+            } if generation == self.generation => {
+                if failed.is_empty() {
+                    self.flash = format!("removed {deleted} node debugger pod(s)");
+                    self.flash_err = false;
+                } else {
+                    let shown: Vec<&str> = failed.iter().take(3).map(String::as_str).collect();
+                    self.flash_warn(&format!(
+                        "debug-clean: removed {deleted}, {} failed — {}",
+                        failed.len(),
+                        shown.join("; ")
+                    ));
+                }
+            }
             Msg::Detail {
                 generation,
                 title,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -198,6 +198,16 @@ enum ConfirmAction {
     /// Uninstall one or more Helm releases (`helm uninstall`), `(name, ns)`
     /// per release — bulk when marked, like [`ConfirmAction::Delete`].
     HelmUninstall { targets: Vec<(String, String)> },
+    /// Launch a privileged node debug pod (`kubectl debug node/<node>`) after
+    /// previewing the host access it grants.
+    NodeDebug {
+        node: String,
+        image: String,
+        namespace: String,
+        profile: Option<String>,
+    },
+    /// Delete the node debugger pods sofka launched this session (`:debug-clean`).
+    CleanupDebuggers,
     /// Run a confirmed plugin (`confirm`/`dangerous`) once accepted — one job
     /// (label, argv) per target, so a bulk run confirms once.
     Plugin {
@@ -355,6 +365,7 @@ enum PaletteAction {
     CanI,
     Journal,
     Debug,
+    DebugClean,
     Diff,
     Events,
     PortForwards,
@@ -405,6 +416,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Debug,
         names: &["debug", "ephemeral", "dbg"],
+    },
+    PaletteCommand {
+        action: PaletteAction::DebugClean,
+        names: &["debug-clean", "debug-cleanup", "dbgclean"],
     },
     PaletteCommand {
         action: PaletteAction::Diff,
@@ -747,6 +762,9 @@ pub struct App {
     /// Ephemeral-debug-container defaults (`[debug]`) for `:debug`, re-applied
     /// on context switch and `:reload`.
     pub debug: crate::config::DebugConfig,
+    /// Node debugger pods launched this session, as `(namespace, node)`, so
+    /// `:debug-clean` can find and delete them. Cleared on context switch.
+    pub launched_node_debuggers: Vec<(String, String)>,
     /// Session-local log of mutating actions taken (`:journal`).
     pub journal: crate::journal::Journal,
     /// A workspace waiting for an in-flight context switch before it opens.
@@ -931,6 +949,7 @@ impl App {
             active_workspace: None,
             guardrails: Vec::new(),
             debug: crate::config::DebugConfig::default(),
+            launched_node_debuggers: Vec::new(),
             journal: crate::journal::Journal::default(),
             rbac_allowed: None,
             last_rbac_ns: None,

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -115,6 +115,17 @@ impl App {
                 self.do_helm_uninstall(targets);
                 self.marked.clear();
             }
+            ConfirmAction::NodeDebug {
+                node,
+                image,
+                namespace,
+                profile,
+            } => {
+                self.do_node_debug(node, image, namespace, profile);
+            }
+            ConfirmAction::CleanupDebuggers => {
+                self.do_cleanup_debuggers();
+            }
             ConfirmAction::Plugin {
                 jobs,
                 name,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -337,6 +337,8 @@ impl App {
         self.workspaces = resolved.config.workspaces;
         self.guardrails = resolved.config.guardrails;
         self.debug = resolved.config.debug;
+        // Tracked debuggers belong to the previous cluster/context.
+        self.launched_node_debuggers.clear();
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);
         plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2493,6 +2493,7 @@ async fn debug_prompt_prefills_image_then_shells_out_to_kubectl_debug() {
     app.debug = crate::config::DebugConfig {
         image: "nicolaka/netshoot:latest".into(),
         command: Vec::new(),
+        ..Default::default()
     };
     app.request_debug(None);
     assert_eq!(app.mode, Mode::Prompt);
@@ -2531,6 +2532,103 @@ async fn debug_from_container_picker_pins_target() {
         panic!("expected a debug shell");
     };
     assert!(argv.iter().any(|a| a == "--target=app"), "{argv:?}");
+}
+
+/// A one-node table with the cursor on it.
+fn app_with_node() -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    app.switch_kind("nodes");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "node-a"}}),
+    );
+    app.table_state.select(Some(0));
+    (app, rx)
+}
+
+#[tokio::test]
+async fn node_debug_previews_host_access_then_launches_debug_pod() {
+    let (mut app, _rx) = app_with_node();
+    app.debug = crate::config::DebugConfig {
+        node_image: "busybox:latest".into(),
+        node_namespace: "kube-system".into(),
+        node_profile: Some("sysadmin".into()),
+        ..Default::default()
+    };
+    // `:debug` on a node previews the host access and requires confirmation.
+    app.request_debug(None);
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("/host") && app.confirm_label.contains("host PID"),
+        "{}",
+        app.confirm_label
+    );
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::NodeDebug { .. })
+    ));
+
+    // Confirming launches kubectl debug node/… and tracks it for cleanup.
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("node debug should suspend into a shell");
+    };
+    assert!(argv.iter().any(|a| a == "debug"));
+    assert!(argv.iter().any(|a| a == "node/node-a"), "{argv:?}");
+    assert!(argv.iter().any(|a| a == "--image=busybox:latest"));
+    assert!(argv.iter().any(|a| a == "--profile=sysadmin"));
+    assert!(argv.iter().any(|a| a == "kube-system"));
+    assert_eq!(
+        app.launched_node_debuggers,
+        vec![("kube-system".into(), "node-a".into())]
+    );
+    assert!(
+        app.journal.lines().iter().any(|l| l.contains("node-debug")),
+        "recorded in journal"
+    );
+}
+
+#[tokio::test]
+async fn node_debug_is_gated_by_readonly_and_guardrail() {
+    let (mut app, _rx) = app_with_node();
+    app.readonly = true;
+    app.request_debug(None);
+    assert_ne!(app.mode, Mode::Confirm, "read-only blocks node debug");
+
+    let (mut app, _rx) = app_with_node();
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["node-debug".into()],
+        deny: true,
+        ..Default::default()
+    }];
+    app.request_debug(None);
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(app.flash.contains("blocked by guardrail"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn debug_clean_without_launches_warns() {
+    let (mut app, _rx) = app_with_node();
+    app.request_debug_cleanup();
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(app.flash.contains("no node debuggers"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn debug_clean_confirms_when_debuggers_were_launched() {
+    let (mut app, _rx) = app_with_node();
+    app.launched_node_debuggers = vec![("default".into(), "node-a".into())];
+    app.request_debug_cleanup();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("node-a"),
+        "{}",
+        app.confirm_label
+    );
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::CleanupDebuggers)
+    ));
 }
 
 #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,18 +86,36 @@ pub struct Config {
 /// [`Self::image`]; leaving [`Self::command`] empty launches an interactive
 /// shell (bash if the debug image has it, else sh), mirroring the pod shell.
 ///
+/// On a **node** (`:debug` on a node row) it instead runs
+/// `kubectl debug node/<node>`, which schedules a privileged diagnostic pod
+/// that mounts the host filesystem at `/host` and joins the host namespaces —
+/// so sofka previews exactly that access and requires confirmation first.
+/// Node debuggers sofka launches this session can be removed with
+/// `:debug-clean`.
+///
 /// ```toml
 /// [debug]
-/// image = "nicolaka/netshoot:latest"   # default debug image
+/// image = "nicolaka/netshoot:latest"   # ephemeral (in-pod) debug image
 /// command = ["bash"]                   # entrypoint; omit for a shell
+/// node_image = "nicolaka/netshoot:latest"  # node debug pod image
+/// node_namespace = "default"           # namespace the node debugger lands in
+/// node_profile = "sysadmin"            # kubectl debug --profile (optional)
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct DebugConfig {
-    /// Image the `:debug` prompt is prefilled with.
+    /// Image the `:debug` prompt is prefilled with (ephemeral container).
     pub image: String,
     /// Entrypoint for the ephemeral container. Empty = an interactive shell.
     pub command: Vec<String>,
+    /// Image for a node debug pod (`kubectl debug node/<node>`).
+    pub node_image: String,
+    /// Namespace the node debugger pod is created in (so `:debug-clean` knows
+    /// where to find it).
+    pub node_namespace: String,
+    /// `kubectl debug --profile` for node debuggers (`legacy`, `sysadmin`,
+    /// `netadmin`, …). `None` = kubectl's default (`legacy`).
+    pub node_profile: Option<String>,
 }
 
 impl Default for DebugConfig {
@@ -106,6 +124,9 @@ impl Default for DebugConfig {
         Self {
             image: "busybox:latest".into(),
             command: Vec::new(),
+            node_image: "busybox:latest".into(),
+            node_namespace: "default".into(),
+            node_profile: None,
         }
     }
 }
@@ -522,8 +543,8 @@ pub fn workspace_warnings(workspaces: &[Workspace]) -> Vec<String> {
 
 /// A declarative safety policy: match dangerous actions by context, namespace,
 /// resource, and action, then require extra confirmation, deny them, or cap a
-/// bulk selection. Gates `delete`, `force-delete`, `drain`, `shell`, and
-/// `debug` today. Empty match lists mean "any"; glob `*` supported in patterns.
+/// bulk selection. Gates `delete`, `force-delete`, `drain`, `shell`, `debug`,
+/// and `node-debug` today. Empty match lists mean "any"; glob `*` supported.
 ///
 /// ```toml
 /// [[guardrails]]
@@ -552,7 +573,7 @@ pub struct Guardrail {
     /// Resource plurals/kinds this applies to (globs). Empty = any.
     pub resources: Vec<String>,
     /// Actions this applies to: `delete`, `force-delete`, `drain`, `shell`,
-    /// `debug`. Empty = any.
+    /// `debug`, `node-debug`. Empty = any.
     pub actions: Vec<String>,
     /// Block the action outright.
     pub deny: bool,

--- a/src/store.rs
+++ b/src/store.rs
@@ -140,6 +140,13 @@ pub enum Msg {
         generation: u64,
         provider: Box<crate::providers::LogProvider>,
     },
+    /// Result of a `:debug-clean` node-debugger cleanup: how many pods were
+    /// deleted and any per-pod failures (`ns/name: reason`).
+    DebuggersCleaned {
+        generation: u64,
+        deleted: usize,
+        failed: Vec<String>,
+    },
     Error {
         generation: u64,
         error: String,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1589,7 +1589,11 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("a", "attach to pod"),
         bind(
             ":debug",
-            "attach an ephemeral debug container to the pod (kubectl debug; d in the container picker targets one)",
+            "pod: ephemeral debug container (d in picker targets one) · node: privileged debug pod",
+        ),
+        bind(
+            ":debug-clean",
+            "delete the node debugger pods launched this session",
         ),
         bind("i", "set container image"),
         bind(


### PR DESCRIPTION
## Summary
Second item of **Milestone 5**: launch a privileged diagnostic pod on a node.

- **`:debug` on a node** runs `kubectl debug node/<node>` — a pod that mounts the host filesystem at `/host` and joins the host PID/network/IPC namespaces.
- Because that access is dangerous, sofka **previews exactly what the pod grants and requires confirmation** before creating it, on top of **read-only gating** and a new **`node-debug` guardrail action**.
- sofka **tracks the node debuggers it launches** this session (kubectl leaves them running after you exit); **`:debug-clean`** deletes them — matched by the `node-debugger-*` name *and* their `spec.nodeName`, so unrelated pods are never touched.
- Recorded in the action journal.

`:debug` is now context-aware: **pod → ephemeral container**, **node → debug pod**.

## Config
```toml
[debug]
node_image = "nicolaka/netshoot:latest"  # node debug pod image
node_namespace = "default"               # namespace the node debugger lands in
node_profile = "sysadmin"                # kubectl debug --profile (optional)
```

## Implementation
- `DebugConfig` gains `node_image` / `node_namespace` / `node_profile`.
- `request_node_debug` / `do_node_debug` / `request_debug_cleanup` / `do_cleanup_debuggers` in `actions.rs`; `ConfirmAction::{NodeDebug, CleanupDebuggers}`; `Msg::DebuggersCleaned`; `App.launched_node_debuggers` (cleared on context switch).
- `:debug-clean` palette command; help + keybinding-table entries.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 321 pass (added preview/launch/tracking, readonly+guardrail gating, and `:debug-clean` confirm/warn tests)
- [x] Live-verified against the home cluster: `:debug` on `icarus001` previewed the host-access warning, confirmed, launched `kubectl debug node/icarus001 -it -n default --image=busybox:latest …`, dropped into a shell where `ls /host` succeeded and `hostname` returned `icarus001` (host namespace); TUI resumed cleanly; the `node-debugger-icarus001-*` pod persisted, then `:debug-clean` removed it (`kubectl get pods` confirmed none remained)