### PR TITLE
release: build tarballs from the Nix outputs, once per platform

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,50 @@
+name: Nix
+
+# Packaging-only guard: releases are the only place Nix builds normally run,
+# so PRs that touch the packaging itself verify it up front instead of
+# finding out at tag time. Path-filtered — ordinary code PRs never pay for
+# this. Darwin is left to the release workflow; packaging breakage is almost
+# never platform-specific and the macOS runners are the slow ones.
+on:
+  pull_request:
+    paths:
+      - package.nix
+      - flake.nix
+      - flake.lock
+      - .github/workflows/nix.yaml
+      - .github/actions/setup-nix/**
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    env:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Flake check
+        run: nix flake check --no-build
+
+      - name: Build sofka-dist
+        run: nix build .#sofka-dist --print-build-logs
+
+      - name: Smoke-test the built binary
+        run: ./result/bin/sofka --version
+
+      - name: Verify the binary is static
+        run: file result/bin/sofka | grep -E 'statically linked|static-pie linked'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,9 +37,10 @@ jobs:
             exit 1
           fi
 
-  # Cross-platform release binaries, one native build per target — every
-  # target below is the runner's own host, so no cross-compilation toolchain
-  # is needed.
+  # One native Nix build per platform produces both the Cachix-cached store
+  # path for flake consumers and the release tarball — the same binary. On
+  # Linux the flake's package is fully static (musl), so it runs on any
+  # distro; the macOS builds link only system libraries.
   build:
     needs: validate
     strategy:
@@ -47,15 +48,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
           - os: macos-latest
             target: aarch64-apple-darwin
           - os: macos-15-intel
             target: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     env:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - name: Checkout release tag
@@ -64,25 +66,32 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
 
-      - name: Cache cargo registry/build
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          key: ${{ matrix.target }}
+      # CI runs no Nix job on ordinary changes, so a release is where flake
+      # or packaging breakage surfaces.
+      - name: Flake check
+        run: nix flake check --no-build
 
-      - name: Build
-        run: cargo build --release --locked --target ${{ matrix.target }}
+      # sofka-dist is the portable variant: the static musl build on Linux,
+      # and on macOS the regular build with its one Nix store reference
+      # (libiconv) rewritten to the system copy. Building it also builds
+      # (and Cachix-pushes) the plain `sofka` package it derives from.
+      - name: Build and cache
+        run: nix build .#sofka-dist --print-build-logs
+
+      - name: Smoke-test the built binary
+        run: ./result/bin/sofka --version
+
+      - name: Verify the Linux binary is static
+        if: runner.os == 'Linux'
+        run: file result/bin/sofka | grep -E 'statically linked|static-pie linked'
 
       - name: Package
         run: |
-          bin="target/${{ matrix.target }}/release/sofka"
-          strip "$bin"
           out="sofka-${RELEASE_TAG}-${{ matrix.target }}.tar.gz"
-          tar -czf "$out" -C "$(dirname "$bin")" sofka
+          tar -czf "$out" -C result/bin sofka
           echo "ASSET=$out" >> "$GITHUB_ENV"
 
       - name: Upload artifact
@@ -127,37 +136,3 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --locked
-
-  # Warms the nkl-sofka Cachix cache for the tagged rev, so `nix build
-  # github:nklmilojevic/sofka?ref=vX.Y.Z` is instant for anyone consuming
-  # this tag afterward.
-  nix-cache:
-    needs: validate
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-          - os: ubuntu-24.04-arm
-          - os: macos-latest
-          - os: macos-15-intel
-    runs-on: ${{ matrix.os }}
-    env:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.release.tag_name }}
-          persist-credentials: false
-
-      - name: Setup Nix
-        uses: ./.github/actions/setup-nix
-
-      # CI no longer runs any Nix job, so this is where flake/packaging
-      # breakage surfaces.
-      - name: Flake check
-        run: nix flake check --no-build
-
-      - name: Build and cache
-        run: nix build .#sofka --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -29,21 +29,60 @@
             inherit system;
             overlays = [ overlay ];
           };
+          # On Linux, ship the fully-static musl build: the same binary works
+          # inside Nix and on any distro, so the release tarballs are just
+          # this package's output (one build per platform, no separate cargo
+          # matrix). macOS can't link static executables; its regular build
+          # links system libraries plus Nix's libiconv (via Rust std) — see
+          # `sofka-dist` below for the portable variant.
+          sofka = if pkgs.stdenv.hostPlatform.isLinux then pkgs.pkgsStatic.sofka else pkgs.sofka;
+          # The distributable binary for release tarballs. On Linux it's the
+          # static build unchanged. On macOS, rewrite the one Nix store
+          # reference (libiconv) to the copy every macOS ships in /usr/lib,
+          # then re-sign (install_name_tool invalidates the ad-hoc signature,
+          # which arm64 macOS refuses to run). Impure by Nix standards, so
+          # it's a separate output — flake consumers keep the pure `sofka`.
+          sofka-dist =
+            if pkgs.stdenv.hostPlatform.isLinux then
+              sofka
+            else
+              pkgs.runCommand "sofka-dist-${sofka.version}"
+                {
+                  nativeBuildInputs = with pkgs; [
+                    darwin.cctools
+                    darwin.sigtool
+                  ];
+                }
+                ''
+                  mkdir -p $out/bin
+                  cp ${sofka}/bin/sofka $out/bin/sofka
+                  chmod +w $out/bin/sofka
+                  old="$(otool -L $out/bin/sofka | awk '/\/nix\/store\/.*libiconv/ { print $1 }')"
+                  [ -n "$old" ] || { echo "no store libiconv reference found"; exit 1; }
+                  install_name_tool -change "$old" /usr/lib/libiconv.2.dylib $out/bin/sofka
+                  codesign -f -s - $out/bin/sofka
+                  chmod -w $out/bin/sofka
+                  # otool's first line is the binary's own (store) path — only
+                  # the dylib lines after it must be store-free.
+                  if otool -L $out/bin/sofka | tail -n +2 | grep -q /nix/store; then
+                    echo "binary still references /nix/store:"; otool -L $out/bin/sofka; exit 1
+                  fi
+                '';
         in
         {
           packages = {
-            default = pkgs.sofka;
-            sofka = pkgs.sofka;
+            default = sofka;
+            inherit sofka sofka-dist;
           };
 
           apps = {
             default = {
               type = "app";
-              program = "${pkgs.sofka}/bin/sofka";
+              program = "${sofka}/bin/sofka";
             };
             sofka = {
               type = "app";
-              program = "${pkgs.sofka}/bin/sofka";
+              program = "${sofka}/bin/sofka";
             };
           };
 


### PR DESCRIPTION
Re-lands #96, which was accidentally merged into its stacked base branch (`ci/prs-only`) instead of main — GitHub doesn't retarget stacked PRs unless the base branch is deleted. This is the identical change cherry-picked onto main; see #96 for the full description, discussion, and the passing Nix workflow run verifying the static musl builds.

Summary: one Nix build per platform now produces both the Cachix store path and the release tarball. Linux packages become fully-static musl builds (`pkgsStatic`, asset triples renamed `-gnu` → `-musl`); macOS ships via the new `sofka-dist` output (store libiconv reference rewritten to `/usr/lib`, re-signed, macOS 14+). The cargo build matrix and `nix-cache` job are gone, and a path-filtered `nix.yaml` workflow guards packaging changes on PRs.