### PR TITLE
feat: redacted diagnostic bundles (:bundle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ Not a marketing number - these are specific, checkable design choices:
   that access and requires confirmation before creating it, gates it behind
   read-only mode and the `node-debug` guardrail, and tracks what it launched
   so `:debug-clean` can remove the debugger pods afterwards.
+- **Diagnostic bundles** (`:bundle`) - assemble a redacted incident bundle for
+  the selected object into one Markdown document: its (redacted) YAML, owner,
+  the incident explanation, recent events, the session timeline, bounded recent
+  logs, and a metrics snapshot. Secret `data`/`stringData`, credential-looking
+  annotations, and `last-applied-configuration` are stripped unconditionally,
+  and a manifest spells out what was included and what was withheld. You review
+  the bundle in a preview, then `:bundle-save` writes it to a file.
 - **RBAC-aware palette** - hides resource kinds you can't `list`.
 - **Namespace switcher** (`n`) with pinned **favourites** (`favorite_namespaces`,
   ★) and per-context session **recents** (·) above the rest, and **context
@@ -534,6 +541,28 @@ node_profile = "sysadmin"                # kubectl debug --profile (optional)
 Both are disabled in read-only mode and gated by guardrails — the `debug`
 action for pods, `node-debug` for nodes.
 
+### Diagnostic bundles
+
+`:bundle` assembles a redacted incident bundle for the selected object — its
+YAML, owner, the incident explanation, recent events, the session timeline,
+bounded recent logs, and a metrics snapshot — into one Markdown document for
+handing off between application and platform teams. It's gathered off-thread
+and shown in a preview; `:bundle-save` then writes it to a temp file.
+
+Redaction is unconditional: Secret `data`/`stringData` values, any
+credential-looking annotation (keys containing `token`, `password`, `secret`,
+`apikey`, `credential`, …), and `last-applied-configuration` are replaced with
+a placeholder, `managedFields` is dropped, and env vars sourced from Secrets
+are flagged (their values are references, not literals). Every bundle carries a
+manifest of exactly what was included and what was withheld.
+
+```toml
+[bundle]
+anonymize = false   # replace context/cluster identity with placeholders
+log_lines = 200     # max recent log lines per pod
+max_pods = 3        # cap how many pods contribute logs
+```
+
 ### Log provider (VictoriaLogs)
 
 `L` (or `:vlogs`) opens log history for the selection from a VictoriaLogs
@@ -663,6 +692,7 @@ header) and switching away restores write mode.
 | `a`                                        | attach to pod                                                                                                                         |
 | `:debug`                                   | pod: ephemeral debug container (`d` in the picker targets one) · node: privileged debug pod (previewed + confirmed)                   |
 | `:debug-clean`                             | delete the node debugger pods launched this session                                                                                   |
