### PR TITLE
feat: replace sort-column cycling with a fuzzy picker on S

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,7 +784,7 @@ header) and switching away restores write mode.
 | `enter`                                       | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources)                               |
 | `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                             |
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                              |
-| `S` / `I`                                     | cycle sort column / invert sort direction                                                                                             |
+| `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction                                                    |
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                              |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                      |
 | `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -59,6 +59,7 @@ impl App {
             Mode::Help => self.key_help(key),
             Mode::Namespaces => self.key_namespaces(key),
             Mode::Contexts => self.key_contexts(key),
+            Mode::SortPicker => self.key_sort_picker(key),
             Mode::Containers => self.key_containers(key),
             Mode::SetImage => self.key_set_image(key),
             Mode::Confirm => self.key_confirm(key),
@@ -150,8 +151,8 @@ impl App {
             KeyCode::Char('C') => self.request_cordon(true),
             KeyCode::Char('U') => self.request_cordon(false),
             KeyCode::Char('D') => self.request_drain(),
-            // Sorting: S cycles the column, I inverts the direction.
-            KeyCode::Char('S') => self.cycle_sort(),
+            // Sorting: S opens the column picker, I inverts the direction.
+            KeyCode::Char('S') => self.open_sort_picker(),
             KeyCode::Char('I') => self.toggle_sort_dir(),
             // Wide mode: show wide-only columns (kubectl `-o wide`).
             KeyCode::Char('w') => self.toggle_wide(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -101,6 +101,8 @@ pub enum Mode {
     Help,
     Namespaces,
     Contexts,
+    /// Fuzzy sort-column picker (`S`).
+    SortPicker,
     Containers,
     SetImage,
     Confirm,
@@ -884,6 +886,9 @@ pub struct App {
     pub ctx_state: ListState,
     /// Type-to-filter buffer for the context switcher.
     pub ctx_filter: String,
+    pub sort_picker_state: ListState,
+    /// Type-to-filter buffer for the sort-column picker.
+    pub sort_picker_filter: String,
     /// All kubeconfig context names, cached once at startup for `:ctx <name>`
     /// palette completion (the switcher popup uses `ctx_list`).
     pub all_contexts: Vec<String>,
@@ -1122,6 +1127,8 @@ impl App {
             ctx_list: Vec::new(),
             ctx_state: ListState::default(),
             ctx_filter: String::new(),
+            sort_picker_state: ListState::default(),
+            sort_picker_filter: String::new(),
             all_contexts: Vec::new(),
             user_aliases: HashMap::new(),
             plugins: Vec::new(),
@@ -1261,6 +1268,7 @@ mod timeline;
 mod workspaces;
 
 use helpers::*;
+pub use pickers::DEFAULT_SORT_LABEL;
 
 #[cfg(test)]
 mod tests;

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -3,6 +3,10 @@ use super::*;
 /// How many recent namespaces to keep per context in the switcher.
 const MAX_RECENT_NAMESPACES: usize = 8;
 
+/// The sort picker's pinned first entry: clears the sort back to the default
+/// (namespace, name) ordering.
+pub const DEFAULT_SORT_LABEL: &str = "default (ns/name)";
+
 impl App {
     /// Open the namespace switcher immediately with a loading placeholder, then
     /// fetch the list off-thread (it arrives as `Msg::Namespaces`).
@@ -134,6 +138,129 @@ impl App {
         while dq.len() > MAX_RECENT_NAMESPACES {
             dq.pop_back();
         }
+    }
+
+    /// Open the sort-column picker (k9s cycles with `S`; sofka jumps straight
+    /// to a column instead, which scales to wide mode and custom views). The
+    /// cursor starts on the active sort so enter-without-typing re-selects it,
+    /// which toggles direction.
+    pub(super) fn open_sort_picker(&mut self) {
+        if self.display_headers().is_empty() {
+            self.flash_warn("no columns to sort by");
+            return;
+        }
+        self.sort_picker_filter.clear();
+        // Entry 0 is the pinned default ordering; columns follow in display
+        // order, so the active sort column sits at index + 1.
+        self.sort_picker_state
+            .select(Some(self.sort_column.map_or(0, |i| i + 1)));
+        self.mode = Mode::SortPicker;
+    }
+
+    /// Entries for the sort picker: the default ordering is always pinned
+    /// first; column headers are fuzzy-matched against the type-to-filter
+    /// buffer (see `filtered_namespaces` for the same pattern).
+    pub fn filtered_sort_entries(&self) -> Vec<String> {
+        let mut out = vec![DEFAULT_SORT_LABEL.to_string()];
+        let headers = self.display_headers();
+        if self.sort_picker_filter.is_empty() {
+            out.extend(headers);
+            return out;
+        }
+        let mut scored: Vec<(i64, String)> = headers
+            .into_iter()
+            .filter_map(|h| {
+                self.matcher
+                    .fuzzy_match(&h, &self.sort_picker_filter)
+                    .map(|s| (s, h))
+            })
+            .collect();
+        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        out.extend(scored.into_iter().map(|(_, h)| h));
+        out
+    }
+
+    pub(super) fn key_sort_picker(&mut self, key: KeyEvent) {
+        if edit_chord(&key, &mut self.sort_picker_filter) {
+            self.select_best_sort_match();
+            return;
+        }
+        let len = self.filtered_sort_entries().len();
+        match key.code {
+            KeyCode::Esc => {
+                // First esc clears the filter, second closes the picker.
+                if self.sort_picker_filter.is_empty() {
+                    self.mode = Mode::Table;
+                } else {
+                    self.sort_picker_filter.clear();
+                    self.select_best_sort_match();
+                }
+            }
+            KeyCode::Down => list_step(&mut self.sort_picker_state, len, true),
+            KeyCode::Up => list_step(&mut self.sort_picker_state, len, false),
+            KeyCode::Enter => {
+                if let Some(entry) = self
+                    .sort_picker_state
+                    .selected()
+                    .and_then(|i| self.filtered_sort_entries().get(i).cloned())
+                {
+                    self.apply_sort_choice(&entry);
+                }
+            }
+            KeyCode::Backspace => {
+                self.sort_picker_filter.pop();
+                self.select_best_sort_match();
+            }
+            KeyCode::Char(c) => {
+                self.sort_picker_filter.push(c);
+                self.select_best_sort_match();
+            }
+            _ => {}
+        }
+    }
+
+    /// Jump the sort-picker cursor to the best fuzzy match after the filter
+    /// buffer changes (the pinned default at index 0 should only hold the
+    /// cursor while browsing — see `select_best_namespace_match`).
+    fn select_best_sort_match(&mut self) {
+        let idx = if self.sort_picker_filter.is_empty() {
+            self.sort_column.map_or(0, |i| i + 1)
+        } else if self.filtered_sort_entries().len() > 1 {
+            1 // right after the pinned default — the top-scored column
+        } else {
+            0
+        };
+        self.sort_picker_state.select(Some(idx));
+    }
+
+    /// Sort by a picked entry: the default entry clears the sort, a new column
+    /// sorts ascending, and re-picking the active column toggles direction
+    /// (the spreadsheet idiom).
+    fn apply_sort_choice(&mut self, entry: &str) {
+        self.mode = Mode::Table;
+        self.sort_picker_filter.clear();
+        if entry == DEFAULT_SORT_LABEL {
+            self.reset_sort();
+            self.invalidate_rows();
+            self.flash = format!("sort by {DEFAULT_SORT_LABEL}");
+            self.flash_err = false;
+            return;
+        }
+        let Some(idx) = self.display_headers().iter().position(|h| h == entry) else {
+            return;
+        };
+        self.sort_desc = self.sort_column == Some(idx) && !self.sort_desc;
+        self.sort_column = Some(idx);
+        self.invalidate_rows();
+        self.flash = format!(
+            "sort by {entry} {}",
+            if self.sort_desc {
+                "↓ desc"
+            } else {
+                "↑ asc"
+            }
+        );
+        self.flash_err = false;
     }
 
     pub(super) fn key_namespaces(&mut self, key: KeyEvent) {

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -434,27 +434,6 @@ impl App {
         self.sort_desc = false;
     }
 
-    /// Cycle the sort column: none → first → … → last → none (k9s `S`).
-    pub(super) fn cycle_sort(&mut self) {
-        let n = self.display_headers().len();
-        if n == 0 {
-            return;
-        }
-        self.sort_column = match self.sort_column {
-            None => Some(0),
-            Some(i) if i + 1 < n => Some(i + 1),
-            Some(_) => None,
-        };
-        self.sort_desc = false;
-        self.invalidate_rows();
-        let label = match self.sort_column {
-            Some(i) => self.display_headers().get(i).cloned().unwrap_or_default(),
-            None => "default (ns/name)".to_string(),
-        };
-        self.flash = format!("sort by {label}");
-        self.flash_err = false;
-    }
-
     /// Toggle ascending/descending for the active sort column (k9s `I`).
     pub(super) fn toggle_sort_dir(&mut self) {
         let Some(i) = self.sort_column else {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1448,6 +1448,72 @@ async fn sort_by_numeric_column_and_invert() {
 }
 
 #[tokio::test]
+async fn sort_picker_picks_toggles_and_clears() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+
+    // `S` opens the picker: default entry pinned first and selected (no sort).
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    assert_eq!(app.mode, Mode::SortPicker);
+    assert_eq!(app.filtered_sort_entries()[0], DEFAULT_SORT_LABEL);
+    assert_eq!(app.sort_picker_state.selected(), Some(0));
+
+    // Type-to-filter fuzzy-matches columns; the cursor lands on the best
+    // match (right after the pinned default) and enter selects it, ascending.
+    for c in "rst".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    assert_eq!(app.filtered_sort_entries()[1], "RESTARTS");
+    assert_eq!(app.sort_picker_state.selected(), Some(1));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    let restarts = app.display_headers().iter().position(|h| h == "RESTARTS");
+    assert!(restarts.is_some());
+    assert_eq!(app.sort_column, restarts);
+    assert!(!app.sort_desc);
+    assert!(app.flash.contains("RESTARTS") && app.flash.contains("asc"));
+
+    // Reopening lands on the active column; re-picking it inverts direction.
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    assert_eq!(app.sort_picker_state.selected(), restarts.map(|i| i + 1));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.sort_column, restarts);
+    assert!(app.sort_desc);
+
+    // Picking a different column resets to ascending.
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    app.sort_picker_state.select(Some(1)); // NAME (first column)
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.sort_column, Some(0));
+    assert!(!app.sort_desc);
+
+    // The pinned default entry clears the sort.
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    app.sort_picker_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.sort_column, None);
+    assert!(!app.sort_desc);
+}
+
+#[tokio::test]
+async fn sort_picker_esc_clears_filter_then_closes() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    assert_eq!(app.sort_picker_filter, "x");
+
+    // First esc clears the filter and stays open; second esc closes without
+    // touching the sort.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::SortPicker);
+    assert!(app.sort_picker_filter.is_empty());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.sort_column, None);
+}
+
+#[tokio::test]
 async fn metrics_update_invalidates_metric_sorted_rows() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::widgets::{
 };
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::{App, Mode, SuggestKind, TRANSFER_MENU_ITEMS};
+use crate::app::{App, DEFAULT_SORT_LABEL, Mode, SuggestKind, TRANSFER_MENU_ITEMS};
 use crate::{columns, theme};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -157,6 +157,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     match app.mode {
         Mode::Namespaces => draw_namespaces(frame, app, chunks[1]),
         Mode::Contexts => draw_contexts(frame, app, chunks[1]),
+        Mode::SortPicker => draw_sort_picker(frame, app, chunks[1]),
         Mode::Containers => draw_containers(frame, app, chunks[1]),
         Mode::SetImage => draw_set_image(frame, app, chunks[1]),
         Mode::Confirm => draw_confirm(frame, app, chunks[1]),
@@ -1706,7 +1707,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("o", "show node hosting the pod"),
         bind("esc", "go back / pop view / clear filter"),
         bind("j/k g/G", "move · top/bottom"),
-        bind("S · I", "sort by column (cycle) · invert direction"),
+        bind("S · I", "sort by column (fuzzy picker) · invert direction"),
         bind("w", "toggle wide columns (kubectl -o wide)"),
         bind(
             "ctrl-e",
@@ -1972,6 +1973,49 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
         items,
         Span::styled(title, theme::title()),
         &mut app.ctx_state,
+    );
+}
+
+/// Sort-column picker (`S`): the default ordering pinned first, then the
+/// displayed columns in table order (so it doubles as a column reference).
+/// The active sort is marked with its direction arrow in the sorter color.
+fn draw_sort_picker(frame: &mut Frame, app: &mut App, area: Rect) {
+    let active = app.sort_column.and_then(|i| {
+        app.display_headers()
+            .get(i)
+            .cloned()
+            .map(|h| (h, app.sort_desc))
+    });
+    let items: Vec<ListItem> = app
+        .filtered_sort_entries()
+        .iter()
+        .map(|e| {
+            if e == DEFAULT_SORT_LABEL {
+                return ListItem::new(Span::styled(e.clone(), Style::default().fg(theme::teal())));
+            }
+            match &active {
+                Some((h, desc)) if h == e => ListItem::new(Span::styled(
+                    format!("{e}{}", if *desc { " ↓" } else { " ↑" }),
+                    Style::default().fg(theme::sorter()),
+                )),
+                _ => ListItem::new(Span::styled(e.clone(), Style::default().fg(theme::text()))),
+            }
+        })
+        .collect();
+    // Show the type-to-filter buffer in the title so it reads like an input.
+    let title = if app.sort_picker_filter.is_empty() {
+        " Sort by (⏎ again inverts) ".to_string()
+    } else {
+        format!(" Sort by · /{}_ ", app.sort_picker_filter)
+    };
+    render_popup_list(
+        frame,
+        area,
+        40,
+        60,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.sort_picker_state,
     );
 }
 


### PR DESCRIPTION
## Summary

- `S` now opens a fuzzy sort-column picker (same overlay idiom as the namespace/context switchers) instead of cycling columns one at a time. Cycling scaled badly with wide mode, custom views, and CRD printer columns — reaching a late column took a keypress per column, and overshooting meant wrapping all the way around.
- The picker pins a `default (ns/name)` entry first, which explicitly clears the sort (replacing the old "cycle past the last column" behavior). Columns follow in display order, so the popup doubles as a column reference.
- Re-picking the currently active column inverts the direction (the spreadsheet idiom); the cursor opens on the active sort, so a plain `S`-`⏎` round-trip inverts without typing. `I` keeps working as the no-modal direction toggle.
- Type-to-filter fuzzy-matches headers with best-match cursor placement; first `esc` clears the filter, second closes. The active sort is marked with its direction arrow in the sorter color.
- Updated help view, README keybinding table, and added tests for pick/toggle/clear and esc semantics.

## Test plan

- [x] `cargo test` (392 tests, including 2 new sort-picker tests)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] Manual: `S` on a wide pods view — filter to a metrics column, confirm sort + arrow; `⏎` again inverts; default entry clears