### PR TITLE
feat: transfer files to/from pods with kubectl cp

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1343,6 +1343,227 @@ impl App {
         );
     }
 
+    /// `t` on a pod row: open the file-transfer menu for the selected pod.
+    /// No container pin — `kubectl cp` targets the pod's default container;
+    /// the container picker's `t` transfers to/from a specific one.
+    pub(super) fn request_transfer(&mut self) {
+        let Some(obj) = self.selected_ref() else {
+            return;
+        };
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        self.open_transfer_menu(ns, name, None);
+    }
+
+    /// Open the download/upload choice for `pod`. A menu rather than a prompt
+    /// straight away, so the direction is always an explicit, visible choice.
+    pub(super) fn open_transfer_menu(
+        &mut self,
+        ns: String,
+        pod: String,
+        container: Option<String>,
+    ) {
+        self.transfer_target = Some((ns, pod, container));
+        self.transfer_menu_state.select(Some(0));
+        self.mode = Mode::TransferMenu;
+    }
+
+    pub(super) fn key_transfer_menu(&mut self, key: KeyEvent) {
+        let len = TRANSFER_MENU_ITEMS.len();
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.transfer_target = None;
+                self.mode = Mode::Table;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                list_step(&mut self.transfer_menu_state, len, true)
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                list_step(&mut self.transfer_menu_state, len, false)
+            }
+            KeyCode::Enter => {
+                let choice = self
+                    .transfer_menu_state
+                    .selected()
+                    .and_then(|i| TRANSFER_MENU_ITEMS.get(i))
+                    .copied();
+                self.mode = Mode::Table;
+                let Some((ns, pod, container)) = self.transfer_target.take() else {
+                    return;
+                };
+                match choice {
+                    Some("Download from pod") => self.prompt_transfer(ns, pod, container, false),
+                    // Upload writes into the container's filesystem — a
+                    // mutation, unlike download.
+                    Some("Upload to pod") if !self.deny_readonly() => {
+                        self.prompt_transfer(ns, pod, container, true);
+                    }
+                    _ => {} // "Cancel" or nothing selected — do nothing.
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// First of the two transfer prompts: the source path (remote for a
+    /// download, local for an upload). `key_prompt` chains into the
+    /// destination prompt with the answer.
+    pub(super) fn prompt_transfer(
+        &mut self,
+        ns: String,
+        pod: String,
+        container: Option<String>,
+        upload: bool,
+    ) {
+        let target = match &container {
+            Some(c) => format!("{pod}:{c}"),
+            None => pod.clone(),
+        };
+        self.prompt_label = if upload {
+            format!("Upload to {target} — local file:")
+        } else {
+            format!("Download from {target} — remote path:")
+        };
+        self.prompt_input.clear();
+        self.prompt_kind = Some(PromptKind::Transfer {
+            ns,
+            pod,
+            container,
+            upload,
+            src: None,
+        });
+        self.mode = Mode::Prompt;
+    }
+
+    /// Run the fully-specified transfer. Downloads start straight away; an
+    /// upload writes into the pod, so it passes through the `transfer`
+    /// guardrail first (no default confirmation, like shell).
+    pub(super) fn do_transfer(
+        &mut self,
+        ns: String,
+        pod: String,
+        container: Option<String>,
+        upload: bool,
+        src: String,
+        dest: String,
+    ) {
+        if !upload {
+            self.start_transfer(ns, pod, container, false, src, dest);
+            return;
+        }
+        let targets = [(pod.clone(), ns.clone())];
+        let Some(level) = self.guard("transfer", "pods", &targets, ConfirmLevel::None) else {
+            return;
+        };
+        let label = format!("Upload {src} to {pod}:{dest}?");
+        let hint = pod.clone();
+        self.begin_guarded(
+            ConfirmAction::Transfer {
+                ns,
+                pod,
+                container,
+                src,
+                dest,
+            },
+            label,
+            level,
+            hint,
+        );
+    }
+
+    /// The `kubectl cp` argv for a transfer, pinned to the active context.
+    pub(super) fn cp_argv(
+        &self,
+        ns: &str,
+        pod: &str,
+        container: Option<&str>,
+        upload: bool,
+        src: &str,
+        dest: &str,
+    ) -> Vec<String> {
+        let (from, to) = if upload {
+            (src.to_string(), format!("{pod}:{dest}"))
+        } else {
+            (format!("{pod}:{src}"), dest.to_string())
+        };
+        let mut argv = self.kubectl_base();
+        argv.extend(["cp".into(), "-n".into(), ns.to_string()]);
+        if let Some(c) = container {
+            argv.extend(["-c".into(), c.to_string()]);
+        }
+        argv.push(from);
+        argv.push(to);
+        argv
+    }
+
+    /// Run `kubectl cp` off-thread and flash the outcome. Not a foreground
+    /// `Suspend::Shell` — cp is non-interactive (and silent on success), and
+    /// a large copy would otherwise freeze the UI for its whole duration.
+    pub(super) fn start_transfer(
+        &mut self,
+        ns: String,
+        pod: String,
+        container: Option<String>,
+        upload: bool,
+        src: String,
+        dest: String,
+    ) {
+        let argv = self.cp_argv(&ns, &pod, container.as_deref(), upload, &src, &dest);
+        let from = argv[argv.len() - 2].clone();
+        let to = argv[argv.len() - 1].clone();
+        self.note_action(
+            if upload { "cp upload" } else { "cp download" },
+            format!("{pod} in {ns}"),
+        );
+        self.flash = format!("copying {from} → {to}…");
+        self.flash_err = false;
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let out = tokio::process::Command::new(&argv[0])
+                .args(&argv[1..])
+                .output()
+                .await;
+            let result = match out {
+                Ok(o) if o.status.success() => Ok(format!("copied {from} → {to}")),
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    // The actual cause (a tar/exec error) comes before
+                    // kubectl's generic "command terminated with exit code"
+                    // trailer — flash the last line that says something.
+                    let line = |skip_trailer: bool| {
+                        stderr
+                            .lines()
+                            .rev()
+                            .map(str::trim)
+                            .find(|l| {
+                                !l.is_empty()
+                                    && !(skip_trailer && l.starts_with("command terminated"))
+                            })
+                            .unwrap_or_default()
+                            .to_string()
+                    };
+                    let err = match line(true) {
+                        e if e.is_empty() => line(false),
+                        e => e,
+                    };
+                    Err(if err.is_empty() {
+                        format!("kubectl cp exited with {}", o.status)
+                    } else {
+                        err
+                    })
+                }
+                Err(e) => Err(format!("kubectl cp failed to start: {e}")),
+            };
+            let _ = tx
+                .send(Msg::TransferDone {
+                    generation: genr,
+                    result,
+                })
+                .await;
+        });
+    }
+
     /// Open the `t` action menu (Flux suspend/resume, CronJob
     /// trigger/suspend/resume) for the marked rows, or the current selection
     /// if none are marked. A menu, not a single-key toggle — suspending

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -69,6 +69,7 @@ impl App {
             Mode::Timeline => self.key_timeline(key),
             Mode::Gitops => self.key_gitops(key),
             Mode::FluxMenu => self.key_flux_menu(key),
+            Mode::TransferMenu => self.key_transfer_menu(key),
             Mode::PortForwards => self.key_port_forwards(key),
             Mode::Skins => self.key_skins(key),
             Mode::Snapshots => self.key_snapshots(key),
@@ -194,8 +195,15 @@ impl App {
                 }
             }
             // Action menu on the marked rows, or current: Flux