+| `:bundle` / `:bundle-save`                 | assemble a redacted diagnostic bundle for the selection · write the previewed bundle to a file                                        |
 | `i`                                        | set container image                                                                                                                   |
 | `r`                                        | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
 | `f` / `shift-f`                            | port-forward (pods/services) - runs in the background                                                                                 |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1200,6 +1200,7 @@ impl App {
         self.workspaces = resolved.config.workspaces;
         self.guardrails = resolved.config.guardrails;
         self.debug = resolved.config.debug;
+        self.bundle_cfg = resolved.config.bundle;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         warnings.extend(crate::config::workspace_warnings(&self.workspaces));

--- a/src/app/bundle.rs
+++ b/src/app/bundle.rs
@@ -1,0 +1,320 @@
+use super::*;
+
+use super::explain::{filter_events, list_selected};
+use crate::bundle::{Doc, redact_to_yaml};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+impl App {
+    /// `:bundle` — assemble a redacted incident bundle for the selected object
+    /// (its YAML, owner, conditions, events, explanation, timeline, bounded
+    /// logs, and a metrics snapshot), gathered off-thread and previewed before
+    /// it can be saved with `:bundle-save`.
+    pub(super) fn open_bundle(&mut self) {
+        if self.kind.is_none() {
+            self.flash_warn("select a resource first");
+            return;
+        }
+        if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") {
+            self.flash_warn("bundle is not available for Helm releases");
+            return;
+        }
+        let Some(obj) = self.selected_ref().cloned() else {
+            self.flash_warn("no selection for bundle");
+            return;
+        };
+
+        // In-memory pieces gathered on the main thread.
+        let rk = row_key(&obj);
+        let plural = self.kind_plural.clone();
+        let timeline: Vec<String> = self
+            .timeline
+            .entries(&plural, &rk)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .map(|e| format!("{}  {}", crate::timeline::clock(e.at), e.text))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        let metric_key = if ns.is_empty() {
+            name.clone()
+        } else {
+            format!("{ns}/{name}")
+        };
+        let metrics = self.metrics.get(&metric_key).copied();
+
+        let kind = self.kind.clone().unwrap();
+        let kind_name = kind.ar.kind.clone();
+        let context = self.cluster.context.clone();
+        let cluster = self.cluster.cluster_name.clone();
+        let anonymize = self.bundle_cfg.anonymize;
+        let log_lines = self.bundle_cfg.log_lines.max(0);
+        let max_pods = self.bundle_cfg.max_pods;
+
+        // Resolve the kinds the gather task needs up front (needs cluster state).
+        let pods_kind = self.cluster.resolve("pods").map(|k| (k.ar, k.namespaced));
+        let events_kind = self.cluster.resolve("events").map(|k| (k.ar, k.namespaced));
+        let owner_ref = obj
+            .metadata
+            .owner_references
+            .as_ref()
+            .and_then(|o| o.first())
+            .cloned();
+        let owner_kind = owner_ref
+            .as_ref()
+            .and_then(|o| self.cluster.resolve(&o.kind.to_lowercase()))
+            .map(|k| (k.ar, k.namespaced));
+
+        let selector = match plural.as_str() {
+            "deployments" | "statefulsets" | "daemonsets" | "replicasets" => {
+                label_selector(&obj, "matchLabels")
+            }
+            _ => None,
+        };
+
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        self.flash = format!("assembling bundle for {name}…");
+        self.flash_err = false;
+
+        tokio::spawn(async move {
+            let ts = k8s_openapi::jiff::Timestamp::now();
+
+            // ---- gather -----------------------------------------------------
+            let pods: Vec<DynamicObject> = if plural == "pods" {
+                vec![obj.clone()]
+            } else if let (Some((ar, nsd)), Some(sel)) = (&pods_kind, &selector) {
+                list_selected(&client, ar, *nsd, &ns, sel).await
+            } else {
+                Vec::new()
+            };
+
+            let (events, events_v1) = match &events_kind {
+                Some((ar, nsd)) => {
+                    let v1 = ar.group == "events.k8s.io";
+                    let all = list_kind(&client, ar, *nsd, &ns).await;
+                    (filter_events(&all, &obj, &pods, v1), v1)
+                }
+                None => (Vec::new(), false),
+            };
+
+            let evidence = crate::explain::Evidence {
+                kind: &kind_name,
+                plural: &plural,
+                obj: &obj,
+                pods: &pods,
+                events: &events,
+                events_v1,
+            };
+            let findings = crate::explain::explain(&evidence);
+
+            let owner = match (&owner_ref, &owner_kind) {
+                (Some(oref), Some((ar, nsd))) => {
+                    let api: Api<DynamicObject> = if *nsd && !ns.is_empty() {
+                        Api::namespaced_with(client.clone(), &ns, ar)
+                    } else {
+                        Api::all_with(client.clone(), ar)
+                    };
+                    api.get(&oref.name).await.ok().map(|mut o| {
+                        o.types = Some(TypeMeta {
+                            api_version: ar.api_version.clone(),
+                            kind: oref.kind.clone(),
+                        });
+                        (oref.kind.clone(), o)
+                    })
+                }
+                _ => None,
+            };
+
+            // Bounded logs for the first container of up to `max_pods` pods.
+            let mut log_blocks: Vec<(String, Vec<String>)> = Vec::new();
+            if log_lines > 0 {
+                for pod in pods.iter().take(max_pods) {
+                    let pname = pod.metadata.name.clone().unwrap_or_default();
+                    let pns = pod.metadata.namespace.clone().unwrap_or(ns.clone());
+                    let container = first_container(pod);
+                    let api: Api<k8s_openapi::api::core::v1::Pod> =
+                        Api::namespaced(client.clone(), &pns);
+                    let lp = LogParams {
+                        container,
+                        tail_lines: Some(log_lines),
+                        timestamps: true,
+                        ..Default::default()
+                    };
+                    let lines = match api.logs(&pname, &lp).await {
+                        Ok(text) => text.lines().map(String::from).collect(),
+                        Err(e) => vec![format!("(logs unavailable: {e})")],
+                    };
+                    log_blocks.push((pname, lines));
+                }
+            }
+
+            // ---- render -----------------------------------------------------
+            let title = format!("Diagnostic bundle — {kind_name}/{name}");
+            let (ctx_shown, cluster_shown) = if anonymize {
+                ("«anonymized»".to_string(), "«anonymized»".to_string())
+            } else {
+                (context, cluster)
+            };
+            let mut doc = Doc::new(&title);
+            doc.field("sofka", &format!("v{VERSION}"));
+            doc.field("collected", &ts.to_string());
+            doc.field("context", &ctx_shown);
+            doc.field("cluster", &cluster_shown);
+            doc.field(
+                "namespace",
+                if ns.is_empty() {
+                    "(cluster-scoped)"
+                } else {
+                    &ns
+                },
+            );
+            doc.field("resource", &format!("{kind_name}/{name}"));
+
+            // Redact the primary object and (if any) its owner, collecting notes.
+            let mut typed = obj.clone();
+            typed.types = Some(TypeMeta {
+                api_version: kind.ar.api_version.clone(),
+                kind: kind_name.clone(),
+            });
+            let (obj_yaml, mut redactions) = redact_to_yaml(&typed, &kind_name);
+            let owner_rendered = owner.as_ref().map(|(ok, oobj)| {
+                let (y, notes) = redact_to_yaml(oobj, ok);
+                redactions.extend(notes.into_iter().map(|n| format!("owner: {n}")));
+                (
+                    ok.clone(),
+                    oobj.metadata.name.clone().unwrap_or_default(),
+                    y,
+                )
+            });
+
+            // Manifest: what's included, then what was redacted.
+            let mut manifest = vec![
+                format!("resource YAML ({kind_name}/{name})"),
+                match &owner_rendered {
+                    Some((ok, oname, _)) => format!("owner ({ok}/{oname})"),
+                    None => "owner: none".into(),
+                },
+                format!("{} related pod(s)", pods.len()),
+                format!("{} event(s)", events.len()),
+                format!("{} explanation finding(s)", findings.len()),
+                format!("{} timeline entry(ies)", timeline.len()),
+                format!(
+                    "logs from {} pod(s) (≤{log_lines} lines each)",
+                    log_blocks.len()
+                ),
+                match metrics {
+                    Some(_) => "metrics snapshot".into(),
+                    None => "metrics: none".into(),
+                },
+            ];
+            if anonymize {
+                manifest.push("context/cluster anonymized".into());
+            }
+
+            doc.heading("Manifest — included");
+            doc.bullets(&manifest);
+            doc.heading("Manifest — redacted");
+            doc.bullets(&if redactions.is_empty() {
+                vec!["nothing sensitive found to redact".into()]
+            } else {
+                redactions
+            });
+
+            doc.heading("Explanation");
+            doc.code("text", &render_findings(&findings));
+
+            if let Some((_, _, y)) = &owner_rendered {
+                doc.heading("Owner");
+                doc.code("yaml", y);
+            }
+
+            doc.heading("Resource");
+            doc.code("yaml", &obj_yaml);
+
+            doc.heading("Events");
+            doc.code("text", &format_event_lines(&events, events_v1));
+
+            doc.heading("Timeline (session-local)");
+            doc.code("text", &timeline);
+
+            doc.heading("Metrics");
+            doc.code(
+                "text",
+                &match metrics {
+                    Some((cpu, mem)) => {
+                        vec![format!("cpu: {cpu}m"), format!("memory: {mem} bytes")]
+                    }
+                    None => Vec::new(),
+                },
+            );
+
+            for (pod, lines) in &log_blocks {
+                doc.heading(&format!("Logs — {pod}"));
+                doc.code("text", lines);
+            }
+
+            let text = doc.finish();
+            let safe: String = format!("{kind_name}-{name}")
+                .chars()
+                .map(|c| if c.is_alphanumeric() { c } else { '-' })
+                .collect();
+            let filename = format!("sofka-bundle-{}-{}.md", safe, ts.as_second());
+
+            let _ = tx
+                .send(Msg::Bundle {
+                    generation: genr,
+                    title,
+                    text,
+                    filename,
+                })
+                .await;
+        });
+    }
+
+    /// `:bundle-save` — write the previewed bundle to a temp file.
+    pub(super) fn save_bundle(&mut self) {
+        let Some((filename, text)) = self.pending_bundle.clone() else {
+            self.flash_warn("no bundle to save — run :bundle first");
+            return;
+        };
+        let path = std::env::temp_dir().join(filename);
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let result = tokio::fs::write(&path, text)
+                .await
+                .map(|_| path)
+                .map_err(|e| e.to_string());
+            let _ = tx
+                .send(Msg::BundleSaved {
+                    generation: genr,
+                    result,
+                })
+                .await;
+        });
+    }
+}
+
+/// Render explanation findings as indented plain-text lines for the bundle.
+fn render_findings(findings: &[crate::explain::Finding]) -> Vec<String> {
+    if findings.is_empty() {
+        return vec!["(healthy — nothing to explain)".into()];
+    }
+    findings
+        .iter()
+        .map(|f| format!("{}{}", "  ".repeat(f.indent as usize), f.text))
+        .collect()
+}
+
+/// The name of a pod's first (non-init) container, for a default log target.
+fn first_container(pod: &DynamicObject) -> Option<String> {
+    pod.data
+        .pointer("/spec/containers/0/name")
+        .and_then(Value::as_str)
+        .map(String::from)
+}

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -197,7 +197,7 @@ impl App {
 }
 
 /// List one kind, narrowed to a label selector (a workload's pods).
