### PR TITLE
ci: run CI on PRs only, speed up release builds with thin LTO

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,9 @@
 name: CI
 
+# PRs only — pushes to main run no CI. The Nix packaging is exercised (and
+# Cachix warmed, for all four platforms) by the release workflow's nix-cache
+# job, so packaging breakage surfaces at tag time instead of on every merge.
 on:
-  push:
-    branches: [main]
   pull_request:
 
 permissions:
@@ -33,41 +34,3 @@ jobs:
 
       - name: Test
         run: cargo test
-
-  nix:
-    # The multi-platform Nix build is slow and expensive; skip it on pull
-    # requests (the `rust` job still runs fmt/clippy/test there) and run the
-    # full matrix only on pushes to main, after merge.
-    if: github.event_name == 'push'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            system: x86_64-linux
-          - os: ubuntu-24.04-arm
-            system: aarch64-linux
-          - os: macos-latest
-            system: aarch64-darwin
-          - os: macos-15-intel
-            system: x86_64-darwin
-    runs-on: ${{ matrix.os }}
-    env:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Setup Nix
-        uses: ./.github/actions/setup-nix
-
-      - name: Flake check
-        run: nix flake check --no-build
-
-      - name: Build sofka
-        run: nix build .#sofka --print-build-logs
-
-      - name: Smoke-test the built binary
-        run: ./result/bin/sofka --version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,5 +154,10 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
+      # CI no longer runs any Nix job, so this is where flake/packaging
+      # breakage surfaces.
+      - name: Flake check
+        run: nix flake check --no-build
+
       - name: Build and cache
         run: nix build .#sofka --print-build-logs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ toml = "1.1.2"
 unicode-width = "0.2.2"
 
 [profile.release]
-lto = true
-codegen-units = 1
+# Thin LTO: within ~1-3% of fat LTO's runtime at a fraction of the build
+# time — this profile is built cold on every release (4 targets + 4 Nix
+# builds), so compile time matters more than the last percent.
+lto = "thin"
 strip = true


### PR DESCRIPTION
## Summary
- Drop the CI `push: main` trigger and the four-platform Nix matrix (~30 job-minutes per merge); CI now runs on pull requests only
- Move `nix flake check --no-build` into the release workflow's `nix-cache` job, now the only place Nix packaging is exercised
- Switch the release profile from fat LTO + `codegen-units = 1` to thin LTO — several times faster to build at ~1–3% runtime cost, paid on every one of the 8 cold release builds (4 cargo targets + 4 Nix platforms)

## Notes
- Cachix is no longer warmed on main pushes — anyone running `nix build github:nklmilojevic/sofka` against an untagged main rev gets a cold build; tagged revs are still cached by the release workflow
- If branch protection lists the `nix (...)` checks as required, they should be removed from the required list

## Test plan
- [x] actionlint clean on both workflows
- [ ] Next release: confirm `nix-cache` runs flake check and build times drop