### PR TITLE
feat: historical right-sizing recommendations (:rightsize)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ Not a marketing number - these are specific, checkable design choices:
   cluster and reaches it through the API-server proxy; or point
   `[providers.logs]` at an external URL. Covers restarted and deleted pods —
   the backend remembers what the kubelet no longer has.
+- **Right-sizing** (`:rightsize`) - when a Prometheus/VictoriaMetrics backend is
+  reachable, estimate right-sized requests for the selected workload from
+  historical usage: per container, current requests vs P50/P95/P99 CPU & memory
+  over a window, a suggested request (P95 + headroom), OOM/throttle evidence,
+  and a **patch preview** — never a mutation. The backend is **autodiscovered**
+  in-cluster (or set `[providers.metrics]`).
 - **Fleet dashboard** (`:fleet`) - an opt-in cross-context health summary:
   connectivity, Kubernetes version, node readiness, unhealthy pods, Flux
   failures, and the read-only policy for each configured context, side by side.
@@ -632,6 +638,40 @@ read-only policy. `⏎` switches to the highlighted context (via the normal
 context-switch path); `r` re-gathers. Only these non-sensitive summaries are
 held in memory.
 
+### Right-sizing (metrics provider)
+
+`:rightsize` on a workload (or pod) estimates right-sized requests from
+historical usage in a **Prometheus-compatible** backend — Prometheus _or_
+VictoriaMetrics, which share the query API. For each container it shows current
+requests, P50/P95/P99 CPU & memory over the window, a suggested request (P95 +
+headroom), OOM/throttle evidence, and a **strategic-merge patch preview**
+(copy with `c`). It **never mutates** — apply the patch yourself with
+`kubectl patch` if you agree.
+
+Zero-config by default: with no `[providers.metrics]` section, sofka
+autodiscovers a Prometheus/VictoriaMetrics query `Service` in the cluster (by
+well-known labels) and reaches it through the API-server proxy, exactly like
+the log provider. Configure it only to point at an external endpoint or tune
+the window/headroom:
+
+```toml
+[providers.metrics]
+type = "prometheus"        # or "victoriametrics" (same query API)
+url = "https://prom.example.com"   # omit to autodiscover in-cluster
+window = "7d"              # lookback for the P50/P95/P99 quantiles
+step = "5m"                # subquery resolution for the CPU rate()
+headroom = 15              # percent added over P95 for the suggestion
+
+[providers.metrics.headers]        # optional
+Authorization = "Bearer <token>"
+```
+
+Uses the standard cAdvisor metric names (`container_cpu_usage_seconds_total`,
+`container_memory_working_set_bytes`, `container_oom_events_total`,
+`container_cpu_cfs_throttled_periods_total`). VictoriaMetrics **cluster** mode
+(vmselect) needs a tenant path in the `url`; single-node VM and Prometheus
+serve the API at the root and autodiscover cleanly.
+
 ### Log provider (VictoriaLogs)
 
 `L` (or `:vlogs`) opens log history for the selection from a VictoriaLogs
