### PR TITLE
feat: runtime diagnostics (:info / sofka --info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Not a marketing number - these are specific, checkable design choices:
 - **Config file** (TOML): aliases, default namespace/resource, favourite
   namespaces, plugins, bookmarks, workspaces, views, thresholds, log provider,
   skin — with per-cluster/per-context overrides and live `:reload`.
+- **Runtime diagnostics** (`:info`, or `sofka --info`) - version/build, config
+  sources, live context/cluster/API server, discovery and Metrics API status,
+  watch error counts, and the state/snapshot/bundle directories. Prints only
+  identifiers and counts — never credentials, tokens, or Secret values.
 
 ## Installation
 
@@ -657,9 +661,11 @@ apply without restarting.
 sofka --check                # connect, run discovery, print a summary, exit
 sofka pods --snapshot        # render one frame of a resource view to stdout
 sofka dp -A --snapshot       # deployments, all namespaces
+sofka --info                 # version/build, config sources, dirs, kubeconfig context (no connection)
 ```
 
-These double as CI smoke tests.
+These double as CI smoke tests. `--info` prints only identifiers and paths —
+never credentials, tokens, or Secret values.
 
 ## Usage
 
@@ -704,6 +710,7 @@ header) and switching away restores write mode.
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
 | `:ctx` / `:ctx <name>`                        | context switcher popup / switch directly (the name tab-completes)                                                                     |
 | `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
+| `:reload` / `:config` / `:info`               | reload config from disk · config sources + warnings · runtime diagnostics                                                             |
 | `l` / `p`                                     | logs (workload = all matching pods) / previous-container logs                                                                         |
 | `c`                                           | copy resource name to clipboard                                                                                                       |
 | `e`                                           | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+impl App {
+    /// `:info` — a runtime diagnostics view: version/build, config sources,
+    /// live cluster identity, discovery/metrics status, watch health, and the
+    /// directories sofka uses. Never prints credentials, tokens, or Secret
+    /// values — only identifiers and counts.
+    pub(super) fn open_info(&mut self) {
+        self.set_return_mode();
+        let mut lines: Vec<String> = Vec::new();
+
+        lines.push(format!("sofka v{}", crate::diagnostics::VERSION));
+        lines.push(format!("  build: {}", crate::diagnostics::build_line()));
+
+        lines.push(String::new());
+        lines.push("Cluster".into());
+        lines.push(format!("  connected:   {}", self.cluster.connected));
+        lines.push(format!(
+            "  context:     {}",
+            blank_as(&self.cluster.context, "(none)")
+        ));
+        lines.push(format!(
+            "  cluster:     {}",
+            blank_as(&self.cluster.cluster_name, "(unknown)")
+        ));
+        lines.push(format!(
+            "  api server:  {}",
+            blank_as(&self.cluster.cluster_url, "(unknown)")
+        ));
+        lines.push(format!(
+            "  namespace:   {}",
+            if self.namespace.is_empty() {
+                "(all)"
+            } else {
+                &self.namespace
+            }
+        ));
+        lines.push(format!(
+            "  discovery:   {} resource kinds",
+            self.cluster.catalog.len()
+        ));
+        lines.push(format!(
+            "  metrics API: {}",
+            if self.metrics_seen {
+                "available (data received)"
+            } else {
+                "no data yet"
+            }
+        ));
+
+        lines.push(String::new());
+        lines.push("Watch health".into());
+        lines.push(format!("  errors: {}", self.watch_errors));
+        match &self.last_error {
+            Some(e) => lines.push(format!("  last error: {e}")),
+            None => lines.push("  last error: none".into()),
+        }
+
+        lines.push(String::new());
+        lines.push("Config sources".into());
+        match self.config.base_path() {
+            Some(path) => {
+                let state = if self.config.has_base() {
+                    "loaded"
+                } else if path.exists() {
+                    "invalid — using defaults"
+                } else {
+                    "absent — using defaults"
+                };
+                lines.push(format!("  {} ({state})", path.display()));
+            }
+            None => lines.push("  no config directory — using defaults".into()),
+        }
+        for path in self
+            .config
+            .override_paths(&self.cluster.context, &self.cluster.cluster_name)
+        {
+            lines.push(format!(
+                "  {} ({})",
+                path.display(),
+                crate::config::file_state(&path)
+            ));
+        }
+
+        lines.push(String::new());
+        lines.push("Active config".into());
+        lines.push(format!(
+            "  skin:      {}",
+            self.active_skin.as_deref().unwrap_or("auto")
+        ));
+        lines.push(format!("  readonly:  {}", self.readonly));
+        lines.push(format!("  aliases:   {}", self.user_aliases.len()));
+        lines.push(format!("  plugins:   {}", self.plugins.len()));
+        lines.push(format!("  views:     {}", self.user_views.len()));
+        lines.push(format!("  bookmarks: {}", self.bookmarks.len()));
+        lines.push(format!("  guardrails: {}", self.guardrails.len()));
+        lines.push(format!("  warnings:  {}", self.config_warnings.len()));
+
+        lines.push(String::new());
+        lines.push("Directories".into());
+        lines.push(format!(
+            "  state:     {}",
+            crate::diagnostics::state_dir().display()
+        ));
+        lines.push(format!(
+            "  snapshots: {}",
+            crate::snapshot::snapshots_dir().display()
+        ));
+        lines.push(format!("  bundles:   {}", std::env::temp_dir().display()));
+
+        if !self.config_warnings.is_empty() {
+            lines.push(String::new());
+            lines.push(format!("Warnings [{}]", self.config_warnings.len()));
+            for w in &self.config_warnings {
+                for (i, l) in w.lines().enumerate() {
+                    let bullet = if i == 0 { "• " } else { "  " };
+                    lines.push(format!("  {bullet}{l}"));
+                }
+            }
+        }
+
+        self.detail = Scrollable {
+            title: "diagnostics (:info)".into(),
+            lines: lines.into(),
+            ..Default::default()
+        };
+        self.mode = Mode::Detail;
+    }
+}
+
+fn blank_as<'a>(s: &'a str, fallback: &'a str) -> &'a str {
+    if s.is_empty() { fallback } else { s }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -524,6 +524,7 @@ impl App {
             PaletteAction::BundleSave => self.save_bundle(),
             PaletteAction::Snapshot => self.take_snapshot(""),
             PaletteAction::Snapshots => self.open_snapshots(),
+            PaletteAction::Info => self.open_info(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -518,6 +518,8 @@ impl App {
             }
             Msg::Synced { generation } if generation == self.generation => self.store.synced = true,
             Msg::Error { generation, error } if generation == self.generation => {
+                self.watch_errors = self.watch_errors.saturating_add(1);
+                self.last_error = Some(error.clone());
                 self.flash = format!("error: {error}");
                 self.flash_err = true;
             }
@@ -551,6 +553,9 @@ impl App {
                         headers.get(i).cloned()
                     })
                     .is_some_and(|h| matches!(h.as_str(), "CPU" | "MEM"));
+                if !data.is_empty() || !containers.is_empty() {
+                    self.metrics_seen = true;
+                }
                 self.metrics = data;
                 self.container_metrics = containers;
                 if sort_uses_metrics {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -372,6 +372,7 @@ enum PaletteAction {
     BundleSave,
     Snapshot,
     Snapshots,
+    Info,
     Diff,
     Events,
     PortForwards,
@@ -470,6 +471,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::ConfigInfo,
         names: &["config", "cfg"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Info,
+        names: &["info", "diagnostics", "about"],
     },
     PaletteCommand {
         action: PaletteAction::Quit,
@@ -795,6 +800,12 @@ pub struct App {
     pub pending_bundle: Option<(String, String)>,
     /// Session-local log of mutating actions taken (`:journal`).
     pub journal: crate::journal::Journal,
+    /// Count of watch/stream errors seen this session, for `:info` diagnostics.
+    pub watch_errors: u64,
+    /// The most recent error message, for `:info` diagnostics.
+    pub last_error: Option<String>,
+    /// Whether the Metrics API has ever returned data this session.
+    pub metrics_seen: bool,
     /// A workspace waiting for an in-flight context switch before it opens.
     pub pending_workspace: Option<crate::config::Workspace>,
     /// The workspace currently being cycled with `Tab`/`Shift-Tab`, if any.
@@ -985,6 +996,9 @@ impl App {
             bundle_cfg: crate::config::BundleConfig::default(),
             pending_bundle: None,
             journal: crate::journal::Journal::default(),
+            watch_errors: 0,
+            last_error: None,
+            metrics_seen: false,
             rbac_allowed: None,
             last_rbac_ns: None,
             container_list: Vec::new(),
@@ -1079,6 +1093,7 @@ mod bookmarks;
 mod bundle;
 mod dashboards;
 mod details;
+mod diagnostics;
 mod explain;
 mod gitops;
 mod guardrails;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4038,6 +4038,30 @@ async fn reload_palette_command_dispatches() {
 }
 
 #[tokio::test]
+async fn info_view_reports_version_cluster_and_watch_health() {
+    let (mut app, _rx) = test_app();
+    app.watch_errors = 3;
+    app.last_error = Some("connection refused".into());
+    assert!(app.run_palette_command("info"));
+    assert_eq!(app.mode, Mode::Detail);
+    let text = app
+        .detail
+        .lines
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains(&format!("sofka v{}", crate::diagnostics::VERSION)));
+    assert!(text.contains("Cluster"), "{text}");
+    assert!(text.contains("api server:"), "{text}");
+    assert!(text.contains("errors: 3"), "{text}");
+    assert!(text.contains("connection refused"), "{text}");
+    assert!(text.contains("Directories"), "{text}");
+    // Never leaks credentials — the report is identifiers and counts only.
+    assert!(!text.to_lowercase().contains("bearer"), "{text}");
+}
+
+#[tokio::test]
 async fn config_view_lists_sources_active_skin_and_warnings() {
     let dir = std::env::temp_dir().join(format!("sofka-app-cfg-view-{}", std::process::id()));
     write_config(&dir, "[skin]\nname = \"catppuccin-mocha\"\n");

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,42 @@
+//! Shared runtime-diagnostics helpers (`:info` / `--info`).
+//!
+//! These are the pieces both the in-app diagnostics view and the headless
+//! `--info` report agree on: the version/build stamp and the directories sofka
+//! reads and writes. Nothing here touches the cluster or emits credentials.
+
+use std::path::PathBuf;
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The build target as `os/arch` plus the compile profile.
+pub fn build_line() -> String {
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    format!(
+        "{}/{} ({profile})",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    )
+}
+
+/// Base state directory: `$XDG_STATE_HOME/sofka`, else `~/.local/state/sofka`,
+/// else a temp fallback. Snapshots and any future on-disk state live under it.
+pub fn state_dir() -> PathBuf {
+    if let Ok(x) = std::env::var("XDG_STATE_HOME")
+        && !x.is_empty()
+    {
+        return PathBuf::from(x).join("sofka");
+    }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home)
+            .join(".local")
+            .join("state")
+            .join("sofka");
+    }
+    std::env::temp_dir().join("sofka")
+}

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -340,6 +340,29 @@ fn current_context_name() -> Option<String> {
     kubeconfig.current_context
 }
 
+/// The current kubeconfig context, its cluster name, and API-server URL, read
+/// offline (no connection). For `--info`. `None` when there's no kubeconfig or
+/// no current context. The server URL never carries credentials.
+pub fn current_context_info() -> Option<(String, String, String)> {
+    let kubeconfig = kube::config::Kubeconfig::read().ok()?;
+    let context = kubeconfig.current_context.clone()?;
+    let cluster_name = kubeconfig
+        .contexts
+        .iter()
+        .find(|c| c.name == context)
+        .and_then(|c| c.context.as_ref())
+        .map(|c| c.cluster.clone())
+        .unwrap_or_default();
+    let server = kubeconfig
+        .clusters
+        .iter()
+        .find(|c| c.name == cluster_name)
+        .and_then(|c| c.cluster.as_ref())
+        .and_then(|c| c.server.clone())
+        .unwrap_or_default();
+    Some((context, cluster_name, server))
+}
+
 /// Kubeconfig cluster name a context points at, when the kubeconfig knows it.
 fn cluster_name_for(context: &str) -> Option<String> {
     let kubeconfig = kube::config::Kubeconfig::read().ok()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod app;
 mod bundle;
 mod columns;
 mod config;
+mod diagnostics;
 mod explain;
 mod filter;
 mod gitops;
@@ -71,12 +72,24 @@ struct Args {
     /// needed). Lets you eyeball the UI headlessly.
     #[arg(long)]
     snapshot: bool,
+
+    /// Print version/build, config sources, directories, and the current
+    /// kubeconfig context, then exit (no cluster connection). For live
+    /// discovery/metrics/watch status, use `:info` inside the TUI.
+    #[arg(long)]
+    info: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
     let (loader, mut config_warnings) = config::ConfigLoader::load();
+
+    // `--info`: print static diagnostics (no cluster connection) and exit.
+    if args.info {
+        print_info(&loader, &config_warnings);
+        return Ok(());
+    }
 
     // Connect before taking over the terminal so errors are readable. An
     // unreachable current context isn't fatal for the interactive TUI: start
@@ -366,6 +379,69 @@ fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String]) {
         .status();
     *terminal = ratatui::init();
     let _ = terminal.clear();
+}
+
+/// `--info`: print static runtime diagnostics (no cluster connection). Emits
+/// only identifiers and paths — never credentials, tokens, or Secret values.
+fn print_info(loader: &config::ConfigLoader, warnings: &[String]) {
+    println!("sofka v{}", diagnostics::VERSION);
+    println!("  build: {}", diagnostics::build_line());
+
+    let (context, cluster, server) = k8s::current_context_info()
+        .unwrap_or_else(|| ("(none)".into(), String::new(), String::new()));
+    println!();
+    println!("Kubeconfig");
+    println!("  current context: {context}");
+    println!(
+        "  cluster:         {}",
+        if cluster.is_empty() {
+            "(unknown)"
+        } else {
+            &cluster
+        }
+    );
+    println!(
+        "  api server:      {}",
+        if server.is_empty() {
+            "(unknown)"
+        } else {
+            &server
+        }
+    );
+
+    println!();
+    println!("Config sources");
+    match loader.base_path() {
+        Some(path) => {
+            let state = if loader.has_base() {
+                "loaded"
+            } else if path.exists() {
+                "invalid — using defaults"
+            } else {
+                "absent — using defaults"
+            };
+            println!("  {} ({state})", path.display());
+        }
+        None => println!("  no config directory — using defaults"),
+    }
+    for path in loader.override_paths(&context, &cluster) {
+        println!("  {} ({})", path.display(), config::file_state(&path));
+    }
+
+    println!();
+    println!("Directories");
+    println!("  state:     {}", diagnostics::state_dir().display());
+    println!("  snapshots: {}", snapshot::snapshots_dir().display());
+    println!("  bundles:   {}", std::env::temp_dir().display());
+
+    if warnings.is_empty() {
+        println!("\nNo config validation warnings.");
+    } else {
+        println!("\nWarnings [{}]", warnings.len());
+        for w in warnings {
+            println!("  • {w}");
+        }
+    }
 }
 
 async fn run(

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -173,24 +173,10 @@ pub fn age(at: i64, now: i64) -> String {
     }
 }
 
-/// Directory snapshots are written to and browsed from: `$XDG_STATE_HOME/sofka/
-/// snapshots`, else `~/.local/state/sofka/snapshots`, else a temp fallback.
+/// Directory snapshots are written to and browsed from:
+/// `<state-dir>/snapshots` (see [`crate::diagnostics::state_dir`]).
 pub fn snapshots_dir() -> PathBuf {
-    if let Ok(x) = std::env::var("XDG_STATE_HOME")
-        && !x.is_empty()
-    {
-        return PathBuf::from(x).join("sofka").join("snapshots");
-    }
-    if let Ok(home) = std::env::var("HOME")
-        && !home.is_empty()
-    {
-        return PathBuf::from(home)
-            .join(".local")
-            .join("state")
-            .join("sofka")
-            .join("snapshots");
-    }
-    std::env::temp_dir().join("sofka").join("snapshots")
+    crate::diagnostics::state_dir().join("snapshots")
 }
 
 #[cfg(test)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1530,8 +1530,8 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind(":pf", "view/stop background port-forwards"),
         bind(":skin", "switch color skin live"),
         bind(
-            ":reload · :config",
-            "reload config from disk · config sources + warnings",
+            ":reload · :config · :info",
+            "reload config · config sources + warnings · runtime diagnostics",
         ),
         bind(
             ":can-i",


### PR DESCRIPTION
## Summary
Fifth item of **Milestone 5**: a runtime diagnostics report, in-app and headless.

- **`:info`** opens a diagnostics view: version/build; live context/cluster/API server/namespace; discovery count + Metrics API status; watch error count + last error; config sources; an active-config summary (skin, readonly, aliases, plugins, views, bookmarks, guardrails, warnings); and the state/snapshot/bundle directories.
- **`sofka --info`** prints the static subset with **no cluster connection** — version/build, config sources, directories, and the current kubeconfig context/cluster/API server (read offline). Handy in CI or a headless shell.
- Both emit **only identifiers, counts, and paths** — never kubeconfig credentials, bearer tokens, or Secret values.

## Implementation
- New pure `diagnostics` module: `VERSION`, `build_line()` (os/arch/profile), `state_dir()`. `snapshot::snapshots_dir()` now derives from it, so the dirs stay in sync.
- `App` gains `watch_errors` / `last_error` / `metrics_seen` counters, updated in `handle_msg`.
- `k8s::current_context_info()` reads the current context/cluster/server from kubeconfig offline for `--info`.
- `--info` flag mirrors the existing `--check`/`--snapshot` headless flags.

## Notes
- The roadmap item also lists **structured application logging** — that's a larger, cross-cutting addition (log framework + redaction at every site) and is deferred to a dedicated follow-up. This PR delivers the diagnostics half.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 337 pass (added an `:info` view test asserting version/cluster/watch-health lines and that no `bearer` token text leaks)
- [x] Verified `sofka --info` offline against the home kubeconfig: printed version/build, context `admin@home-kubernetes` / cluster / `https://…:6443`, config sources, and directories — with no connection