### PR TITLE
feat: cache view snapshots for instant navigation

### DIFF
--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -18,8 +18,10 @@ impl App {
             self.flash_warn("no fleet contexts — set [fleet] contexts = [\"ctx-a\", …]");
             return;
         }
-        // Leaving the table view: stop its watches (like the pulse dashboard).
+        // Leaving the table view: stop its watches (like the pulse dashboard),
+        // stashing its rows so returning to it renders instantly.
         self.bump_generation();
+        self.stash_view_snapshot();
         self.store.clear();
         self.invalidate_rows();
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -252,11 +252,27 @@ impl App {
         for t in self.tasks.drain(..) {
             t.abort();
         }
+        // Stash the outgoing view's rows, then show the incoming view's
+        // cached snapshot (if it was visited recently) so navigation renders
+        // instantly — the fresh watch relists behind it and swaps in on sync.
+        self.stash_view_snapshot();
+        let watch_labels = join_selectors(&self.labels, &self.applied_filter_labels);
+        let watch_fields = join_selectors(&self.fields, &self.applied_filter_fields);
+        let key = ViewKey {
+            kind_plural: self.kind_plural.clone(),
+            namespace: self.namespace.clone(),
+            labels: watch_labels.clone(),
+            fields: watch_fields.clone(),
+        };
         self.store.clear();
+        if let Some(cached) = self.view_cache.get(&key) {
+            self.store.seed(cached.clone());
+        }
+        self.watch_key = Some(key);
         self.metrics.clear();
         self.container_metrics.clear();
         self.marked.clear();
-        self.invalidate_rows();
+        self.clear_rows_cache();
         if self.table_state.selected().is_none() {
             self.table_state.select(Some(0));
         }
@@ -266,8 +282,8 @@ impl App {
         let handle = self.cluster.spawn_watch(
             &kind,
             &self.namespace,
-            join_selectors(&self.labels, &self.applied_filter_labels),
-            join_selectors(&self.fields, &self.applied_filter_fields),
+            watch_labels,
+            watch_fields,
             self.generation,
             self.tx.clone(),
         );
@@ -282,6 +298,35 @@ impl App {
             self.last_rbac_ns = Some(self.namespace.clone());
             self.refresh_rbac();
         }
+    }
+
+    /// Stash the current store contents in the view cache under the running
+    /// watch's key, so navigating back to this view renders it instantly.
+    /// Only a fully-synced set is kept — a partial initial list would read as
+    /// "resources disappeared" when redisplayed later.
+    pub(super) fn stash_view_snapshot(&mut self) {
+        let Some(key) = self.watch_key.take() else {
+            return;
+        };
+        if !self.store.synced || self.store.len() == 0 {
+            return;
+        }
+        self.view_cache_order.retain(|k| *k != key);
+        self.view_cache_order.push_back(key.clone());
+        self.view_cache.insert(key, self.store.take_items());
+        while self.view_cache_order.len() > VIEW_CACHE_MAX {
+            if let Some(oldest) = self.view_cache_order.pop_front() {
+                self.view_cache.remove(&oldest);
+            }
+        }
+    }
+
+    /// Drop every cached view snapshot (context switch: another cluster's
+    /// resources, and possibly different RBAC, must never be redisplayed).
+    pub(super) fn clear_view_cache(&mut self) {
+        self.watch_key = None;
+        self.view_cache.clear();
+        self.view_cache_order.clear();
     }
 
     /// For a custom resource with neither curated columns nor a user view,
@@ -496,8 +541,12 @@ impl App {
     pub fn handle_msg(&mut self, msg: Msg) {
         match msg {
             Msg::Reset { generation } if generation == self.generation => {
-                self.store.clear();
-                self.clear_rows_cache();
+                // With rows on screen (cached snapshot or established watch)
+                // the store buffers the relist and keeps showing them; only a
+                // genuine clear invalidates what's rendered.
+                if self.store.begin_reset() {
+                    self.clear_rows_cache();
+                }
             }
             Msg::Applied {
                 generation,
@@ -507,7 +556,7 @@ impl App {
                 // Record state changes against the previous version before it's
                 // overwritten (session-local timeline).
                 self.timeline
-                    .observe(&self.kind_plural, &key, self.store.get(&key), &obj);
+                    .observe(&self.kind_plural, &key, self.store.latest(&key), &obj);
                 self.store.apply(key.clone(), *obj);
                 self.invalidate_row(&key);
             }
@@ -516,7 +565,11 @@ impl App {
                 self.store.remove(&key);
                 self.invalidate_row(&key);
             }
-            Msg::Synced { generation } if generation == self.generation => self.store.synced = true,
+            Msg::Synced { generation } if generation == self.generation => {
+                if self.store.finish_sync() {
+                    self.clear_rows_cache();
+                }
+            }
             Msg::Error { generation, error } if generation == self.generation => {
                 self.watch_errors = self.watch_errors.saturating_add(1);
                 self.last_error = Some(error.clone());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -762,6 +762,23 @@ impl TableCellCache<'_> {
 /// Maximum root views kept in the `[`/`]` history.
 const HISTORY_MAX: usize = 50;
 
+/// Maximum view snapshots kept for instant redisplay when navigating back to
+/// a recently-watched view (least-recently-used beyond this).
+const VIEW_CACHE_MAX: usize = 8;
+
+/// Identity of a watch scope, used to key cached view snapshots. Two visits
+/// with the same key list exactly the same server-side set, so the previous
+/// rows are safe to show while the fresh watch syncs. `labels`/`fields` are
+/// the *merged* selectors the watch was started with (drill-down + `-l`/`-f`
+/// filter terms).
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct ViewKey {
+    kind_plural: String,
+    namespace: String,
+    labels: Option<String>,
+    fields: Option<String>,
+}
+
 /// One root view for the `[`/`]` history: which kind was listed in which
 /// namespace. Drill-down state (selectors, filter, scope) is deliberately not
 /// kept — history replays root views; the breadcrumb stack handles drills.
@@ -800,6 +817,15 @@ pub struct App {
     pub tasks: Vec<JoinHandle<()>>,
     pub tx: Sender<Msg>,
     stack: Vec<Frame>,
+    /// Scope of the running watch, so its rows can be stashed under the right
+    /// key when the user navigates away.
+    watch_key: Option<ViewKey>,
+    /// Snapshots of recently-left views: shown instantly (marked syncing) when
+    /// the user navigates back, while the fresh watch relists in the
+    /// background. Bounded by [`VIEW_CACHE_MAX`]; cleared on context switch.
+    view_cache: HashMap<ViewKey, HashMap<String, DynamicObject>>,
+    /// LRU order for [`Self::view_cache`] (front = oldest).
+    view_cache_order: VecDeque<ViewKey>,
     /// Browser-style history of root views for `[`/`]`: every root switch
     /// (kind and/or namespace) is recorded; navigating with `[`/`]` moves the
     /// cursor without re-recording, and a fresh switch truncates the forward
@@ -1061,6 +1087,9 @@ impl App {
             tasks: Vec::new(),
             tx,
             stack: Vec::new(),
+            watch_key: None,
+            view_cache: HashMap::new(),
+            view_cache_order: VecDeque::new(),
             history: Vec::new(),
             history_pos: 0,
             mode: Mode::Table,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -312,8 +312,11 @@ impl App {
         self.flash = format!("switching to {name}…");
         self.flash_err = false;
         // Stop the current context's watches and clear stale rows while we
-        // reconnect; the new watch starts when the connection lands.
+        // reconnect; the new watch starts when the connection lands. The rows
+        // are stashed first — if the switch fails we stay on this context,
+        // where they're still valid (a successful switch drops the cache).
         self.bump_generation();
+        self.stash_view_snapshot();
         self.store.clear();
         self.invalidate_rows();
         let tx = self.tx.clone();
@@ -367,6 +370,8 @@ impl App {
         self.metrics_provider = metrics_provider;
         // Printer-column fallbacks came from the old cluster's CRDs.
         self.crd_views.clear();
+        // Cached view snapshots hold the old cluster's resources.
+        self.clear_view_cache();
         // The timeline recorded the old cluster's objects.
         self.timeline.clear();
         self.skin_colors = resolved.config.skin.colors;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4966,3 +4966,152 @@ async fn logs_time_anchors_set_provider_lookback() {
         crate::providers::DEFAULT_LOOKBACK
     );
 }
+
+// ----- view cache (instant redisplay on navigation) -------------------------
+
+fn pod(name: &str) -> serde_json::Value {
+    json!({"apiVersion": "v1", "kind": "Pod",
+           "metadata": {"name": name, "namespace": "default"}})
+}
+
+/// Drive the current view through a full initial sync with the given pods.
+fn sync_view(app: &mut App, names: &[&str]) {
+    app.handle_msg(Msg::Reset {
+        generation: app.generation,
+    });
+    for n in names {
+        apply(app, pod(n));
+    }
+    app.handle_msg(Msg::Synced {
+        generation: app.generation,
+    });
+}
+
+#[tokio::test]
+async fn returning_to_a_view_shows_cached_rows_instantly() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    sync_view(&mut app, &["a", "b"]);
+
+    app.switch_kind("deployments");
+    assert_eq!(app.store.len(), 0, "no cache for a first visit");
+
+    app.switch_kind("pods");
+    assert_eq!(
+        app.store.len(),
+        2,
+        "cached rows shown before the watch syncs"
+    );
+    assert!(app.store.get("default/a").is_some());
+    assert!(
+        !app.store.synced,
+        "cached rows must be marked syncing, not live"
+    );
+}
+
+#[tokio::test]
+async fn relist_over_cached_rows_swaps_atomically_on_sync() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    sync_view(&mut app, &["a"]);
+    app.switch_kind("deployments");
+    app.switch_kind("pods"); // seeded with cached "a"
+
+    // The fresh watch relists: the stale row stays visible while the new
+    // set streams in, then the sync swaps it in wholesale.
+    app.handle_msg(Msg::Reset {
+        generation: app.generation,
+    });
+    apply(&mut app, pod("b"));
+    assert!(
+        app.store.get("default/a").is_some(),
+        "stale row still shown mid-relist"
+    );
+    assert!(
+        app.store.get("default/b").is_none(),
+        "incoming rows buffer until the sync"
+    );
+
+    app.handle_msg(Msg::Synced {
+        generation: app.generation,
+    });
+    assert!(app.store.synced);
+    assert!(
+        app.store.get("default/a").is_none(),
+        "stale row swapped out"
+    );
+    assert!(app.store.get("default/b").is_some());
+    assert_eq!(app.store.len(), 1);
+}
+
+#[tokio::test]
+async fn first_visit_still_streams_rows_progressively() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.handle_msg(Msg::Reset {
+        generation: app.generation,
+    });
+    apply(&mut app, pod("a"));
+    assert_eq!(
+        app.store.len(),
+        1,
+        "with nothing on screen, rows appear as they stream in"
+    );
+    assert!(!app.store.synced);
+}
+
+#[tokio::test]
+async fn unsynced_view_is_not_cached() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.handle_msg(Msg::Reset {
+        generation: app.generation,
+    });
+    apply(&mut app, pod("a")); // partial list, never synced
+
+    app.switch_kind("deployments");
+    app.switch_kind("pods");
+    assert_eq!(
+        app.store.len(),
+        0,
+        "a partial list must not be redisplayed as if complete"
+    );
+}
+
+#[tokio::test]
+async fn context_switch_drops_cached_views() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    sync_view(&mut app, &["a"]);
+    app.switch_kind("deployments");
+
+    app.apply_context_switch("prod".into(), Box::new(Cluster::fake()));
+    app.switch_kind("pods");
+    assert_eq!(
+        app.store.len(),
+        0,
+        "another cluster's rows must never be redisplayed"
+    );
+}
+
+#[tokio::test]
+async fn view_cache_evicts_least_recently_used() {
+    let (mut app, _rx) = test_app();
+    // Fill the cache beyond its cap with distinct (kind, namespace) views.
+    app.switch_kind("pods");
+    sync_view(&mut app, &["a"]);
+    for i in 0..VIEW_CACHE_MAX {
+        app.switch_kind_ns("pods", Some(&format!("ns{i}")));
+        sync_view(&mut app, &["x"]);
+    }
+    app.switch_kind_ns("pods", Some("default"));
+    assert_eq!(
+        app.store.len(),
+        0,
+        "the oldest snapshot is evicted once the cache is full"
+    );
+    // The most recent one is still cached.
+    sync_view(&mut app, &["y"]);
+    app.switch_kind_ns("pods", Some(&format!("ns{}", VIEW_CACHE_MAX - 1)));
+    assert_eq!(app.store.len(), 1);
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -232,21 +232,89 @@ pub fn row_key(obj: &DynamicObject) -> String {
 #[derive(Default)]
 pub struct Store {
     items: HashMap<String, DynamicObject>,
+    /// Fresh rows accumulating during a (re)list while `items` still shows the
+    /// previous set — a cached view snapshot or the pre-relist state. Swapped
+    /// in wholesale on `Synced`, so stale rows are replaced atomically instead
+    /// of the table blanking out while the initial list streams in.
+    pending: Option<HashMap<String, DynamicObject>>,
     pub synced: bool,
 }
 
 impl Store {
     pub fn clear(&mut self) {
         self.items.clear();
+        self.pending = None;
         self.synced = false;
     }
 
+    /// Replace the contents with a cached snapshot from a previous visit to
+    /// this view — shown (unsynced) until the new watch's initial list lands.
+    pub fn seed(&mut self, items: HashMap<String, DynamicObject>) {
+        self.items = items;
+        self.pending = None;
+        self.synced = false;
+    }
+
+    /// Move the items out (for stashing in the view cache), leaving the store
+    /// empty.
+    pub fn take_items(&mut self) -> HashMap<String, DynamicObject> {
+        self.pending = None;
+        self.synced = false;
+        std::mem::take(&mut self.items)
+    }
+
+    /// Handle a watch (re)list starting. With rows on screen (a seeded cache
+    /// snapshot, or an established watch relisting) the incoming list is
+    /// buffered so they stay visible until `finish_sync` swaps it in; an empty
+    /// store keeps the old behavior of applying rows as they stream in.
+    /// Returns whether the visible items were cleared.
+    pub fn begin_reset(&mut self) -> bool {
+        self.synced = false;
+        if self.items.is_empty() {
+            self.pending = None;
+            true
+        } else {
+            self.pending = Some(HashMap::new());
+            false
+        }
+    }
+
+    /// Mark the initial list complete, swapping in the buffered rows if a
+    /// reset was in progress. Returns whether a swap replaced the visible set.
+    pub fn finish_sync(&mut self) -> bool {
+        self.synced = true;
+        match self.pending.take() {
+            Some(fresh) => {
+                self.items = fresh;
+                true
+            }
+            None => false,
+        }
+    }
+
     pub fn apply(&mut self, key: String, obj: DynamicObject) {
-        self.items.insert(key, obj);
+        match &mut self.pending {
+            Some(pending) => pending.insert(key, obj),
+            None => self.items.insert(key, obj),
+        };
     }
 
     pub fn remove(&mut self, key: &str) {
-        self.items.remove(key);
+        match &mut self.pending {
+            Some(pending) => pending.remove(key),
+            None => self.items.remove(key),
+        };
+    }
+
+    /// The newest known version of `key`: the in-flight buffered one during a
+    /// reset, else the visible one. Used as the "previous version" for
+    /// timeline diffs, where [`Self::get`]'s stale visible copy would be wrong
+    /// if the same object came through the buffer twice.
+    pub fn latest(&self, key: &str) -> Option<&DynamicObject> {
+        self.pending
+            .as_ref()
+            .and_then(|p| p.get(key))
+            .or_else(|| self.items.get(key))
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
## Summary
- Switching views no longer blanks the table while the new watch's initial list streams in — the previous visit's rows render instantly, marked "○ syncing", and flip to "● live" once the fresh list lands
- Leaving a view stashes its fully-synced rows in an LRU cache (8 views), keyed by the watch scope (kind, namespace, merged label/field selectors) so drill-downs and server-side filters cache independently
- The store buffers an incoming (re)list in a pending map whenever rows are on screen and swaps it in atomically on sync — this also removes the table blanking on mid-watch relists (e.g. after a watch error)
- First visits still stream rows progressively; partial (unsynced) lists are never cached; the cache is dropped on context switch so another cluster's rows are never redisplayed
- Timeline diffs now compare against the newest known version (`Store::latest`), so changes that happened while a view wasn't watched are still recorded on return

## Test plan
- [x] 6 new unit tests: cache seeding on return, atomic relist swap, progressive first load, partial-list exclusion, context-switch invalidation, LRU eviction (390 total pass)
- [x] Verified against a live cluster in tmux: `:pods all` (193 rows) → `:deploy all` → `:pods all` shows all 193 cached rows on the next frame marked syncing, swapping to live ~100 ms later with no empty-table window
- [x] clippy + rustfmt clean

Fixes #92