@@ -755,6 +795,7 @@ header) and switching away restores write mode.
 | `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                  |
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
+| `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                             |
 | `:ctx` / `:ctx <name>`                        | context switcher popup / switch directly (the name tab-completes)                                                                     |
 | `:fleet`                                      | cross-context health dashboard (opt-in `[fleet]` contexts; `⏎` switches, `r` refreshes)                                               |
 | `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1217,6 +1217,10 @@ impl App {
             crate::providers::compile(resolved.config.providers.logs.as_ref());
         self.log_provider = log_provider;
         warnings.extend(provider_warnings);
+        let (metrics_provider, metrics_warnings) =
+            crate::providers::compile_metrics(resolved.config.providers.metrics.as_ref());
+        self.metrics_provider = metrics_provider;
+        warnings.extend(metrics_warnings);
         self.skin_colors = resolved.config.skin.colors;
         self.readonly = self.readonly_override.unwrap_or(resolved.config.readonly);
         self.cluster.add_aliases(&self.user_aliases);

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -534,6 +534,7 @@ impl App {
             PaletteAction::Snapshots => self.open_snapshots(),
             PaletteAction::Info => self.open_info(),
             PaletteAction::Fleet => self.open_fleet(),
+            PaletteAction::Rightsize => self.open_rightsize(),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -371,6 +371,7 @@ enum PaletteAction {
     Snapshots,
     Info,
     Fleet,
+    Rightsize,
     Diff,
     Events,
     PortForwards,
@@ -477,6 +478,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Fleet,
         names: &["fleet", "clusters", "multi"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Rightsize,
+        names: &["rightsize", "sizing", "vpa"],
     },
     PaletteCommand {
         action: PaletteAction::Quit,
@@ -946,6 +951,9 @@ pub struct App {
     /// Compiled log provider from `[providers.logs]`, re-resolved on context
     /// switch and `:reload` so each cluster can point at its own backend.
     pub log_provider: Option<crate::providers::LogProvider>,
+    /// Prometheus/VictoriaMetrics backend for right-sizing (`:rightsize`),
+    /// resolved to the API-server proxy on first use when autodiscovered.
+    pub metrics_provider: Option<crate::providers::MetricsProvider>,
     /// Compiled custom views from config, re-resolved on context switch.
     pub user_views: HashMap<String, crate::views::View>,
     /// Compiled warning/critical coloring thresholds from config, re-resolved
@@ -1097,6 +1105,7 @@ impl App {
                 cells: HashMap::new(),
             }),
             log_provider: None,
+            metrics_provider: None,
             user_views: HashMap::new(),
             thresholds: crate::thresholds::Compiled::default(),
             crd_views: HashMap::new(),
@@ -1142,6 +1151,7 @@ mod logs;
 mod navigation;
 mod overlays;
 mod pickers;
+mod rightsize;
 mod rows;
 mod snapshot;
 mod timeline;

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -354,6 +354,9 @@ impl App {
         let (log_provider, provider_warnings) =
             crate::providers::compile(resolved.config.providers.logs.as_ref());
         self.log_provider = log_provider;
+        let (metrics_provider, _mw) =
+            crate::providers::compile_metrics(resolved.config.providers.metrics.as_ref());
+        self.metrics_provider = metrics_provider;
         // Printer-column fallbacks came from the old cluster's CRDs.
         self.crd_views.clear();
         // The timeline recorded the old cluster's objects.

--- a/src/app/rightsize.rs
+++ b/src/app/rightsize.rs
@@ -1,0 +1,264 @@
+use super::*;
+
+use crate::columns::{fmt_cpu, fmt_mem, parse_cpu_milli, parse_mem_bytes};
+use crate::rightsize::{ContainerRec, Quantiles, patch_preview, suggest};
+
+/// One container's spec pulled off the selected object before the gather.
+struct ContainerSpec {
+    name: String,
+    cpu_request: Option<f64>,
+    mem_request: Option<f64>,
+}
+
+impl App {
+    /// `:rightsize` — estimate right-sized requests for the selected workload
+    /// (or pod) from historical usage in a Prometheus/VictoriaMetrics backend,
+    /// and preview the patch. Never mutates.
+    pub(super) fn open_rightsize(&mut self) {
+        let Some(obj) = self.selected_ref() else {
+            self.flash_warn("no selection to right-size");
+            return;
+        };
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        // Container list + a PromQL `pod` matcher: a bare pod matches exactly;
+        // a workload matches its replica pods by name prefix.
+        let (path, pod_matcher) = match self.kind_plural.as_str() {
+            "pods" => ("/spec/containers", format!("^{}$", regex_escape(&name))),
+            "deployments" | "statefulsets" | "daemonsets" | "replicasets" => (
+                "/spec/template/spec/containers",
+                format!("^{}-.*", regex_escape(&name)),
+            ),
+            _ => {
+                self.flash_warn("right-size applies to workloads (deploy/sts/ds/rs) and pods");
+                return;
+            }
+        };
+        let containers = container_specs(obj, path);
+        if containers.is_empty() {
+            self.flash_warn("no containers found to right-size");
+            return;
+        }
+
+        // Zero-config: with no [providers.metrics], autodiscover in-cluster.
+        let provider = self.metrics_provider.clone().unwrap_or_default();
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        let kind_name = self
+            .kind
+            .as_ref()
+            .map(|k| k.ar.kind.clone())
+            .unwrap_or_else(|| self.kind_plural.clone());
+        self.flash = format!("right-sizing {name} over {}…", provider.window);
+        self.flash_err = false;
+
+        tokio::spawn(async move {
+            let title = format!("right-size — {kind_name}/{name}");
+            // Resolve the transport (autodiscover) on first use.
+            let provider = if provider.needs_discovery() {
+                match crate::providers::discover_metrics(client, &provider).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Msg::Detail {
+                                generation: genr,
+                                title,
+                                lines: vec![format!("no metrics backend: {e}")],
+                                warn: Some("right-size needs Prometheus/VictoriaMetrics".into()),
+                            })
+                            .await;
+                        return;
+                    }
+                }
+            } else {
+                provider
+            };
+
+            let window = provider.window.clone();
+            let step = provider.step.clone();
+            let headroom = provider.headroom;
+
+            let mut recs = Vec::new();
+            for c in &containers {
+                recs.push(
+                    gather_container(&provider, &ns, &pod_matcher, c, &window, &step, headroom)
+                        .await,
+                );
+            }
+
+            let lines = render_report(&provider.location(), &window, headroom, &recs);
+            let _ = tx
+                .send(Msg::Detail {
+                    generation: genr,
+                    title,
+                    lines,
+                    warn: None,
+                })
+                .await;
+        });
+    }
+}
+
+/// Query the four PromQL series for one container and assemble its rec.
+async fn gather_container(
+    provider: &crate::providers::MetricsProvider,
+    ns: &str,
+    pod_matcher: &str,
+    spec: &ContainerSpec,
+    window: &str,
+    step: &str,
+    headroom: u32,
+) -> ContainerRec {
+    let sel = format!(
+        "namespace=\"{ns}\",pod=~\"{pod_matcher}\",container=\"{}\"",
+        spec.name
+    );
+    let cpu_q = |q: &str| {
+        format!(
+            "max(quantile_over_time({q}, rate(container_cpu_usage_seconds_total{{{sel}}}[{step}])[{window}:{step}]))*1000"
+        )
+    };
+    let mem_q = |q: &str| {
+        format!(
+            "max(quantile_over_time({q}, container_memory_working_set_bytes{{{sel}}}[{window}]))"
+        )
+    };
+    let q =
+        |promql: String| async move { provider.query(&promql).await.ok().flatten().unwrap_or(0.0) };
+
+    let cpu = Quantiles {
+        p50: q(cpu_q("0.5")).await,
+        p95: q(cpu_q("0.95")).await,
+        p99: q(cpu_q("0.99")).await,
+    };
+    let mem = Quantiles {
+        p50: q(mem_q("0.5")).await,
+        p95: q(mem_q("0.95")).await,
+        p99: q(mem_q("0.99")).await,
+    };
+    let oom = q(format!(
+        "sum(increase(container_oom_events_total{{{sel}}}[{window}]))"
+    ))
+    .await;
+    let throttle = q(format!(
+        "sum(increase(container_cpu_cfs_throttled_periods_total{{{sel}}}[{window}]))"
+    ))
+    .await;
+
+    ContainerRec {
+        container: spec.name.clone(),
+        suggested_cpu: if cpu.p95 > 0.0 {
+            suggest(cpu.p95, headroom)
+        } else {
+            0.0
+        },
+        suggested_mem: if mem.p95 > 0.0 {
+            suggest(mem.p95, headroom)
+        } else {
+            0.0
+        },
+        cpu,
+        mem,
+        cpu_request: spec.cpu_request,
+        mem_request: spec.mem_request,
+        oom,
+        throttle,
+    }
+}
+
+/// Render the recommendation report as document lines.
+fn render_report(
+    location: &str,
+    window: &str,
+    headroom: u32,
+    recs: &[ContainerRec],
+) -> Vec<String> {
+    let opt_cpu = |v: Option<f64>| v.map(|n| fmt_cpu(n as i64)).unwrap_or_else(|| "—".into());
+    let opt_mem = |v: Option<f64>| v.map(|n| fmt_mem(n as i64)).unwrap_or_else(|| "—".into());
+
+    let mut lines = vec![
+        format!("source:  {location}"),
+        format!("window:  {window}   headroom: +{headroom}% over P95"),
+        String::new(),
+    ];
+    for r in recs {
+        lines.push(format!("container: {}", r.container));
+        lines.push(format!(
+            "  cpu   request {:<8} P50 {:<8} P95 {:<8} P99 {:<8} → suggest {}   [{}]",
+            opt_cpu(r.cpu_request),
+            fmt_cpu(r.cpu.p50 as i64),
+            fmt_cpu(r.cpu.p95 as i64),
+            fmt_cpu(r.cpu.p99 as i64),
+            fmt_cpu(r.suggested_cpu as i64),
+            r.cpu_verdict().label(),
+        ));
+        lines.push(format!(
+            "  mem   request {:<8} P50 {:<8} P95 {:<8} P99 {:<8} → suggest {}   [{}]",
+            opt_mem(r.mem_request),
+            fmt_mem(r.mem.p50 as i64),
+            fmt_mem(r.mem.p95 as i64),
+            fmt_mem(r.mem.p99 as i64),
+            fmt_mem(r.suggested_mem as i64),
+            r.mem_verdict().label(),
+        ));
+        if r.oom > 0.0 || r.throttle > 0.0 {
+            lines.push(format!(
+                "  evidence: {} OOM kill(s) · {} throttled CPU period(s) over {window}",
+                r.oom.round() as i64,
+                r.throttle.round() as i64,
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    match patch_preview(recs) {
+        Some(patch) => {
+            lines.push(
+                "suggested patch (preview only — copy with c, apply with kubectl patch):".into(),
+            );
+            lines.push(String::new());
+            lines.extend(patch.lines().map(String::from));
+        }
+        None => lines
+            .push("no usage data found — is the workload scraped by the metrics backend?".into()),
+    }
+    lines
+}
+
+/// Extract each container's name and current CPU/memory requests from the pod
+/// spec at `path` (`/spec/containers` for pods, `/spec/template/spec/containers`
+/// for workloads).
+fn container_specs(obj: &DynamicObject, path: &str) -> Vec<ContainerSpec> {
+    obj.data
+        .pointer(path)
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| {
+                    let name = c.get("name").and_then(Value::as_str)?.to_string();
+                    let req = c.pointer("/resources/requests");
+                    let cpu_request = req
+                        .and_then(|r| r.get("cpu"))
+                        .and_then(Value::as_str)
+                        .map(|s| parse_cpu_milli(s) as f64);
+                    let mem_request = req
+                        .and_then(|r| r.get("memory"))
+                        .and_then(Value::as_str)
+                        .map(|s| parse_mem_bytes(s) as f64);
+                    Some(ContainerSpec {
+                        name,
+                        cpu_request,
+                        mem_request,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Escape the regex metacharacters that can appear in a Kubernetes object name
+/// (really just `.`), so the PromQL `pod=~` matcher is anchored to the literal.
+fn regex_escape(name: &str) -> String {
+    name.replace('.', "\\.")
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3600,6 +3600,51 @@ async fn wide_toggle_reveals_pod_columns_and_keeps_sort() {
 }
 
 #[tokio::test]
+async fn rightsize_rejects_non_workload_kinds() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("configmaps");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "ConfigMap",
+               "metadata": {"name": "cm", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    app.open_rightsize();
+    assert_ne!(app.mode, Mode::Detail);
+    assert!(app.flash.contains("right-size applies"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn rightsize_report_renders_verdicts_and_patch() {
+    // The report + patch are pure; exercise them directly with known numbers.
+    use crate::rightsize::{ContainerRec, Quantiles};
+    let recs = vec![ContainerRec {
+        container: "app".into(),
+        cpu: Quantiles {
+            p50: 40.0,
+            p95: 100.0,
+            p99: 130.0,
+        },
+        mem: Quantiles {
+            p50: 100_000_000.0,
+            p95: 130_000_000.0,
+            p99: 140_000_000.0,
+        },
+        cpu_request: Some(500.0),        // way over P95 → over-provisioned
+        mem_request: Some(64_000_000.0), // under P95 → under-provisioned
+        oom: 0.0,
+        throttle: 0.0,
+        suggested_cpu: crate::rightsize::suggest(100.0, 15),
+        suggested_mem: crate::rightsize::suggest(130_000_000.0, 15),
+    }];
+    assert_eq!(recs[0].cpu_verdict(), crate::rightsize::Verdict::Over);
+    assert_eq!(recs[0].mem_verdict(), crate::rightsize::Verdict::Under);
+    let patch = crate::rightsize::patch_preview(&recs).unwrap();
+    assert!(patch.contains("\"name\": \"app\""));
+    assert!(patch.contains("cpu") && patch.contains("memory"));
+}
+
+#[tokio::test]
 async fn fleet_without_configured_contexts_warns() {
     let (mut app, _rx) = test_app();
     app.open_fleet();

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,6 +282,43 @@ pub struct Providers {
     /// A log-search backend, queried for the selected object with `L` — see
     /// [`crate::providers`] for the full example.
     pub logs: Option<LogProviderConfig>,
+    /// A Prometheus-compatible metrics backend for right-sizing (`:rightsize`).
+    pub metrics: Option<MetricsProviderConfig>,
+}
+
+/// A Prometheus-compatible historical-metrics backend for `:rightsize`. Works
+/// against Prometheus or VictoriaMetrics (same query API). Everything is
+/// optional except `type`, including the section: without a `url`, sofka
+/// autodiscovers a Prometheus/VictoriaMetrics query service in the cluster and
+/// reaches it through the API-server proxy.
+///
+/// ```toml
+/// [providers.metrics]
+/// type = "prometheus"          # or "victoriametrics" (same query API)
+/// url = "https://prom.example.com"  # omit to autodiscover in-cluster
+/// window = "7d"                # lookback for the P50/P95/P99 quantiles
+/// step = "5m"                  # subquery resolution for CPU rate()
+/// headroom = 15                # percent added over P95 for the suggestion
+///
+/// [providers.metrics.headers]  # optional: sent with every request
+/// Authorization = "Bearer <token>"
+/// ```
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct MetricsProviderConfig {
+    /// Backend kind: `"prometheus"` or `"victoriametrics"` (same query API).
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Base URL, e.g. `https://prom.example.com`. Empty/omitted: autodiscover.
+    pub url: String,
+    /// Lookback window for the quantiles (`"7d"`, `"24h"`).
+    pub window: Option<String>,
+    /// Subquery resolution for the CPU `rate()` (`"5m"`).
+    pub step: Option<String>,
+    /// Percent headroom added over P95 for the suggested request.
+    pub headroom: Option<u32>,
+    /// Extra HTTP headers, e.g. an Authorization bearer token.
+    pub headers: HashMap<String, String>,
 }
 
 /// One log backend. Only `type = "victorialogs"` is supported today.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod k8s;
 mod keys;
 mod logfilter;
 mod providers;
