### PR TITLE
feat: richer log controls (regex/inverse filter, tail/buffer/since, clear)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "ratatui",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"
 k8s-openapi = { version = "0.28", features = ["latest"] }
 kube = { version = "4.0.0", features = ["runtime", "client", "derive", "ws"] }
 ratatui = "0.30.1"
+regex = "1"
 serde = "1.0.228"
 serde_json = "1.0.150"
 serde_yaml = "0.9.34"

--- a/README.md
+++ b/README.md
@@ -227,8 +227,10 @@ Not a marketing number - these are specific, checkable design choices:
   switcher** (`:ctx`).
 - **YAML view** (`y`) and **describe** (`d`, via `kubectl`).
 - **Logs** (`l`) - per-container on a pod, aggregated across all matching
-  pods on a workload/service. In-logs **search** (`/`) with highlighting;
-  `p` for previous-container logs. ANSI color codes from the source app are
+  pods on a workload/service. In-logs **filter** (`/`): case-insensitive
+  substring (highlighted), `/regex/`, or `!` to invert; `z` clears the buffer,
+  `p` shows previous-container logs. Configurable initial tail, follow buffer,
+  and `since` lookback (`[logs]`). ANSI color codes from the source app are
   parsed and mapped onto the active skin, not printed as literal escapes.
 - **VictoriaLogs integration** (`L` / `:vlogs`) - log history for the
   selected pod, container, workload, service, or whole namespace from a
@@ -586,6 +588,23 @@ into a viewer with a staleness banner (it's a point-in-time capture), and `d`
 deletes the highlighted file. This is distinct from the one-frame `--snapshot`
 CI flag — it's an interactive capture-and-review workflow.
 
+### Log controls
+
+The kubelet logs view (`l`) keeps a bounded follow buffer. Tune the initial
+tail, the buffer size, and an optional `since` lookback:
+
+```toml
+[logs]
+tail = 300       # initial lines fetched per stream (kubectl --tail)
+buffer = 5000    # max lines kept while following (oldest dropped)
+since = "1h"     # optional: only logs newer than this — replaces tail
+```
+
+In the view, `/` filters with a case-insensitive substring, a `/regex/`, or a
+leading `!` to invert (keep non-matching lines); a malformed regex is flagged
+rather than hiding everything. `z` clears the on-screen buffer (the live stream
+keeps appending). A pod's logs already stream every container at once.
+
 ### Log provider (VictoriaLogs)
 
 `L` (or `:vlogs`) opens log history for the selection from a VictoriaLogs
@@ -730,9 +749,10 @@ header) and switching away restores write mode.
 | `?`                                           | help                                                                                                                                  |
 | _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                           |
 
