### PR TITLE
feat: trigger, suspend, and resume CronJobs from the t menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Not a marketing number - these are specific, checkable design choices:
   through owner references to pods and containers.
 - **Flux CD controls** (`t`) - suspend/resume/reconcile menu, native k8s API
   patches.
+- **CronJob controls** (`t`) - trigger now (creates a Job from the
+  jobTemplate, like `kubectl create job --from`), suspend, resume.
 - **Background port-forwards** (`f`/`F` to start, `:pf` to manage).
 - **Plugins** - config-defined shell-out commands bound to keys, scoped per
   resource. Keys are full **chords** (`ctrl-g`, `alt-x`, `shift-b`, `f5`);
@@ -812,7 +814,7 @@ header) and switching away restores write mode.
 | `i`                                           | set container image                                                                                                                   |
 | `r`                                           | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
 | `f` / `shift-f`                               | port-forward (pods/services) - runs in the background                                                                                 |
-| `t`                                           | Flux: suspend/resume/reconcile menu                                                                                                   |
+| `t`                                           | Flux: suspend/resume/reconcile menu · CronJobs: trigger/suspend/resume menu                                                           |
 | `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                      |
 | `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
 | `:q`, `ctrl-c`                                | quit                                                                                                                                  |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1343,16 +1343,17 @@ impl App {
         );
     }
 
-    /// Open the Flux suspend/resume menu (`t`) for the marked rows, or the
-    /// current selection if none are marked. A menu, not a single-key
-    /// toggle — suspending something always takes an explicit, visible
-    /// choice (`j`/`k` + Enter) rather than one accidental keystroke.
+    /// Open the `t` action menu (Flux suspend/resume, CronJob
+    /// trigger/suspend/resume) for the marked rows, or the current selection
+    /// if none are marked. A menu, not a single-key toggle — suspending
+    /// something always takes an explicit, visible choice (`j`/`k` + Enter)
+    /// rather than one accidental keystroke.
     pub(super) fn request_flux_menu(&mut self) {
         if self.deny_readonly() {
             return;
         }
-        if !self.flux_suspendable() {
-            self.flash_warn("suspend/resume only applies to Flux resources (ks/hr/git-, helm-, oci-repos, buckets, image automation, alerts, receivers)");
+        if !self.flux_suspendable() && !self.cronjob_kind() {
+            self.flash_warn("suspend/resume only applies to CronJobs and Flux resources (ks/hr/git-, helm-, oci-repos, buckets, image automation, alerts, receivers)");
             return;
         }
         if self.action_targets().is_empty() {
@@ -1363,7 +1364,8 @@ impl App {
     }
 
     pub(super) fn key_flux_menu(&mut self, key: KeyEvent) {
-        let len = FLUX_MENU_ITEMS.len();
+        let items = self.action_menu_items();
+        let len = items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
             KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.flux_menu_state, len, true),
@@ -1372,7 +1374,7 @@ impl App {
                 let choice = self
                     .flux_menu_state
                     .selected()
-                    .and_then(|i| FLUX_MENU_ITEMS.get(i))
+                    .and_then(|i| items.get(i))
                     .copied();
                 self.mode = Mode::Table;
                 match choice {
@@ -1388,6 +1390,7 @@ impl App {
                         let targets = self.action_targets();
                         self.do_reconcile(targets);
                     }
+                    Some("Trigger now") => self.do_trigger_cronjobs(),
                     _ => {} // "Cancel" or nothing selected — do nothing.
                 }
             }
@@ -1440,6 +1443,79 @@ impl App {
             Patch::Merge(reconcile_patch(&now)),
             |name, e| format!("reconcile {name} failed: {e}"),
         );
+    }
+
+    /// Run the marked CronJobs (or the current selection) immediately by
+    /// creating a Job from each one's jobTemplate — what `kubectl create job
+    /// --from=cronjob/…` does, manual-instantiate annotation and owner
+    /// reference included. Works on suspended CronJobs too (the suspend flag
+    /// only gates the schedule, not manually created Jobs).
+    pub(super) fn do_trigger_cronjobs(&mut self) {
+        let objs = self.action_target_objects();
+        // Seconds-resolution suffix: unique enough for a manual action, and a
+        // repeat trigger of the same CronJob within a second fails loudly
+        // with AlreadyExists rather than silently double-running.
+        let suffix = format!("{:x}", k8s_openapi::jiff::Timestamp::now().as_second());
+        let jobs: Vec<(String, String, Value)> = objs
+            .iter()
+            .filter_map(|o| {
+                let name = o.metadata.name.clone()?;
+                let ns = o.metadata.namespace.clone().unwrap_or_default();
+                let job = cronjob_manual_job(o, &suffix)?;
+                Some((name, ns, job))
+            })
+            .collect();
+        if jobs.is_empty() {
+            return;
+        }
+        let targets: Vec<(String, String)> = jobs
+            .iter()
+            .map(|(name, ns, _)| (name.clone(), ns.clone()))
+            .collect();
+        let label = self.action_label(&targets);
+        self.note_action("trigger", label);
+        self.flash = if jobs.len() == 1 {
+            format!("triggering {}…", jobs[0].0)
+        } else {
+            format!("triggering {} {}…", jobs.len(), self.kind_plural)
+        };
+        self.flash_err = false;
+        self.marked.clear();
+        let job_ar = ApiResource {
+            group: "batch".into(),
+            version: "v1".into(),
+            api_version: "batch/v1".into(),
+            kind: "Job".into(),
+            plural: "jobs".into(),
+        };
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            for (name, ns, job) in jobs {
+                let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &job_ar);
+                let job: DynamicObject = match serde_json::from_value(job) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Msg::Error {
+                                generation: genr,
+                                error: format!("trigger {name} failed: {e}"),
+                            })
+                            .await;
+                        continue;
+                    }
+                };
+                if let Err(e) = api.create(&PostParams::default(), &job).await {
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("trigger {name} failed: {e}"),
+                        })
+                        .await;
+                }
+            }
+        });
     }
 
     /// Force an immediate External Secrets Operator refresh on the marked rows

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -43,6 +43,54 @@ pub(super) fn node_unschedulable_patch(unschedulable: bool) -> Value {
     json!({ "spec": { "unschedulable": unschedulable } })
 }
 
