### PR TITLE
feat: screen dumps and structured snapshots (:snapshot / :snapshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ Not a marketing number - these are specific, checkable design choices:
   annotations, and `last-applied-configuration` are stripped unconditionally,
   and a manifest spells out what was included and what was withheld. You review
   the bundle in a preview, then `:bundle-save` writes it to a file.
+- **Snapshots** (`:snapshot`) - capture the current table view (its columns and
+  visible rows, with metadata) to a file as an aligned text table, JSON, or
+  YAML. `:snapshots` browses saved captures (newest first, with age), opens one
+  into a viewer marked stale, and deletes with `d`. Distinct from the one-frame
+  `--snapshot` CI mode — this is an interactive capture-and-review workflow.
 - **RBAC-aware palette** - hides resource kinds you can't `list`.
 - **Namespace switcher** (`n`) with pinned **favourites** (`favorite_namespaces`,
   ★) and per-context session **recents** (·) above the rest, and **context
@@ -563,6 +568,20 @@ log_lines = 200     # max recent log lines per pod
 max_pods = 3        # cap how many pods contribute logs
 ```
 
+### Snapshots
+
+`:snapshot` captures the current table view — its columns and visible rows,
+plus metadata (context, cluster, namespace, resource, filter, timestamp) — to
+a file. An optional argument picks the format: `text` (default; an aligned
+table with a header block), `json`, or `yaml`. Files are written to
+`$XDG_STATE_HOME/sofka/snapshots` (falling back to
+`~/.local/state/sofka/snapshots`).
+
+`:snapshots` browses saved captures, newest first with their age. `⏎` opens one
+into a viewer with a staleness banner (it's a point-in-time capture), and `d`
+deletes the highlighted file. This is distinct from the one-frame `--snapshot`
+CI flag — it's an interactive capture-and-review workflow.
+
 ### Log provider (VictoriaLogs)
 
 `L` (or `:vlogs`) opens log history for the selection from a VictoriaLogs
@@ -662,46 +681,47 @@ header) and switching away restores write mode.
 
 ### Keys
 
-| Key                                        | Action                                                                                                                                |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `:<resource>`                              | command palette - fuzzy over kinds and built-in commands                                                                              |
-| `:<resource> <ns>`                         | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                         |
-| `[` / `]`                                  | view history - back / forward through visited kind+namespace views                                                                    |
-| `Tab` / `shift-Tab`                        | cycle views of the active workspace (when one is open)                                                                                |
-| `enter`                                    | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources)                               |
-| `esc`                                      | go back / pop the view stack / clear filter / clear marks                                                                             |
-| `j`/`k`, `↓`/`↑`, `g`/`G`                  | navigate                                                                                                                              |
-| `S` / `I`                                  | cycle sort column / invert sort direction                                                                                             |
-| `space`                                    | mark/unmark row for bulk actions                                                                                                      |
-| `/`                                        | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |
-| `n` / `0`                                  | namespace switcher / all namespaces                                                                                                   |
-| `shift-j`                                  | jump to owner/controller                                                                                                              |
-| `o`                                        | show the node hosting the selected pod                                                                                                |
-| `ctrl-r`                                   | refresh the watch                                                                                                                     |
-| `y` / `d` / `E`                            | view YAML / describe (`kubectl`) / live events                                                                                        |
-| `X` / `T`                                  | explain why the selection is unhealthy / session-local state-change timeline                                                          |
-| `:gitops` / `:flux`                        | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                  |
-| `:can-i` / `:can-i <verb> <resource> [ns]` | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
-| `:journal` / `:audit`                      | session-local log of the mutating actions you've taken                                                                                |
-| `:ctx` / `:ctx <name>`                     | context switcher popup / switch directly (the name tab-completes)                                                                     |
-| `:skin`                                    | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
-| `l` / `p`                                  | logs (workload = all matching pods) / previous-container logs                                                                         |
-| `c`                                        | copy resource name to clipboard                                                                                                       |
-| `e`                                        | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |
-| `s`                                        | shell into pod / scale a workload (context-dependent)                                                                                 |
-| `a`                                        | attach to pod                                                                                                                         |
-| `:debug`                                   | pod: ephemeral debug container (`d` in the picker targets one) · node: privileged debug pod (previewed + confirmed)                   |
-| `:debug-clean`                             | delete the node debugger pods launched this session                                                                                   |
-| `:bundle` / `:bundle-save`                 | assemble a redacted diagnostic bundle for the selection · write the previewed bundle to a file                                        |
-| `i`                                        | set container image                                                                                                                   |
-| `r`                                        | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
-| `f` / `shift-f`                            | port-forward (pods/services) - runs in the background                                                                                 |
-| `t`                                        | Flux: suspend/resume/reconcile menu                                                                                                   |
-| `C` / `U` / `D`                            | nodes: cordon / uncordon / drain                                                                                                      |
-| `ctrl-d` / `ctrl-k`                        | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
-| `:q`, `ctrl-c`                             | quit                                                                                                                                  |
-| `?`                                        | help                                                                                                                                  |
-| _(config)_                                 | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                           |
+| Key                                           | Action                                                                                                                                |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `:<resource>`                                 | command palette - fuzzy over kinds and built-in commands                                                                              |
+| `:<resource> <ns>`                            | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                         |
+| `[` / `]`                                     | view history - back / forward through visited kind+namespace views                                                                    |
+| `Tab` / `shift-Tab`                           | cycle views of the active workspace (when one is open)                                                                                |
+| `enter`                                       | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources)                               |
+| `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                             |
+| `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                              |
+| `S` / `I`                                     | cycle sort column / invert sort direction                                                                                             |
+| `space`                                       | mark/unmark row for bulk actions                                                                                                      |
+| `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |
+| `n` / `0`                                     | namespace switcher / all namespaces                                                                                                   |
+| `shift-j`                                     | jump to owner/controller                                                                                                              |
+| `o`                                           | show the node hosting the selected pod                                                                                                |
+| `ctrl-r`                                      | refresh the watch                                                                                                                     |
+| `y` / `d` / `E`                               | view YAML / describe (`kubectl`) / live events                                                                                        |
+| `X` / `T`                                     | explain why the selection is unhealthy / session-local state-change timeline                                                          |
+| `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                  |
+| `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
+| `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
+| `:ctx` / `:ctx <name>`                        | context switcher popup / switch directly (the name tab-completes)                                                                     |
+| `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
+| `l` / `p`                                     | logs (workload = all matching pods) / previous-container logs                                                                         |
+| `c`                                           | copy resource name to clipboard                                                                                                       |
+| `e`                                           | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |
+| `s`                                           | shell into pod / scale a workload (context-dependent)                                                                                 |
+| `a`                                           | attach to pod                                                                                                                         |
+| `:debug`                                      | pod: ephemeral debug container (`d` in the picker targets one) · node: privileged debug pod (previewed + confirmed)                   |
+| `:debug-clean`                                | delete the node debugger pods launched this session                                                                                   |
+| `:bundle` / `:bundle-save`                    | assemble a redacted diagnostic bundle for the selection · write the previewed bundle to a file                                        |
+| `:snapshot [text\|json\|yaml]` / `:snapshots` | capture the current view to a file · browse, open, and delete saved snapshots                                                         |
+| `i`                                           | set container image                                                                                                                   |
+| `r`                                           | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
+| `f` / `shift-f`                               | port-forward (pods/services) - runs in the background                                                                                 |
+| `t`                                           | Flux: suspend/resume/reconcile menu                                                                                                   |
+| `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                      |
+| `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
+| `:q`, `ctrl-c`                                | quit                                                                                                                                  |
+| `?`                                           | help                                                                                                                                  |
+| _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                           |
 
 **Logs view:** `/` search+highlight · `s` autoscroll · `w` wrap · `t`
 timestamps · `x` stop/resume stream · `c` copy buffer · `ctrl-s` save to file

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -64,6 +64,7 @@ impl App {
             Mode::FluxMenu => self.key_flux_menu(key),
             Mode::PortForwards => self.key_port_forwards(key),
             Mode::Skins => self.key_skins(key),
+            Mode::Snapshots => self.key_snapshots(key),
         }
         Ok(())
     }