-**Logs view:** `/` search+highlight · `s` autoscroll · `w` wrap · `t`
-timestamps · `x` stop/resume stream · `c` copy buffer · `ctrl-s` save to file
-· `esc` back. The newest line anchors to the bottom of the viewport.
+**Logs view:** `/` filter (substring · `/regex/` · `!invert`) · `s` autoscroll
+· `w` wrap · `t` timestamps · `x` stop/resume stream · `z` clear buffer · `c`
+copy buffer · `ctrl-s` save to file · `esc` back. The newest line anchors to
+the bottom of the viewport.
 
 **Document views** (YAML, describe, diff, events): `/` searches vim-style —
 the whole document stays on screen with every match highlighted, and `n` / `N`

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -454,12 +454,11 @@ impl App {
     }
 
     pub(super) fn filtered_log_text(&self) -> String {
-        let f = self.logs.filter.to_lowercase();
         self.logs
             .view
             .lines
             .iter()
-            .filter(|l| f.is_empty() || l.to_lowercase().contains(&f))
+            .filter(|l| self.logs.matches(l))
             .cloned()
             .collect::<Vec<_>>()
             .join("\n")
@@ -1201,6 +1200,7 @@ impl App {
         self.guardrails = resolved.config.guardrails;
         self.debug = resolved.config.debug;
         self.bundle_cfg = resolved.config.bundle;
+        self.logs_cfg = resolved.config.logs;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         warnings.extend(crate::config::workspace_warnings(&self.workspaces));

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -888,7 +888,12 @@ impl App {
                 self.logs.follow = !self.logs.follow;
                 if self.logs.follow {
                     // Resumed tailing — trim the backlog accumulated while paused.
-                    let overflow = self.logs.view.lines.len().saturating_sub(MAX_LOG_LINES);
+                    let overflow = self
+                        .logs
+                        .view
+                        .lines
+                        .len()
+                        .saturating_sub(self.logs_cfg.buffer.max(1));
                     if overflow > 0 {
                         self.logs.view.lines.drain(0..overflow);
                     }
@@ -955,6 +960,14 @@ impl App {
                 self.copy_logs();
                 return;
             }
+            // Clear the on-screen buffer (the live stream keeps appending).
+            KeyCode::Char('z') => {
+                self.logs.view.lines.clear();
+                self.logs.view.scroll = 0;
+                self.flash = "log buffer cleared".into();
+                self.flash_err = false;
+                return;
+            }
             KeyCode::Char('/') => {
                 self.mode = Mode::LogFilter;
                 return;
@@ -1008,14 +1021,20 @@ impl App {
     pub(super) fn key_log_filter(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Esc => {
-                self.logs.filter.clear();
+                self.logs.set_filter(String::new());
                 self.mode = Mode::Logs;
             }
             KeyCode::Enter => self.mode = Mode::Logs,
             KeyCode::Backspace => {
-                self.logs.filter.pop();
+                let mut f = self.logs.filter.clone();
+                f.pop();
+                self.logs.set_filter(f);
             }
-            KeyCode::Char(c) => self.logs.filter.push(c),
+            KeyCode::Char(c) => {
+                let mut f = self.logs.filter.clone();
+                f.push(c);
+                self.logs.set_filter(f);
+            }
             _ => {}
         }
     }

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -20,7 +20,7 @@ impl App {
         // trimming so indices don't shift under the frozen view (only a huge
         // backlog hits the larger paused cap).
         let cap = if self.logs.follow {
-            MAX_LOG_LINES
+            self.logs_cfg.buffer.max(1)
         } else {
             MAX_LOG_LINES_PAUSED
         };
@@ -33,14 +33,13 @@ impl App {
         // rows the dropped lines occupied on screen — filtered lines take none,
         // wrapped lines take several — so the frozen view stays put.
         if !self.logs.follow {
-            let filter = self.logs.filter.to_lowercase();
             let rows: usize = self
                 .logs
                 .view
                 .lines
                 .iter()
                 .take(overflow)
-                .filter(|l| filter.is_empty() || l.to_lowercase().contains(&filter))
+                .filter(|l| self.logs.matches(l))
                 .map(|l| match self.logs.last_wrap_width {
                     0 => 1,
                     w => crate::ui::wrapped_height(l, w),
@@ -257,7 +256,7 @@ impl App {
             ..Default::default()
         };
         self.logs.follow = true;
-        self.logs.filter.clear();
+        self.logs.set_filter(String::new());
         self.logs.stopped = false;
         self.mode = Mode::Logs;
         self.restart_log_stream();
@@ -419,14 +418,25 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.log_gen;
         let flag = self.log_flag.clone();
+        let (tail, since) = self.log_tail_and_since();
         let handle = tokio::spawn(async move {
             let api: Api<Pod> = Api::namespaced(client, &ns);
+            // `since` and `tail` are mutually exclusive in the API; prefer the
+            // configured lookback when set. Previous-container logs take neither.
+            let (tail_lines, since_seconds) = if previous {
+                (None, None)
+            } else if since.is_some() {
+                (None, since)
+            } else {
+                (Some(tail), None)
+            };
             let lp = LogParams {
                 follow: !previous,
                 previous,
                 container,
                 timestamps,
-                tail_lines: if previous { None } else { Some(300) },
+                tail_lines,
+                since_seconds,
                 ..Default::default()
             };
             forward_log_stream(api, pod, lp, prefix, tx, genr, flag).await;
@@ -434,11 +444,27 @@ impl App {
         self.log_tasks.push(handle);
     }
 
+    /// The configured initial `tail` line count and optional `since` lookback
+    /// (epoch seconds), parsed from `[logs]`. An unparseable `since` is ignored.
+    fn log_tail_and_since(&self) -> (i64, Option<i64>) {
+        let tail = self.logs_cfg.tail.max(1);
+        let since = self
+            .logs_cfg
+            .since
+            .as_deref()
+            .and_then(|s| crate::providers::parse_lookback(s).ok());
+        (tail, since)
+    }
+
     pub(super) fn spawn_selector_logs(&mut self, ns: String, labels: String, timestamps: bool) {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.log_gen;
         let flag = self.log_flag.clone();
+        let (tail, since) = self.log_tail_and_since();
+        // Bound the per-pod tail so an aggregate over many pods stays sane; the
+        // follow buffer trims the total anyway.
+        let per_pod_tail = tail.min(100);
         let handle = tokio::spawn(async move {
             let list_api: Api<Pod> = if ns.is_empty() {
                 Api::all(client.clone())
@@ -485,11 +511,16 @@ impl App {
                     let (pn, pns) = (pod_name.clone(), pod_ns.clone());
                     streams.spawn(async move {
                         let api: Api<Pod> = Api::namespaced(client, &pns);
+                        let (tail_lines, since_seconds) = match since {
+                            Some(s) => (None, Some(s)),
+                            None => (Some(per_pod_tail), None),
+                        };
                         let lp = LogParams {
                             follow: true,
                             container: Some(c),
                             timestamps,
-                            tail_lines: Some(100),
+                            tail_lines,
+                            since_seconds,
                             ..Default::default()
                         };
                         forward_log_stream(api, pn, lp, prefix, tx, genr, flag).await;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,15 +33,10 @@ use crate::store::{Msg, Pulse, Store, XrayItem, row_key};
 
 pub(crate) use guardrails::ConfirmLevel;
 
-/// Maximum number of buffered log lines while following. A chatty pod would
-/// otherwise grow the buffer (and the unbounded channel feeding it) without
-/// limit; we keep the most recent lines, like k9s' tail buffer.
-const MAX_LOG_LINES: usize = 5_000;
-
 /// Larger cap used while autoscroll is paused: we stop trimming so the line
 /// indices don't shift under the frozen view (which would make it appear to
 /// resume scrolling). Only a runaway firehose during a very long pause hits
-/// this; resuming follow trims back to [`MAX_LOG_LINES`].
+/// this; resuming follow trims back to the configured `[logs] buffer`.
 const MAX_LOG_LINES_PAUSED: usize = 100_000;
 
 /// Log streams batch lines before sending them through the UI channel. This
@@ -567,6 +562,9 @@ pub struct LogsView {
     pub view: Scrollable,
     pub follow: bool,
     pub filter: String,
+    /// Compiled form of [`Self::filter`] (substring / regex / inverse). Rebuilt
+    /// by [`Self::set_filter`] whenever the filter text changes.
+    pub matcher: crate::logfilter::LogMatcher,
     pub wrap: bool,
     pub timestamps: bool,
     pub stopped: bool,
@@ -591,6 +589,7 @@ impl Default for LogsView {
             view: Scrollable::empty(),
             follow: true,
             filter: String::new(),
+            matcher: crate::logfilter::LogMatcher::default(),
             wrap: false,
             timestamps: false,
             stopped: false,
@@ -599,6 +598,20 @@ impl Default for LogsView {
             last_wrap_width: 0,
             source: None,
         }
+    }
+}
+
+impl LogsView {
+    /// Replace the filter text and recompile its matcher (substring / regex /
+    /// inverse) in one place, so the cached matcher never drifts.
+    pub fn set_filter(&mut self, filter: String) {
+        self.matcher = crate::logfilter::LogMatcher::new(&filter);
+        self.filter = filter;
+    }
+
+    /// Whether `line` passes the active filter (empty filter = everything).
+    pub fn matches(&self, line: &str) -> bool {
+        self.matcher.matches(line)
     }
 }
 
@@ -795,6 +808,8 @@ pub struct App {
     /// Diagnostic-bundle (`:bundle`) options, re-applied on context switch and
     /// `:reload`.
     pub bundle_cfg: crate::config::BundleConfig,
+    /// Log-view options (`[logs]`), re-applied on context switch and `:reload`.
+    pub logs_cfg: crate::config::LogsConfig,
     /// The last bundle assembled by `:bundle`, previewed in the detail view and
     /// written to disk by `:bundle-save`: `(filename, text)`.
     pub pending_bundle: Option<(String, String)>,
@@ -994,6 +1009,7 @@ impl App {
             debug: crate::config::DebugConfig::default(),
             launched_node_debuggers: Vec::new(),
             bundle_cfg: crate::config::BundleConfig::default(),
+            logs_cfg: crate::config::LogsConfig::default(),
             pending_bundle: None,
             journal: crate::journal::Journal::default(),
             watch_errors: 0,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -338,6 +338,7 @@ impl App {
         self.guardrails = resolved.config.guardrails;
         self.debug = resolved.config.debug;
         self.bundle_cfg = resolved.config.bundle;
+        self.logs_cfg = resolved.config.logs;
         // Tracked debuggers belong to the previous cluster/context.
         self.launched_node_debuggers.clear();
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1052,17 +1052,18 @@ async fn log_lines_expand_tabs_and_strip_cr() {
 #[tokio::test]
 async fn log_buffer_is_capped() {
     let (mut app, _rx) = test_app();
-    for i in 0..(MAX_LOG_LINES + 50) {
+    let cap = app.logs_cfg.buffer;
+    for i in 0..(cap + 50) {
         app.handle_msg(Msg::LogLines {
             generation: app.log_gen,
             lines: vec![format!("line {i}")],
         });
     }
-    assert_eq!(app.logs.view.lines.len(), MAX_LOG_LINES);
+    assert_eq!(app.logs.view.lines.len(), cap);
     // Oldest lines dropped; newest retained.
     assert_eq!(
         app.logs.view.lines.back().unwrap(),
-        &format!("line {}", MAX_LOG_LINES + 49)
+        &format!("line {}", cap + 49)
     );
 }
 
@@ -1082,11 +1083,45 @@ async fn filtered_log_text_respects_active_filter() {
         app.filtered_log_text(),
         "api request started\nworker finished\napi request finished"
     );
-    app.logs.filter = "api".into();
+    app.logs.set_filter("api".into());
     assert_eq!(
         app.filtered_log_text(),
         "api request started\napi request finished"
     );
+}
+
+#[tokio::test]
+async fn log_filter_supports_regex_inverse_and_clear() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.handle_msg(Msg::LogLines {
+        generation: app.log_gen,
+        lines: vec![
+            "GET /api 200".into(),
+            "GET /healthz 200".into(),
+            "GET /api 503".into(),
+        ],
+    });
+
+    // Regex: keep 5xx.
+    app.logs.set_filter("/5\\d\\d/".into());
+    assert_eq!(app.filtered_log_text(), "GET /api 503");
+    assert!(!app.logs.matcher.is_error());
+
+    // Inverse substring: hide health checks.
+    app.logs.set_filter("!healthz".into());
+    assert_eq!(app.filtered_log_text(), "GET /api 200\nGET /api 503");
+
+    // Bad regex: flagged, matches nothing.
+    app.logs.set_filter("/[bad/".into());
+    assert!(app.logs.matcher.is_error());
+    assert_eq!(app.filtered_log_text(), "");
+
+    // `z` clears the buffer (stream keeps running underneath).
+    app.logs.set_filter(String::new());
+    app.handle_key(press(KeyCode::Char('z'))).unwrap();
+    assert!(app.logs.view.lines.is_empty());
+    assert!(app.flash.contains("cleared"), "{}", app.flash);
 }
 
 #[tokio::test]
@@ -1637,6 +1672,7 @@ async fn container_picker_shell_targets_selected_container() {
 #[tokio::test]
 async fn paused_logs_do_not_trim_below_paused_cap() {
     let (mut app, _rx) = test_app();
+    let cap = app.logs_cfg.buffer;
     app.logs.follow = false; // autoscroll OFF
     let lg = app.log_gen;
     let line = |i: usize| Msg::LogLines {
@@ -1645,16 +1681,16 @@ async fn paused_logs_do_not_trim_below_paused_cap() {
     };
     // Well past the *following* cap, but under the paused cap: nothing is
     // dropped, so a frozen view never appears to resume scrolling.
-    for i in 0..(MAX_LOG_LINES + 500) {
+    for i in 0..(cap + 500) {
         app.handle_msg(line(i));
     }
-    assert_eq!(app.logs.view.lines.len(), MAX_LOG_LINES + 500);
+    assert_eq!(app.logs.view.lines.len(), cap + 500);
 
     // Resuming follow trims the backlog back to the tight cap.
     app.mode = Mode::Logs;
     app.handle_key(press(KeyCode::Char('s'))).unwrap(); // follow on
     assert!(app.logs.follow);
-    assert_eq!(app.logs.view.lines.len(), MAX_LOG_LINES);
+    assert_eq!(app.logs.view.lines.len(), cap);
 }
 
 #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,39 @@ pub struct Config {
     pub debug: DebugConfig,
     /// Diagnostic-bundle (`:bundle`) options — see [`BundleConfig`].
     pub bundle: BundleConfig,
+    /// Log-view options — see [`LogsConfig`].
+    pub logs: LogsConfig,
+}
+
+/// Log-view controls (kubelet streams).
+///
+/// ```toml
+/// [logs]
+/// tail = 300       # initial lines fetched per stream
+/// buffer = 5000    # max lines retained while following (bounded tail)
+/// since = "1h"     # optional: only logs newer than this (overrides tail)
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct LogsConfig {
+    /// Initial lines requested per stream (`kubectl logs --tail`).
+    pub tail: i64,
+    /// Maximum lines retained in the follow buffer before the oldest are
+    /// dropped (keeps a chatty pod from growing memory without bound).
+    pub buffer: usize,
+    /// Optional lookback (`30m`, `4h`, `2d`): stream only logs newer than this.
+    /// When set it replaces `tail` (Kubernetes accepts one or the other).
+    pub since: Option<String>,
+}
+
+impl Default for LogsConfig {
+    fn default() -> Self {
+        Self {
+            tail: 300,
+            buffer: 5000,
+            since: None,
+        }
+    }
 }
 
 /// Options for the `:bundle` diagnostic-bundle export.

--- a/src/logfilter.rs
+++ b/src/logfilter.rs
@@ -1,0 +1,150 @@
+//! Log-view filter matching: substring, regex, and inverse.
+//!
+//! The `/` filter in the logs view accepts three forms, so a busy stream can be
+//! narrowed the way you'd expect from `grep`:
+//!
+//! - `text`        — case-insensitive substring (the default)
+//! - `/re/`        — a regular expression (case-insensitive)
+//! - `!text`,`!/re/` — inverse: keep the lines that *don't* match
+//!
+//! An empty filter matches everything. A malformed regex matches nothing and is
+//! flagged via [`LogMatcher::is_error`] so the view can say so instead of
+//! silently hiding the whole buffer.
+
+/// A compiled log filter. Cheap to query per line; build once when the filter
+/// text changes.
+pub struct LogMatcher {
+    negate: bool,
+    kind: Kind,
+}
+
+enum Kind {
+    /// Empty filter — everything matches.
+    All,
+    /// Case-insensitive substring (stored lowercased).
+    Substr(String),
+    Regex(regex::Regex),
+    /// A `/…/` that failed to compile.
+    BadRegex,
+}
+
+impl Default for LogMatcher {
+    fn default() -> Self {
+        LogMatcher {
+            negate: false,
+            kind: Kind::All,
+        }
+    }
+}
+
+impl LogMatcher {
+    /// Compile `input` into a matcher. Never fails — a bad regex becomes a
+    /// [`Kind::BadRegex`] that matches nothing.
+    pub fn new(input: &str) -> Self {
+        let (negate, rest) = match input.strip_prefix('!') {
+            Some(r) => (true, r),
+            None => (false, input),
+        };
+        if rest.is_empty() {
+            // `` → All; `!` alone → negate All (matches nothing), which reads
+            // as "hide everything", a reasonable literal interpretation.
+            return LogMatcher {
+                negate,
+                kind: Kind::All,
+            };
+        }
+        // `/pattern/` (at least the two slashes) is a regex.
+        let kind = if rest.len() >= 2 && rest.starts_with('/') && rest.ends_with('/') {
+            let pattern = &rest[1..rest.len() - 1];
+            match regex::RegexBuilder::new(pattern)
+                .case_insensitive(true)
+                .build()
+            {
+                Ok(re) => Kind::Regex(re),
+                Err(_) => Kind::BadRegex,
+            }
+        } else {
+            Kind::Substr(rest.to_lowercase())
+        };
+        LogMatcher { negate, kind }
+    }
+
+    /// Whether `line` passes the filter.
+    pub fn matches(&self, line: &str) -> bool {
+        // A broken regex hides everything (and `is_error` lets the UI explain),
+        // regardless of negation — negating a typo shouldn't reveal the buffer.
+        if matches!(self.kind, Kind::BadRegex) {
+            return false;
+        }
+        let base = match &self.kind {
+            Kind::All => true,
+            Kind::Substr(s) => line.to_lowercase().contains(s),
+            Kind::Regex(re) => re.is_match(line),
+            Kind::BadRegex => false,
+        };
+        base ^ self.negate
+    }
+
+    /// True when the filter is a `/…/` regex that didn't compile.
+    pub fn is_error(&self) -> bool {
+        matches!(self.kind, Kind::BadRegex)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_matches_everything() {
+        let m = LogMatcher::new("");
+        assert!(m.matches("anything"));
+        assert!(!m.is_error());
+    }
+
+    #[test]
+    fn substring_is_case_insensitive() {
+        let m = LogMatcher::new("Error");
+        assert!(m.matches("an ERROR happened"));
+        assert!(!m.matches("all good"));
+    }
+
+    #[test]
+    fn inverse_substring_hides_matches() {
+        let m = LogMatcher::new("!health");
+        assert!(!m.matches("GET /healthz 200"));
+        assert!(m.matches("GET /api 500"));
+    }
+
+    #[test]
+    fn regex_matches_and_is_case_insensitive() {
+        let m = LogMatcher::new("/level=(warn|error)/");
+        assert!(m.matches("ts=1 level=ERROR msg=boom"));
+        assert!(!m.matches("ts=1 level=info msg=ok"));
+    }
+
+    #[test]
+    fn inverse_regex() {
+        let m = LogMatcher::new("!/2\\d\\d/");
+        assert!(!m.matches("status 200"));
+        assert!(m.matches("status 503"));
+    }
+
+    #[test]
+    fn bad_regex_matches_nothing_and_flags_error() {
+        let m = LogMatcher::new("/[unclosed/");
+        assert!(m.is_error());
+        assert!(!m.matches("anything"));
+        // Even negated, a broken regex hides everything.
+        let n = LogMatcher::new("!/[unclosed/");
+        assert!(!n.matches("anything"));
+    }
+
+    #[test]
+    fn slashes_need_both_ends_to_be_a_regex() {
+        // A single leading slash is a literal substring, not a regex.
+        let m = LogMatcher::new("/api");
+        assert!(m.matches("GET /api/v1"));
+        assert!(!m.is_error());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod helm;
 mod journal;
 mod k8s;
 mod keys;
+mod logfilter;
 mod providers;
 mod snapshot;
 mod store;
@@ -175,6 +176,7 @@ async fn main() -> Result<()> {
     app.guardrails = cfg.guardrails.clone();
     app.debug = cfg.debug.clone();
     app.bundle_cfg = cfg.bundle.clone();
+    app.logs_cfg = cfg.logs.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -746,8 +746,6 @@ fn draw_scrollable(
 /// not a full restyle; and the display-row offset is a `usize`, immune to the
 /// `u16` ceiling of `Paragraph::scroll`.
 fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
-    let filter = app.logs.filter.to_lowercase();
-    let active = !filter.is_empty();
     let inner_w = area.width.saturating_sub(2).max(1) as usize;
     let inner_h = area.height.saturating_sub(2) as usize;
 
@@ -756,8 +754,18 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
         .view
         .lines
         .iter()
-        .filter(|l| !active || l.to_lowercase().contains(&filter))
+        .filter(|l| app.logs.matches(l))
         .collect();
+
+    let filter = app.logs.filter.clone();
+    let active = !filter.is_empty();
+    let bad_regex = app.logs.matcher.is_error();
+    // Highlight matches only for a plain substring filter — not inverse (`!…`,
+    // which hides matches) or regex (`/…/`, whose spans we don't track).
+    let is_plain = active
+        && !filter.starts_with('!')
+        && !(filter.len() >= 2 && filter.starts_with('/') && filter.ends_with('/'));
+    let highlight = if is_plain { filter.as_str() } else { "" };
 
     // Exact display height of every shown line, so follow can anchor the
     // newest line to the *bottom* of the viewport (not the top).
@@ -805,7 +813,7 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
         if row >= scroll + inner_h {
             break;
         }
-        let line = render_log_line(l, &app.logs.filter);
+        let line = render_log_line(l, highlight);
         if app.logs.wrap {
             for (j, sub) in wrap_line(line, inner_w).into_iter().enumerate() {
                 let r = row + j;
@@ -835,11 +843,16 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
         if app.logs.wrap { " wrap" } else { "" },
         if app.logs.timestamps { " ts" } else { "" },
     );
-    let title = if active {
+    let title = if bad_regex {
+        format!(
+            " {} · /{} [invalid regex]{} ",
+            app.logs.view.title, filter, flags
+        )
+    } else if active {
         format!(
             " {} · /{} [{}]{} ",
             app.logs.view.title,
-            app.logs.filter,
+            filter,
             shown.len(),
             flags
         )
@@ -1625,8 +1638,14 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         Line::from(""),
         Line::from(Span::styled("  Logs view", theme::title())),
-        bind("/ · s · w · t", "search · autoscroll · wrap · timestamps"),
-        bind("x · c · ctrl-s", "stop/resume · copy · save to file"),
+        bind(
+            "/ · s · w · t",
+            "filter (text · /regex/ · !invert) · autoscroll · wrap · timestamps",
+        ),
+        bind(
+            "x · z · c · ctrl-s",
+            "stop/resume · clear buffer · copy · save to file",
+        ),
         bind(
             "shift-t",
             "provider logs: change lookback period (30m, 4h, 2d)",
@@ -2580,7 +2599,7 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         }
         Mode::LogFilter => Line::from(vec![
             Span::styled(
-                "log search /",
+                "log filter (text · /re/ · !invert) /",
                 Style::default()
                     .fg(theme::teal())
                     .add_modifier(Modifier::BOLD),
@@ -2611,9 +2630,9 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Mode::Logs => {
             let hint = if app.provider_logs_active() {
-                "  /search  s:autoscroll  w:wrap  t:timestamps  T:period  x:stop/resume  c:copy  ^s:save  esc:back"
+                "  /filter  s:autoscroll  w:wrap  t:timestamps  T:period  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
             } else {
-                "  /search  s:autoscroll  w:wrap  t:timestamps  x:stop/resume  c:copy  ^s:save  esc:back"
+                "  /filter  s:autoscroll  w:wrap  t:timestamps  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
             };
             Line::from(Span::styled(hint, theme::dim()))
         }


### PR DESCRIPTION
## Summary
Sixth and final item of **Milestone 5**: richer controls for the kubelet logs view.

- **Regex + inverse filtering** — the `/` filter now accepts a case-insensitive substring (highlighted, as before), a **`/regex/`**, or a leading **`!`** to invert (keep non-matching lines). A malformed regex is flagged `[invalid regex]` instead of silently hiding the whole buffer.
- **Clear buffer** — `z` clears the on-screen buffer; the live stream keeps appending.
- **Configurable tail / buffer / since** via a new `[logs]` section: initial `tail`, follow `buffer` (replaces the hardcoded 5000 cap), and an optional `since` lookback (replaces tail).
- A pod already streams **all its containers** at once (unchanged, noted in docs).

## Config
```toml
[logs]
tail = 300       # initial lines fetched per stream
buffer = 5000    # max lines kept while following
since = "1h"     # optional: only logs newer than this — replaces tail
```

## Implementation
- New pure `logfilter` module (`LogMatcher`: substring / regex / inverse, with `is_error`) — 7 unit tests. Adds `regex` as a direct dependency (already in the tree via kube).
- `LogsView` caches the compiled matcher via `set_filter`, used by the renderer, the paused-scroll math, and copy.
- `[logs]` config wired at all three config-application sites; `tail`/`since` feed `LogParams`, `buffer` bounds the follow trim.

## Notes
Remaining roadmap sub-bullets — container-prefix toggle, reconnect-status/retry controls, and full-screen default — are smaller polish items deferred to a follow-up; the filtering/buffer ergonomics here are the high-value core.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 345 pass (logfilter unit tests + app-level regex/inverse/bad-regex/clear + updated buffer-cap tests to the configured value)
- [x] Live-verified against the home cluster: `/404/` regex filtered to matches only, `!404` inverted (99 vs 217 lines), `/[bad/` showed `[invalid regex]`, and `z` cleared the buffer (stream resumed appending)