### PR TITLE
feat(nix): drop flake-utils, add checks for all packages and devShells

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,75 +1,24 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783816212,
-        "narHash": "sha256-2aZisVTVGSFEk3MYcOiWQp3zvwyzbqpktB69Rcfp150=",
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b32825de172d0bc85664f495edb096b10862524",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-darwin-intel": {
-      "locked": {
-        "lastModified": 1783868237,
-        "narHash": "sha256-MDQLbs882ugMi408mpSwa2nw2yzN43hHtOxx0zbUcZA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "76fe02659c00bef75e12fbfdd45ca665115e9302",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-26.05-darwin",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-darwin-intel": "nixpkgs-darwin-intel"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,73 +2,107 @@
   description = "sofka - a Kubernetes TUI, reimagined in Rust";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    # nixpkgs >= 26.11 dropped x86_64-darwin; keep Intel macs on the 26.05 release
-    nixpkgs-darwin-intel.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
-    flake-utils.url = "github:numtide/flake-utils";
+    # Current stable release. Unlike unstable (which dropped x86_64-darwin
+    # after 26.05), this branch still covers all four platforms the release
+    # workflow builds for, so a single input suffices.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
   };
 
   outputs =
-    { self, nixpkgs, nixpkgs-darwin-intel, flake-utils }:
+    { self, nixpkgs }:
     let
-      overlay = final: prev: {
-        sofka = final.callPackage ./package.nix { };
-      };
-    in
-    flake-utils.lib.eachSystem
-      [
+      inherit (nixpkgs) lib;
+
+      systems = [
         "x86_64-linux"
         "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
-      ]
-      (
+      ];
+
+      overlay = final: prev: {
+        sofka = final.callPackage ./package.nix { };
+      };
+
+      pkgsFor = lib.genAttrs systems (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+        }
+      );
+
+      forAllSystems = f: lib.genAttrs systems (system: f pkgsFor.${system});
+    in
+    {
+      overlays.default = overlay;
+
+      packages = forAllSystems (pkgs: {
+        default = pkgs.sofka;
+        sofka = pkgs.sofka;
+      });
+
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${pkgs.sofka}/bin/sofka";
+        };
+        sofka = {
+          type = "app";
+          program = "${pkgs.sofka}/bin/sofka";
+        };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            cargo
+            rustc
+            clippy
+            rustfmt
+            rust-analyzer
+            cargo-watch
+            kubectl
+            kind
+            fluxcd
+            cachix
+            just
+            nixpkgs-fmt
+            lefthook
+            zizmor
+            oxfmt
+          ];
+        };
+      });
+
+      # Every package and devShell doubles as a check so `nix flake check`
+      # builds all of them; fmt mirrors CI's format check. Clippy is left to
+      # CI (nixpkgs' clippy version drifts from rustup stable and flags
+      # different lints), and the cargo test suite is not run here — it
+      # needs native root CA certs the build sandbox lacks (see package.nix).
+      checks = lib.genAttrs systems (
         system:
         let
-          pkgs = import (if system == "x86_64-darwin" then nixpkgs-darwin-intel else nixpkgs) {
-            inherit system;
-            overlays = [ overlay ];
-          };
+          pkgs = pkgsFor.${system};
         in
-        {
-          packages = {
-            default = pkgs.sofka;
-            sofka = pkgs.sofka;
-          };
-
-          apps = {
-            default = {
-              type = "app";
-              program = "${pkgs.sofka}/bin/sofka";
-            };
-            sofka = {
-              type = "app";
-              program = "${pkgs.sofka}/bin/sofka";
-            };
-          };
-
-          devShells.default = pkgs.mkShell {
-            packages = with pkgs; [
-              cargo
-              rustc
-              clippy
-              rustfmt
-              rust-analyzer
-              cargo-watch
-              kubectl
-              kind
-              fluxcd
-              cachix
-              just
-              nixpkgs-fmt
-              lefthook
-              zizmor
-              oxfmt
-            ];
-          };
+        self.packages.${system}
+        // lib.mapAttrs' (name: drv: lib.nameValuePair "devshell-${name}" drv) self.devShells.${system}
+        // {
+          fmt =
+            pkgs.runCommand "sofka-fmt-check"
+              {
+                nativeBuildInputs = [
+                  pkgs.cargo
+                  pkgs.rustfmt
+                ];
+              }
+              ''
+                export HOME=$TMPDIR
+                cd ${self}
+                cargo fmt --all --check
+                touch $out
+              '';
         }
-      )
-    // {
-      overlays.default = overlay;
+      );
     };
 }


### PR DESCRIPTION
## Summary

- Rework `flake.nix` to plain per-system attrsets (`lib.genAttrs`) instead of `flake-utils`
- Collapse to a single `nixos-26.05` input — the current stable branch still supports `x86_64-darwin`, so the separate `nixpkgs-26.05-darwin` pin for Intel Macs is no longer needed
- Add a `checks` output: every package and devShell is mirrored into checks so `nix flake check` builds all of them, plus a `fmt` check mirroring CI's `cargo fmt --all --check` gate
- `apps`, `overlays.default`, and `package.nix` are unchanged, so `nix build .#sofka` and the release workflow's Cachix warming keep working

## Deliberate omissions

- **Clippy is not a flake check** — nixpkgs' clippy version drifts from rustup stable and flags different lints (9 `collapsible_match`-style lints on 26.05 today), which would break `nix flake check` on nixpkgs bumps rather than real regressions. CI's clippy job keeps covering this with the matching toolchain.
- **Tests don't run inside the Nix build** — the suite needs native root CA certs unavailable in the sandbox (`doCheck = false` in `package.nix`, as before). CI runs `cargo test` on PRs.

## Testing

- `nix flake show --json --allow-import-from-derivation` succeeds
- `nix flake check` passes with package, devShell, and fmt checks built locally (aarch64-darwin)
- `nix flake check --all-systems --no-build` confirms all four systems evaluate