-async fn list_selected(
+pub(super) async fn list_selected(
     client: &Client,
     ar: &ApiResource,
     namespaced: bool,
@@ -217,7 +217,7 @@ async fn list_selected(
 
 /// Keep only events that regard the object or one of its pods, matching by UID
 /// (falling back to name when an event carries no UID).
-fn filter_events(
+pub(super) fn filter_events(
     all: &[DynamicObject],
     obj: &DynamicObject,
     pods: &[DynamicObject],

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -519,6 +519,8 @@ impl App {
             PaletteAction::Journal => self.open_journal(),
             PaletteAction::Debug => self.request_debug(None),
             PaletteAction::DebugClean => self.request_debug_cleanup(),
+            PaletteAction::Bundle => self.open_bundle(),
+            PaletteAction::BundleSave => self.save_bundle(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -686,6 +686,32 @@ impl App {
                     ));
                 }
             }
+            Msg::Bundle {
+                generation,
+                title,
+                text,
+                filename,
+            } if generation == self.generation => {
+                self.detail = Scrollable {
+                    title: format!("{title} (:bundle-save to write)"),
+                    lines: text.lines().map(String::from).collect(),
+                    ..Default::default()
+                };
+                self.pending_bundle = Some((filename, text));
+                self.set_return_mode();
+                self.mode = Mode::Detail;
+                self.flash = "bundle ready — review, then :bundle-save".into();
+                self.flash_err = false;
+            }
+            Msg::BundleSaved { generation, result } if generation == self.generation => {
+                match result {
+                    Ok(path) => {
+                        self.flash = format!("saved bundle → {}", path.display());
+                        self.flash_err = false;
+                    }
+                    Err(e) => self.flash_warn(&format!("bundle save failed: {e}")),
+                }
+            }
             Msg::Detail {
                 generation,
                 title,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -366,6 +366,8 @@ enum PaletteAction {
     Journal,
     Debug,
     DebugClean,
+    Bundle,
+    BundleSave,
     Diff,
     Events,
     PortForwards,
@@ -420,6 +422,14 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::DebugClean,
         names: &["debug-clean", "debug-cleanup", "dbgclean"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Bundle,
+        names: &["bundle", "diag", "incident"],
+    },
+    PaletteCommand {
+        action: PaletteAction::BundleSave,
+        names: &["bundle-save", "bundle-write"],
     },
     PaletteCommand {
         action: PaletteAction::Diff,
@@ -765,6 +775,12 @@ pub struct App {
     /// Node debugger pods launched this session, as `(namespace, node)`, so
     /// `:debug-clean` can find and delete them. Cleared on context switch.
     pub launched_node_debuggers: Vec<(String, String)>,
+    /// Diagnostic-bundle (`:bundle`) options, re-applied on context switch and
+    /// `:reload`.
+    pub bundle_cfg: crate::config::BundleConfig,
+    /// The last bundle assembled by `:bundle`, previewed in the detail view and
+    /// written to disk by `:bundle-save`: `(filename, text)`.
+    pub pending_bundle: Option<(String, String)>,
     /// Session-local log of mutating actions taken (`:journal`).
     pub journal: crate::journal::Journal,
     /// A workspace waiting for an in-flight context switch before it opens.
@@ -950,6 +966,8 @@ impl App {
             guardrails: Vec::new(),
             debug: crate::config::DebugConfig::default(),
             launched_node_debuggers: Vec::new(),
+            bundle_cfg: crate::config::BundleConfig::default(),
+            pending_bundle: None,
             journal: crate::journal::Journal::default(),
             rbac_allowed: None,
             last_rbac_ns: None,
@@ -1040,6 +1058,7 @@ impl App {
 mod actions;
 mod authz;
 mod bookmarks;
+mod bundle;
 mod dashboards;
 mod details;
 mod explain;

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -337,6 +337,7 @@ impl App {
         self.workspaces = resolved.config.workspaces;
         self.guardrails = resolved.config.guardrails;
         self.debug = resolved.config.debug;
+        self.bundle_cfg = resolved.config.bundle;
         // Tracked debuggers belong to the previous cluster/context.
         self.launched_node_debuggers.clear();
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1537,6 +1537,47 @@ async fn shellouts_pin_to_active_context() {
 }
 
 #[tokio::test]
+async fn bundle_save_without_a_pending_bundle_warns() {
+    let (mut app, _rx) = app_with_pod();
+    app.save_bundle();
+    assert!(app.flash.contains("no bundle to save"), "{}", app.flash);
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn bundle_needs_a_selection() {
+    let (mut app, _rx) = test_app();
+    // No kind/selection yet — bundle refuses rather than assembling nothing.
+    app.open_bundle();
+    assert_ne!(app.mode, Mode::Detail);
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn bundle_redaction_strips_secret_values_from_yaml() {
+    // A real DynamicObject through the app's own YAML path must not leak the
+    // Secret's data once redacted.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("secrets");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Secret",
+               "metadata": {"name": "creds", "namespace": "default"},
+               "data": {"password": "aHVudGVyMg=="}}),
+    );
+    app.table_state.select(Some(0));
+    let obj = app.selected_ref().unwrap().clone();
+    let (yaml, notes) = crate::bundle::redact_to_yaml(&obj, "Secret");
+    let joined = yaml.join("\n");
+    assert!(
+        !joined.contains("aHVudGVyMg=="),
+        "secret value leaked: {joined}"
+    );
+    assert!(joined.contains(crate::bundle::REDACTED));
+    assert!(notes.iter().any(|n| n.contains("Secret data")));
+}
+
+#[tokio::test]
 async fn container_picker_shell_targets_selected_container() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,0 +1,270 @@
+//! Redacted incident-bundle assembly for `:bundle`.
+//!
+//! A diagnostic bundle gathers everything sofka knows about one object — its
+//! (redacted) YAML, its owner, conditions, recent events, the incident
+//! explanation, the session timeline, bounded logs, and a metrics snapshot —
+//! into one Markdown document for handoff between application and platform
+//! teams. The redaction here is the safety-critical part: Secret data and
+//! credential-looking annotations never reach the file, and the manifest spells
+//! out exactly what was included and what was withheld.
+
+use kube::core::DynamicObject;
+use serde_json::Value;
+
+/// Placeholder substituted for any redacted value.
+pub const REDACTED: &str = "«redacted»";
+
+/// Annotation-key substrings that mark a value as credential-like. Matched
+/// case-insensitively against the whole key.
+const CREDENTIAL_HINTS: &[&str] = &[
+    "token",
+    "password",
+    "passwd",
+    "secret",
+    "apikey",
+    "api-key",
+    "credential",
+    "private-key",
+    "privatekey",
+];
+
+/// Redact one object's JSON in place, returning human-readable notes of what
+/// was removed (for the bundle manifest). Deterministic and side-effect free.
+///
+/// Redacts: `managedFields` (noise), the `last-applied-configuration`
+/// annotation (can embed a whole Secret), any annotation whose key looks like a
+/// credential, and — for Secrets — every `data`/`stringData` value. Env vars
+/// sourced from Secrets are counted and flagged (their values are references,
+/// not literals, so nothing to strip).
+pub fn redact_object(kind: &str, v: &mut Value) -> Vec<String> {
+    let mut notes = Vec::new();
+
+    if let Some(md) = v.get_mut("metadata").and_then(Value::as_object_mut) {
+        md.remove("managedFields");
+        if let Some(ann) = md.get_mut("annotations").and_then(Value::as_object_mut) {
+            for (k, val) in ann.iter_mut() {
+                let kl = k.to_lowercase();
+                if k == "kubectl.kubernetes.io/last-applied-configuration" {
+                    *val = Value::String(REDACTED.into());
+                    notes.push("annotation last-applied-configuration".into());
+                } else if CREDENTIAL_HINTS.iter().any(|h| kl.contains(h)) {
+                    *val = Value::String(REDACTED.into());
+                    notes.push(format!("annotation {k}"));
+                }
+            }
+        }
+    }
+
+    if kind == "Secret" {
+        for field in ["data", "stringData"] {
+            if let Some(obj) = v.get_mut(field).and_then(Value::as_object_mut) {
+                let n = obj.len();
+                for val in obj.values_mut() {
+                    *val = Value::String(REDACTED.into());
+                }
+                if n > 0 {
+                    notes.push(format!("Secret {field}: {n} value(s)"));
+                }
+            }
+        }
+    }
+
+    let secret_env = count_secret_env(v);
+    if secret_env > 0 {
+        notes.push(format!(
+            "{secret_env} env var(s) sourced from Secrets (values not included)"
+        ));
+    }
+
+    notes
+}
+
+/// Count `env[*].valueFrom.secretKeyRef` across every container list in a pod
+/// (or pod-template) spec, at any nesting depth.
+fn count_secret_env(v: &Value) -> usize {
+    let mut n = 0;
+    walk(v, &mut n);
+    return n;
+
+    fn walk(v: &Value, n: &mut usize) {
+        match v {
+            Value::Object(map) => {
+                if map.get("env").is_some_and(Value::is_array) {
+                    for e in map["env"].as_array().unwrap() {
+                        if e.pointer("/valueFrom/secretKeyRef").is_some() {
+                            *n += 1;
+                        }
+                    }
+                }
+                for val in map.values() {
+                    walk(val, n);
+                }
+            }
+            Value::Array(arr) => {
+                for val in arr {
+                    walk(val, n);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Redact an object and render it as YAML lines, plus the redaction notes.
+/// `kind` seeds Secret detection when the object carries no `kind` of its own.
+pub fn redact_to_yaml(obj: &DynamicObject, kind: &str) -> (Vec<String>, Vec<String>) {
+    let mut v = serde_json::to_value(obj).unwrap_or(Value::Null);
+    let effective_kind = if kind.is_empty() {
+        v.get("kind")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string()
+    } else {
+        kind.to_string()
+    };
+    let notes = redact_object(&effective_kind, &mut v);
+    let yaml = serde_yaml::to_string(&v).unwrap_or_else(|e| format!("# error: {e}"));
+    (yaml.lines().map(String::from).collect(), notes)
+}
+
+/// A Markdown document builder for the bundle. Sections are appended in order;
+/// [`Self::finish`] returns the full text.
+#[derive(Default)]
+pub struct Doc {
+    out: String,
+}
+
+impl Doc {
+    pub fn new(title: &str) -> Self {
+        let mut d = Doc::default();
+        d.out.push_str(&format!("# {title}\n"));
+        d
+    }
+
+    /// A `key: value` metadata line (used for the header block).
+    pub fn field(&mut self, key: &str, value: &str) {
+        self.out.push_str(&format!("- **{key}:** {value}\n"));
+    }
+
+    /// A `## heading`.
+    pub fn heading(&mut self, h: &str) {
+        self.out.push_str(&format!("\n## {h}\n\n"));
+    }
+
+    /// A bullet list; renders a `_none_` placeholder when empty.
+    pub fn bullets(&mut self, items: &[String]) {
+        if items.is_empty() {
+            self.out.push_str("_none_\n");
+            return;
+        }
+        for i in items {
+            self.out.push_str(&format!("- {i}\n"));
+        }
+    }
+
+    /// A fenced code block; renders a `_none_` placeholder when empty.
+    pub fn code(&mut self, lang: &str, lines: &[String]) {
+        if lines.is_empty() {
+            self.out.push_str("_none_\n");
+            return;
+        }
+        self.out.push_str(&format!("```{lang}\n"));
+        for l in lines {
+            self.out.push_str(l);
+            self.out.push('\n');
+        }
+        self.out.push_str("```\n");
+    }
+
+    pub fn finish(self) -> String {
+        self.out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn redacts_secret_data_and_stringdata() {
+        let mut v = json!({
+            "kind": "Secret",
+            "metadata": {"name": "creds"},
+            "data": {"password": "aHVudGVyMg==", "user": "YWRtaW4="},
+            "stringData": {"token": "plain-text-token"}
+        });
+        let notes = redact_object("Secret", &mut v);
+        assert_eq!(v["data"]["password"], REDACTED);
+        assert_eq!(v["data"]["user"], REDACTED);
+        assert_eq!(v["stringData"]["token"], REDACTED);
+        // The literal secret values must be gone from the serialized form.
+        let dumped = v.to_string();
+        assert!(!dumped.contains("aHVudGVyMg=="), "{dumped}");
+        assert!(!dumped.contains("plain-text-token"), "{dumped}");
+        assert!(notes.iter().any(|n| n.contains("data: 2")));
+        assert!(notes.iter().any(|n| n.contains("stringData: 1")));
+    }
+
+    #[test]
+    fn redacts_credential_annotations_and_last_applied() {
+        let mut v = json!({
+            "kind": "ConfigMap",
+            "metadata": {"name": "cm", "annotations": {
+                "kubectl.kubernetes.io/last-applied-configuration": "{\"data\":{\"x\":\"y\"}}",
+                "example.com/api-token": "abc123",
+                "harmless": "keep-me"
+            }}
+        });
+        let notes = redact_object("ConfigMap", &mut v);
+        let ann = &v["metadata"]["annotations"];
+        assert_eq!(
+            ann["kubectl.kubernetes.io/last-applied-configuration"],
+            REDACTED
+        );
+        assert_eq!(ann["example.com/api-token"], REDACTED);
+        assert_eq!(ann["harmless"], "keep-me", "non-credential kept");
+        assert!(notes.iter().any(|n| n.contains("last-applied")));
+    }
+
+    #[test]
+    fn drops_managed_fields_and_counts_secret_env() {
+        let mut v = json!({
+            "kind": "Pod",
+            "metadata": {"name": "p", "managedFields": [{"manager": "kubelet"}]},
+            "spec": {"containers": [{"name": "c", "env": [
+                {"name": "PW", "valueFrom": {"secretKeyRef": {"name": "s", "key": "pw"}}},
+                {"name": "PLAIN", "value": "hi"}
+            ]}]}
+        });
+        let notes = redact_object("Pod", &mut v);
+        assert!(v["metadata"].get("managedFields").is_none());
+        assert!(notes.iter().any(|n| n.contains("1 env var")), "{notes:?}");
+    }
+
+    #[test]
+    fn non_secret_data_is_not_touched() {
+        let mut v = json!({
+            "kind": "ConfigMap",
+            "metadata": {"name": "cm"},
+            "data": {"key": "value"}
+        });
+        redact_object("ConfigMap", &mut v);
+        assert_eq!(v["data"]["key"], "value", "ConfigMap data is plain config");
+    }
+
+    #[test]
+    fn doc_renders_sections_and_placeholders() {
+        let mut d = Doc::new("incident");
+        d.field("resource", "pods/api");
+        d.heading("Events");
+        d.bullets(&[]);
+        d.heading("YAML");
+        d.code("yaml", &["kind: Pod".into()]);
+        let out = d.finish();
+        assert!(out.starts_with("# incident\n"));
+        assert!(out.contains("**resource:** pods/api"));
+        assert!(out.contains("## Events\n\n_none_"));
+        assert!(out.contains("```yaml\nkind: Pod\n```"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,38 @@ pub struct Config {
     /// Defaults for the ephemeral-debug-container workflow (`:debug`) — see
     /// [`DebugConfig`].
     pub debug: DebugConfig,
+    /// Diagnostic-bundle (`:bundle`) options — see [`BundleConfig`].
+    pub bundle: BundleConfig,
+}
+
+/// Options for the `:bundle` diagnostic-bundle export.
+///
+/// ```toml
+/// [bundle]
+/// anonymize = true    # replace context/cluster identity with placeholders
+/// log_lines = 200     # max recent log lines per pod
+/// max_pods = 3        # cap how many pods contribute logs
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct BundleConfig {
+    /// Replace the context and cluster identity with placeholders (for sharing
+    /// a bundle without leaking which cluster it came from).
+    pub anonymize: bool,
+    /// Maximum recent log lines fetched per pod.
+    pub log_lines: i64,
+    /// Cap on how many pods contribute logs to a workload's bundle.
+    pub max_pods: usize,
+}
+
+impl Default for BundleConfig {
+    fn default() -> Self {
+        Self {
+            anonymize: false,
+            log_lines: 200,
+            max_pods: 3,
+        }
+    }
 }
 
 /// Defaults for `:debug`, which attaches an ephemeral debug container to the

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 //! A from-scratch reimagining of k9s built on kube-rs + ratatui, async-first.
 
 mod app;
+mod bundle;
 mod columns;
 mod config;
 mod explain;
@@ -159,6 +160,7 @@ async fn main() -> Result<()> {
     app.workspaces = cfg.workspaces.clone();
     app.guardrails = cfg.guardrails.clone();
     app.debug = cfg.debug.clone();
+    app.bundle_cfg = cfg.bundle.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))

--- a/src/store.rs
+++ b/src/store.rs
@@ -147,6 +147,19 @@ pub enum Msg {
         deleted: usize,
         failed: Vec<String>,
     },
+    /// An assembled diagnostic bundle (`:bundle`), ready to preview and save.
+    Bundle {
+        generation: u64,
+        title: String,
+        text: String,
+        /// Suggested filename for `:bundle-save`.
+        filename: String,
+    },
+    /// Result of writing a bundle to disk (`:bundle-save`).
+    BundleSaved {
+        generation: u64,
+        result: Result<std::path::PathBuf, String>,
+    },
     Error {
         generation: u64,
         error: String,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1595,6 +1595,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             ":debug-clean",
             "delete the node debugger pods launched this session",
         ),
+        bind(
+            ":bundle · :bundle-save",
+            "assemble a redacted diagnostic bundle for the selection · write it to a file",
+        ),
         bind("i", "set container image"),
         bind(
             "r",


### PR DESCRIPTION
## Summary
Third item of **Milestone 5**: export a bounded, redacted incident bundle for handoff between application and platform teams.

`:bundle` assembles a single Markdown document for the selected object, gathered off-thread and shown in a preview; `:bundle-save` then writes it to a temp file. It contains:

- **Header** — sofka version, collection timestamp, context/cluster (optionally anonymized), namespace, resource.
- **Manifest** — exactly what was included, and what was redacted.
- **Explanation** — the same incident analysis as `:explain`.
- **Resource + Owner YAML** — redacted.
- **Events**, **session timeline**, **metrics snapshot**, and **bounded recent logs** (per pod).

## Safety (the tested core)
Redaction is unconditional and lives in a pure, unit-tested `bundle` module:
- Secret `data`/`stringData` values → placeholder.
- Any credential-looking annotation (key contains `token`/`password`/`secret`/`apikey`/`credential`/…) and `kubectl.kubernetes.io/last-applied-configuration` → placeholder.
- `managedFields` dropped; Secret-sourced env vars flagged (values are references, not literals).
- Every bundle carries a manifest of what was withheld — conservative over-redaction is the intended failure mode.

## Config
```toml
[bundle]
anonymize = false   # replace context/cluster identity with placeholders
log_lines = 200     # max recent log lines per pod
max_pods = 3        # cap how many pods contribute logs
```

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 329 pass (pure redaction tests: Secret data, credential annotations, last-applied, managedFields, secret-env counting, doc rendering; app-level: no-pending-save warn, needs-selection guard, and Secret redaction through the real YAML path)
- [x] Live-verified against the home cluster:
  - Pod bundle: all sections present (614 lines), `managedFields` absent, real bounded logs included, secret-sourced env flagged in the manifest.
  - **Secret bundle: `data.HOMEASSISTANT_TOKEN` → `«redacted»`; the real base64 value from the cluster is confirmed absent from the file.** Manifest disclosed the redactions.
  - Preview → `:bundle-save` wrote the `.md` file and flashed its path.