@@ -521,6 +522,8 @@ impl App {
             PaletteAction::DebugClean => self.request_debug_cleanup(),
             PaletteAction::Bundle => self.open_bundle(),
             PaletteAction::BundleSave => self.save_bundle(),
+            PaletteAction::Snapshot => self.take_snapshot(""),
+            PaletteAction::Snapshots => self.open_snapshots(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),
@@ -549,6 +552,19 @@ impl App {
             } else {
                 self.apply_skin(&rest);
             }
+            return true;
+        }
+        // `:snapshot [format]` captures the current view; the optional arg is
+        // the output format (text/json/yaml).
+        let mut parts = cmd.split_whitespace();
+        if let Some(first) = parts.next()
+            && matches!(
+                first.to_ascii_lowercase().as_str(),
+                "snapshot" | "snap" | "dump"
+            )
+        {
+            let rest = parts.collect::<Vec<_>>().join(" ");
+            self.take_snapshot(&rest);
             return true;
         }
         // `:can-i <verb> <resource> [ns]` checks one action; bare `:can-i`

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -712,6 +712,15 @@ impl App {
                     Err(e) => self.flash_warn(&format!("bundle save failed: {e}")),
                 }
             }
+            Msg::SnapshotSaved { generation, result } if generation == self.generation => {
+                match result {
+                    Ok(path) => {
+                        self.flash = format!("saved snapshot → {}", path.display());
+                        self.flash_err = false;
+                    }
+                    Err(e) => self.flash_warn(&format!("snapshot save failed: {e}")),
+                }
+            }
             Msg::Detail {
                 generation,
                 title,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -111,6 +111,8 @@ pub enum Mode {
     FluxMenu,
     PortForwards,
     Skins,
+    /// Browsing saved snapshots (`:snapshots`).
+    Snapshots,
 }
 
 /// A request for the run loop to suspend the TUI and run an interactive
@@ -368,6 +370,8 @@ enum PaletteAction {
     DebugClean,
     Bundle,
     BundleSave,
+    Snapshot,
+    Snapshots,
     Diff,
     Events,
     PortForwards,
@@ -430,6 +434,14 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::BundleSave,
         names: &["bundle-save", "bundle-write"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Snapshot,
+        names: &["snapshot", "snap", "dump"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Snapshots,
+        names: &["snapshots", "dumps"],
     },
     PaletteCommand {
         action: PaletteAction::Diff,
@@ -810,6 +822,10 @@ pub struct App {
 
     pub skin_list: Vec<String>,
     pub skin_state: ListState,
+    /// Saved snapshots for the `:snapshots` browser: `(path, display label)`,
+    /// newest first. Rebuilt each time the browser opens.
+    pub snapshot_list: Vec<(std::path::PathBuf, String)>,
+    pub snapshot_state: ListState,
     /// Per-swatch color overrides from config, re-applied when switching skins.
     pub skin_colors: HashMap<String, String>,
     /// Config loader kept for the session so `:ctx` switches can re-resolve
@@ -984,6 +1000,8 @@ impl App {
                 .map(|name| (*name).to_string())
                 .collect(),
             skin_state: ListState::default(),
+            snapshot_list: Vec::new(),
+            snapshot_state: ListState::default(),
             skin_colors: HashMap::new(),
             config: crate::config::ConfigLoader::default(),
             session_skin: None,
@@ -1073,6 +1091,7 @@ mod navigation;
 mod overlays;
 mod pickers;
 mod rows;
+mod snapshot;
 mod timeline;
 mod workspaces;
 

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -1,0 +1,235 @@
+use super::*;
+
+use crate::snapshot::{Format, Snapshot, age, clock, snapshots_dir};
+
+impl App {
+    /// `:snapshot [format]` — capture the current table view (columns + visible
+    /// rows) and write it to the snapshots directory. `format` is `text`
+    /// (default), `json`, or `yaml`.
+    pub(super) fn take_snapshot(&mut self, arg: &str) {
+        let Some(format) = Format::parse(arg) else {
+            self.flash_warn(&format!("unknown snapshot format '{arg}' (text/json/yaml)"));
+            return;
+        };
+        if self.kind.is_none() {
+            self.flash_warn("select a resource first");
+            return;
+        }
+        let (columns, rows) = self.snapshot_table();
+        let snap = Snapshot {
+            captured_at: k8s_openapi::jiff::Timestamp::now().as_second(),
+            context: self.cluster.context.clone(),
+            cluster: self.cluster.cluster_name.clone(),
+            namespace: self.namespace.clone(),
+            resource: self.kind_plural.clone(),
+            filter: self.filter.clone(),
+            columns,
+            rows,
+        };
+        let text = snap.render(format);
+        let path = snapshots_dir().join(snap.filename(format));
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        self.flash = format!("saving snapshot ({} rows)…", snap.rows.len());
+        self.flash_err = false;
+        tokio::spawn(async move {
+            let result = write_snapshot(&path, &text).await;
+            let _ = tx
+                .send(Msg::SnapshotSaved {
+                    generation: genr,
+                    result,
+                })
+                .await;
+        });
+    }
+
+    /// The current table as plain (unstyled) columns + rows — the same layout
+    /// the table renders (NAMESPACE prepended across namespaces, CPU/MEM
+    /// appended for pods/nodes, volatile cells resolved), minus the coloring.
+    pub(super) fn snapshot_table(&self) -> (Vec<String>, Vec<Vec<String>>) {
+        let headers = self.display_headers();
+        let show_ns = self.show_namespace_column();
+        let metrics_cols = self.metrics_columns();
+        let pods_view = self.kind_plural == "pods";
+
+        let objs = self.rows();
+        self.ensure_table_cell_cache(&objs);
+        let cache = self.table_cell_cache();
+        let spec = self.view_spec();
+
+        let rows = objs
+            .iter()
+            .map(|obj| {
+                let rk = row_key(obj);
+                let mut cells: Vec<String> = Vec::with_capacity(headers.len());
+                if show_ns {
+                    cells.push(obj.metadata.namespace.clone().unwrap_or_default());
+                }
+                if let Some((base_cells, _)) = cache.get(&rk) {
+                    for (i, cell) in base_cells.iter().enumerate() {
+                        match spec.volatile(obj, &self.kind_plural, i) {
+                            Some(v) => cells.push(v),
+                            None => cells.push(cell.clone()),
+                        }
+                    }
+                }
+                if metrics_cols {
+                    let name = obj.metadata.name.as_deref().unwrap_or_default();
+                    let key = if pods_view {
+                        format!(
+                            "{}/{}",
+                            obj.metadata.namespace.as_deref().unwrap_or_default(),
+                            name
+                        )
+                    } else {
+                        name.to_string()
+                    };
+                    let (cpu, mem) = self.metrics.get(&key).copied().unwrap_or((0, 0));
+                    cells.push(crate::columns::fmt_cpu(cpu));
+                    cells.push(crate::columns::fmt_mem(mem));
+                }
+                cells
+            })
+            .collect();
+        (headers, rows)
+    }
+
+    /// `:snapshots` — open the saved-snapshot browser.
+    pub(super) fn open_snapshots(&mut self) {
+        self.reload_snapshot_list();
+        if self.snapshot_list.is_empty() {
+            self.flash_warn("no snapshots yet — capture one with :snapshot");
+            return;
+        }
+        self.snapshot_state.select(Some(0));
+        self.mode = Mode::Snapshots;
+    }
+
+    /// Rebuild [`Self::snapshot_list`] from the snapshots directory, newest
+    /// first, labelling each with its age and size.
+    fn reload_snapshot_list(&mut self) {
+        let now = k8s_openapi::jiff::Timestamp::now().as_second();
+        let mut entries: Vec<(std::path::PathBuf, i64, String)> = Vec::new();
+        if let Ok(dir) = std::fs::read_dir(snapshots_dir()) {
+            for entry in dir.flatten() {
+                let path = entry.path();
+                if !path.is_file() {
+                    continue;
+                }
+                let modified = entry
+                    .metadata()
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                entries.push((path, modified, name));
+            }
+        }
+        entries.sort_by_key(|e| std::cmp::Reverse(e.1));
+        self.snapshot_list = entries
+            .into_iter()
+            .map(|(path, modified, name)| {
+                let label = format!("{name}   ({})", age(modified, now));
+                (path, label)
+            })
+            .collect();
+    }
+
+    pub(super) fn key_snapshots(&mut self, key: KeyEvent) {
+        let len = self.snapshot_list.len();
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
+            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.snapshot_state, len, true),
+            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.snapshot_state, len, false),
+            KeyCode::Enter => self.open_selected_snapshot(),
+            KeyCode::Char('d') => self.delete_selected_snapshot(),
+            _ => {}
+        }
+    }
+
+    /// Load the highlighted snapshot into the detail view, marked stale.
+    fn open_selected_snapshot(&mut self) {
+        let Some(path) = self
+            .snapshot_state
+            .selected()
+            .and_then(|i| self.snapshot_list.get(i))
+            .map(|(p, _)| p.clone())
+        else {
+            return;
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(body) => {
+                let now = k8s_openapi::jiff::Timestamp::now().as_second();
+                let modified = std::fs::metadata(&path)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(now);
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                let mut lines = vec![
+                    format!(
+                        "⚠ snapshot captured {} ({}) — a point-in-time capture, likely stale",
+                        clock(modified),
+                        age(modified, now)
+                    ),
+                    String::new(),
+                ];
+                lines.extend(body.lines().map(String::from));
+                self.detail = Scrollable {
+                    title: name,
+                    lines: lines.into(),
+                    ..Default::default()
+                };
+                self.return_mode = Mode::Snapshots;
+                self.mode = Mode::Detail;
+            }
+            Err(e) => self.flash_warn(&format!("read snapshot failed: {e}")),
+        }
+    }
+
+    /// `d` in the browser — delete the highlighted snapshot file.
+    fn delete_selected_snapshot(&mut self) {
+        let Some(i) = self.snapshot_state.selected() else {
+            return;
+        };
+        let Some((path, _)) = self.snapshot_list.get(i).cloned() else {
+            return;
+        };
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                self.flash = "snapshot deleted".into();
+                self.flash_err = false;
+                self.reload_snapshot_list();
+                if self.snapshot_list.is_empty() {
+                    self.mode = Mode::Table;
+                } else {
+                    let n = self.snapshot_list.len();
+                    self.snapshot_state.select(Some(i.min(n - 1)));
+                }
+            }
+            Err(e) => self.flash_warn(&format!("delete failed: {e}")),
+        }
+    }
+}
+
+/// Create the snapshots directory (if needed) and write `text` to `path`.
+async fn write_snapshot(path: &std::path::Path, text: &str) -> Result<std::path::PathBuf, String> {
+    if let Some(dir) = path.parent() {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+    tokio::fs::write(path, text)
+        .await
+        .map(|_| path.to_path_buf())
+        .map_err(|e| e.to_string())
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1537,6 +1537,38 @@ async fn shellouts_pin_to_active_context() {
 }
 
 #[tokio::test]
+async fn snapshot_rejects_unknown_format() {
+    let (mut app, _rx) = app_with_pod();
+    app.take_snapshot("xml");
+    assert!(
+        app.flash.contains("unknown snapshot format"),
+        "{}",
+        app.flash
+    );
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn snapshot_captures_current_columns_and_rows() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["api-1", "api-2"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+    app.table_state.select(Some(0));
+    let (columns, rows) = app.snapshot_table();
+    assert!(columns.iter().any(|c| c == "NAME"));
+    assert_eq!(rows.len(), 2);
+    // Every captured row carries a cell per column.
+    assert!(rows.iter().all(|r| r.len() == columns.len()));
+    assert!(rows.iter().any(|r| r.contains(&"api-1".to_string())));
+}
+
+#[tokio::test]
 async fn bundle_save_without_a_pending_bundle_warns() {
     let (mut app, _rx) = app_with_pod();
     app.save_bundle();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod journal;
 mod k8s;
 mod keys;
 mod providers;
+mod snapshot;
 mod store;
 mod theme;
 mod thresholds;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,264 @@
+//! Screen dumps and structured snapshots.
+//!
+//! A snapshot is a point-in-time capture of the current table view — its
+//! metadata (context, namespace, resource, filter) plus the visible columns
+//! and rows — saved to disk for later inspection and browsable from
+//! `:snapshots`. Unlike the one-frame `--snapshot` CI mode, this is an
+//! interactive capture-and-review workflow. Captures can be written as plain
+//! text (an aligned table), JSON, or YAML.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// Output format for a snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// Aligned plain-text table (a text screen dump).
+    Text,
+    Json,
+    Yaml,
+}
+
+impl Format {
+    /// Parse a format name (`text`/`txt`, `json`, `yaml`/`yml`); `None` for
+    /// anything else.
+    pub fn parse(s: &str) -> Option<Format> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "" | "text" | "txt" => Some(Format::Text),
+            "json" => Some(Format::Json),
+            "yaml" | "yml" => Some(Format::Yaml),
+            _ => None,
+        }
+    }
+
+    pub fn ext(self) -> &'static str {
+        match self {
+            Format::Text => "txt",
+            Format::Json => "json",
+            Format::Yaml => "yaml",
+        }
+    }
+}
+
+/// A captured table view.
+#[derive(Debug, Clone, Serialize)]
+pub struct Snapshot {
+    /// Epoch seconds at capture.
+    pub captured_at: i64,
+    pub context: String,
+    pub cluster: String,
+    /// Namespace scope, empty when listing across all namespaces.
+    pub namespace: String,
+    /// Resource plural.
+    pub resource: String,
+    /// Active row filter, if any.
+    pub filter: String,
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+impl Snapshot {
+    /// Serialize into the requested format.
+    pub fn render(&self, format: Format) -> String {
+        match format {
+            Format::Text => self.to_text(),
+            Format::Json => {
+                serde_json::to_string_pretty(self).unwrap_or_else(|e| format!("// error: {e}"))
+            }
+            Format::Yaml => serde_yaml::to_string(self).unwrap_or_else(|e| format!("# error: {e}")),
+        }
+    }
+
+    /// A human-readable header block plus the rows as an aligned table.
+    fn to_text(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!("# sofka snapshot — {}\n", self.resource));
+        out.push_str(&format!("# captured: {}\n", clock(self.captured_at)));
+        out.push_str(&format!("# context:  {}\n", self.context));
+        out.push_str(&format!("# cluster:  {}\n", self.cluster));
+        out.push_str(&format!(
+            "# namespace: {}\n",
+            if self.namespace.is_empty() {
+                "(all)"
+            } else {
+                &self.namespace
+            }
+        ));
+        if !self.filter.is_empty() {
+            out.push_str(&format!("# filter:   {}\n", self.filter));
+        }
+        out.push_str(&format!("# rows:     {}\n\n", self.rows.len()));
+        out.push_str(&align_table(&self.columns, &self.rows));
+        out
+    }
+
+    /// A default filename for this snapshot in the given format.
+    pub fn filename(&self, format: Format) -> String {
+        let ns = if self.namespace.is_empty() {
+            "all".to_string()
+        } else {
+            self.namespace.clone()
+        };
+        let safe: String = format!("{}-{}", self.resource, ns)
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect();
+        format!(
+            "sofka-snapshot-{safe}-{}.{}",
+            self.captured_at,
+            format.ext()
+        )
+    }
+}
+
+/// Render `columns` + `rows` as a left-aligned, space-padded table.
+fn align_table(columns: &[String], rows: &[Vec<String>]) -> String {
+    let ncols = columns.len();
+    let mut widths: Vec<usize> = columns.iter().map(|c| c.chars().count()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate().take(ncols) {
+            widths[i] = widths[i].max(cell.chars().count());
+        }
+    }
+    let fmt_row = |cells: &[String]| -> String {
+        let mut line = String::new();
+        for (i, &w) in widths.iter().enumerate() {
+            let cell = cells.get(i).map(String::as_str).unwrap_or("");
+            line.push_str(cell);
+            // No trailing padding on the last column.
+            if i + 1 < ncols {
+                let pad = w.saturating_sub(cell.chars().count());
+                line.push_str(&" ".repeat(pad + 2));
+            }
+        }
+        line.trim_end().to_string()
+    };
+    let mut out = String::new();
+    out.push_str(&fmt_row(columns));
+    out.push('\n');
+    for row in rows {
+        out.push_str(&fmt_row(row));
+        out.push('\n');
+    }
+    out
+}
+
+/// Format an epoch second as `YYYY-MM-DD HH:MM:SS` UTC.
+pub fn clock(at: i64) -> String {
+    use k8s_openapi::jiff::Timestamp;
+    match Timestamp::from_second(at) {
+        Ok(ts) => ts
+            .to_string()
+            .split('.')
+            .next()
+            .unwrap_or("")
+            .replace('T', " ")
+            .replace('Z', ""),
+        Err(_) => at.to_string(),
+    }
+}
+
+/// A compact "5m ago" / "2h ago" age for `at` relative to `now` (epoch secs).
+pub fn age(at: i64, now: i64) -> String {
+    let secs = (now - at).max(0);
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86400)
+    }
+}
+
+/// Directory snapshots are written to and browsed from: `$XDG_STATE_HOME/sofka/
+/// snapshots`, else `~/.local/state/sofka/snapshots`, else a temp fallback.
+pub fn snapshots_dir() -> PathBuf {
+    if let Ok(x) = std::env::var("XDG_STATE_HOME")
+        && !x.is_empty()
+    {
+        return PathBuf::from(x).join("sofka").join("snapshots");
+    }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home)
+            .join(".local")
+            .join("state")
+            .join("sofka")
+            .join("snapshots");
+    }
+    std::env::temp_dir().join("sofka").join("snapshots")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Snapshot {
+        Snapshot {
+            captured_at: 1_700_000_000,
+            context: "prod".into(),
+            cluster: "eu".into(),
+            namespace: "web".into(),
+            resource: "pods".into(),
+            filter: "app=api".into(),
+            columns: vec!["NAME".into(), "READY".into()],
+            rows: vec![
+                vec!["api-1".into(), "1/1".into()],
+                vec!["api-longer-name".into(), "0/1".into()],
+            ],
+        }
+    }
+
+    #[test]
+    fn text_render_aligns_and_includes_metadata() {
+        let text = sample().render(Format::Text);
+        assert!(text.contains("# context:  prod"));
+        assert!(text.contains("# filter:   app=api"));
+        assert!(text.contains("# rows:     2"));
+        // The NAME column is padded to the widest cell.
+        let body = text.lines().find(|l| l.starts_with("api-1")).unwrap();
+        assert!(body.starts_with("api-1           "), "{body:?}");
+        assert!(body.contains("1/1"));
+    }
+
+    #[test]
+    fn json_and_yaml_roundtrip_the_fields() {
+        let json = sample().render(Format::Json);
+        assert!(json.contains("\"resource\": \"pods\""));
+        assert!(json.contains("\"api-longer-name\""));
+        let yaml = sample().render(Format::Yaml);
+        assert!(yaml.contains("resource: pods"));
+        assert!(yaml.contains("- api-1"));
+    }
+
+    #[test]
+    fn format_parse_accepts_aliases_and_rejects_garbage() {
+        assert_eq!(Format::parse(""), Some(Format::Text));
+        assert_eq!(Format::parse("TXT"), Some(Format::Text));
+        assert_eq!(Format::parse("json"), Some(Format::Json));
+        assert_eq!(Format::parse("yml"), Some(Format::Yaml));
+        assert_eq!(Format::parse("xml"), None);
+    }
+
+    #[test]
+    fn filename_is_filesystem_safe_and_carries_the_extension() {
+        let s = sample();
+        assert_eq!(
+            s.filename(Format::Json),
+            "sofka-snapshot-pods-web-1700000000.json"
+        );
+    }
+
+    #[test]
+    fn age_buckets_by_unit() {
+        assert_eq!(age(100, 130), "30s ago");
+        assert_eq!(age(0, 120), "2m ago");
+        assert_eq!(age(0, 7200), "2h ago");
+        assert_eq!(age(0, 172_800), "2d ago");
+        assert_eq!(age(200, 100), "0s ago"); // clamps negatives
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -160,6 +160,11 @@ pub enum Msg {
         generation: u64,
         result: Result<std::path::PathBuf, String>,
     },
+    /// Result of writing a snapshot to disk (`:snapshot`).
+    SnapshotSaved {
+        generation: u64,
+        result: Result<std::path::PathBuf, String>,
+    },
     Error {
         generation: u64,
         error: String,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -113,6 +113,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Command => draw_palette(frame, app, chunks[1]),
         Mode::FluxMenu => draw_flux_menu(frame, app, chunks[1]),
         Mode::Skins => draw_skins(frame, app, chunks[1]),
+        Mode::Snapshots => draw_snapshots(frame, app, chunks[1]),
         _ => {}
     }
 
@@ -1599,6 +1600,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             ":bundle · :bundle-save",
             "assemble a redacted diagnostic bundle for the selection · write it to a file",
         ),