+/// A Job manifest that runs `cj`'s jobTemplate immediately — what `kubectl
+/// create job --from=cronjob/…` builds: the template's spec and labels, its
+/// annotations plus `cronjob.kubernetes.io/instantiate: manual`, and a
+/// non-controller owner reference back to the CronJob. `None` when `cj` has
+/// no jobTemplate spec (not actually a CronJob).
+pub(super) fn cronjob_manual_job(cj: &DynamicObject, suffix: &str) -> Option<Value> {
+    let name = cj.metadata.name.clone()?;
+    let spec = cj.data.pointer("/spec/jobTemplate/spec")?.clone();
+    let mut annotations = cj
+        .data
+        .pointer("/spec/jobTemplate/metadata/annotations")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    annotations["cronjob.kubernetes.io/instantiate"] = json!("manual");
+    let mut metadata = json!({
+        "name": manual_job_name(&name, suffix),
+        "annotations": annotations,
+    });
+    if let Some(ns) = &cj.metadata.namespace {
+        metadata["namespace"] = json!(ns);
+    }
+    if let Some(labels) = cj.data.pointer("/spec/jobTemplate/metadata/labels") {
+        metadata["labels"] = labels.clone();
+    }
+    if let Some(uid) = &cj.metadata.uid {
+        metadata["ownerReferences"] = json!([{
+            "apiVersion": "batch/v1",
+            "kind": "CronJob",
+            "name": name,
+            "uid": uid,
+        }]);
+    }
+    Some(json!({
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": metadata,
+        "spec": spec,
+    }))
+}
+
+/// `<cronjob>-manual-<suffix>`, with the CronJob name truncated so the Job
+/// name stays well under the 63-char label-value limit its pods inherit
+/// (k9s truncates at 42 for the same reason).
+pub(super) fn manual_job_name(cronjob: &str, suffix: &str) -> String {
+    let base: String = cronjob.chars().take(42).collect();
+    format!("{base}-manual-{suffix}")
+}
+
 /// A compact journal label for a set of node names.
 pub(super) fn node_targets_label(targets: &[String]) -> String {
     match targets {
@@ -240,6 +288,21 @@ impl App {
     /// Whether the current kind supports the Flux suspend/resume menu (`t`).
     pub fn flux_suspendable(&self) -> bool {
         FLUX_SUSPENDABLE_KINDS.contains(&self.kind_plural.as_str())
+    }
+
+    /// Whether the current kind is CronJobs, which get their own `t` menu
+    /// (trigger/suspend/resume).
+    pub fn cronjob_kind(&self) -> bool {
+        self.kind_plural == "cronjobs"
+    }
+
+    /// The items shown in the `t` action menu for the current kind.
+    pub fn action_menu_items(&self) -> &'static [&'static str] {
+        if self.cronjob_kind() {
+            CRONJOB_MENU_ITEMS
+        } else {
+            FLUX_MENU_ITEMS
+        }
     }
 
     /// Whether the current kind is an External Secrets resource that honours

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -193,7 +193,8 @@ impl App {
                     self.start_watch();
                 }
             }
-            // Flux CD: toggle suspend/resume on the marked rows, or current.
+            // Action menu on the marked rows, or current: Flux
+            // suspend/resume/reconcile, CronJob trigger/suspend/resume.
             KeyCode::Char('t') => self.request_flux_menu(),
             KeyCode::Char('?') => {
                 self.help_filter.clear();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,7 +18,8 @@ use fuzzy_matcher::skim::SkimMatcherV2;
 use k8s_openapi::api::core::v1::Pod;
 use kube::Client;
 use kube::api::{
-    Api, DeleteParams, EvictParams, ListParams, LogParams, Patch, PatchParams, PropagationPolicy,
+    Api, DeleteParams, EvictParams, ListParams, LogParams, Patch, PatchParams, PostParams,
+    PropagationPolicy,
 };
 use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;
@@ -68,6 +69,12 @@ const FLUX_SUSPENDABLE_KINDS: &[&str] = &[
 /// now" patches the same `reconcile.fluxcd.io/requestedAt` annotation the
 /// `flux reconcile` CLI uses, shared by every controller in the toolkit.
 pub const FLUX_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Reconcile now", "Cancel"];
+
+/// Items in the CronJob action menu (`t`), in display order. "Trigger now"
+/// creates a Job from the CronJob's jobTemplate the same way `kubectl create
+/// job --from=cronjob/…` does; Suspend/Resume patch `spec.suspend` exactly
+/// like the Flux menu (CronJobs share the field).
+pub const CRONJOB_MENU_ITEMS: &[&str] = &["Trigger now", "Suspend", "Resume", "Cancel"];
 
 /// External Secrets Operator kinds that honour the `force-sync` annotation to
 /// trigger an immediate secret refresh. Both are namespaced; the cluster-scoped
@@ -879,7 +886,8 @@ pub struct App {
     /// QoS class of the pod shown by the container picker (empty if unknown).
     pub container_qos: String,
 
-    /// Cursor into [`FLUX_MENU_ITEMS`] for the Flux suspend/resume menu.
+    /// Cursor into [`FLUX_MENU_ITEMS`] / [`CRONJOB_MENU_ITEMS`] for the `t`
+    /// action menu (Flux suspend/resume, CronJob trigger/suspend/resume).
     pub flux_menu_state: ListState,
 
     /// Background `kubectl port-forward` processes started with `f`/`F`.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -825,6 +825,133 @@ async fn flux_menu_reconcile_now() {
     assert!(app.flash.contains("reconciling infra"), "{}", app.flash);
 }
 
+fn cronjob(name: &str) -> serde_json::Value {
+    json!({
+        "apiVersion": "batch/v1", "kind": "CronJob",
+        "metadata": {"name": name, "namespace": "default", "uid": "cj-uid-1"},
+        "spec": {
+            "schedule": "0 * * * *",
+            "suspend": false,
+            "jobTemplate": {
+                "metadata": {
+                    "labels": {"app": name},
+                    "annotations": {"team": "platform"}
+                },
+                "spec": {
+                    "template": {"spec": {
+                        "containers": [{"name": "main", "image": "busybox"}],
+                        "restartPolicy": "Never"
+                    }}
+                }
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn cronjob_menu_opens_with_trigger_first() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("cronjobs");
+    apply(&mut app, cronjob("backup"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.mode, Mode::FluxMenu);
+    assert_eq!(app.action_menu_items(), CRONJOB_MENU_ITEMS);
+    assert_eq!(app.flux_menu_state.selected(), Some(0)); // "Trigger now"
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("triggering backup"), "{}", app.flash);
+    assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn cronjob_menu_suspend_and_resume() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("cronjobs");
+    apply(&mut app, cronjob("backup"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    let idx = CRONJOB_MENU_ITEMS
+        .iter()
+        .position(|s| *s == "Suspend")
+        .unwrap();
+    app.flux_menu_state.select(Some(idx));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("suspending backup"), "{}", app.flash);
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    let idx = CRONJOB_MENU_ITEMS
+        .iter()
+        .position(|s| *s == "Resume")
+        .unwrap();
+    app.flux_menu_state.select(Some(idx));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("resuming backup"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn cronjob_trigger_acts_on_marked_rows() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("cronjobs");
+    apply(&mut app, cronjob("backup"));
+    let mut second = cronjob("cleanup");
+    second["metadata"]["uid"] = json!("cj-uid-2");
+    apply(&mut app, second);
+    app.marked.insert("default/backup".into());
+    app.marked.insert("default/cleanup".into());
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // "Trigger now"
+    assert!(app.flash.contains("triggering 2 cronjobs"), "{}", app.flash);
+    assert!(app.marked.is_empty()); // cleared after the bulk action
+}
+
+#[test]
+fn cronjob_manual_job_matches_kubectl_create_job_from() {
+    let cj: DynamicObject = serde_json::from_value(cronjob("backup")).unwrap();
+    let job = cronjob_manual_job(&cj, "abc12").unwrap();
+    assert_eq!(job["apiVersion"], "batch/v1");
+    assert_eq!(job["kind"], "Job");
+    assert_eq!(job["metadata"]["name"], "backup-manual-abc12");
+    assert_eq!(job["metadata"]["namespace"], "default");
+    assert_eq!(
+        job["metadata"]["annotations"]["cronjob.kubernetes.io/instantiate"],
+        "manual"
+    );
+    // jobTemplate metadata carries over alongside the instantiate marker.
+    assert_eq!(job["metadata"]["annotations"]["team"], "platform");
+    assert_eq!(job["metadata"]["labels"]["app"], "backup");
+    // Owner reference points back at the CronJob (non-controller, like kubectl).
+    assert_eq!(job["metadata"]["ownerReferences"][0]["kind"], "CronJob");
+    assert_eq!(job["metadata"]["ownerReferences"][0]["name"], "backup");
+    assert_eq!(job["metadata"]["ownerReferences"][0]["uid"], "cj-uid-1");
+    // The Job spec is the jobTemplate's spec, verbatim.
+    assert_eq!(
+        job["spec"]["template"]["spec"]["containers"][0]["image"],
+        "busybox"
+    );
+}
+
+#[test]
+fn cronjob_manual_job_requires_a_job_template() {
+    let not_a_cj: DynamicObject = serde_json::from_value(json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "p", "namespace": "default"}
+    }))
+    .unwrap();
+    assert!(cronjob_manual_job(&not_a_cj, "x").is_none());
+}
+
+#[test]
+fn manual_job_name_stays_within_limits() {
+    assert_eq!(manual_job_name("backup", "abc12"), "backup-manual-abc12");
+    let long = "x".repeat(80);
+    let name = manual_job_name(&long, "abc12");
+    assert_eq!(name.len(), 42 + "-manual-abc12".len());
+    assert!(name.len() <= 63);
+}
+
 #[tokio::test]
 async fn r_force_syncs_external_secrets() {
     let (mut app, _rx) = test_app();

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -467,6 +467,11 @@ impl Cluster {
             "namespaces".to_string(),
             mk("", "Namespace", "namespaces", false),
         );
+        registry.insert("jobs".to_string(), mk("batch", "Job", "jobs", true));
+        registry.insert(
+            "cronjobs".to_string(),
+            mk("batch", "CronJob", "cronjobs", true),
+        );
         registry.insert(
             "kustomizations".to_string(),
             mk(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -458,6 +458,9 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
     if app.flux_suspendable() {
         lines.push(hint_line(&[("t", "flux menu")]));
     }
+    if app.cronjob_kind() {
+        lines.push(hint_line(&[("t", "trigger/suspend")]));
+    }
     if app.external_secret_kind() {
         lines.push(hint_line(&[("r", "force-sync")]));
     }
@@ -1780,7 +1783,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind(
             "t",
-            "flux: suspend/resume/reconcile menu (ks/hr/repos/buckets…)",
+            "flux: suspend/resume/reconcile menu (ks/hr/repos/buckets…) · cronjobs: trigger/suspend/resume",
         ),
         bind("C · U · D", "nodes: cordon · uncordon · drain"),
         bind("space", "mark/unmark row for bulk actions (esc clears)"),
@@ -1967,9 +1970,9 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
-/// Flux suspend/resume action menu (`t`). Deliberately a menu rather than a
-/// single-key toggle, so acting on a live resource always takes an explicit,
-/// visible choice.
+/// Flux suspend/resume / CronJob trigger action menu (`t`). Deliberately a
+/// menu rather than a single-key toggle, so acting on a live resource always
+/// takes an explicit, visible choice.
 fn draw_flux_menu(frame: &mut Frame, app: &mut App, area: Rect) {
     let count = app.marked.len().max(1);
     let target = if count == 1 {
@@ -1977,24 +1980,30 @@ fn draw_flux_menu(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         format!("{count} marked {}", app.kind_plural)
     };
-    let items: Vec<ListItem> = crate::app::FLUX_MENU_ITEMS
+    let items: Vec<ListItem> = app
+        .action_menu_items()
         .iter()
         .map(|label| {
             let color = match *label {
                 "Suspend" => theme::peach(),
-                "Resume" => theme::green(),
+                "Resume" | "Trigger now" => theme::green(),
                 _ => theme::overlay1(),
             };
             ListItem::new(Span::styled(*label, Style::default().fg(color)))
         })
         .collect();
+    let subject = if app.cronjob_kind() {
+        "CronJob"
+    } else {
+        "Flux"
+    };
     render_popup_list(
         frame,
         area,
         36,
         24,
         items,
-        Span::styled(format!(" Flux: {target} "), theme::title()),
+        Span::styled(format!(" {subject}: {target} "), theme::title()),
         &mut app.flux_menu_state,
     );
 }


### PR DESCRIPTION
## Summary

Closes #81.

- `t` on a CronJob now opens an action menu — **Trigger now / Suspend / Resume / Cancel** — mirroring k9s's `t` (trigger) and `shift+s` (suspend/resume), but through sofka's explicit-choice menu pattern shared with the Flux menu.
- **Trigger now** creates a Job from the CronJob's `jobTemplate` exactly the way `kubectl create job --from=cronjob/…` does: template spec verbatim, template labels/annotations carried over, `cronjob.kubernetes.io/instantiate: manual` annotation, and a non-controller owner reference back to the CronJob. Job names are `<name>-manual-<hex-timestamp>` with the CronJob name truncated at 42 chars (same limit k9s uses) so pod label values stay legal. Works on suspended CronJobs, since suspend only gates the schedule.
- **Suspend/Resume** reuse the existing `spec.suspend` merge patch — CronJobs share the field with Flux resources.
- Composes with multiselect (`space`) for bulk trigger/suspend/resume, goes through the kube API directly (no kubectl shell-out), and is blocked in read-only mode like every other mutating action.
- Header hints show `t trigger/suspend` on the cronjobs view; help and README updated.

## Test plan

- [x] 8 new unit tests: menu opens with Trigger first, suspend/resume flashes, bulk trigger on marked rows, Job manifest shape vs `kubectl create job --from`, non-CronJob rejected, name truncation (375 total pass)
- [x] Verified end-to-end against a live Talos cluster: created a suspended test CronJob, drove the real TUI in tmux — Trigger now produced `hello-manual-6a55f26e` which ran to Complete with the manual annotation, template labels, and CronJob owner reference; Resume flipped `spec.suspend` to `false` and Suspend back to `true`
- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean