### PR TITLE
feat: logs fullscreen toggle (F) and time anchors (0–5)

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -922,6 +922,22 @@ impl App {
                 self.flash_err = false;
                 return;
             }
+            // Fullscreen: whole frame, no borders, so terminal text selection
+            // copies clean lines (k9s binds `f`, taken here by follow).
+            KeyCode::Char('F') => {
+                self.logs.fullscreen = !self.logs.fullscreen;
+                self.flash = format!(
+                    "fullscreen: {}",
+                    if self.logs.fullscreen { "on" } else { "off" }
+                );
+                self.flash_err = false;
+                return;
+            }
+            // k9s time anchors: `0` re-tails, `1`-`5` re-stream a window.
+            KeyCode::Char(c @ '0'..='5') => {
+                self.apply_log_anchor(c);
+                return;
+            }
             // Provider logs: `T` changes the lookback period (re-queries).
             KeyCode::Char('T') => {
                 if self.provider_logs_active() {

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -445,15 +445,54 @@ impl App {
     }
 
     /// The configured initial `tail` line count and optional `since` lookback
-    /// (epoch seconds), parsed from `[logs]`. An unparseable `since` is ignored.
-    fn log_tail_and_since(&self) -> (i64, Option<i64>) {
+    /// (epoch seconds), parsed from `[logs]`. An unparseable `since` is
+    /// ignored. A `0`–`5` time anchor overrides the config for the session.
+    pub(super) fn log_tail_and_since(&self) -> (i64, Option<i64>) {
         let tail = self.logs_cfg.tail.max(1);
-        let since = self
-            .logs_cfg
-            .since
-            .as_deref()
-            .and_then(|s| crate::providers::parse_lookback(s).ok());
+        let since = match self.logs.since_anchor {
+            Some(0) => None, // `0`: forced plain tail
+            Some(secs) => Some(secs),
+            None => self
+                .logs_cfg
+                .since
+                .as_deref()
+                .and_then(|s| crate::providers::parse_lookback(s).ok()),
+        };
         (tail, since)
+    }
+
+    /// Apply a `0`–`5` time anchor (k9s): `0` re-tails, `1`–`5` re-stream the
+    /// last 1m/5m/15m/30m/1h. On a provider view the digit sets the provider
+    /// lookback instead (`0` = the default window).
+    pub(super) fn apply_log_anchor(&mut self, key: char) {
+        let (secs, label) = match key {
+            '0' => (0, "tail"),
+            '1' => (60, "1m"),
+            '2' => (300, "5m"),
+            '3' => (900, "15m"),
+            '4' => (1800, "30m"),
+            '5' => (3600, "1h"),
+            _ => return,
+        };
+        if self.provider_logs_active() {
+            let label = if key == '0' {
+                crate::providers::DEFAULT_LOOKBACK
+            } else {
+                label
+            };
+            self.apply_provider_lookback(label);
+            return;
+        }
+        self.logs.since_anchor = Some(secs);
+        self.flash = if secs == 0 {
+            format!("showing tail ({} lines)", self.logs_cfg.tail.max(1))
+        } else {
+            format!("showing last {label}")
+        };
+        self.flash_err = false;
+        if !self.logs.stopped {
+            self.retail_logs();
+        }
     }
 
     pub(super) fn spawn_selector_logs(&mut self, ns: String, labels: String, timestamps: bool) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -580,6 +580,14 @@ pub struct LogsView {
     pub wrap: bool,
     pub timestamps: bool,
     pub stopped: bool,
+    /// Fullscreen (`F`, k9s): the pane takes the whole frame with no header,
+    /// borders, or status line, so terminal text selection copies clean lines.
+    /// Session-sticky like `wrap`/`timestamps`; seeded from `[logs] fullscreen`.
+    pub fullscreen: bool,
+    /// Time anchor for the kubelet streams, set by the `0`–`5` keys (k9s):
+    /// `Some(secs)` streams only logs newer than `secs`, `Some(0)` forces the
+    /// plain tail, `None` follows the config (`[logs] since`/`tail`).
+    pub since_anchor: Option<i64>,
     /// Total rendered rows (post-wrap, post-filter) and inner viewport height
     /// from the last draw. Recorded so key handlers clamp the scroll in the
     /// same *display-row* units the renderer uses — otherwise a wrapped buffer
@@ -605,6 +613,8 @@ impl Default for LogsView {
             wrap: false,
             timestamps: false,
             stopped: false,
+            fullscreen: false,
+            since_anchor: None,
             viewport_rows: 0,
             viewport_h: 0,
             last_wrap_width: 0,
@@ -624,6 +634,19 @@ impl LogsView {
     /// Whether `line` passes the active filter (empty filter = everything).
     pub fn matches(&self, line: &str) -> bool {
         self.matcher.matches(line)
+    }
+
+    /// Title label for the active `0`–`5` time anchor, if any.
+    pub fn anchor_label(&self) -> Option<&'static str> {
+        match self.since_anchor? {
+            0 => Some("tail"),
+            60 => Some("1m"),
+            300 => Some("5m"),
+            900 => Some("15m"),
+            1800 => Some("30m"),
+            3600 => Some("1h"),
+            _ => None,
+        }
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4559,3 +4559,84 @@ async fn lookback_key_only_applies_to_provider_logs() {
     assert_eq!(app.mode, Mode::Logs);
     assert!(app.flash.contains("provider logs"), "{}", app.flash);
 }
+
+#[tokio::test]
+async fn logs_fullscreen_toggles_with_shift_f() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.return_mode = Mode::Table;
+
+    assert!(!app.logs.fullscreen);
+    app.handle_key(press(KeyCode::Char('F'))).unwrap();
+    assert!(app.logs.fullscreen);
+    assert!(app.flash.contains("fullscreen: on"), "{}", app.flash);
+    assert_eq!(app.mode, Mode::Logs, "toggling must not leave the view");
+
+    app.handle_key(press(KeyCode::Char('F'))).unwrap();
+    assert!(!app.logs.fullscreen);
+}
+
+#[tokio::test]
+async fn logs_time_anchors_restream_kubelet_logs() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.return_mode = Mode::Table;
+    app.logs.source = Some(LogSource::Pod {
+        ns: "default".into(),
+        name: "web".into(),
+        containers: vec![],
+    });
+
+    // No anchor: the config decides (default = tail, no since).
+    assert_eq!(app.log_tail_and_since(), (app.logs_cfg.tail, None));
+
+    // `2` anchors to the last 5m and re-streams (generation bumps).
+    let gen_before = app.log_gen;
+    app.handle_key(press(KeyCode::Char('2'))).unwrap();
+    assert_eq!(app.logs.since_anchor, Some(300));
+    assert_eq!(app.logs.anchor_label(), Some("5m"));
+    assert_eq!(app.log_tail_and_since().1, Some(300));
+    assert!(app.log_gen > gen_before, "anchor must restart the stream");
+    assert!(app.flash.contains("5m"), "{}", app.flash);
+
+    // `0` forces the plain tail, even over a configured `since`.
+    app.logs_cfg.since = Some("4h".into());
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    assert_eq!(app.logs.since_anchor, Some(0));
+    assert_eq!(app.log_tail_and_since(), (app.logs_cfg.tail, None));
+    assert_eq!(app.logs.anchor_label(), Some("tail"));
+
+    // Without an anchor the configured `since` applies again.
+    app.logs.since_anchor = None;
+    assert_eq!(app.log_tail_and_since().1, Some(4 * 3600));
+}
+
+#[tokio::test]
+async fn logs_time_anchors_set_provider_lookback() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.return_mode = Mode::Table;
+    app.logs.source = Some(LogSource::Provider {
+        request: crate::providers::LogRequest::Namespace {
+            ns: "default".into(),
+        },
+    });
+    app.logs.view.title = "ns/default — victorialogs (1h)".into();
+
+    // `3` maps to the 15m window on the provider, not the kubelet anchor.
+    app.handle_key(press(KeyCode::Char('3'))).unwrap();
+    assert_eq!(app.provider_lookback_label(), "15m");
+    assert!(
+        app.logs.view.title.ends_with("victorialogs (15m)"),
+        "{}",
+        app.logs.view.title
+    );
+    assert_eq!(app.logs.since_anchor, None);
+
+    // `0` resets to the default lookback window.
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    assert_eq!(
+        app.provider_lookback_label(),
+        crate::providers::DEFAULT_LOOKBACK
+    );
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,9 +105,10 @@ pub struct FleetConfig {
 ///
 /// ```toml
 /// [logs]
-/// tail = 300       # initial lines fetched per stream
-/// buffer = 5000    # max lines retained while following (bounded tail)
-/// since = "1h"     # optional: only logs newer than this (overrides tail)
+/// tail = 300         # initial lines fetched per stream
+/// buffer = 5000      # max lines retained while following (bounded tail)
+/// since = "1h"       # optional: only logs newer than this (overrides tail)
+/// fullscreen = false # open log views fullscreen (F toggles; k9s fullScreenLogs)
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
@@ -120,6 +121,9 @@ pub struct LogsConfig {
     /// Optional lookback (`30m`, `4h`, `2d`): stream only logs newer than this.
     /// When set it replaces `tail` (Kubernetes accepts one or the other).
     pub since: Option<String>,
+    /// Start log views fullscreen — the pane takes the whole frame, without
+    /// header or borders (k9s `fullScreenLogs`). `F` toggles per session.
+    pub fullscreen: bool,
 }
 
 impl Default for LogsConfig {
@@ -128,6 +132,7 @@ impl Default for LogsConfig {
             tail: 300,
             buffer: 5000,
             since: None,
+            fullscreen: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,9 @@ async fn main() -> Result<()> {
     app.debug = cfg.debug.clone();
     app.bundle_cfg = cfg.bundle.clone();
     app.logs_cfg = cfg.logs.clone();
+    // Seed the session toggle once; later `F` presses (and per-context config
+    // reloads) don't fight the user's in-session choice.
+    app.logs.fullscreen = cfg.logs.fullscreen;
     app.fleet_cfg = cfg.fleet.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -75,6 +75,32 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         app.mode,
         Mode::Command | Mode::Filter | Mode::LogFilter | Mode::DocFilter
     );
+
+    // Fullscreen logs (F): the pane takes the whole frame — no header, status
+    // line, or crumbs — so terminal text selection copies clean lines. The
+    // prompt line stays while typing a filter, and the lookback prompt still
+    // pops up over the logs.
+    if app.logs.fullscreen
+        && (matches!(app.mode, Mode::Logs | Mode::LogFilter)
+            || (app.mode == Mode::Prompt && app.prompt_over_logs()))
+    {
+        let mut constraints = vec![Constraint::Min(3)];
+        if needs_prompt {
+            constraints.push(Constraint::Length(1));
+        }
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(frame.area());
+        draw_logs(frame, app, chunks[0]);
+        if app.mode == Mode::Prompt {
+            draw_prompt_popup(frame, app, chunks[0]);
+        }
+        if needs_prompt {
+            draw_prompt(frame, app, chunks[1]);
+        }
+        return;
+    }
     let mut constraints = vec![
         Constraint::Length(if compact { 1 } else { 7 }), // header
         Constraint::Min(3),                              // body
@@ -839,8 +865,20 @@ fn draw_scrollable(
 /// not a full restyle; and the display-row offset is a `usize`, immune to the
 /// `u16` ceiling of `Paragraph::scroll`.
 fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
-    let inner_w = area.width.saturating_sub(2).max(1) as usize;
-    let inner_h = area.height.saturating_sub(2) as usize;
+    // Fullscreen drops the borders (side glyphs would end up in every
+    // terminal-selection copy); the title still takes the top row.
+    let fullscreen = app.logs.fullscreen;
+    let (inner_w, inner_h) = if fullscreen {
+        (
+            area.width.max(1) as usize,
+            area.height.saturating_sub(1) as usize,
+        )
+    } else {
+        (
+            area.width.saturating_sub(2).max(1) as usize,
+            area.height.saturating_sub(2) as usize,
+        )
+    };
 
     let shown: Vec<&String> = app
         .logs
@@ -925,7 +963,7 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
     }
 
     let flags = format!(
-        "{}{}{}",
+        "{}{}{}{}",
         if app.logs.stopped {
             " ⏹stopped"
         } else if app.logs.follow {
@@ -935,6 +973,11 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
         },
         if app.logs.wrap { " wrap" } else { "" },
         if app.logs.timestamps { " ts" } else { "" },
+        // Provider views manage the window in their own title suffix.
+        match app.logs.anchor_label() {
+            Some(l) if !app.provider_logs_active() => format!(" ⏱{l}"),
+            _ => String::new(),
+        },
     );
     let title = if bad_regex {
         format!(
@@ -955,14 +998,18 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // The rows are already the exact viewport slice — no Paragraph scroll or
     // wrap, so ratatui can't re-lay-out (and disagree with) the math above.
-    let p = Paragraph::new(rows).block(
+    let block = if fullscreen {
+        // Borderless: `Block::inner` still reserves one row for the top title,
+        // matching the fullscreen `inner_h` above.
+        Block::default().title(Span::styled(title, theme::title()))
+    } else {
         Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(theme::green()))
-            .title(Span::styled(title, theme::title())),
-    );
-    frame.render_widget(p, area);
+            .title(Span::styled(title, theme::title()))
+    };
+    frame.render_widget(Paragraph::new(rows).block(block), area);
 }
 
 /// Display rows `raw` occupies when char-wrapped to `width` columns: ANSI
@@ -1750,6 +1797,11 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind(
             "x · z · c · ctrl-s",
             "stop/resume · clear buffer · copy · save to file",
+        ),
+        bind("shift-f", "fullscreen (no borders — easy terminal copying)"),
+        bind(
+            "0 – 5",
+            "time anchor: tail · 1m · 5m · 15m · 30m · 1h (re-streams)",
         ),
         bind(
             "shift-t",
@@ -2822,9 +2874,9 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Mode::Logs => {
             let hint = if app.provider_logs_active() {
-                "  /filter  s:autoscroll  w:wrap  t:timestamps  T:period  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
+                "  /filter  s:autoscroll  w:wrap  t:timestamps  F:fullscreen  0-5:since  T:period  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
             } else {
-                "  /filter  s:autoscroll  w:wrap  t:timestamps  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
+                "  /filter  s:autoscroll  w:wrap  t:timestamps  F:fullscreen  0-5:since  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
             };
             Line::from(Span::styled(hint, theme::dim()))
         }
@@ -3347,5 +3399,60 @@ mod tests {
         assert_eq!(spans[0].style.fg, Some(theme::sky()));
         assert_eq!(spans.last().unwrap().content, "Running");
         assert_eq!(spans.last().unwrap().style.fg, Some(theme::green()));
+    }
+
+    /// Fullscreen logs (`F`) own the entire frame: no header above, no status
+    /// line below, and no border glyphs anywhere — so a terminal text
+    /// selection copies clean log lines.
+    #[tokio::test]
+    async fn fullscreen_logs_take_the_whole_frame_without_borders() {
+        use crate::k8s::Cluster;
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let mut app = App::new(Cluster::fake(), tx);
+        app.mode = Mode::Logs;
+        app.logs.view.title = "web — logs".into();
+        app.logs.view.lines = (0..3).map(|i| format!("log line {i}")).collect();
+
+        let render = |app: &mut App| {
+            let mut term = Terminal::new(TestBackend::new(60, 12)).unwrap();
+            term.draw(|f| draw(f, app)).unwrap();
+            let buffer = term.backend().buffer().clone();
+            (0..buffer.area.height)
+                .map(|y| {
+                    (0..buffer.area.width)
+                        .map(|x| buffer[(x, y)].symbol())
+                        .collect::<String>()
+                })
+                .collect::<Vec<String>>()
+        };
+
+        // Bordered by default: the pane sits under the 7-line header.
+        let normal = render(&mut app);
+        assert!(
+            normal.iter().any(|r| r.contains('╭')),
+            "normal logs view should draw its border"
+        );
+        assert!(!normal[0].contains("web — logs"), "header owns the top row");
+
+        app.logs.fullscreen = true;
+        let full = render(&mut app);
+        assert!(
+            full[0].contains("web — logs"),
+            "fullscreen title owns the top row: {:?}",
+            full[0]
+        );
+        assert!(
+            full.iter().any(|r| r.starts_with("log line")),
+            "lines start at column 0 (no left border)"
+        );
+        for r in &full {
+            assert!(
+                !r.contains('╭') && !r.contains('│') && !r.contains('╰'),
+                "no border glyphs in fullscreen: {r:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **`F` — fullscreen logs** (user request; k9s binds `f`, taken here by follow). The log pane takes the entire frame: no header, status line, crumbs, or borders — the side `│` glyphs are what pollute terminal selections when copying log lines. The title/flags line stays as the single top row; the `/` filter prompt line and the provider lookback popup still work in fullscreen. Session-sticky like `wrap`/`timestamps`, and the new `[logs] fullscreen = true` config option starts log views fullscreen (k9s `fullScreenLogs` parity).
- **`0`–`5` — time anchors** (user request, k9s parity): `0` re-tails with the configured tail count (overriding a configured `since`), `1`–`5` re-stream the last 1m/5m/15m/30m/1h. The active anchor shows in the title flags (`⏱5m`). Works for single-pod and aggregated selector streams; on a provider (VictoriaLogs) view the digits set the provider lookback instead (`0` = the default window), reusing the `T`-prompt plumbing.
- Help (`?`) and the logs hint line document both.
- Rendering note: ratatui's `Block::inner` reserves a top row for a borderless title, so the hand-computed scroll math in `draw_logs` uses `height−1` in fullscreen; a render test pins the agreement so follow/scroll anchoring can't drift.

## Test plan
- [x] 368 tests pass (4 new: toggle behavior, kubelet anchor re-stream + config `since` interplay, provider lookback mapping, full-frame borderless render geometry); clippy clean on all targets
- [x] Live TUI in tmux against a real cluster: `2` → `⏱5m` re-stream, `F` → borderless full frame, `/watchdog` filter while fullscreen, `0` → `⏱tail`, `Esc` → table + header restored
- [x] Headless `--snapshot` renders verified for both normal and fullscreen layouts