-            // suspend/resume/reconcile, CronJob trigger/suspend/resume.
-            KeyCode::Char('t') => self.request_flux_menu(),
+            // suspend/resume/reconcile, CronJob trigger/suspend/resume. On
+            // pods, `t` is the file-transfer menu (kubectl cp) instead.
+            KeyCode::Char('t') => {
+                if self.kind_plural == "pods" {
+                    self.request_transfer();
+                } else {
+                    self.request_flux_menu();
+                }
+            }
             KeyCode::Char('?') => {
                 self.help_filter.clear();
                 self.mode = Mode::Help;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -757,6 +757,15 @@ impl App {
                     .scroll
                     .min(self.detail.lines.len().saturating_sub(1));
             }
+            Msg::TransferDone { generation, result } if generation == self.generation => {
+                match result {
+                    Ok(summary) => {
+                        self.flash = summary;
+                        self.flash_err = false;
+                    }
+                    Err(e) => self.flash_warn(&format!("cp failed: {e}")),
+                }
+            }
             Msg::LogsSaved { generation, result } if generation == self.log_gen => match result {
                 Ok(path) => {
                     self.flash = format!("saved logs → {}", path.display());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -76,6 +76,11 @@ pub const FLUX_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Reconcile now", "Ca
 /// like the Flux menu (CronJobs share the field).
 pub const CRONJOB_MENU_ITEMS: &[&str] = &["Trigger now", "Suspend", "Resume", "Cancel"];
 
+/// Items in the pod file-transfer menu (`t` on a pod), in display order. Both
+/// directions shell out to `kubectl cp` (which needs `tar` in the container),
+/// prompting for the source and destination paths.
+pub const TRANSFER_MENU_ITEMS: &[&str] = &["Download from pod", "Upload to pod", "Cancel"];
+
 /// External Secrets Operator kinds that honour the `force-sync` annotation to
 /// trigger an immediate secret refresh. Both are namespaced; the cluster-scoped
 /// `ClusterExternalSecret` is deliberately left out so the namespaced patch
@@ -111,6 +116,8 @@ pub enum Mode {
     Diff,
     Events,
     FluxMenu,
+    /// Download-or-upload choice for a pod file transfer (`t` on a pod).
+    TransferMenu,
     PortForwards,
     Skins,
     /// Browsing saved snapshots (`:snapshots`).
@@ -191,6 +198,16 @@ enum ConfirmAction {
     Edit { argv: Vec<String> },
     /// Shell into a pod, once a guardrail confirmation is satisfied.
     Exec { ns: String, name: String },
+    /// Upload a local file into a pod (`kubectl cp`), once a guardrail
+    /// confirmation is satisfied. Upload only — a download doesn't mutate
+    /// the pod, so it never needs confirming.
+    Transfer {
+        ns: String,
+        pod: String,
+        container: Option<String>,
+        src: String,
+        dest: String,
+    },
     /// One or more node names to cordon and drain.
     Drain { targets: Vec<String> },
     /// Roll a Helm release back to an earlier revision (`helm rollback`) —
@@ -291,6 +308,17 @@ enum PromptKind {
         ns: String,
         pod: String,
         target: Option<String>,
+    },
+    /// File-transfer path prompts (`t` on a pod), asked in two steps: the
+    /// source path first (`src` is `None`), then the destination with the
+    /// answered source carried along. `container` pins `-c` when launched
+    /// from the container picker.
+    Transfer {
+        ns: String,
+        pod: String,
+        container: Option<String>,
+        upload: bool,
+        src: Option<String>,
     },
     /// New lookback period for the provider logs view (`T`) — the only
     /// prompt opened from (and returning to) [`Mode::Logs`].
@@ -890,6 +918,11 @@ pub struct App {
     /// action menu (Flux suspend/resume, CronJob trigger/suspend/resume).
     pub flux_menu_state: ListState,
 
+    /// Cursor into [`TRANSFER_MENU_ITEMS`] for the pod file-transfer menu
+    /// (`t` on a pod), and the `(ns, pod, container)` it acts on.
+    pub transfer_menu_state: ListState,
+    pub transfer_target: Option<(String, String, Option<String>)>,
+
     /// Background `kubectl port-forward` processes started with `f`/`F`.
     /// Viewed/stopped via `:pf`; killed automatically on drop.
     pub port_forwards: Vec<PortForward>,
@@ -1081,6 +1114,8 @@ impl App {
             container_resources: HashMap::new(),
             container_qos: String::new(),
             flux_menu_state: ListState::default(),
+            transfer_menu_state: ListState::default(),
+            transfer_target: None,
             port_forwards: Vec::new(),
             pf_state: ListState::default(),
             skin_list: crate::theme::BUILTIN_NAMES

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -55,6 +55,15 @@ impl App {
                     self.launch_provider_container_logs(ns, name, c);
                 }
             }
+            // Transfer files to/from this container (`kubectl cp -c`).
+            KeyCode::Char('t') => {
+                if let Some(i) = self.container_state.selected()
+                    && let Some(c) = self.container_list.get(i).cloned()
+                    && let Some((ns, name)) = self.container_pod.clone()
+                {
+                    self.open_transfer_menu(ns, name, Some(c));
+                }
+            }
             // Debug an ephemeral container targeting this container's namespace
             // (`kubectl debug --target`). The picker's pod is the selected row,
             // so request_debug reads it back from the table selection.
@@ -103,6 +112,15 @@ impl App {
             }
             ConfirmAction::Exec { ns, name } => {
                 self.exec_into(ns, name, None);
+            }
+            ConfirmAction::Transfer {
+                ns,
+                pod,
+                container,
+                src,
+                dest,
+            } => {
+                self.start_transfer(ns, pod, container, true, src, dest);
             }
             ConfirmAction::Drain { targets } => {
                 self.do_drain_nodes(targets);
@@ -254,6 +272,52 @@ impl App {
                             self.flash_warn("no debug image given");
                         } else {
                             self.do_debug(ns, pod, target, input);
+                        }
+                    }
+                    // The transfer prompts chain: source path first, then the
+                    // destination (prefilled with the source's file name on
+                    // download, since it usually lands in the CWD as-is).
+                    Some(PromptKind::Transfer {
+                        ns,
+                        pod,
+                        container,
+                        upload,
+                        src: None,
+                    }) => {
+                        if input.is_empty() {
+                            self.flash_warn("no path given — transfer cancelled");
+                        } else {
+                            self.prompt_label = if upload {
+                                format!("Upload {input} to {pod} — remote path:")
+                            } else {
+                                format!("Download {pod}:{input} — local path:")
+                            };
+                            self.prompt_input = if upload {
+                                String::new()
+                            } else {
+                                input.rsplit('/').next().unwrap_or_default().to_string()
+                            };
+                            self.prompt_kind = Some(PromptKind::Transfer {
+                                ns,
+                                pod,
+                                container,
+                                upload,
+                                src: Some(input),
+                            });
+                            self.mode = Mode::Prompt;
+                        }
+                    }
+                    Some(PromptKind::Transfer {
+                        ns,
+                        pod,
+                        container,
+                        upload,
+                        src: Some(src),
+                    }) => {
+                        if input.is_empty() {
+                            self.flash_warn("no path given — transfer cancelled");
+                        } else {
+                            self.do_transfer(ns, pod, container, upload, src, input);
                         }
                     }
                     // Empty input = cancel, keep the current period.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1871,6 +1871,109 @@ async fn container_picker_shell_targets_selected_container() {
 }
 
 #[tokio::test]
+async fn transfer_menu_chains_download_prompts() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "p", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.mode, Mode::TransferMenu);
+    // Enter on the default selection ("Download from pod") → source prompt.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert!(
+        app.prompt_label.contains("remote path"),
+        "{}",
+        app.prompt_label
+    );
+    app.prompt_input = "/var/log/app.log".into();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    // Chains into the destination prompt, prefilled with the file name.
+    assert_eq!(app.mode, Mode::Prompt);
+    assert!(
+        app.prompt_label.contains("local path"),
+        "{}",
+        app.prompt_label
+    );
+    assert_eq!(app.prompt_input, "app.log");
+}
+
+#[tokio::test]
+async fn transfer_argv_pins_context_and_direction() {
+    let (app, _rx) = test_app();
+    let argv = app.cp_argv(
+        "default",
+        "p",
+        Some("sidecar"),
+        false,
+        "/var/log/app.log",
+        "app.log",
+    );
+    assert_eq!(&argv[..3], ["kubectl", "--context", "test"]);
+    assert_eq!(argv[3], "cp");
+    let n = argv.iter().position(|a| a == "-n").unwrap();
+    assert_eq!(argv[n + 1], "default");
+    let c = argv.iter().position(|a| a == "-c").unwrap();
+    assert_eq!(argv[c + 1], "sidecar");
+    // Download: remote source, local destination.
+    assert_eq!(argv[argv.len() - 2], "p:/var/log/app.log");
+    assert_eq!(argv[argv.len() - 1], "app.log");
+
+    // Upload flips the direction (and no -c without a container pin).
+    let argv = app.cp_argv("default", "p", None, true, "notes.txt", "/tmp/notes.txt");
+    assert_eq!(argv[argv.len() - 2], "notes.txt");
+    assert_eq!(argv[argv.len() - 1], "p:/tmp/notes.txt");
+    assert!(!argv.contains(&"-c".to_string()));
+}
+
+#[tokio::test]
+async fn transfer_upload_blocked_in_readonly() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "p", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    app.readonly = true;
+    // The menu itself opens — download doesn't mutate anything.
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.mode, Mode::TransferMenu);
+    // Choosing "Upload to pod" is refused.
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("read-only"), "{}", app.flash);
+    assert_ne!(app.mode, Mode::Prompt);
+}
+
+#[tokio::test]
+async fn container_picker_transfer_pins_container() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "p", "namespace": "default"},
+               "spec": {"containers": [{"name": "app"}, {"name": "sidecar"}]}}),
+    );
+    app.table_state.select(Some(0));
+    let obj = app.selected_ref().unwrap().clone();
+    app.open_containers(&obj);
+    app.container_state.select(Some(1)); // "sidecar"
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.mode, Mode::TransferMenu);
+    assert_eq!(
+        app.transfer_target,
+        Some(("default".into(), "p".into(), Some("sidecar".into())))
+    );
+}
+
+#[tokio::test]
 async fn paused_logs_do_not_trim_below_paused_cap() {
     let (mut app, _rx) = test_app();
     let cap = app.logs_cfg.buffer;

--- a/src/store.rs
+++ b/src/store.rs
@@ -97,6 +97,12 @@ pub enum Msg {
         title: String,
         lines: Vec<String>,
     },
+    /// Result of a background `kubectl cp` transfer (`t` on a pod): a
+    /// "copied …" summary, or kubectl's error.
+    TransferDone {
+        generation: u64,
+        result: Result<String, String>,
+    },
     /// Result of an off-thread log save.
     LogsSaved {
         generation: u64,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::widgets::{
 };
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::{App, Mode, SuggestKind};
+use crate::app::{App, Mode, SuggestKind, TRANSFER_MENU_ITEMS};
 use crate::{columns, theme};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -163,6 +163,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Prompt => draw_prompt_popup(frame, app, chunks[1]),
         Mode::Command => draw_palette(frame, app, chunks[1]),
         Mode::FluxMenu => draw_flux_menu(frame, app, chunks[1]),
+        Mode::TransferMenu => draw_transfer_menu(frame, app, chunks[1]),
         Mode::Skins => draw_skins(frame, app, chunks[1]),
         Mode::Snapshots => draw_snapshots(frame, app, chunks[1]),
         _ => {}
@@ -396,7 +397,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
     let mut lines = match app.kind_plural.as_str() {
         "pods" => vec![
             hint_line(&[("⏎", "containers"), ("l", "logs"), ("p", "prev logs")]),
-            hint_line(&[("s", "shell"), ("a", "attach"), ("f", "port-fwd")]),
+            hint_line(&[("s", "shell"), ("t", "transfer"), ("f", "port-fwd")]),
             hint_line(&[("y", "yaml"), ("d", "describe"), ("E", "events")]),
             hint_line(&[("e", "edit"), ("o", "node"), ("J", "owner")]),
             hint_line(&[("X", "explain"), ("T", "timeline"), ("^d", "delete")]),
@@ -1787,7 +1788,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind(
             "t",
-            "flux: suspend/resume/reconcile menu (ks/hr/repos/buckets…) · cronjobs: trigger/suspend/resume",
+            "pods: file transfer (kubectl cp, in picker targets a container) · flux: suspend/resume/reconcile · cronjobs: trigger/suspend/resume",
         ),
         bind("C · U · D", "nodes: cordon · uncordon · drain"),
         bind("space", "mark/unmark row for bulk actions (esc clears)"),
@@ -2012,6 +2013,36 @@ fn draw_flux_menu(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+/// Pod file-transfer menu (`t` on a pod): download from or upload to the pod
+/// via `kubectl cp`, then two prompts for the source and destination paths.
+fn draw_transfer_menu(frame: &mut Frame, app: &mut App, area: Rect) {
+    let target = match &app.transfer_target {
+        Some((_, pod, Some(c))) => format!("{pod}:{c}"),
+        Some((_, pod, None)) => pod.clone(),
+        None => String::new(),
+    };
+    let items: Vec<ListItem> = TRANSFER_MENU_ITEMS
+        .iter()
+        .map(|label| {
+            let color = match *label {
+                "Download from pod" => theme::green(),
+                "Upload to pod" => theme::peach(),
+                _ => theme::overlay1(),
+            };
+            ListItem::new(Span::styled(*label, Style::default().fg(color)))
+        })
+        .collect();
+    render_popup_list(
+        frame,
+        area,
+        36,
+        24,
+        items,
+        Span::styled(format!(" Transfer: {target} "), theme::title()),
+        &mut app.transfer_menu_state,
+    );
+}
+
 /// Background port-forwards (`:pf`). A full-width view, not a popup — closing
 /// it (`esc`) does not stop the forwards; only `x`/`s` on a row does.
 fn draw_port_forwards(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -2231,7 +2262,7 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         format!(" · {}", app.container_qos)
     };
     let title = format!(" Containers{qos} ");
-    let footer = " ⏎ logs · p previous · s shell · d debug · L provider ";
+    let footer = " ⏎ logs · p previous · s shell · t transfer · d debug · L provider ";
 
     // Size the box to its contents: header + rows + borders, and wide enough
     // for the columns, the title, or the footer — whichever needs the most.


### PR DESCRIPTION
## Summary

Closes #85.

Pressing `t` on a pod now opens a file-transfer menu instead of the (no-op for pods) Flux menu — on every other kind `t` keeps its existing Flux/CronJob behavior.

- **Download from pod / Upload to pod** menu, then two chained prompts for the source and destination paths (the download destination is prefilled with the remote file's name).
- Runs `kubectl cp` **in the background** (pinned to the active context like every other shell-out) and flashes the outcome — a large copy never freezes the TUI, unlike a foreground `Suspend::Shell`. Failures surface the meaningful last stderr line (e.g. `tar: executable file not found`), not kubectl's generic exit-code trailer.
- `t` in the **container picker** pins `-c <container>` for multi-container pods.
- **Uploads** are blocked in read-only mode and pass through a `transfer` guardrail (no default confirmation, like shell); downloads don't mutate the pod so they run straight away. Both directions are recorded in the action journal.
- Discoverability: pods header hints now show `t transfer` (replacing the niche `a attach`, which stays in `?` help), the container-picker footer and `?` help list it too.

## Test plan

- [x] `just check` (fmt, clippy, 382 tests) passes
- [x] New tests: menu → prompt chaining with prefill, `cp` argv shape (context pin, `-n`/`-c`, direction), read-only upload refusal, container-picker pinning
- [x] Verified the exact generated argv end-to-end against a live cluster: download OK, upload OK (writable mount), and confirmed the error surfaces for a distroless container (no `tar`) and a read-only filesystem