### PR TITLE
docs: mark Milestone 5 (debugging & collaboration) complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,12 +866,12 @@ platform binaries, publishes crates.io, and warms the Nix cache.
 
 ### Milestone 5: debugging and collaboration
 
-- [ ] Ephemeral container workflow.
-- [ ] Node debug pod workflow.
-- [ ] Redacted diagnostic bundles.
-- [ ] Screen dumps and structured snapshots.
-- [ ] Runtime diagnostics and structured logs.
-- [ ] Richer log controls.
+- [x] Ephemeral container workflow.
+- [x] Node debug pod workflow.
+- [x] Redacted diagnostic bundles.
+- [x] Screen dumps and structured snapshots.
+- [x] Runtime diagnostics. _(Structured application logging is still to come.)_
+- [x] Richer log controls.
 
 ### Milestone 6: fleet and integrations
 


### PR DESCRIPTION
## Summary
Flips the Milestone 5 roadmap checkboxes now that all six features have shipped:

- [x] Ephemeral container workflow (`:debug`) — #66
- [x] Node debug pod workflow — #67
- [x] Redacted diagnostic bundles (`:bundle`) — #68
- [x] Screen dumps and structured snapshots (`:snapshot`/`:snapshots`) — #69
- [x] Runtime diagnostics (`:info` / `sofka --info`) — #70 _(structured application logging noted as still to come)_
- [x] Richer log controls (regex/inverse filter, `[logs]` tail/buffer/since, clear) — #71

Each feature's own docs (feature bullets, keybinding rows, config sections) landed with its PR; this is just the roadmap-status pass.

## Test plan
- [x] Docs-only; lefthook markdown format passed