### PR TITLE
feat: compact mode (ctrl-e) for tiled panes

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": []
+}

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Not a marketing number - these are specific, checkable design choices:
   cluster and reaches it through the API-server proxy; or point
   `[providers.logs]` at an external URL. Covers restarted and deleted pods —
   the backend remembers what the kubelet no longer has.
+- **Compact mode** (`ctrl-e`) - collapse the seven-line header and the footer
+  into a single info line (kind · count · namespace · context, plus a flash and
+  the live indicator), so a tiled or multiplexed pane is almost all table.
 - **Skinnable** - built-in Catppuccin, Gruvbox, Solarized, Nord, Dracula,
   Tokyo Night, One Dark, Rosé Pine, and Monokai palettes, auto-detected
   dark/light default, plus per-swatch overrides in config.
@@ -716,6 +719,7 @@ header) and switching away restores write mode.
 | `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                             |
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                              |
 | `S` / `I`                                     | cycle sort column / invert sort direction                                                                                             |
+| `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                              |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                      |
 | `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |
 | `n` / `0`                                     | namespace switcher / all namespaces                                                                                                   |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -11,6 +11,13 @@ impl App {
                     self.should_quit = true;
                     return Ok(());
                 }
+                // Compact mode: collapse the header to one line and hide the
+                // footer (k9s ctrl-e/ctrl-g, folded into one toggle). Works in
+                // every mode, so it never reaches the plain-key bindings.
+                KeyCode::Char('e') => {
+                    self.compact = !self.compact;
+                    return Ok(());
+                }
                 KeyCode::Char('d') if self.mode == Mode::Table => {
                     self.request_delete(false);
                     return Ok(());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -943,6 +943,9 @@ pub struct App {
     crd_views: HashMap<String, Option<crate::views::View>>,
     /// Wide mode (`w`): show wide-only columns.
     pub wide: bool,
+    /// Compact mode (`ctrl-e`): collapse the header to one line and hide the
+    /// footer, so a tiled/multiplexed pane shows mostly table.
+    pub compact: bool,
     /// Active column layout for the current view; rebuilt by
     /// [`App::refresh_view_spec`] whenever kind/views/wide change.
     spec: crate::columns::ViewSpec,
@@ -1082,6 +1085,7 @@ impl App {
             thresholds: crate::thresholds::Compiled::default(),
             crd_views: HashMap::new(),
             wide: false,
+            compact: false,
             spec: crate::columns::build_spec("", None, None, false),
         }
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -16,6 +16,10 @@ fn press(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)
 }
 
+fn ctrl(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::CONTROL)
+}
+
 /// Inject a watched object as the current generation would.
 fn apply(app: &mut App, v: serde_json::Value) {
     let o = obj(v);
@@ -3593,6 +3597,24 @@ async fn wide_toggle_reveals_pod_columns_and_keeps_sort() {
     app.sort_column = Some(4); // IP
     app.handle_key(press(KeyCode::Char('w'))).unwrap();
     assert_eq!(app.sort_column, None);
+}
+
+#[tokio::test]
+async fn ctrl_e_toggles_compact_mode_from_any_mode() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    assert!(!app.compact);
+
+    // Toggles on from the table…
+    app.handle_key(ctrl(KeyCode::Char('e'))).unwrap();
+    assert!(app.compact);
+    assert_eq!(app.mode, Mode::Table, "compact toggle doesn't change mode");
+
+    // …and off again from a doc view (it's global, not table-only).
+    app.mode = Mode::Detail;
+    app.handle_key(ctrl(KeyCode::Char('e'))).unwrap();
+    assert!(!app.compact);
+    assert_eq!(app.mode, Mode::Detail);
 }
 
 #[tokio::test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -66,17 +66,41 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         frame.buffer_mut().set_style(area, Style::default().bg(bg));
     }
 
+    // Compact mode (ctrl-e) trades the 7-line header + footer for a single
+    // header line, so a small tiled pane is almost all table. The prompt line
+    // still appears while typing a command/filter; the status line and hint
+    // crumbs are folded away (a flash + sync dot ride in the compact header).
+    let compact = app.compact;
+    let needs_prompt = matches!(
+        app.mode,
+        Mode::Command | Mode::Filter | Mode::LogFilter | Mode::DocFilter
+    );
+    let mut constraints = vec![
+        Constraint::Length(if compact { 1 } else { 7 }), // header
+        Constraint::Min(3),                              // body
+    ];
+    let prompt_idx = if !compact || needs_prompt {
+        constraints.push(Constraint::Length(1));
+        Some(constraints.len() - 1)
+    } else {
+        None
+    };
+    let status_idx = if !compact {
+        constraints.push(Constraint::Length(1));
+        Some(constraints.len() - 1)
+    } else {
+        None
+    };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(7), // header
-            Constraint::Min(3),    // body
-            Constraint::Length(1), // prompt
-            Constraint::Length(1), // status
-        ])
+        .constraints(constraints)
         .split(frame.area());
 
-    draw_header(frame, app, chunks[0]);
+    if compact {
+        draw_compact_header(frame, app, chunks[0]);
+    } else {
+        draw_header(frame, app, chunks[0]);
+    }
 
     match app.mode {
         Mode::Detail => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
@@ -117,8 +141,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         _ => {}
     }
 
-    draw_prompt(frame, app, chunks[2]);
-    draw_status(frame, app, chunks[3]);
+    if let Some(i) = prompt_idx {
+        draw_prompt(frame, app, chunks[i]);
+    }
+    if let Some(i) = status_idx {
+        draw_status(frame, app, chunks[i]);
+    }
 }
 
 /// Width reserved for the per-kind key-hint column inside the header box:
@@ -226,6 +254,70 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(Span::styled(format!("   sofka v{VERSION}"), theme::dim())),
     ];
     frame.render_widget(Paragraph::new(logo).alignment(Alignment::Right), cols[1]);
+}
+
+/// The single-line header for compact mode (`ctrl-e`): kind · count ·
+/// namespace · context on the left; a transient flash and the live/sync dot on
+/// the right. Everything the full header shows that still matters when you've
+/// traded it for screen space.
+fn draw_compact_header(frame: &mut Frame, app: &App, area: Rect) {
+    let ns = if app.all_namespaces() {
+        "<all>".to_string()
+    } else if app.namespace.is_empty() {
+        "<none>".to_string()
+    } else {
+        app.namespace.clone()
+    };
+    let mut kind = app.resource_title();
+    if let Some(scope) = &app.scope_label {
+        kind = format!("{kind} ‹ {scope}");
+    }
+
+    let mut spans = vec![
+        Span::styled(" sofka ", theme::title()),
+        Span::styled(kind, Style::default().fg(theme::peach())),
+        Span::styled(format!(" [{}]", app.store.len()), theme::dim()),
+        Span::styled("  ns:", theme::dim()),
+        Span::styled(ns, Style::default().fg(theme::green())),
+        Span::styled("  ", theme::dim()),
+        Span::styled(
+            app.cluster.context.clone(),
+            Style::default().fg(theme::mauve()),
+        ),
+    ];
+    if app.readonly {
+        spans.push(Span::styled(" [ro]", Style::default().fg(theme::red())));
+    }
+    // A flash is transient but can carry errors — surface it inline since the
+    // status line is hidden in compact mode.
+    if !app.flash.is_empty() {
+        let style = if app.flash_err {
+            Style::default().fg(theme::red())
+        } else {
+            Style::default().fg(theme::subtext0())
+        };
+        spans.push(Span::styled("  — ", theme::dim()));
+        spans.push(Span::styled(app.flash.clone(), style));
+    }
+
+    let (synced, sync_color) = if app.store.synced {
+        ("● live", theme::green())
+    } else {
+        ("○ syncing", theme::yellow())
+    };
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(10), Constraint::Length(10)])
+        .split(area);
+    frame.render_widget(Paragraph::new(Line::from(spans)), cols[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            synced,
+            Style::default().fg(sync_color),
+        )))
+        .alignment(Alignment::Right),
+        cols[1],
+    );
 }
 
 /// Whether the frame is wide enough for the header's key-hint column:
@@ -1560,6 +1652,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("j/k g/G", "move · top/bottom"),
         bind("S · I", "sort by column (cycle) · invert direction"),
         bind("w", "toggle wide columns (kubectl -o wide)"),
+        bind(
+            "ctrl-e",
+            "compact mode: collapse header + footer (for tiled panes)",
+        ),
         bind(
             "/",
             "filter: fuzzy · !inverse · -l/-f selectors (server-side on ⏎) · col=val cpu>500m age<2h",


### PR DESCRIPTION
## Summary
Closes #65. Adds a **compact mode** toggle (`ctrl-e`) that collapses the seven-line header and the footer into a single info line, so a small tiled or multiplexed pane is almost all table.

The one-line header keeps the essentials: **kind · count · namespace · context** (with a `[ro]` marker in read-only mode), plus a transient **flash** and the **live/sync** dot. The command/filter prompt line still appears while typing; toggling `ctrl-e` again restores the full chrome. Folds k9s's separate header (`ctrl-e`) and footer (`ctrl-g`) toggles into one, as requested.

## Before / after (110×16 pane)
- Normal: 7-line header + 2 footer lines → **4 pod rows** visible.
- Compact: 1-line header, no footer → **all 11 pod rows** visible.

## Implementation
- `App.compact` toggled by a global `ctrl-e` in `handle_key` (works in every mode).
- `draw()` builds its vertical layout dynamically: 1-line vs 7-line header; prompt/status lines included only when needed (prompt still shows for `Command`/`Filter`/`LogFilter`/`DocFilter`).
- New `draw_compact_header` renders the single-line summary.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 346 pass (added `ctrl_e_toggles_compact_mode_from_any_mode`)
- [x] Live-verified in a 110×16 tmux pane: `ctrl-e` collapsed the chrome (4 → 11 rows), one-line header showed `pods [11]  ns:ai  admin@home-kubernetes  ● live`, `:` still opened the palette, second `ctrl-e` restored the full header