### PR TITLE
feat: opt-in cross-context fleet dashboard (:fleet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ Not a marketing number - these are specific, checkable design choices:
   cluster and reaches it through the API-server proxy; or point
   `[providers.logs]` at an external URL. Covers restarted and deleted pods —
   the backend remembers what the kubelet no longer has.
+- **Fleet dashboard** (`:fleet`) - an opt-in cross-context health summary:
+  connectivity, Kubernetes version, node readiness, unhealthy pods, Flux
+  failures, and the read-only policy for each configured context, side by side.
+  Only the contexts listed in `[fleet]` are queried, each gathered concurrently
+  with its own timeout so one slow cluster never blocks the rest; `⏎` switches
+  to a context, `r` refreshes.
 - **Compact mode** (`ctrl-e`) - collapse the seven-line header and the footer
   into a single info line (kind · count · namespace · context, plus a flash and
   the live indicator), so a tiled or multiplexed pane is almost all table.
@@ -608,6 +614,24 @@ leading `!` to invert (keep non-matching lines); a malformed regex is flagged
 rather than hiding everything. `z` clears the on-screen buffer (the live stream
 keeps appending). A pod's logs already stream every container at once.
 
+### Fleet dashboard
+
+`:fleet` summarizes several clusters side by side without switching through
+them. It is **opt-in**: only the kubeconfig contexts you list are ever queried.
+
+```toml
+[fleet]
+contexts = ["prod-eu", "prod-us", "staging"]
+```
+
+Each context is gathered concurrently (bounded, with a per-context timeout), so
+an unreachable or slow cluster shows an error on its own row instead of
+blocking the others. Rows show connectivity, Kubernetes version, node
+readiness, unhealthy pod count, Flux `Ready=False` failures, and the resolved
+read-only policy. `⏎` switches to the highlighted context (via the normal
+context-switch path); `r` re-gathers. Only these non-sensitive summaries are
+held in memory.
+
 ### Log provider (VictoriaLogs)
 
 `L` (or `:vlogs`) opens log history for the selection from a VictoriaLogs
@@ -732,6 +756,7 @@ header) and switching away restores write mode.
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
 | `:ctx` / `:ctx <name>`                        | context switcher popup / switch directly (the name tab-completes)                                                                     |
