### PR TITLE
docs: mark Milestone 6 progress (fleet, metrics provider, right-sizing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,13 +945,14 @@ platform binaries, publishes crates.io, and warms the Nix cache.
 
 ### Milestone 6: fleet and integrations
 
-- [ ] Opt-in cross-context health dashboard.
-- [ ] Historical metrics provider interface.
+- [x] Opt-in cross-context health dashboard (`:fleet`).
+- [x] Historical metrics provider interface (Prometheus/VictoriaMetrics:
+      autodiscovery or configured URL).
 - [x] Log provider interface (VictoriaLogs: autodiscovery or configured URL).
 - [ ] Trace provider interface.
 - [ ] Extended relationship graph.
 - [ ] Vulnerability scanner integration.
-- [ ] Historical right-sizing recommendations.
+- [x] Historical right-sizing recommendations (`:rightsize`).
 
 ### Milestone 7: distribution polish
 


### PR DESCRIPTION
## Summary
Roadmap-status pass for the Milestone 6 items shipped so far:

- [x] Opt-in cross-context health dashboard (`:fleet`) — #75
- [x] Historical metrics provider interface (Prometheus/VictoriaMetrics) — #76
- [x] Log provider interface (VictoriaLogs) — already done
- [x] Historical right-sizing recommendations (`:rightsize`) — #76

Still open in Milestone 6: trace provider interface, extended relationship graph, vulnerability scanner integration.

Each feature's own docs (feature bullets, keybinding rows, config sections) landed with its PR; this is just the checkbox flip.

## Test plan
- [x] Docs-only; lefthook markdown format passed