### PR TITLE
feat: confirm before rollout restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Not a marketing number - these are specific, checkable design choices:
   it - the same answer `kubectl auth can-i` gives, without leaving the TUI.
 - **Declarative guardrails** (`[[guardrails]]`) - config-defined rules that
   match on context/namespace/resource/action globs to **deny** a destructive
-  action outright (`delete`/`force-delete`/`drain`/`shell`/`debug`/`node-debug`), force
+  action outright (`delete`/`force-delete`/`drain`/`restart`/`shell`/`debug`/`node-debug`), force
   **type-to-confirm** (resource name or `context/name`), or cap **bulk**
   operations - so "never delete in prod", "always confirm a prod shell", and
   "no more than one at once" are enforced, not remembered.
@@ -515,7 +515,7 @@ remember. Each rule matches on `contexts`, `namespaces`, `resources`, and
 the strictest of: `deny` (block outright), `confirmation` (type to confirm),
 and `max_bulk` (cap how many rows one action may touch). The gated `actions`
 are the destructive verbs sofka takes directly — `delete`, `force-delete`,
-`drain`, `shell` (exec), `debug`, and `node-debug`. The first matching rule
+`drain`, `restart`, `shell` (exec), `debug`, and `node-debug`. The first matching rule
 wins; `reason` is shown when it fires.
 
 ```toml

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -548,6 +548,8 @@ impl App {
     }
 
     /// Rollout-restart a workload by stamping the template annotation (k9s `r`).
+    /// Confirmed (y/n) before running, so an accidental keypress can't restart
+    /// a workload — and configurable via `restart` guardrails.
     pub(super) fn request_restart(&mut self) {
         if self.deny_readonly() {
             return;
@@ -560,6 +562,31 @@ impl App {
         };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        let plural = self.kind_plural.clone();
+        let Some(level) = self.guard(
+            "restart",
+            &plural,
+            &[(name.clone(), ns.clone())],
+            ConfirmLevel::Plain,
+        ) else {
+            return;
+        };
+        let label = format!("Restart {name} in {ns}?");
+        self.begin_guarded(
+            ConfirmAction::Restart {
+                kind,
+                name: name.clone(),
+                ns,
+            },
+            label,
+            level,
+            name,
+        );
+    }
+
+    /// Stamp the pod template's `restartedAt` annotation to trigger a rollout
+    /// restart. Runs once the [`request_restart`] confirmation is satisfied.
+    pub(super) fn do_restart(&mut self, kind: Kind, name: String, ns: String) {
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
         self.note_action("restart", format!("{name} in {ns}"));
         self.flash = format!("restarting {name}…");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -210,6 +210,14 @@ enum ConfirmAction {
     },
     /// One or more node names to cordon and drain.
     Drain { targets: Vec<String> },
+    /// Rollout-restart a workload by stamping the pod template's
+    /// `restartedAt` annotation (k9s `r`). Single-target — acts on the
+    /// selected row, never bulk.
+    Restart {
+        kind: Kind,
+        name: String,
+        ns: String,
+    },
     /// Roll a Helm release back to an earlier revision (`helm rollback`) —
     /// always a single revision, never bulk (mirrors k9s: rollback acts on
     /// the one selected history row).

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -126,6 +126,9 @@ impl App {
                 self.do_drain_nodes(targets);
                 self.marked.clear();
             }
+            ConfirmAction::Restart { kind, name, ns } => {
+                self.do_restart(kind, name, ns);
+            }
             ConfirmAction::HelmRollback { ns, name, revision } => {
                 self.do_helm_rollback(ns, name, revision);
             }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -682,6 +682,32 @@ async fn node_drain_key_opens_confirm_for_marked_nodes() {
 }
 
 #[tokio::test]
+async fn restart_key_opens_confirm() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    apply(
+        &mut app,
+        json!({"apiVersion": "apps/v1", "kind": "Deployment",
+               "metadata": {"name": "web", "namespace": "default"}}),
+    );
+
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert_eq!(app.confirm_label, "Restart web in default?");
+    assert!(!app.confirm_allows_force_toggle());
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::Restart { ref name, ref ns, .. })
+            if name == "web" && ns == "default"
+    ));
+
+    // Cancelling leaves the workload untouched.
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.confirm_action.is_none());
+}
+
+#[tokio::test]
 async fn esc_clears_marks_before_popping() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/config.rs
+++ b/src/config.rs
@@ -666,8 +666,9 @@ pub fn workspace_warnings(workspaces: &[Workspace]) -> Vec<String> {
 
 /// A declarative safety policy: match dangerous actions by context, namespace,
 /// resource, and action, then require extra confirmation, deny them, or cap a
-/// bulk selection. Gates `delete`, `force-delete`, `drain`, `shell`, `debug`,
-/// and `node-debug` today. Empty match lists mean "any"; glob `*` supported.
+/// bulk selection. Gates `delete`, `force-delete`, `drain`, `restart`,
+/// `shell`, `debug`, and `node-debug` today. Empty match lists mean "any";
+/// glob `*` supported.
 ///
 /// ```toml
 /// [[guardrails]]


### PR DESCRIPTION
## Summary
- Route the rollout-restart action (`r` on Deployments/StatefulSets/DaemonSets) through the same guardrail/confirm flow as delete and drain, so an accidental keypress can no longer restart a workload. Pressing `r` now shows a `Restart <name> in <ns>?` y/n dialog.
- Add a `Restart` `ConfirmAction` variant; split `request_restart` (builds the confirm) from `do_restart` (performs the annotation-stamping patch, run only after confirmation).
- Expose `restart` as a gated guardrail action, so it can be denied, escalated to type-to-confirm, or capped via `[[guardrails]]` — documented in the README and config.
- Add a test covering the confirm dialog and cancel path.

Closes #87

## Test plan
- [x] \`cargo test\` — 383 passed
- [x] \`cargo clippy\` clean
- [ ] Press \`r\` on a Deployment/StatefulSet/DaemonSet and confirm the dialog appears; \`y\` restarts, \`n\`/esc cancels