+| `:fleet`                                      | cross-context health dashboard (opt-in `[fleet]` contexts; `⏎` switches, `r` refreshes)                                               |
 | `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
 | `:reload` / `:config` / `:info`               | reload config from disk · config sources + warnings · runtime diagnostics                                                             |
 | `l` / `p`                                     | logs (workload = all matching pods) / previous-container logs                                                                         |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1201,6 +1201,7 @@ impl App {
         self.debug = resolved.config.debug;
         self.bundle_cfg = resolved.config.bundle;
         self.logs_cfg = resolved.config.logs;
+        self.fleet_cfg = resolved.config.fleet;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         warnings.extend(crate::config::workspace_warnings(&self.workspaces));

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -1,0 +1,206 @@
+use super::*;
+
+use crate::fleet::{FleetRow, FleetStatus};
+
+/// Never query more than this many contexts at once, so opening the dashboard
+/// against a large fleet doesn't open a connection storm.
+const FLEET_CONCURRENCY: usize = 4;
+/// Per-context budget: a slow or unreachable context fails here instead of
+/// hanging the row (the others are unaffected).
+const FLEET_TIMEOUT_SECS: u64 = 8;
+
+impl App {
+    /// `:fleet` — open the opt-in cross-context health dashboard. Only the
+    /// contexts in `[fleet].contexts` are queried; each is gathered off-thread
+    /// with its own timeout so one slow context never blocks the rest.
+    pub(super) fn open_fleet(&mut self) {
+        if self.fleet_cfg.contexts.is_empty() {
+            self.flash_warn("no fleet contexts — set [fleet] contexts = [\"ctx-a\", …]");
+            return;
+        }
+        // Leaving the table view: stop its watches (like the pulse dashboard).
+        self.bump_generation();
+        self.store.clear();
+        self.invalidate_rows();
+
+        // Seed a "connecting" row per context, resolving each one's read-only
+        // policy up front (the CLI flag wins; else the per-context config).
+        self.fleet_rows = self
+            .fleet_cfg
+            .contexts
+            .iter()
+            .map(|ctx| {
+                let cluster = crate::k8s::cluster_name_for_context(ctx);
+                let readonly = self
+                    .readonly_override
+                    .unwrap_or_else(|| self.config.resolve(ctx, &cluster).config.readonly);
+                FleetRow::connecting(ctx.clone(), readonly)
+            })
+            .collect();
+        self.fleet_state.select(Some(0));
+        self.flash = format!("fleet — {} contexts", self.fleet_rows.len());
+        self.flash_err = false;
+        self.mode = Mode::Fleet;
+        self.spawn_fleet_gathers();
+    }
+
+    fn spawn_fleet_gathers(&mut self) {
+        let sema = Arc::new(tokio::sync::Semaphore::new(FLEET_CONCURRENCY));
+        for row in &self.fleet_rows {
+            let ctx = row.context.clone();
+            let readonly = row.readonly;
+            let tx = self.tx.clone();
+            let genr = self.generation;
+            let sema = sema.clone();
+            let handle = tokio::spawn(async move {
+                // Bound concurrency: hold a permit for the whole gather.
+                let _permit = sema.acquire().await;
+                let dur = Duration::from_secs(FLEET_TIMEOUT_SECS);
+                let row = match tokio::time::timeout(dur, gather_context(&ctx, readonly)).await {
+                    Ok(row) => row,
+                    Err(_) => {
+                        let mut r = FleetRow::connecting(ctx.clone(), readonly);
+                        r.status = FleetStatus::Error("timed out".into());
+                        r
+                    }
+                };
+                let _ = tx
+                    .send(Msg::FleetRow {
+                        generation: genr,
+                        row: Box::new(row),
+                    })
+                    .await;
+            });
+            self.tasks.push(handle);
+        }
+    }
+
+    /// Apply a gathered summary to its row (matched by context name).
+    pub(super) fn apply_fleet_row(&mut self, row: FleetRow) {
+        if let Some(slot) = self
+            .fleet_rows
+            .iter_mut()
+            .find(|r| r.context == row.context)
+        {
+            *slot = row;
+        }
+    }
+
+    pub(super) fn key_fleet(&mut self, key: KeyEvent) {
+        let len = self.fleet_rows.len();
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
+            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.fleet_state, len, true),
+            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.fleet_state, len, false),
+            KeyCode::Char('r') => {
+                // Re-gather: reset rows to connecting, keeping resolved policy.
+                for r in &mut self.fleet_rows {
+                    *r = FleetRow::connecting(r.context.clone(), r.readonly);
+                }
+                self.spawn_fleet_gathers();
+            }
+            // Enter switches to the highlighted context via the normal
+            // context-switch path, landing on its default view.
+            KeyCode::Enter => {
+                if let Some(ctx) = self
+                    .fleet_state
+                    .selected()
+                    .and_then(|i| self.fleet_rows.get(i))
+                    .map(|r| r.context.clone())
+                {
+                    self.mode = Mode::Table;
+                    self.switch_context(ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Gather one context's summary: connect, then read version, node readiness,
+/// unhealthy pods, and Flux failures. Any connection/auth error becomes an
+/// `Error` row rather than propagating.
+async fn gather_context(ctx: &str, readonly: bool) -> FleetRow {
+    let mut row = FleetRow::connecting(ctx.to_string(), readonly);
+    let cluster = match Cluster::connect_context(ctx).await {
+        Ok(c) => c,
+        Err(e) => {
+            row.status = FleetStatus::Error(short_error(&format!("{e:#}")));
+            return row;
+        }
+    };
+    let client = cluster.client.clone();
+
+    row.version = match client.apiserver_version().await {
+        Ok(info) => info.git_version,
+        Err(_) => "?".into(),
+    };
+
+    if let Some(k) = cluster.resolve("nodes") {
+        let nodes = list_kind(&client, &k.ar, false, "").await;
+        row.nodes_total = nodes.len();
+        row.nodes_ready = nodes.iter().filter(|o| node_ready(o)).count();
+    }
+
+    if let Some(k) = cluster.resolve("pods") {
+        let pods = list_kind(&client, &k.ar, k.namespaced, "").await;
+        row.pods_total = pods.len();
+        row.pods_unhealthy = pods.iter().filter(|o| !pod_healthy(o)).count();
+    }
+
+    // Flux failures: only report a count when the toolkit CRDs exist.
+    let mut flux_failed = None;
+    for kind in ["kustomizations", "helmreleases"] {
+        if let Some(k) = cluster.resolve(kind) {
+            let items = list_kind(&client, &k.ar, k.namespaced, "").await;
+            let failed = items.iter().filter(|o| ready_is_false(o)).count();
+            *flux_failed.get_or_insert(0) += failed;
+        }
+    }
+    row.flux_failed = flux_failed;
+
+    row.status = FleetStatus::Ok;
+    row
+}
+
+/// A pod counts as healthy when it's Running-and-ready or Succeeded.
+fn pod_healthy(o: &DynamicObject) -> bool {
+    match phase(o).as_str() {
+        "Succeeded" => true,
+        "Running" => o
+            .data
+            .pointer("/status/conditions")
+            .and_then(Value::as_array)
+            .is_some_and(|cs| {
+                cs.iter().any(|c| {
+                    c.get("type").and_then(Value::as_str) == Some("Ready")
+                        && c.get("status").and_then(Value::as_str) == Some("True")
+                })
+            }),
+        _ => false,
+    }
+}
+
+/// Whether an object carries a `Ready` condition explicitly set to `False`
+/// (a failing Flux reconciliation).
+fn ready_is_false(o: &DynamicObject) -> bool {
+    o.data
+        .pointer("/status/conditions")
+        .and_then(Value::as_array)
+        .is_some_and(|cs| {
+            cs.iter().any(|c| {
+                c.get("type").and_then(Value::as_str) == Some("Ready")
+                    && c.get("status").and_then(Value::as_str) == Some("False")
+            })
+        })
+}
+
+/// First line of a connection error, trimmed for the one-line status cell.
+fn short_error(e: &str) -> String {
+    let first = e.lines().next().unwrap_or(e).trim();
+    if first.len() > 60 {
+        format!("{}…", &first[..59])
+    } else {
+        first.to_string()
+    }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -72,6 +72,7 @@ impl App {
             Mode::PortForwards => self.key_port_forwards(key),
             Mode::Skins => self.key_skins(key),
             Mode::Snapshots => self.key_snapshots(key),
+            Mode::Fleet => self.key_fleet(key),
         }
         Ok(())
     }
@@ -532,6 +533,7 @@ impl App {
             PaletteAction::Snapshot => self.take_snapshot(""),
             PaletteAction::Snapshots => self.open_snapshots(),
             PaletteAction::Info => self.open_info(),
+            PaletteAction::Fleet => self.open_fleet(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -717,6 +717,9 @@ impl App {
                     Err(e) => self.flash_warn(&format!("bundle save failed: {e}")),
                 }
             }
+            Msg::FleetRow { generation, row } if generation == self.generation => {
+                self.apply_fleet_row(*row);
+            }
             Msg::SnapshotSaved { generation, result } if generation == self.generation => {
                 match result {
                     Ok(path) => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -108,6 +108,8 @@ pub enum Mode {
     Skins,
     /// Browsing saved snapshots (`:snapshots`).
     Snapshots,
+    /// Cross-context fleet health dashboard (`:fleet`).
+    Fleet,
 }
 
 /// A request for the run loop to suspend the TUI and run an interactive
@@ -368,6 +370,7 @@ enum PaletteAction {
     Snapshot,
     Snapshots,
     Info,
+    Fleet,
     Diff,
     Events,
     PortForwards,
@@ -470,6 +473,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Info,
         names: &["info", "diagnostics", "about"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Fleet,
+        names: &["fleet", "clusters", "multi"],
     },
     PaletteCommand {
         action: PaletteAction::Quit,
@@ -810,6 +817,12 @@ pub struct App {
     pub bundle_cfg: crate::config::BundleConfig,
     /// Log-view options (`[logs]`), re-applied on context switch and `:reload`.
     pub logs_cfg: crate::config::LogsConfig,
+    /// Cross-context fleet dashboard config (`[fleet]`).
+    pub fleet_cfg: crate::config::FleetConfig,
+    /// Fleet dashboard rows (one per configured context), filled in as each
+    /// context's summary lands.
+    pub fleet_rows: Vec<crate::fleet::FleetRow>,
+    pub fleet_state: ListState,
     /// The last bundle assembled by `:bundle`, previewed in the detail view and
     /// written to disk by `:bundle-save`: `(filename, text)`.
     pub pending_bundle: Option<(String, String)>,
@@ -1013,6 +1026,9 @@ impl App {
             launched_node_debuggers: Vec::new(),
             bundle_cfg: crate::config::BundleConfig::default(),
             logs_cfg: crate::config::LogsConfig::default(),
+            fleet_cfg: crate::config::FleetConfig::default(),
+            fleet_rows: Vec::new(),
+            fleet_state: ListState::default(),
             pending_bundle: None,
             journal: crate::journal::Journal::default(),
             watch_errors: 0,
@@ -1115,6 +1131,7 @@ mod dashboards;
 mod details;
 mod diagnostics;
 mod explain;
+mod fleet;
 mod gitops;
 mod guardrails;
 mod helpers;

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -339,6 +339,7 @@ impl App {
         self.debug = resolved.config.debug;
         self.bundle_cfg = resolved.config.bundle;
         self.logs_cfg = resolved.config.logs;
+        self.fleet_cfg = resolved.config.fleet;
         // Tracked debuggers belong to the previous cluster/context.
         self.launched_node_debuggers.clear();
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3600,6 +3600,62 @@ async fn wide_toggle_reveals_pod_columns_and_keeps_sort() {
 }
 
 #[tokio::test]
+async fn fleet_without_configured_contexts_warns() {
+    let (mut app, _rx) = test_app();
+    app.open_fleet();
+    assert_ne!(
+        app.mode,
+        Mode::Fleet,
+        "no contexts → dashboard stays closed"
+    );
+    assert!(app.flash.contains("no fleet contexts"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn fleet_seeds_connecting_rows_and_applies_summaries() {
+    let (mut app, _rx) = test_app();
+    app.fleet_cfg = crate::config::FleetConfig {
+        contexts: vec!["prod".into(), "staging".into()],
+    };
+    app.open_fleet();
+    assert_eq!(app.mode, Mode::Fleet);
+    // One connecting row per configured context, up front.
+    assert_eq!(app.fleet_rows.len(), 2);
+    assert!(
+        app.fleet_rows
+            .iter()
+            .all(|r| r.status == crate::fleet::FleetStatus::Connecting)
+    );
+
+    // A gathered summary lands and replaces the matching row by context name.
+    let mut row = crate::fleet::FleetRow::connecting("staging".into(), false);
+    row.status = crate::fleet::FleetStatus::Ok;
+    row.version = "v1.31.0".into();
+    row.nodes_ready = 3;
+    row.nodes_total = 3;
+    app.handle_msg(Msg::FleetRow {
+        generation: app.generation,
+        row: Box::new(row),
+    });
+    let staging = app
+        .fleet_rows
+        .iter()
+        .find(|r| r.context == "staging")
+        .unwrap();
+    assert_eq!(staging.status, crate::fleet::FleetStatus::Ok);
+    assert_eq!(staging.version, "v1.31.0");
+    // The other context is untouched.
+    assert_eq!(
+        app.fleet_rows
+            .iter()
+            .find(|r| r.context == "prod")
+            .unwrap()
+            .status,
+        crate::fleet::FleetStatus::Connecting
+    );
+}
+
+#[tokio::test]
 async fn ctrl_e_toggles_compact_mode_from_any_mode() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,22 @@ pub struct Config {
     pub bundle: BundleConfig,
     /// Log-view options — see [`LogsConfig`].
     pub logs: LogsConfig,
+    /// Cross-context fleet dashboard (`:fleet`) — see [`FleetConfig`].
+    pub fleet: FleetConfig,
+}
+
+/// The opt-in cross-context fleet dashboard (`:fleet`). Only the kubeconfig
+/// contexts listed here are ever queried.
+///
+/// ```toml
+/// [fleet]
+/// contexts = ["prod-eu", "prod-us", "staging"]
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct FleetConfig {
+    /// Kubeconfig context names to summarize. Empty = the dashboard is off.
+    pub contexts: Vec<String>,
 }
 
 /// Log-view controls (kubelet streams).

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -1,0 +1,121 @@
+//! Cross-context fleet dashboard model (`:fleet`).
+//!
+//! An opt-in summary of several kubeconfig contexts at once — connectivity,
+//! Kubernetes version, node readiness, unhealthy workloads, Flux failures, and
+//! the read-only policy — so you can eyeball a fleet without switching through
+//! contexts one at a time. Only explicitly configured contexts are queried, and
+//! each is gathered independently so one slow cluster never blocks the rest.
+//! Only these non-sensitive summaries are held in memory.
+
+/// Where a context's summary stands.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FleetStatus {
+    /// Still connecting / gathering.
+    Connecting,
+    /// Reachable and summarized.
+    Ok,
+    /// Unreachable, unauthenticated, or the gather timed out.
+    Error(String),
+}
+
+/// One context's summary row.
+#[derive(Clone, Debug)]
+pub struct FleetRow {
+    pub context: String,
+    pub status: FleetStatus,
+    /// API-server version (`git_version`), empty until known.
+    pub version: String,
+    pub nodes_ready: usize,
+    pub nodes_total: usize,
+    /// Pods not `Running`/`Succeeded` (or Running-but-not-ready).
+    pub pods_unhealthy: usize,
+    pub pods_total: usize,
+    /// Flux resources with `Ready=False`; `None` when the cluster has no Flux
+    /// toolkit CRDs.
+    pub flux_failed: Option<usize>,
+    /// The read-only policy resolved for this context.
+    pub readonly: bool,
+}
+
+impl FleetRow {
+    /// A freshly-seeded row shown while the gather is in flight.
+    pub fn connecting(context: String, readonly: bool) -> Self {
+        FleetRow {
+            context,
+            status: FleetStatus::Connecting,
+            version: String::new(),
+            nodes_ready: 0,
+            nodes_total: 0,
+            pods_unhealthy: 0,
+            pods_total: 0,
+            flux_failed: None,
+            readonly,
+        }
+    }
+
+    /// Whether the context reads as fully healthy: reachable, every node ready,
+    /// no unhealthy pods, and no Flux failures.
+    pub fn is_healthy(&self) -> bool {
+        self.status == FleetStatus::Ok
+            && self.nodes_ready == self.nodes_total
+            && self.pods_unhealthy == 0
+            && self.flux_failed.unwrap_or(0) == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok_row() -> FleetRow {
+        FleetRow {
+            context: "prod".into(),
+            status: FleetStatus::Ok,
+            version: "v1.30.2".into(),
+            nodes_ready: 3,
+            nodes_total: 3,
+            pods_unhealthy: 0,
+            pods_total: 40,
+            flux_failed: Some(0),
+            readonly: true,
+        }
+    }
+
+    #[test]
+    fn connecting_row_is_not_healthy() {
+        let r = FleetRow::connecting("staging".into(), false);
+        assert_eq!(r.status, FleetStatus::Connecting);
+        assert!(!r.is_healthy());
+    }
+
+    #[test]
+    fn healthy_requires_ready_nodes_no_bad_pods_no_flux_failures() {
+        assert!(ok_row().is_healthy());
+
+        let mut r = ok_row();
+        r.nodes_ready = 2; // a node down
+        assert!(!r.is_healthy());
+
+        let mut r = ok_row();
+        r.pods_unhealthy = 1;
+        assert!(!r.is_healthy());
+
+        let mut r = ok_row();
+        r.flux_failed = Some(2);
+        assert!(!r.is_healthy());
+    }
+
+    #[test]
+    fn errored_context_is_never_healthy() {
+        let mut r = ok_row();
+        r.status = FleetStatus::Error("deadline elapsed".into());
+        assert!(!r.is_healthy());
+    }
+
+    #[test]
+    fn no_flux_crds_does_not_count_as_a_failure() {
+        let mut r = ok_row();
+        r.flux_failed = None;
+        assert!(r.is_healthy());
+    }
+}

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -363,6 +363,12 @@ pub fn current_context_info() -> Option<(String, String, String)> {
     Some((context, cluster_name, server))
 }
 
+/// Public wrapper over [`cluster_name_for`] for resolving per-context config
+/// (fleet dashboard read-only policy) without a live connection.
+pub fn cluster_name_for_context(context: &str) -> String {
+    cluster_name_for(context).unwrap_or_default()
+}
+
 /// Kubeconfig cluster name a context points at, when the kubeconfig knows it.
 fn cluster_name_for(context: &str) -> Option<String> {
     let kubeconfig = kube::config::Kubeconfig::read().ok()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod diagnostics;
 mod explain;
 mod filter;
+mod fleet;
 mod gitops;
 mod helm;
 mod journal;
@@ -177,6 +178,7 @@ async fn main() -> Result<()> {
     app.debug = cfg.debug.clone();
     app.bundle_cfg = cfg.bundle.clone();
     app.logs_cfg = cfg.logs.clone();
+    app.fleet_cfg = cfg.fleet.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))

--- a/src/store.rs
+++ b/src/store.rs
@@ -165,6 +165,12 @@ pub enum Msg {
         generation: u64,
         result: Result<std::path::PathBuf, String>,
     },
+    /// One context's summary for the fleet dashboard (`:fleet`), arriving
+    /// independently so a slow context never blocks the rest.
+    FleetRow {
+        generation: u64,
+        row: Box<crate::fleet::FleetRow>,
+    },
     Error {
         generation: u64,
         error: String,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -124,6 +124,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Gitops => draw_gitops(frame, app, chunks[1]),
         Mode::Timeline => draw_timeline(frame, app, chunks[1]),
         Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
+        Mode::Fleet => draw_fleet(frame, app, chunks[1]),
         _ => draw_table(frame, app, chunks[1]),
     }
 
@@ -1628,6 +1629,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("[ · ]", "view history — back · forward"),
         bind(":ctx · :pulse", "switch context · cluster-health dashboard"),
         bind(
+            ":fleet",
+            "cross-context health dashboard (opt-in [fleet] contexts; ⏎ switches)",
+        ),
+        bind(
             ":xray · :diff",
             "hierarchical tree · live-vs-last-applied diff",
         ),
@@ -2398,6 +2403,93 @@ fn draw_xray(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+fn draw_fleet(frame: &mut Frame, app: &mut App, area: Rect) {
+    use crate::fleet::FleetStatus;
+    let items: Vec<ListItem> = app
+        .fleet_rows
+        .iter()
+        .map(|r| {
+            let (glyph, gcolor) = match &r.status {
+                FleetStatus::Connecting => ("◐", theme::overlay1()),
+                FleetStatus::Error(_) => ("●", theme::red()),
+                FleetStatus::Ok if r.is_healthy() => ("●", theme::green()),
+                FleetStatus::Ok => ("●", theme::yellow()),
+            };
+            let mut spans = vec![
+                Span::styled(format!("{glyph} "), Style::default().fg(gcolor)),
+                Span::styled(
+                    format!("{:<26}", truncate_cols(&r.context, 26)),
+                    Style::default().fg(theme::text()),
+                ),
+            ];
+            match &r.status {
+                FleetStatus::Connecting => {
+                    spans.push(Span::styled("connecting…", theme::dim()));
+                }
+                FleetStatus::Error(e) => {
+                    spans.push(Span::styled(
+                        format!("error: {e}"),
+                        Style::default().fg(theme::red()),
+                    ));
+                }
+                FleetStatus::Ok => {
+                    let nodes_color = if r.nodes_ready == r.nodes_total {
+                        theme::green()
+                    } else {
+                        theme::red()
+                    };
+                    let pods_color = if r.pods_unhealthy == 0 {
+                        theme::subtext0()
+                    } else {
+                        theme::red()
+                    };
+                    spans.push(Span::styled(
+                        format!("{:<12}", truncate_cols(&r.version, 12)),
+                        theme::dim(),
+                    ));
+                    spans.push(Span::styled(
+                        format!("nodes {}/{}", r.nodes_ready, r.nodes_total),
+                        Style::default().fg(nodes_color),
+                    ));
+                    spans.push(Span::styled(
+                        format!("   pods {}✗/{}", r.pods_unhealthy, r.pods_total),
+                        Style::default().fg(pods_color),
+                    ));
+                    match r.flux_failed {
+                        Some(0) => spans.push(Span::styled(
+                            "   flux ok".to_string(),
+                            Style::default().fg(theme::green()),
+                        )),
+                        Some(n) => spans.push(Span::styled(
+                            format!("   flux {n}✗"),
+                            Style::default().fg(theme::red()),
+                        )),
+                        None => spans.push(Span::styled("   flux —".to_string(), theme::dim())),
+                    }
+                    let (pol, pc) = if r.readonly {
+                        ("   read-only", theme::yellow())
+                    } else {
+                        ("   write", theme::overlay1())
+                    };
+                    spans.push(Span::styled(pol.to_string(), Style::default().fg(pc)));
+                }
+            }
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+    let title = format!(
+        " Fleet [{}]  (⏎ switch · r refresh · esc back) ",
+        app.fleet_rows.len()
+    );
+    render_framed_list(
+        frame,
+        area,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.fleet_state,
+    );
+}
+
 /// Explain-unhealthy view: a ranked, evidence-backed list of findings for the
 /// selected object. Lines carrying a navigation target are marked with a `→`.
 /// Render a list of [`crate::explain::Finding`]s (shared by the explain and
@@ -2759,6 +2851,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Mode::Snapshots => Line::from(Span::styled(
             "  j/k: move   ⏎: open   d: delete   esc: close",
+            theme::dim(),
+        )),
+        Mode::Fleet => Line::from(Span::styled(
+            "  j/k: move   ⏎: switch to context   r: refresh   esc: back",
             theme::dim(),
         )),
         _ => {


### PR DESCRIPTION
## Summary
First of two Milestone 6 items: an **opt-in cross-context health dashboard**.

`:fleet` summarizes several kubeconfig contexts side by side — one row each — so you can eyeball a fleet without switching through them:

- **Connectivity / auth** (a clear error on the row if a context is unreachable)
- **Kubernetes version**
- **Node readiness** (ready/total)
- **Unhealthy pods** (not Running-and-ready / Succeeded)
- **Flux failures** (`Ready=False` across Kustomizations + HelmReleases; `—` when there are no toolkit CRDs)
- **Read-only policy** (resolved per context)

`⏎` switches to the highlighted context via the normal context-switch path; `r` re-gathers.

## Safety / robustness (per the roadmap constraints)
- **Opt-in**: only the contexts in `[fleet].contexts` are ever queried.
- **Bounded concurrency** (4) + a **per-context timeout** (8s): a slow or unreachable cluster errors on its own row and **never blocks the others** — rows arrive independently via `Msg::FleetRow`.
- Only **non-sensitive summaries** are held in memory.

## Config
```toml
[fleet]
contexts = ["prod-eu", "prod-us", "staging"]
```

## Implementation
- New pure `fleet` module (`FleetRow` / `FleetStatus` + `is_healthy`) — 4 unit tests.
- `Mode::Fleet` view (`draw_fleet`), `open_fleet` / `gather_context` / `key_fleet`, `Msg::FleetRow`, `[fleet]` config wired at all three sites.
- `k8s::cluster_name_for_context` for offline per-context read-only resolution.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 352 pass (opt-in guard + seed/apply-row tests)
- [x] Live-verified against the home cluster with a deliberately-bogus second context: `admin@home-kubernetes` showed `v1.36.2, nodes 3/3, pods 0✗/189, flux ok, write` (green); `does-not-exist` showed a red error on its own row without blocking; `r` re-gathered; `⏎` switched to the home context and the table repopulated (189 pods, matching the fleet count)