### PR TITLE
fix: support word/line deletion chords in text inputs

### DIFF
--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -91,6 +91,35 @@ pub(super) fn manual_job_name(cronjob: &str, suffix: &str) -> String {
     format!("{base}-manual-{suffix}")
 }
 
+/// Readline-style line edits shared by every text input (command palette,
+/// filters, prompts, pickers). These are what terminals send for the macOS
+/// editing chords: cmd+delete arrives as ctrl-u (kill line) and
+/// option+delete as alt-backspace or ctrl-w (kill word). Returns whether the
+/// key was handled, so callers run their post-edit refresh and skip the
+/// plain-key arms.
+pub(super) fn edit_chord(key: &KeyEvent, buf: &mut String) -> bool {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    match key.code {
+        KeyCode::Char('u') if ctrl => buf.clear(),
+        KeyCode::Char('w') if ctrl => pop_word(buf),
+        KeyCode::Backspace if alt || ctrl => pop_word(buf),
+        _ => return false,
+    }
+    true
+}
+
+/// Delete the trailing word: trailing whitespace first, then the run of
+/// non-whitespace before it (readline's unix-word-rubout).
+fn pop_word(buf: &mut String) {
+    while buf.chars().next_back().is_some_and(char::is_whitespace) {
+        buf.pop();
+    }
+    while buf.chars().next_back().is_some_and(|c| !c.is_whitespace()) {
+        buf.pop();
+    }
+}
+
 /// A compact journal label for a set of node names.
 pub(super) fn node_targets_label(targets: &[String]) -> String {
     match targets {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -430,6 +430,10 @@ impl App {
     }
 
     pub(super) fn key_command(&mut self, key: KeyEvent) {
+        if edit_chord(&key, &mut self.command) {
+            self.update_suggestions();
+            return;
+        }
         match key.code {
             KeyCode::Esc => self.mode = Mode::Table,
             KeyCode::Down | KeyCode::Tab => {
@@ -797,6 +801,11 @@ impl App {
     /// apply live per keystroke; `-l`/`-f` selectors are sent to the API on
     /// ⏎, since that restarts the watch (see `sync_filter_selectors`).
     pub(super) fn key_filter(&mut self, key: KeyEvent) {
+        if edit_chord(&key, &mut self.filter) {
+            self.invalidate_rows();
+            self.table_state.select(Some(0));
+            return;
+        }
         match key.code {
             KeyCode::Esc => {
                 self.filter.clear();
@@ -1046,6 +1055,11 @@ impl App {
     }
 
     pub(super) fn key_log_filter(&mut self, key: KeyEvent) {
+        let mut edited = self.logs.filter.clone();
+        if edit_chord(&key, &mut edited) {
+            self.logs.set_filter(edited);
+            return;
+        }
         match key.code {
             KeyCode::Esc => {
                 self.logs.set_filter(String::new());
@@ -1083,6 +1097,9 @@ impl App {
     /// events, help). Mirrors [`Self::key_log_filter`]: enter keeps the query,
     /// esc clears it; either returns to the view it was opened from.
     pub(super) fn key_doc_filter(&mut self, key: KeyEvent) {
+        if edit_chord(&key, self.doc_filter_mut()) {
+            return;
+        }
         match key.code {
             KeyCode::Esc => {
                 self.doc_filter_mut().clear();

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -199,6 +199,9 @@ impl App {
     }
 
     pub(super) fn key_prompt(&mut self, key: KeyEvent) {
+        if edit_chord(&key, &mut self.prompt_input) {
+            return;
+        }
         match key.code {
             KeyCode::Esc => {
                 // The lookback prompt is the one prompt opened from the logs

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -137,6 +137,10 @@ impl App {
     }
 
     pub(super) fn key_namespaces(&mut self, key: KeyEvent) {
+        if edit_chord(&key, &mut self.ns_filter) {
+            self.select_best_namespace_match();
+            return;
+        }
         let len = self.filtered_namespaces().len();
         match key.code {
             KeyCode::Esc => {
@@ -257,6 +261,10 @@ impl App {
     }
 
     pub(super) fn key_contexts(&mut self, key: KeyEvent) {
+        if edit_chord(&key, &mut self.ctx_filter) {
+            self.ctx_state.select(Some(0));
+            return;
+        }
         let len = self.filtered_contexts().len();
         match key.code {
             KeyCode::Esc => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20,6 +20,10 @@ fn ctrl(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::CONTROL)
 }
 
+fn alt(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::ALT)
+}
+
 /// Inject a watched object as the current generation would.
 fn apply(app: &mut App, v: serde_json::Value) {
     let o = obj(v);
@@ -941,6 +945,72 @@ fn cronjob_manual_job_requires_a_job_template() {
     }))
     .unwrap();
     assert!(cronjob_manual_job(&not_a_cj, "x").is_none());
+}
+
+#[tokio::test]
+async fn filter_edit_chords_delete_word_and_clear_line() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    assert_eq!(app.mode, Mode::Filter);
+    for c in "hello world".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+
+    // option+delete (alt-backspace) kills the last word…
+    app.handle_key(alt(KeyCode::Backspace)).unwrap();
+    assert_eq!(app.filter, "hello ");
+    // …ctrl-w does the same, eating the separator first…
+    app.handle_key(ctrl(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.filter, "");
+
+    // …and cmd+delete (ctrl-u) clears the whole line.
+    for c in "app=nginx running".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    assert_eq!(app.filter, "");
+    assert_eq!(app.mode, Mode::Filter); // still typing, not kicked out
+}
+
+#[tokio::test]
+async fn command_palette_edit_chords() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "cronjobs kube-system".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(ctrl(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.command, "cronjobs ");
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    assert_eq!(app.command, "");
+}
+
+#[tokio::test]
+async fn namespace_picker_edit_chords() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.mode, Mode::Namespaces);
+    for c in "monitoring".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    assert_eq!(app.ns_filter, "");
+    assert_eq!(app.mode, Mode::Namespaces);
+}
+
+#[test]
+fn edit_chord_leaves_plain_keys_alone() {
+    let mut buf = "abc".to_string();
+    assert!(!edit_chord(&press(KeyCode::Char('u')), &mut buf));
+    assert!(!edit_chord(&press(KeyCode::Backspace), &mut buf));
+    assert_eq!(buf, "abc");
+    // Word rubout trims trailing spaces before the word, readline-style.
+    let mut buf = "one two   ".to_string();
+    assert!(edit_chord(&alt(KeyCode::Backspace), &mut buf));
+    assert_eq!(buf, "one ");
 }
 
 #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1715,6 +1715,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "/",
             "filter: fuzzy · !inverse · -l/-f selectors (server-side on ⏎) · col=val cpu>500m age<2h",
         ),
+        bind(
+            "ctrl-u · ctrl-w",
+            "text inputs: clear line (cmd-⌫) · delete word (opt-⌫)",
+        ),
         bind("n · 0-9", "namespace switcher · 0 = all namespaces"),
         bind("ctrl-r", "refresh watch"),
         Line::from(""),


### PR DESCRIPTION
## Summary

cmd+delete and option+delete did nothing useful while typing in the `/` filter (or any other text input). Terminals encode these macOS editing shortcuts as readline chords — cmd+delete arrives as `ctrl-u` and option+delete as `alt-backspace` (or `ctrl-w`) — and the input handlers only matched plain `Backspace`/`Char`, so `ctrl-u` inserted a literal `u` and option+delete deleted a single character.

- New shared `edit_chord` helper: `ctrl-u` clears the line, `ctrl-w` / `alt-backspace` delete the trailing word (readline unix-word-rubout: trailing whitespace, then the word).
- Wired into every text input: row filter (`/`), command palette (`:`), log filter, doc/YAML/help search, prompts (scale, port-forward, image, debug, guardrail confirm), and the namespace/context pickers — each running its own post-edit refresh (suggestions, row invalidation, best-match selection).
- Help view documents the chords under the filter binding.

## Test plan

- [x] 4 new tests covering the filter, command palette, and namespace picker chords plus the word-rubout edge cases (378 total pass)
- [x] Verified in the live TUI via tmux against a real cluster, sending the exact byte sequences terminals emit: `ESC DEL` (option+delete) killed the last filter word, `0x15` (cmd+delete) cleared the filter and restored the unfiltered row set, `ctrl-w` killed a word
- [x] fmt + clippy clean (pre-commit hooks)