+mod rightsize;
 mod snapshot;
 mod store;
 mod theme;
@@ -203,6 +204,12 @@ async fn main() -> Result<()> {
         eprintln!("warning: {w}");
     }
     app.log_provider = log_provider;
+    let (metrics_provider, metrics_warnings) =
+        providers::compile_metrics(cfg.providers.metrics.as_ref());
+    for w in &metrics_warnings {
+        eprintln!("warning: {w}");
+    }
+    app.metrics_provider = metrics_provider;
     app.skin_colors = cfg.skin.colors.clone();
     app.config = loader;
     app.session_skin = Some(session_skin);

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -878,6 +878,278 @@ fn parse_entry(line: &str, fields: &Fields) -> Option<LogEntry> {
     })
 }
 
+// ===== metrics provider (right-sizing) =====================================
+
+/// Label selectors that identify a Prometheus-compatible query service across
+/// common installs: the VictoriaMetrics k8s-stack / operator (`vmsingle`), the
+/// single-node Helm chart, and kube-prometheus-stack Prometheus.
+const METRICS_DISCOVERY_SELECTORS: &[&str] = &[
+    "app.kubernetes.io/name=vmsingle",
+    "app.kubernetes.io/name=victoria-metrics-single",
+    "app.kubernetes.io/name=prometheus",
+    "operated-prometheus=true",
+];
+
+pub const DEFAULT_METRICS_WINDOW: &str = "7d";
+const DEFAULT_METRICS_STEP: &str = "5m";
+const DEFAULT_HEADROOM: u32 = 15;
+
+/// A compiled Prometheus-compatible metrics backend for `:rightsize`. Reaches
+/// the query API at `/api/v1/query` over the same transports as the log
+/// provider (direct URL or the API-server service proxy).
+#[derive(Clone)]
+pub struct MetricsProvider {
+    transport: Transport,
+    headers: Vec<(String, String)>,
+    /// Quantile lookback (`"7d"`), verbatim for the PromQL and titles.
+    pub window: String,
+    /// Subquery resolution for the CPU `rate()` (`"5m"`).
+    pub step: String,
+    /// Percent headroom added over P95 for the suggested request.
+    pub headroom: u32,
+}
+
+impl Default for MetricsProvider {
+    fn default() -> Self {
+        Self {
+            transport: Transport::Auto,
+            headers: Vec::new(),
+            window: DEFAULT_METRICS_WINDOW.into(),
+            step: DEFAULT_METRICS_STEP.into(),
+            headroom: DEFAULT_HEADROOM,
+        }
+    }
+}
+
+/// Validate `[providers.metrics]` into a [`MetricsProvider`]. An omitted/empty
+/// url means "autodiscover in-cluster" (resolved on first use). Accepts
+/// `prometheus` and `victoriametrics` (the same query API).
+pub fn compile_metrics(
+    cfg: Option<&crate::config::MetricsProviderConfig>,
+) -> (Option<MetricsProvider>, Vec<String>) {
+    let Some(cfg) = cfg else {
+        return (None, Vec::new());
+    };
+    let mut warnings = Vec::new();
+    match cfg.kind.as_str() {
+        "prometheus" | "victoriametrics" => {}
+        "" => {
+            warnings.push(
+                "providers.metrics: missing `type` (expected \"prometheus\" or \"victoriametrics\")"
+                    .into(),
+            );
+            return (None, warnings);
+        }
+        other => {
+            warnings.push(format!(
+                "providers.metrics: unsupported type {other:?} (expected \"prometheus\"/\"victoriametrics\")"
+            ));
+            return (None, warnings);
+        }
+    }
+
+    let url = cfg.url.trim().trim_end_matches('/').to_string();
+    let transport = if url.is_empty() {
+        Transport::Auto
+    } else if url.starts_with("http://") || url.starts_with("https://") {
+        Transport::Direct { url }
+    } else {
+        warnings.push(format!(
+            "providers.metrics: url {:?} must start with http:// or https:// (or be omitted for autodiscovery)",
+            cfg.url
+        ));
+        return (None, warnings);
+    };
+
+    let window = cfg
+        .window
+        .clone()
+        .unwrap_or_else(|| DEFAULT_METRICS_WINDOW.into());
+    if let Err(e) = parse_lookback(&window) {
+        warnings.push(format!("providers.metrics: window: {e}"));
+        return (None, warnings);
+    }
+    let step = cfg
+        .step
+        .clone()
+        .unwrap_or_else(|| DEFAULT_METRICS_STEP.into());
+    if let Err(e) = parse_lookback(&step) {
+        warnings.push(format!("providers.metrics: step: {e}"));
+        return (None, warnings);
+    }
+
+    (
+        Some(MetricsProvider {
+            transport,
+            headers: cfg
+                .headers
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+            window,
+            step,
+            headroom: cfg.headroom.unwrap_or(DEFAULT_HEADROOM),
+        }),
+        warnings,
+    )
+}
+
+/// Find a Prometheus/VictoriaMetrics query `Service` and resolve `base`'s
+/// transport to the API-server proxy for it.
+pub async fn discover_metrics(
+    client: kube::Client,
+    base: &MetricsProvider,
+) -> Result<MetricsProvider, String> {
+    let api: Api<Service> = Api::all(client.clone());
+    for selector in METRICS_DISCOVERY_SELECTORS {
+        let list = api
+            .list(&ListParams::default().labels(selector))
+            .await
+            .map_err(|e| format!("discovering metrics services: {e}"))?
+            .items;
+        if let Some((ns, service, port)) = pick_metrics_service(&list) {
+            let mut provider = base.clone();
+            provider.transport = Transport::ServiceProxy {
+                client,
+                ns,
+                service,
+                port,
+            };
+            return Ok(provider);
+        }
+    }
+    Err(
+        "no Prometheus/VictoriaMetrics service found — set [providers.metrics] url in config.toml"
+            .into(),
+    )
+}
+
+/// First (by namespace/name) service with a usable port, preferring `http`,
+/// then the well-known query ports (Prometheus 9090, VM single 8428/8429).
+fn pick_metrics_service(services: &[Service]) -> Option<(String, String, i32)> {
+    let mut candidates: Vec<(&Service, i32)> = services
+        .iter()
+        .filter_map(|s| {
+            let ports = s.spec.as_ref()?.ports.as_ref()?;
+            let port = ports
+                .iter()
+                .find(|p| p.name.as_deref() == Some("http"))
+                .or_else(|| ports.iter().find(|p| matches!(p.port, 9090 | 8428 | 8429)))
+                .or_else(|| ports.first())?;
+            Some((s, port.port))
+        })
+        .collect();
+    candidates.sort_by_key(|(s, _)| {
+        (
+            s.metadata.namespace.clone().unwrap_or_default(),
+            s.metadata.name.clone().unwrap_or_default(),
+        )
+    });
+    let (svc, port) = candidates.first()?;
+    Some((
+        svc.metadata.namespace.clone().unwrap_or_default(),
+        svc.metadata.name.clone().unwrap_or_default(),
+        *port,
+    ))
+}
+
+impl MetricsProvider {
+    /// Whether the transport still needs [`discover_metrics`].
+    pub fn needs_discovery(&self) -> bool {
+        matches!(self.transport, Transport::Auto)
+    }
+
+    /// A human-readable description of where queries go, for messages.
+    pub fn location(&self) -> String {
+        match &self.transport {
+            Transport::Direct { url } => url.clone(),
+            Transport::ServiceProxy {
+                ns, service, port, ..
+            } => format!("{ns}/{service}:{port} (API-server proxy)"),
+            Transport::Auto => "autodiscover".into(),
+        }
+    }
+
+    /// Run one instant query, returning the first sample value (`None` = no
+    /// data). Bounded by [`QUERY_TIMEOUT_SECS`].
+    pub async fn query(&self, promql: &str) -> Result<Option<f64>, String> {
+        let fut = self.fetch_query(promql);
+        let body = tokio::time::timeout(std::time::Duration::from_secs(QUERY_TIMEOUT_SECS), fut)
+            .await
+            .map_err(|_| format!("query timed out after {QUERY_TIMEOUT_SECS}s"))??;
+        Ok(crate::rightsize::scalar_from_query(&body))
+    }
+
+    /// POST `query=<promql>` to `/api/v1/query` over the active transport.
+    async fn fetch_query(&self, promql: &str) -> Result<String, String> {
+        let params = [("query", promql)];
+        match &self.transport {
+            Transport::ServiceProxy {
+                client,
+                ns,
+                service,
+                port,
+            } => {
+                let uri =
+                    format!("/api/v1/namespaces/{ns}/services/{service}:{port}/proxy/api/v1/query");
+                let mut req = http::Request::post(uri).header(
+                    http::header::CONTENT_TYPE,
+                    "application/x-www-form-urlencoded",
+                );
+                for (name, value) in &self.headers {
+                    req = req.header(name.as_str(), value.as_str());
+                }
+                let req = req
+                    .body(form_body(&params).into_bytes())
+                    .map_err(|e| format!("building request: {e}"))?;
+                client
+                    .request_text(req)
+                    .await
+                    .map_err(|e| format!("{}: {e}", self.location()))
+            }
+            Transport::Direct { url } => {
+                let https = hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_native_roots()
+                    .map_err(|e| format!("loading system TLS roots: {e}"))?
+                    .https_or_http()
+                    .enable_http1()
+                    .build();
+                let http_client = hyper_util::client::legacy::Client::builder(
+                    hyper_util::rt::TokioExecutor::new(),
+                )
+                .build(https);
+                let full = format!("{url}/api/v1/query");
+                let mut req = hyper::Request::post(&full).header(
+                    http::header::CONTENT_TYPE,
+                    "application/x-www-form-urlencoded",
+                );
+                for (name, value) in &self.headers {
+                    req = req.header(name.as_str(), value.as_str());
+                }
+                let req = req
+                    .body(Full::new(Bytes::from(form_body(&params))))
+                    .map_err(|e| format!("building request: {e}"))?;
+                let resp = http_client
+                    .request(req)
+                    .await
+                    .map_err(|e| format!("{full}: {e}"))?;
+                let status = resp.status();
+                let body = resp
+                    .into_body()
+                    .collect()
+                    .await
+                    .map_err(|e| format!("reading response: {e}"))?
+                    .to_bytes();
+                if !status.is_success() {
+                    return Err(http_error(status, &body));
+                }
+                Ok(String::from_utf8_lossy(&body).into_owned())
+            }
+            Transport::Auto => Err("metrics provider not discovered yet".into()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/rightsize.rs
+++ b/src/rightsize.rs
@@ -1,0 +1,245 @@
+//! Historical right-sizing: Prometheus response parsing, the recommendation
+//! math, and strategic-merge patch synthesis.
+//!
+//! Given P50/P95/P99 CPU and memory for a workload's containers (gathered from
+//! a Prometheus-compatible backend), sofka suggests a request sized at P95 plus
+//! a headroom margin, classifies over/under-provisioning, and previews the
+//! patch that would apply it — but never mutates anything itself. All of the
+//! logic here is pure and unit-tested; the HTTP queries live in the provider.
+
+use serde_json::{Value, json};
+
+/// Parse a Prometheus/VictoriaMetrics instant-query response body and return
+/// the first sample's value. `None` for a non-success status, an empty result
+/// vector, or a malformed body — callers treat that as "no data".
+pub fn scalar_from_query(body: &str) -> Option<f64> {
+    let v: Value = serde_json::from_str(body).ok()?;
+    if v.get("status").and_then(Value::as_str) != Some("success") {
+        return None;
+    }
+    let result = v.pointer("/data/result")?.as_array()?;
+    let value = result.first()?.get("value")?.as_array()?.get(1)?.as_str()?;
+    value.parse::<f64>().ok()
+}
+
+/// P50/P95/P99 of one resource over the window (CPU in millicores, memory in
+/// bytes). Missing samples read as 0.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Quantiles {
+    pub p50: f64,
+    pub p95: f64,
+    pub p99: f64,
+}
+
+/// A right-sizing verdict for one resource.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// No current request set — can't compare.
+    Unset,
+    /// Request is well above observed peak — wasting reservation.
+    Over,
+    /// Request is close to observed peak — sized about right.
+    Ok,
+    /// Request is below observed peak (risk of eviction/throttling).
+    Under,
+}
+
+impl Verdict {
+    pub fn label(self) -> &'static str {
+        match self {
+            Verdict::Unset => "no request set",
+            Verdict::Over => "over-provisioned",
+            Verdict::Ok => "sized about right",
+            Verdict::Under => "under-provisioned",
+        }
+    }
+}
+
+/// The suggested request: P95 plus `headroom_pct`% margin.
+pub fn suggest(p95: f64, headroom_pct: u32) -> f64 {
+    p95 * (1.0 + headroom_pct as f64 / 100.0)
+}
+
+/// Classify a current request against the observed P95. `Over` when the request
+/// exceeds P95 by more than half again (lots of slack); `Under` when it's below
+/// P95 (peak already breaches the request); `Ok` in between.
+pub fn verdict(current_request: Option<f64>, p95: f64) -> Verdict {
+    match current_request {
+        None => Verdict::Unset,
+        Some(req) if req <= 0.0 => Verdict::Unset,
+        Some(req) if p95 > req => Verdict::Under,
+        Some(req) if req > p95 * 1.5 => Verdict::Over,
+        Some(_) => Verdict::Ok,
+    }
+}
+
+/// A right-sizing recommendation for one container.
+#[derive(Clone, Debug)]
+pub struct ContainerRec {
+    pub container: String,
+    /// CPU quantiles in millicores.
+    pub cpu: Quantiles,
+    /// Memory quantiles in bytes.
+    pub mem: Quantiles,
+    /// Current requests (millicores / bytes), when set.
+    pub cpu_request: Option<f64>,
+    pub mem_request: Option<f64>,
+    /// OOM kills and CPU-throttled periods observed over the window.
+    pub oom: f64,
+    pub throttle: f64,
+    /// Suggested requests (millicores / bytes).
+    pub suggested_cpu: f64,
+    pub suggested_mem: f64,
+}
+
+impl ContainerRec {
+    pub fn cpu_verdict(&self) -> Verdict {
+        verdict(self.cpu_request, self.cpu.p95)
+    }
+    pub fn mem_verdict(&self) -> Verdict {
+        // An OOM kill in the window forces an under-provisioned verdict even if
+        // the sampled working set never appeared to breach the request.
+        if self.oom > 0.0 {
+            return Verdict::Under;
+        }
+        verdict(self.mem_request, self.mem.p95)
+    }
+}
+
+/// Round CPU millicores up to a whole-millicore Kubernetes quantity (`"120m"`).
+pub fn cpu_quantity(millicores: f64) -> String {
+    format!("{}m", millicores.ceil().max(1.0) as i64)
+}
+
+/// Round memory bytes up to a whole-mebibyte Kubernetes quantity (`"128Mi"`).
+pub fn mem_quantity(bytes: f64) -> String {
+    let mi = (bytes / (1024.0 * 1024.0)).ceil().max(1.0) as i64;
+    format!("{mi}Mi")
+}
+
+/// Build the strategic-merge patch that would apply the suggested requests to a
+/// workload's pod template, as pretty JSON. `path_root` is the pointer prefix
+/// to the container list — `spec.template.spec` for Deployments/StatefulSets/
+/// DaemonSets. Returns `None` when no container has a suggestion.
+pub fn patch_preview(recs: &[ContainerRec]) -> Option<String> {
+    let containers: Vec<Value> = recs
+        .iter()
+        .filter(|r| r.suggested_cpu > 0.0 || r.suggested_mem > 0.0)
+        .map(|r| {
+            let mut requests = serde_json::Map::new();
+            if r.suggested_cpu > 0.0 {
+                requests.insert("cpu".into(), json!(cpu_quantity(r.suggested_cpu)));
+            }
+            if r.suggested_mem > 0.0 {
+                requests.insert("memory".into(), json!(mem_quantity(r.suggested_mem)));
+            }
+            json!({ "name": r.container, "resources": { "requests": requests } })
+        })
+        .collect();
+    if containers.is_empty() {
+        return None;
+    }
+    let patch = json!({
+        "spec": { "template": { "spec": { "containers": containers } } }
+    });
+    serde_json::to_string_pretty(&patch).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_prometheus_vector_sample() {
+        let body = r#"{"status":"success","data":{"resultType":"vector",
+            "result":[{"metric":{},"value":[1700000000,"117743616"]}]}}"#;
+        assert_eq!(scalar_from_query(body), Some(117743616.0));
+    }
+
+    #[test]
+    fn empty_or_failed_query_is_none() {
+        let empty = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
+        assert_eq!(scalar_from_query(empty), None);
+        let failed = r#"{"status":"error","error":"boom"}"#;
+        assert_eq!(scalar_from_query(failed), None);
+        assert_eq!(scalar_from_query("not json"), None);
+    }
+
+    #[test]
+    fn suggest_applies_headroom_over_p95() {
+        assert!((suggest(100.0, 15) - 115.0).abs() < 1e-6);
+        assert_eq!(suggest(200.0, 0), 200.0);
+    }
+
+    #[test]
+    fn verdict_classifies_against_p95() {
+        assert_eq!(verdict(None, 100.0), Verdict::Unset);
+        assert_eq!(verdict(Some(0.0), 100.0), Verdict::Unset);
+        assert_eq!(verdict(Some(50.0), 100.0), Verdict::Under); // peak > request
+        assert_eq!(verdict(Some(120.0), 100.0), Verdict::Ok); // a little slack
+        assert_eq!(verdict(Some(500.0), 100.0), Verdict::Over); // >1.5× P95
+    }
+
+    #[test]
+    fn oom_forces_memory_under_provisioned() {
+        let rec = ContainerRec {
+            container: "app".into(),
+            cpu: Quantiles::default(),
+            mem: Quantiles {
+                p50: 10.0,
+                p95: 20.0,
+                p99: 25.0,
+            },
+            cpu_request: Some(100.0),
+            mem_request: Some(1_000_000.0), // request far above sampled p95…
+            oom: 3.0,                       // …but it was OOM-killed
+            throttle: 0.0,
+            suggested_cpu: 0.0,
+            suggested_mem: 30.0,
+        };
+        assert_eq!(rec.mem_verdict(), Verdict::Under);
+    }
+
+    #[test]
+    fn quantities_round_up_to_k8s_units() {
+        assert_eq!(cpu_quantity(4.5), "5m");
+        assert_eq!(cpu_quantity(0.1), "1m"); // never zero
+        assert_eq!(mem_quantity(117_743_616.0), "113Mi");
+        assert_eq!(mem_quantity(1.0), "1Mi");
+    }
+
+    #[test]
+    fn patch_preview_covers_containers_with_a_suggestion() {
+        let recs = vec![
+            ContainerRec {
+                container: "app".into(),
+                cpu: Quantiles::default(),
+                mem: Quantiles::default(),
+                cpu_request: None,
+                mem_request: None,
+                oom: 0.0,
+                throttle: 0.0,
+                suggested_cpu: 120.0,
+                suggested_mem: 134_217_728.0,
+            },
+            ContainerRec {
+                container: "sidecar".into(),
+                cpu: Quantiles::default(),
+                mem: Quantiles::default(),
+                cpu_request: None,
+                mem_request: None,
+                oom: 0.0,
+                throttle: 0.0,
+                suggested_cpu: 0.0, // no data → excluded from the patch
+                suggested_mem: 0.0,
+            },
+        ];
+        let patch = patch_preview(&recs).unwrap();
+        assert!(patch.contains("\"name\": \"app\""));
+        assert!(patch.contains("\"cpu\": \"120m\""));
+        assert!(patch.contains("\"memory\": \"128Mi\""));
+        assert!(!patch.contains("sidecar"), "no-data container omitted");
+        // Empty input → no patch at all.
+        assert!(patch_preview(&[]).is_none());
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1690,6 +1690,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "session-local state-change history for the selection",
         ),
         bind(
+            ":rightsize",
+            "historical right-sizing: P50/P95/P99 usage → suggested requests + patch (needs [providers.metrics])",
+        ),
+        bind(
             ":gitops · :flux",
             "Flux owner, source, revisions & reconciliation chain (⏎ to jump)",
         ),