+        bind(
+            ":snapshot [fmt] · :snapshots",
+            "capture the current view (text/json/yaml) · browse saved snapshots",
+        ),
         bind("i", "set container image"),
         bind(
             "r",
@@ -1863,6 +1868,31 @@ fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
         items,
         Span::styled(" Skins (enter apply · esc close) ", theme::title()),
         &mut app.skin_state,
+    );
+}
+
+fn draw_snapshots(frame: &mut Frame, app: &mut App, area: Rect) {
+    let items: Vec<ListItem> = app
+        .snapshot_list
+        .iter()
+        .map(|(_, label)| {
+            ListItem::new(Span::styled(
+                label.clone(),
+                Style::default().fg(theme::text()),
+            ))
+        })
+        .collect();
+    render_popup_list(
+        frame,
+        area,
+        70,
+        70,
+        items,
+        Span::styled(
+            " Snapshots (⏎ open · d delete · esc close) ",
+            theme::title(),
+        ),
+        &mut app.snapshot_state,
     );
 }
 
@@ -2610,6 +2640,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Mode::PortForwards => Line::from(Span::styled(
             "  j/k: move   x/s: stop   esc: close (others keep running)",
+            theme::dim(),
+        )),
+        Mode::Snapshots => Line::from(Span::styled(
+            "  j/k: move   ⏎: open   d: delete   esc: close",
             theme::dim(),
         )),
         _ => {


### PR DESCRIPTION
## Summary
Fourth item of **Milestone 5**: capture and review point-in-time snapshots of the current view.

- **`:snapshot [format]`** captures the current table — its columns and visible rows, plus metadata (context, cluster, namespace, resource, filter, timestamp) — to a file. Format is `text` (default; an aligned table with a header block), `json`, or `yaml`.
- **`:snapshots`** browses saved captures newest-first with their age; `⏎` opens one into a viewer with a staleness banner, `d` deletes the highlighted file.
- Files land in `$XDG_STATE_HOME/sofka/snapshots` (falling back to `~/.local/state/sofka/snapshots`).
- Distinct from the one-frame `--snapshot` CI flag — this is an interactive capture-and-review workflow.

## Implementation
- New pure `snapshot` module: `Snapshot` (serde), `Format` (parse + ext), text/JSON/YAML rendering, aligned-table layout, `clock`/`age` helpers, `snapshots_dir()`.
- App side: `snapshot_table()` reuses the exact table layout (NAMESPACE prepend, CPU/MEM append, volatile cells) minus color; `Mode::Snapshots` browser reusing `render_popup_list`; `Msg::SnapshotSaved`.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 336 pass (pure: text alignment + metadata, JSON/YAML fields, format parsing, filename safety, age bucketing; app: capture columns/rows shape, unknown-format rejection)
- [x] Live-verified against the home cluster: captured the same pods view as `text`/`json`/`yaml` (aligned table with live CPU/MEM, structured fields), browsed all three in `:snapshots` (ages shown), opened the JSON one (staleness banner), and `d` deleted it (confirmed removed from disk)