### PR DESCRIPTION
## Summary
Second Milestone 6 item. `:rightsize` on a workload (or pod) estimates right-sized requests from **historical usage** in a Prometheus-compatible backend, and previews the patch — **never mutating**.

Per container it reports:
- **Current requests** vs **P50/P95/P99** CPU & memory over the window
- A **suggested request** = P95 + headroom (default +15%)
- A **verdict** (over- / under-provisioned / about right)
- **OOM & CPU-throttle evidence** over the window
- A **strategic-merge patch preview** (copy with `c`; apply yourself with `kubectl patch`)

## Provider (Prometheus *or* VictoriaMetrics)
Same query API, so one provider covers both. **Zero-config**: with no `[providers.metrics]`, sofka autodiscovers a query `Service` in-cluster by well-known labels (`vmsingle` / `victoria-metrics-single` / `prometheus` / `operated-prometheus`) and reaches it through the API-server proxy — mirroring the VictoriaLogs provider. Config overrides:

```toml
[providers.metrics]
type = "prometheus"        # or "victoriametrics"
url = "https://prom.example.com"   # omit to autodiscover
window = "7d"
step = "5m"
headroom = 15
```

Uses standard cAdvisor metric names. VM **cluster** (vmselect) needs a tenant path in `url`; single-node VM and Prometheus autodiscover cleanly.

## Implementation
- Pure `rightsize` module: Prometheus response parsing, the recommendation math (suggest/verdict, OOM→under), k8s-quantity rounding, and patch synthesis — 7 unit tests.
- `MetricsProvider` in `providers.rs`: `compile_metrics` / `discover_metrics` / instant `query`, reusing the log provider's `Transport` (direct URL or API-server proxy) with a query timeout.
- `:rightsize` (aliases `:sizing`, `:vpa`) → off-thread gather → report + patch in the detail view via `Msg::Detail`. No key binding, no apply.

## Test plan
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test` — 361 pass (parse/suggest/verdict/quantity/patch unit tests + app guard/report tests)
- [x] Live-verified against the home cluster's **autodiscovered VictoriaMetrics** (`vmsingle` in `monitoring`, via API-server proxy): `:rightsize` on the `hermes` Deployment showed cpu `request 100m · P95 19m → 22m [over-provisioned]`, mem `request 512Mi · P95 830Mi → 954Mi [under-provisioned]`, and the strategic-merge patch (`cpu: "23m"`, `memory: "955Mi"`) — no mutation