### PR TITLE
fix: surface swallowed read errors, panic safety, and hot-path perf

### DIFF
--- a/src/app/bundle.rs
+++ b/src/app/bundle.rs
@@ -85,10 +85,11 @@ impl App {
             let ts = k8s_openapi::jiff::Timestamp::now();
 
             // ---- gather -----------------------------------------------------
+            let mut warn = None;
             let pods: Vec<DynamicObject> = if plural == "pods" {
                 vec![obj.clone()]
             } else if let (Some((ar, nsd)), Some(sel)) = (&pods_kind, &selector) {
-                list_selected(&client, ar, *nsd, &ns, sel).await
+                list_selected(&client, ar, *nsd, &ns, sel, &mut warn).await
             } else {
                 Vec::new()
             };
@@ -96,7 +97,7 @@ impl App {
             let (events, events_v1) = match &events_kind {
                 Some((ar, nsd)) => {
                     let v1 = ar.group == "events.k8s.io";
-                    let all = list_kind(&client, ar, *nsd, &ns).await;
+                    let all = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
                     (filter_events(&all, &obj, &pods, v1), v1)
                 }
                 None => (Vec::new(), false),
@@ -110,7 +111,8 @@ impl App {
                 events: &events,
                 events_v1,
             };
-            let findings = crate::explain::explain(&evidence);
+            let mut findings = crate::explain::explain(&evidence);
+            prepend_warn_finding(&mut findings, warn);
 
             let owner = match (&owner_ref, &owner_kind) {
                 (Some(oref), Some((ar, nsd))) => {

--- a/src/app/dashboards.rs
+++ b/src/app/dashboards.rs
@@ -35,14 +35,17 @@ impl App {
                     break;
                 }
                 let mut p = Pulse::default();
+                // A denied/failed list must not render as "0 healthy" tiles —
+                // record it so the view can say the numbers are incomplete.
+                let mut warn = None;
 
                 if let Some((ar, _)) = &nodes {
-                    let items = list_kind(&client, ar, false, "").await;
+                    let items = list_or_warn(&client, ar, false, "", &mut warn).await;
                     p.nodes_total = items.len();
                     p.nodes_ready = items.iter().filter(|o| node_ready(o)).count();
                 }
                 if let Some((ar, nsd)) = &pods {
-                    let items = list_kind(&client, ar, *nsd, &ns).await;
+                    let items = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
                     p.pods_total = items.len();
                     for o in &items {
                         match phase(o).as_str() {
@@ -55,7 +58,7 @@ impl App {
                     }
                 }
                 if let Some((ar, nsd)) = &deploys {
-                    let items = list_kind(&client, ar, *nsd, &ns).await;
+                    let items = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
                     p.deploys_total = items.len();
                     p.deploys_ready = items
                         .iter()
@@ -63,7 +66,7 @@ impl App {
                         .count();
                 }
                 if let Some((ar, nsd)) = &sts {
-                    let items = list_kind(&client, ar, *nsd, &ns).await;
+                    let items = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
                     p.sts_total = items.len();
                     p.sts_ready = items
                         .iter()
@@ -71,7 +74,7 @@ impl App {
                         .count();
                 }
                 if let Some((ar, nsd)) = &ds {
-                    let items = list_kind(&client, ar, *nsd, &ns).await;
+                    let items = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
                     p.ds_total = items.len();
                     p.ds_ready = items
                         .iter()
@@ -81,13 +84,14 @@ impl App {
                         .count();
                 }
                 if let Some((ar, nsd)) = &jobs {
-                    p.jobs_total = list_kind(&client, ar, *nsd, &ns).await.len();
+                    p.jobs_total = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await.len();
                 }
                 if let Some((ar, nsd)) = &pvc {
-                    let items = list_kind(&client, ar, *nsd, &ns).await;
+                    let items = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
                     p.pvc_total = items.len();
                     p.pvc_bound = items.iter().filter(|o| phase(o) == "Bound").count();
                 }
+                p.warn = warn;
 
                 if tx
                     .send(Msg::PulseData {
@@ -160,10 +164,11 @@ impl App {
                 if flag.load(Ordering::SeqCst) != genr {
                     break;
                 }
-                let roots = list_kind(&client, &root_ar, root_nsd, &ns).await;
+                let mut warn = None;
+                let roots = list_or_warn(&client, &root_ar, root_nsd, &ns, &mut warn).await;
                 let mut pool: Vec<(String, DynamicObject)> = Vec::new();
                 for (label, ar, namespaced) in &pool_kinds {
-                    for o in list_kind(&client, ar, *namespaced, &ns).await {
+                    for o in list_or_warn(&client, ar, *namespaced, &ns, &mut warn).await {
                         pool.push((label.clone(), o));
                     }
                 }
@@ -190,6 +195,7 @@ impl App {
                     .send(Msg::XrayData {
                         generation: genr,
                         items,
+                        warn,
                     })
                     .await
                     .is_err()
@@ -211,7 +217,11 @@ impl App {
             }
             KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.xray_state, len, true),
             KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.xray_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home => self.xray_state.select(Some(0)),
+            KeyCode::Char('g') | KeyCode::Home => {
+                if len > 0 {
+                    self.xray_state.select(Some(0));
+                }
+            }
             KeyCode::Char('G') | KeyCode::End => {
                 if len > 0 {
                     self.xray_state.select(Some(len - 1));

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -47,6 +47,9 @@ impl App {
                 "no data yet"
             }
         ));
+        if let Some(e) = &self.metrics_error {
+            lines.push(format!("  metrics poll error: {e}"));
+        }
 
         lines.push(String::new());
         lines.push("Watch health".into());

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -72,10 +72,11 @@ impl App {
         self.flash_err = false;
 
         tokio::spawn(async move {
+            let mut warn = None;
             let pods: Vec<DynamicObject> = if plural == "pods" {
                 vec![obj.clone()]
             } else if let (Some((ar, nsd)), Some(sel)) = (&pods_kind, &selector) {
-                list_selected(&client, ar, *nsd, &ns, sel).await
+                list_selected(&client, ar, *nsd, &ns, sel, &mut warn).await
             } else {
                 Vec::new()
             };
@@ -83,7 +84,7 @@ impl App {
             let (events, events_v1) = match &events_kind {
                 Some((ar, nsd)) => {
                     let v1 = ar.group == "events.k8s.io";
-                    let all = list_kind(&client, ar, *nsd, &ns).await;
+                    let all = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
                     (filter_events(&all, &obj, &pods, v1), v1)
                 }
                 None => (Vec::new(), false),
@@ -97,7 +98,8 @@ impl App {
                 events: &events,
                 events_v1,
             };
-            let findings = crate::explain::explain(&evidence);
+            let mut findings = crate::explain::explain(&evidence);
+            prepend_warn_finding(&mut findings, warn);
             let _ = tx
                 .send(Msg::Explain {
                     generation: genr,
@@ -196,23 +198,29 @@ impl App {
     }
 }
 
-/// List one kind, narrowed to a label selector (a workload's pods).
+/// List one kind, narrowed to a label selector (a workload's pods). A failure
+/// degrades to an empty list recorded in `warn` — a 403 must not read as "no
+/// pods" to the analysis downstream.
 pub(super) async fn list_selected(
     client: &Client,
     ar: &ApiResource,
     namespaced: bool,
     ns: &str,
     selector: &str,
+    warn: &mut Option<String>,
 ) -> Vec<DynamicObject> {
     let api: Api<DynamicObject> = if namespaced && !ns.is_empty() {
         Api::namespaced_with(client.clone(), ns, ar)
     } else {
         Api::all_with(client.clone(), ar)
     };
-    api.list(&ListParams::default().labels(selector))
-        .await
-        .map(|l| l.items)
-        .unwrap_or_default()
+    match api.list(&ListParams::default().labels(selector)).await {
+        Ok(l) => l.items,
+        Err(e) => {
+            warn.get_or_insert(format!("listing {}: {e}", ar.plural));
+            Vec::new()
+        }
+    }
 }
 
 /// Keep only events that regard the object or one of its pods, matching by UID

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -138,14 +138,18 @@ async fn gather_context(ctx: &str, readonly: bool) -> FleetRow {
         Err(_) => "?".into(),
     };
 
+    // A failed list must not summarize as "0 unhealthy" — record it and mark
+    // the row, keeping whatever partial counts did arrive.
+    let mut warn = None;
+
     if let Some(k) = cluster.resolve("nodes") {
-        let nodes = list_kind(&client, &k.ar, false, "").await;
+        let nodes = list_or_warn(&client, &k.ar, false, "", &mut warn).await;
         row.nodes_total = nodes.len();
         row.nodes_ready = nodes.iter().filter(|o| node_ready(o)).count();
     }
 
     if let Some(k) = cluster.resolve("pods") {
-        let pods = list_kind(&client, &k.ar, k.namespaced, "").await;
+        let pods = list_or_warn(&client, &k.ar, k.namespaced, "", &mut warn).await;
         row.pods_total = pods.len();
         row.pods_unhealthy = pods.iter().filter(|o| !pod_healthy(o)).count();
     }
@@ -154,14 +158,17 @@ async fn gather_context(ctx: &str, readonly: bool) -> FleetRow {
     let mut flux_failed = None;
     for kind in ["kustomizations", "helmreleases"] {
         if let Some(k) = cluster.resolve(kind) {
-            let items = list_kind(&client, &k.ar, k.namespaced, "").await;
+            let items = list_or_warn(&client, &k.ar, k.namespaced, "", &mut warn).await;
             let failed = items.iter().filter(|o| ready_is_false(o)).count();
             *flux_failed.get_or_insert(0) += failed;
         }
     }
     row.flux_failed = flux_failed;
 
-    row.status = FleetStatus::Ok;
+    row.status = match warn {
+        Some(w) => FleetStatus::Error(short_error(&w)),
+        None => FleetStatus::Ok,
+    };
     row
 }
 
@@ -199,10 +206,5 @@ fn ready_is_false(o: &DynamicObject) -> bool {
 
 /// First line of a connection error, trimmed for the one-line status cell.
 fn short_error(e: &str) -> String {
-    let first = e.lines().next().unwrap_or(e).trim();
-    if first.len() > 60 {
-        format!("{}…", &first[..59])
-    } else {
-        first.to_string()
-    }
+    crate::text::ellipsize(e.lines().next().unwrap_or(e).trim(), 60)
 }

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -78,13 +78,14 @@ impl App {
         self.flash_err = false;
 
         tokio::spawn(async move {
+            let mut warn = None;
             // Owner: the selection itself, or fetched from its label reference.
             let owner = match owner_ref {
                 None => None,
                 Some(r) => {
                     let (plural, obj) = match (owner_inline, owner_plural_inline) {
                         (Some(o), Some(p)) => (p, Some(o)),
-                        _ => fetch_flux(&client, &flux, &r).await,
+                        _ => fetch_flux(&client, &flux, &r, &mut warn).await,
                     };
                     Some(Node {
                         reference: r,
@@ -99,7 +100,7 @@ impl App {
             let mut deps = Vec::new();
             if let Some(owner_obj) = owner.as_ref().and_then(|n| n.obj.as_ref()) {
                 if let Some(sr) = gitops::source_ref(owner_obj) {
-                    let (plural, obj) = fetch_flux(&client, &flux, &sr).await;
+                    let (plural, obj) = fetch_flux(&client, &flux, &sr, &mut warn).await;
                     source = Some(Node {
                         reference: sr,
                         plural,
@@ -107,7 +108,7 @@ impl App {
                     });
                 }
                 for dr in gitops::depends_on(owner_obj) {
-                    let (plural, obj) = fetch_flux(&client, &flux, &dr).await;
+                    let (plural, obj) = fetch_flux(&client, &flux, &dr, &mut warn).await;
                     deps.push(Node {
                         reference: dr,
                         plural,
@@ -123,7 +124,8 @@ impl App {
                 source,
                 deps,
             };
-            let findings = gitops::describe(&ev);
+            let mut findings = gitops::describe(&ev);
+            prepend_warn_finding(&mut findings, warn);
             let _ = tx
                 .send(Msg::Gitops {
                     generation: genr,
@@ -191,10 +193,13 @@ impl App {
 
 /// Fetch one Flux object by reference, returning its resolved plural (empty if
 /// the kind is unknown to the cluster) and the object (`None` if not found).
+/// A read *failure* (a 403, a timeout) is recorded in `warn` — folding it into
+/// `None` would make the chain view assert the object doesn't exist.
 async fn fetch_flux(
     client: &Client,
     flux: &FluxKinds,
     r: &FluxRef,
+    warn: &mut Option<String>,
 ) -> (String, Option<DynamicObject>) {
     let Some((ar, namespaced, plural)) = flux.get(&r.kind.to_lowercase()) else {
         return (String::new(), None);
@@ -204,5 +209,13 @@ async fn fetch_flux(
     } else {
         Api::all_with(client.clone(), ar)
     };
-    (plural.clone(), api.get(&r.name).await.ok())
+    let obj = match api.get(&r.name).await {
+        Ok(o) => Some(o),
+        Err(kube::Error::Api(ae)) if ae.code == 404 => None,
+        Err(e) => {
+            warn.get_or_insert(format!("reading {}/{}: {e}", plural, r.name));
+            None
+        }
+    };
+    (plural.clone(), obj)
 }

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -51,9 +51,12 @@ pub(super) fn node_unschedulable_patch(unschedulable: bool) -> Value {
 pub(super) fn cronjob_manual_job(cj: &DynamicObject, suffix: &str) -> Option<Value> {
     let name = cj.metadata.name.clone()?;
     let spec = cj.data.pointer("/spec/jobTemplate/spec")?.clone();
+    // Re-key non-object annotations (invalid, but cluster data is untrusted
+    // and `Value`'s IndexMut panics on a type mismatch).
     let mut annotations = cj
         .data
         .pointer("/spec/jobTemplate/metadata/annotations")
+        .filter(|a| a.is_object())
         .cloned()
         .unwrap_or_else(|| json!({}));
     annotations["cronjob.kubernetes.io/instantiate"] = json!("manual");
@@ -714,7 +717,7 @@ pub(super) async fn list_kind(
     ar: &ApiResource,
     namespaced: bool,
     ns: &str,
-) -> Vec<DynamicObject> {
+) -> Result<Vec<DynamicObject>, String> {
     let api: Api<DynamicObject> = if namespaced && !ns.is_empty() {
         Api::namespaced_with(client.clone(), ns, ar)
     } else {
@@ -723,7 +726,46 @@ pub(super) async fn list_kind(
     api.list(&ListParams::default())
         .await
         .map(|l| l.items)
-        .unwrap_or_default()
+        .map_err(|e| format!("listing {}: {e}", ar.plural))
+}
+
+/// [`list_kind`], degrading a failure to an empty list while recording why in
+/// `warn` (first error wins). For read paths that aggregate several kinds:
+/// a denied or failed list must surface as "couldn't look", never render as a
+/// confident zero.
+pub(super) async fn list_or_warn(
+    client: &Client,
+    ar: &ApiResource,
+    namespaced: bool,
+    ns: &str,
+    warn: &mut Option<String>,
+) -> Vec<DynamicObject> {
+    match list_kind(client, ar, namespaced, ns).await {
+        Ok(items) => items,
+        Err(e) => {
+            warn.get_or_insert(e);
+            Vec::new()
+        }
+    }
+}
+
+/// Prepend an "evidence incomplete" warning to a findings list when one of
+/// the gather reads failed — the analysis below it saw only partial data.
+pub(super) fn prepend_warn_finding(
+    findings: &mut Vec<crate::explain::Finding>,
+    warn: Option<String>,
+) {
+    if let Some(w) = warn {
+        findings.insert(
+            0,
+            crate::explain::Finding {
+                indent: 0,
+                level: crate::explain::Level::Warn,
+                text: format!("evidence incomplete — {w}"),
+                target: None,
+            },
+        );
+    }
 }
 
 pub(super) fn phase(o: &DynamicObject) -> String {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -106,7 +106,7 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => self.move_selection(-1),
             KeyCode::Char('g') | KeyCode::Home => self.table_state.select(Some(0)),
             KeyCode::Char('G') | KeyCode::End => {
-                let len = self.rows().len();
+                let len = self.row_count();
                 if len > 0 {
                     self.table_state.select(Some(len - 1));
                 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -495,33 +495,38 @@ impl App {
                 } else {
                     Api::all_with(client.clone(), &ar)
                 };
-                if let Ok(list) = api.list(&ListParams::default()).await {
-                    let mut data = HashMap::new();
-                    let mut containers = HashMap::new();
-                    for item in list {
-                        let name = item.metadata.name.clone().unwrap_or_default();
-                        let key = match &item.metadata.namespace {
-                            Some(n) => format!("{n}/{name}"),
-                            None => name,
-                        };
-                        if !is_node {
-                            for (container, usage) in container_usage_of(&item) {
-                                containers.insert(format!("{key}/{container}"), usage);
+                let msg = match api.list(&ListParams::default()).await {
+                    Ok(list) => {
+                        let mut data = HashMap::new();
+                        let mut containers = HashMap::new();
+                        for item in list {
+                            let name = item.metadata.name.clone().unwrap_or_default();
+                            let key = match &item.metadata.namespace {
+                                Some(n) => format!("{n}/{name}"),
+                                None => name,
+                            };
+                            if !is_node {
+                                for (container, usage) in container_usage_of(&item) {
+                                    containers.insert(format!("{key}/{container}"), usage);
+                                }
                             }
+                            data.insert(key, usage_of(&item, is_node));
                         }
-                        data.insert(key, usage_of(&item, is_node));
-                    }
-                    if tx
-                        .send(Msg::Metrics {
+                        Msg::Metrics {
                             generation: genr,
                             data,
                             containers,
-                        })
-                        .await
-                        .is_err()
-                    {
-                        break;
+                        }
                     }
+                    // A present-but-broken metrics API previously died here in
+                    // silence, leaving the CPU/MEM columns frozen forever.
+                    Err(e) => Msg::MetricsError {
+                        generation: genr,
+                        error: e.to_string(),
+                    },
+                };
+                if tx.send(msg).await.is_err() {
+                    break;
                 }
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }
@@ -576,6 +581,11 @@ impl App {
                 self.flash = format!("error: {error}");
                 self.flash_err = true;
             }
+            Msg::Panic(error) => {
+                self.last_error = Some(error.clone());
+                self.flash = format!("internal error: {error}");
+                self.flash_err = true;
+            }
             Msg::LogLines { generation, lines } if generation == self.log_gen => {
                 self.push_log_lines(lines);
             }
@@ -609,11 +619,15 @@ impl App {
                 if !data.is_empty() || !containers.is_empty() {
                     self.metrics_seen = true;
                 }
+                self.metrics_error = None;
                 self.metrics = data;
                 self.container_metrics = containers;
                 if sort_uses_metrics {
                     self.invalidate_rows();
                 }
+            }
+            Msg::MetricsError { generation, error } if generation == self.generation => {
+                self.metrics_error = Some(error);
             }
             Msg::PrinterColumns {
                 generation,
@@ -627,6 +641,10 @@ impl App {
                 }
             }
             Msg::PulseData { generation, data } if generation == self.generation => {
+                if let Some(w) = &data.warn {
+                    self.flash = format!("pulse is incomplete — {w}");
+                    self.flash_err = true;
+                }
                 self.pulse = data;
             }
             Msg::Rbac {
@@ -636,7 +654,15 @@ impl App {
             } if generation == self.generation && ns == self.namespace => {
                 self.rbac_allowed = Some(allowed);
             }
-            Msg::XrayData { generation, items } if generation == self.generation => {
+            Msg::XrayData {
+                generation,
+                items,
+                warn,
+            } if generation == self.generation => {
+                if let Some(w) = warn {
+                    self.flash = format!("xray is incomplete — {w}");
+                    self.flash_err = true;
+                }
                 let keep = self.xray_state.selected().unwrap_or(0);
                 self.xray_items = items;
                 self.xray_state

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -10,11 +10,19 @@ impl App {
         // Strip carriage returns so progress output doesn't overwrite a row,
         // and expand tabs to spaces — many loggers separate timestamp/level/body
         // with tabs, which some terminals render awkwardly in a TUI cell.
-        self.logs.view.lines.extend(
-            lines
-                .into_iter()
-                .map(|line| line.replace('\r', "").replace('\t', " ")),
-        );
+        // Clean lines (the vast majority) pass through without reallocating.
+        self.logs.view.lines.extend(lines.into_iter().map(|line| {
+            if !line.contains('\r') && !line.contains('\t') {
+                return line;
+            }
+            line.chars()
+                .filter_map(|c| match c {
+                    '\r' => None,
+                    '\t' => Some(' '),
+                    c => Some(c),
+                })
+                .collect()
+        }));
 
         // While following, keep a tight tail buffer. While paused, avoid
         // trimming so indices don't shift under the frozen view (only a huge

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -697,6 +697,7 @@ impl LogsView {
 
 /// A comparable value for one cell, so columns sort numerically where it makes
 /// sense (RESTARTS, CPU, AGE…) and lexically otherwise (NAME, STATUS…).
+#[derive(Clone)]
 enum SortKey {
     Num(f64),
     Text(String),
@@ -739,6 +740,9 @@ struct RowsCache {
     dirty: bool,
     keys: Vec<String>,
     cells: HashMap<String, CellCacheEntry>,
+    /// Computed primary sort keys, valid per (sort header, resourceVersion) —
+    /// a rebuild touches every object, but only changed rows re-extract.
+    sort_keys: HashMap<String, SortKeyEntry>,
 }
 
 struct CellCacheEntry {
@@ -746,6 +750,12 @@ struct CellCacheEntry {
     resource_version: Option<String>,
     cells: Vec<String>,
     status_idx: Option<usize>,
+}
+
+struct SortKeyEntry {
+    header: String,
+    resource_version: Option<String>,
+    key: SortKey,
 }
 
 pub(crate) struct TableCellCache<'a> {
@@ -936,6 +946,9 @@ pub struct App {
     pub last_error: Option<String>,
     /// Whether the Metrics API has ever returned data this session.
     pub metrics_seen: bool,
+    /// The metrics poll's most recent failure (`None` while it works), for
+    /// `:info` — a broken metrics-server must not read as "usage is zero".
+    pub metrics_error: Option<String>,
     /// A workspace waiting for an in-flight context switch before it opens.
     pub pending_workspace: Option<crate::config::Workspace>,
     /// The workspace currently being cycled with `Tab`/`Shift-Tab`, if any.
@@ -1150,6 +1163,7 @@ impl App {
             watch_errors: 0,
             last_error: None,
             metrics_seen: false,
+            metrics_error: None,
             rbac_allowed: None,
             last_rbac_ns: None,
             container_list: Vec::new(),
@@ -1213,6 +1227,7 @@ impl App {
                 dirty: true,
                 keys: Vec::new(),
                 cells: HashMap::new(),
+                sort_keys: HashMap::new(),
             }),
             log_provider: None,
             metrics_provider: None,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -357,14 +357,27 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
-            let mut list = Cluster::list_contexts();
-            list.sort();
-            let _ = tx
-                .send(Msg::Contexts {
-                    generation: genr,
-                    list,
-                })
-                .await;
+            match Cluster::list_contexts() {
+                Ok(mut list) => {
+                    list.sort();
+                    let _ = tx
+                        .send(Msg::Contexts {
+                            generation: genr,
+                            list,
+                        })
+                        .await;
+                }
+                // An unreadable kubeconfig must say so — an empty picker
+                // over a parse error looks like "you have no contexts".
+                Err(e) => {
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: e,
+                        })
+                        .await;
+                }
+            }
         });
     }
 

--- a/src/app/rightsize.rs
+++ b/src/app/rightsize.rs
@@ -79,28 +79,37 @@ impl App {
             let step = provider.step.clone();
             let headroom = provider.headroom;
 
+            // All containers (and all eight queries within each) gathered
+            // concurrently — serialized this was 8N round trips.
+            let results = futures_util::future::join_all(containers.iter().map(|c| {
+                gather_container(&provider, &ns, &pod_matcher, c, &window, &step, headroom)
+            }))
+            .await;
             let mut recs = Vec::new();
-            for c in &containers {
-                recs.push(
-                    gather_container(&provider, &ns, &pod_matcher, c, &window, &step, headroom)
-                        .await,
-                );
+            let mut errors = Vec::new();
+            for (rec, errs) in results {
+                recs.push(rec);
+                errors.extend(errs);
             }
 
-            let lines = render_report(&provider.location(), &window, headroom, &recs);
+            let lines = render_report(&provider.location(), &window, headroom, &recs, &errors);
+            let warn =
+                (!errors.is_empty()).then(|| format!("{} metrics queries failed", errors.len()));
             let _ = tx
                 .send(Msg::Detail {
                     generation: genr,
                     title,
                     lines,
-                    warn: None,
+                    warn,
                 })
                 .await;
         });
     }
 }
 
-/// Query the four PromQL series for one container and assemble its rec.
+/// Query the eight PromQL series for one container (concurrently) and
+/// assemble its rec, plus any query errors. A failed query yields `None` —
+/// never a zero the report would then present as measured usage.
 async fn gather_container(
     provider: &crate::providers::MetricsProvider,
     ns: &str,
@@ -109,7 +118,7 @@ async fn gather_container(
     window: &str,
     step: &str,
     headroom: u32,
-) -> ContainerRec {
+) -> (ContainerRec, Vec<String>) {
     let sel = format!(
         "namespace=\"{ns}\",pod=~\"{pod_matcher}\",container=\"{}\"",
         spec.name
@@ -124,47 +133,56 @@ async fn gather_container(
             "max(quantile_over_time({q}, container_memory_working_set_bytes{{{sel}}}[{window}]))"
         )
     };
-    let q =
-        |promql: String| async move { provider.query(&promql).await.ok().flatten().unwrap_or(0.0) };
+    let q = |promql: String| async move { provider.query(&promql).await };
 
+    let (c50, c95, c99, m50, m95, m99, oom, throttle) = tokio::join!(
+        q(cpu_q("0.5")),
+        q(cpu_q("0.95")),
+        q(cpu_q("0.99")),
+        q(mem_q("0.5")),
+        q(mem_q("0.95")),
+        q(mem_q("0.99")),
+        q(format!(
+            "sum(increase(container_oom_events_total{{{sel}}}[{window}]))"
+        )),
+        q(format!(
+            "sum(increase(container_cpu_cfs_throttled_periods_total{{{sel}}}[{window}]))"
+        )),
+    );
+
+    let mut errors = Vec::new();
+    let mut take = |r: Result<Option<f64>, String>| match r {
+        Ok(v) => v,
+        Err(e) => {
+            errors.push(e);
+            None
+        }
+    };
     let cpu = Quantiles {
-        p50: q(cpu_q("0.5")).await,
-        p95: q(cpu_q("0.95")).await,
-        p99: q(cpu_q("0.99")).await,
+        p50: take(c50),
+        p95: take(c95),
+        p99: take(c99),
     };
     let mem = Quantiles {
-        p50: q(mem_q("0.5")).await,
-        p95: q(mem_q("0.95")).await,
-        p99: q(mem_q("0.99")).await,
+        p50: take(m50),
+        p95: take(m95),
+        p99: take(m99),
     };
-    let oom = q(format!(
-        "sum(increase(container_oom_events_total{{{sel}}}[{window}]))"
-    ))
-    .await;
-    let throttle = q(format!(
-        "sum(increase(container_cpu_cfs_throttled_periods_total{{{sel}}}[{window}]))"
-    ))
-    .await;
+    let oom = take(oom);
+    let throttle = take(throttle);
 
-    ContainerRec {
+    let rec = ContainerRec {
         container: spec.name.clone(),
-        suggested_cpu: if cpu.p95 > 0.0 {
-            suggest(cpu.p95, headroom)
-        } else {
-            0.0
-        },
-        suggested_mem: if mem.p95 > 0.0 {
-            suggest(mem.p95, headroom)
-        } else {
-            0.0
-        },
+        suggested_cpu: cpu.p95.filter(|v| *v > 0.0).map(|p| suggest(p, headroom)),
+        suggested_mem: mem.p95.filter(|v| *v > 0.0).map(|p| suggest(p, headroom)),
         cpu,
         mem,
         cpu_request: spec.cpu_request,
         mem_request: spec.mem_request,
         oom,
         throttle,
-    }
+    };
+    (rec, errors)
 }
 
 /// Render the recommendation report as document lines.
@@ -173,6 +191,7 @@ fn render_report(
     window: &str,
     headroom: u32,
     recs: &[ContainerRec],
+    errors: &[String],
 ) -> Vec<String> {
     let opt_cpu = |v: Option<f64>| v.map(|n| fmt_cpu(n as i64)).unwrap_or_else(|| "—".into());
     let opt_mem = |v: Option<f64>| v.map(|n| fmt_mem(n as i64)).unwrap_or_else(|| "—".into());
@@ -182,31 +201,40 @@ fn render_report(
         format!("window:  {window}   headroom: +{headroom}% over P95"),
         String::new(),
     ];
+    if !errors.is_empty() {
+        lines.push(format!(
+            "⚠ {} metrics quer{} failed — '—' below means unknown, not zero",
+            errors.len(),
+            if errors.len() == 1 { "y" } else { "ies" },
+        ));
+        lines.push(format!("  first error: {}", errors[0]));
+        lines.push(String::new());
+    }
     for r in recs {
         lines.push(format!("container: {}", r.container));
         lines.push(format!(
             "  cpu   request {:<8} P50 {:<8} P95 {:<8} P99 {:<8} → suggest {}   [{}]",
             opt_cpu(r.cpu_request),
-            fmt_cpu(r.cpu.p50 as i64),
-            fmt_cpu(r.cpu.p95 as i64),
-            fmt_cpu(r.cpu.p99 as i64),
-            fmt_cpu(r.suggested_cpu as i64),
+            opt_cpu(r.cpu.p50),
+            opt_cpu(r.cpu.p95),
+            opt_cpu(r.cpu.p99),
+            opt_cpu(r.suggested_cpu),
             r.cpu_verdict().label(),
         ));
         lines.push(format!(
             "  mem   request {:<8} P50 {:<8} P95 {:<8} P99 {:<8} → suggest {}   [{}]",
             opt_mem(r.mem_request),
-            fmt_mem(r.mem.p50 as i64),
-            fmt_mem(r.mem.p95 as i64),
-            fmt_mem(r.mem.p99 as i64),
-            fmt_mem(r.suggested_mem as i64),
+            opt_mem(r.mem.p50),
+            opt_mem(r.mem.p95),
+            opt_mem(r.mem.p99),
+            opt_mem(r.suggested_mem),
             r.mem_verdict().label(),
         ));
-        if r.oom > 0.0 || r.throttle > 0.0 {
+        if r.oom.unwrap_or(0.0) > 0.0 || r.throttle.unwrap_or(0.0) > 0.0 {
             lines.push(format!(
                 "  evidence: {} OOM kill(s) · {} throttled CPU period(s) over {window}",
-                r.oom.round() as i64,
-                r.throttle.round() as i64,
+                r.oom.unwrap_or(0.0).round() as i64,
+                r.throttle.unwrap_or(0.0).round() as i64,
             ));
         }
         lines.push(String::new());

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -11,12 +11,14 @@ impl App {
         cache.dirty = true;
         cache.keys.clear();
         cache.cells.clear();
+        cache.sort_keys.clear();
     }
 
     pub(super) fn invalidate_row(&self, key: &str) {
         let mut cache = self.rows_cache.borrow_mut();
         cache.dirty = true;
         cache.cells.remove(key);
+        cache.sort_keys.remove(key);
     }
 
     /// The parsed form of the active filter, reparsed only when the string
@@ -93,15 +95,14 @@ impl App {
 
     /// The displayed cell a comparison key names (case-insensitive column
     /// header), plus NAMESPACE and a `/status/phase` fallback for kinds
-    /// without a STATUS column.
+    /// without a STATUS column. Extracts only the named column — this runs
+    /// per object per rebuild when a structured filter is active.
     fn column_cell(&self, o: &DynamicObject, key: &str) -> Option<String> {
         if key.eq_ignore_ascii_case("namespace") || key.eq_ignore_ascii_case("ns") {
             return Some(o.metadata.namespace.clone().unwrap_or_default());
         }
-        let base = self.spec.headers();
-        if let Some(i) = base.iter().position(|h| h.eq_ignore_ascii_case(key)) {
-            let (cells, _) = self.spec.cells(o);
-            return cells.get(i).cloned();
+        if let Some(i) = self.spec.header_index(key) {
+            return self.spec.cell_at(o, i);
         }
         if key.eq_ignore_ascii_case("status") {
             let phase = phase(o);
@@ -153,12 +154,16 @@ impl App {
         let sort_header = self
             .sort_column
             .and_then(|i| headers.get(i).map(String::as_str));
+        // CPU/MEM sort by the live metrics snapshot, which moves without a new
+        // resourceVersion, so those keys can never be cached.
+        let volatile_sort = matches!(sort_header, Some("CPU" | "MEM"));
         // The aggregated Helm release list (`helm list` semantics) shows only
         // the latest revision per release; `helmhistory` (one release's full
         // history) shows every revision, so it skips this.
         let helm_latest = (self.kind_plural == "helm").then(|| self.helm_latest_revision_keys());
+        let sort_keys = &mut cache.sort_keys;
         // (primary sort key, (ns, name) tiebreak, store key)
-        let mut entries: Vec<(SortKey, (String, String), String)> = self
+        let mut entries: Vec<(SortKey, (&str, &str), &String)> = self
             .store
             .iter()
             .filter(|(_, o)| self.matches_filter(o))
@@ -167,15 +172,40 @@ impl App {
                 None => true,
             })
             .map(|(k, o)| {
+                // One watch event marks the whole ordering dirty, so the
+                // rebuild touches every object — computed sort keys are
+                // cached per resourceVersion so the N-1 unchanged rows reuse
+                // theirs instead of re-extracting (and, for helm, re-gunzipping)
+                // their cells.
                 let primary = match sort_header {
-                    Some(h) => self.column_sort_key(o, h),
                     None => SortKey::Text(String::new()),
+                    Some(h) if volatile_sort => self.column_sort_key(o, h),
+                    Some(h) => {
+                        let rv = o.metadata.resource_version.as_deref();
+                        match sort_keys.get(k) {
+                            Some(e) if e.header == h && e.resource_version.as_deref() == rv => {
+                                e.key.clone()
+                            }
+                            _ => {
+                                let key = self.column_sort_key(o, h);
+                                sort_keys.insert(
+                                    k.clone(),
+                                    SortKeyEntry {
+                                        header: h.to_string(),
+                                        resource_version: o.metadata.resource_version.clone(),
+                                        key: key.clone(),
+                                    },
+                                );
+                                key
+                            }
+                        }
+                    }
                 };
                 let tie = (
-                    o.metadata.namespace.clone().unwrap_or_default(),
-                    o.metadata.name.clone().unwrap_or_default(),
+                    o.metadata.namespace.as_deref().unwrap_or(""),
+                    o.metadata.name.as_deref().unwrap_or(""),
                 );
-                (primary, tie, k.clone())
+                (primary, tie, k)
             })
             .collect();
         let desc = self.sort_desc && sort_header.is_some();
@@ -187,7 +217,7 @@ impl App {
             // Ties always fall back to namespace/name ascending.
             ord.then_with(|| a.1.cmp(&b.1))
         });
-        cache.keys = entries.into_iter().map(|(_, _, k)| k).collect();
+        cache.keys = entries.into_iter().map(|(_, _, k)| k.clone()).collect();
         cache.dirty = false;
     }
 
@@ -227,6 +257,21 @@ impl App {
             .borrow()
             .keys
             .iter()
+            .filter_map(|k| self.store.get(k))
+            .collect()
+    }
+
+    /// The rows for one viewport: `n` display-ordered rows starting at
+    /// `offset`. What the table renderer wants per frame — it must not pay
+    /// for materializing every off-screen row just to draw one screenful.
+    pub fn rows_window(&self, offset: usize, n: usize) -> Vec<&DynamicObject> {
+        self.ensure_rows_cache();
+        self.rows_cache
+            .borrow()
+            .keys
+            .iter()
+            .skip(offset)
+            .take(n)
             .filter_map(|k| self.store.get(k))
             .collect()
     }
@@ -455,9 +500,10 @@ impl App {
     }
 
     pub fn selected_ref(&self) -> Option<&DynamicObject> {
-        let rows = self.rows();
         let idx = self.table_state.selected()?;
-        rows.get(idx).copied()
+        self.ensure_rows_cache();
+        let cache = self.rows_cache.borrow();
+        self.store.get(cache.keys.get(idx)?)
     }
 
     pub fn selected(&self) -> Option<DynamicObject> {
@@ -529,7 +575,7 @@ impl App {
     }
 
     pub(super) fn move_selection(&mut self, delta: i32) {
-        let len = self.rows().len() as i32;
+        let len = self.row_count() as i32;
         if len == 0 {
             return;
         }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -365,6 +365,57 @@ async fn skin_palette_command_opens_picker() {
 }
 
 #[tokio::test]
+async fn pulse_and_xray_warns_surface_as_flash() {
+    let (mut app, _rx) = test_app();
+    let data = crate::store::Pulse {
+        warn: Some("listing pods: 403".into()),
+        ..Default::default()
+    };
+    app.handle_msg(Msg::PulseData {
+        generation: app.generation,
+        data,
+    });
+    assert!(app.flash_err);
+    assert!(app.flash.contains("incomplete"), "{}", app.flash);
+
+    app.flash_err = false;
+    app.handle_msg(Msg::XrayData {
+        generation: app.generation,
+        items: Vec::new(),
+        warn: Some("listing replicasets: 403".into()),
+    });
+    assert!(app.flash_err);
+    assert!(app.flash.contains("incomplete"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn metrics_error_is_stored_and_cleared_by_next_success() {
+    let (mut app, _rx) = test_app();
+    app.handle_msg(Msg::MetricsError {
+        generation: app.generation,
+        error: "metrics-server 500".into(),
+    });
+    assert_eq!(app.metrics_error.as_deref(), Some("metrics-server 500"));
+
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::new(),
+        containers: HashMap::new(),
+    });
+    assert_eq!(app.metrics_error, None);
+}
+
+#[tokio::test]
+async fn panic_msg_flashes_regardless_of_generation() {
+    let (mut app, _rx) = test_app();
+    app.generation = 7; // a Panic has no generation tag and must never be dropped as stale
+    app.handle_msg(Msg::Panic("boom".into()));
+    assert!(app.flash_err);
+    assert!(app.flash.contains("boom"), "{}", app.flash);
+    assert_eq!(app.last_error.as_deref(), Some("boom"));
+}
+
+#[tokio::test]
 async fn logs_pause_freezes_and_survives_new_lines() {
     let (mut app, _rx) = test_app();
     app.mode = Mode::Logs;
@@ -1445,6 +1496,49 @@ async fn sort_by_numeric_column_and_invert() {
     app.switch_kind("services");
     assert_eq!(app.sort_column, None);
     assert!(!app.sort_desc);
+}
+
+#[tokio::test]
+async fn sorted_order_updates_when_an_object_changes() {
+    // Sort keys are cached per resourceVersion; an update must invalidate the
+    // changed row's cached key (via invalidate_row) and re-sort with the new
+    // value, while unchanged rows reuse theirs.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let pod = |name: &str, rv: &str, restarts: i64| {
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": name, "namespace": "default", "resourceVersion": rv},
+            "status": {
+                "phase": "Running",
+                "containerStatuses": [
+                    {"ready": true, "restartCount": restarts, "state": {"running": {}}}
+                ]
+            }
+        })
+    };
+    apply(&mut app, pod("a", "1", 5));
+    apply(&mut app, pod("b", "1", 1));
+    apply(&mut app, pod("c", "1", 9));
+    assert_eq!(app.display_headers()[3], "RESTARTS");
+    app.sort_column = Some(3);
+    app.invalidate_rows();
+    let names = |app: &App| -> Vec<String> {
+        app.rows()
+            .iter()
+            .map(|o| o.metadata.name.clone().unwrap())
+            .collect()
+    };
+    assert_eq!(names(&app), ["b", "a", "c"]); // 1, 5, 9
+
+    apply(&mut app, pod("b", "2", 20));
+    assert_eq!(names(&app), ["a", "c", "b"]); // 5, 9, 20
+
+    // Changing the sort column must not reuse keys computed for the old one.
+    assert_eq!(app.display_headers()[0], "NAME");
+    app.sort_column = Some(0);
+    app.invalidate_rows();
+    assert_eq!(names(&app), ["a", "b", "c"]);
 }
 
 #[tokio::test]
@@ -4013,21 +4107,21 @@ async fn rightsize_report_renders_verdicts_and_patch() {
     let recs = vec![ContainerRec {
         container: "app".into(),
         cpu: Quantiles {
-            p50: 40.0,
-            p95: 100.0,
-            p99: 130.0,
+            p50: Some(40.0),
+            p95: Some(100.0),
+            p99: Some(130.0),
         },
         mem: Quantiles {
-            p50: 100_000_000.0,
-            p95: 130_000_000.0,
-            p99: 140_000_000.0,
+            p50: Some(100_000_000.0),
+            p95: Some(130_000_000.0),
+            p99: Some(140_000_000.0),
         },
         cpu_request: Some(500.0),        // way over P95 → over-provisioned
         mem_request: Some(64_000_000.0), // under P95 → under-provisioned
-        oom: 0.0,
-        throttle: 0.0,
-        suggested_cpu: crate::rightsize::suggest(100.0, 15),
-        suggested_mem: crate::rightsize::suggest(130_000_000.0, 15),
+        oom: Some(0.0),
+        throttle: Some(0.0),
+        suggested_cpu: Some(crate::rightsize::suggest(100.0, 15)),
+        suggested_mem: Some(crate::rightsize::suggest(130_000_000.0, 15)),
     }];
     assert_eq!(recs[0].cpu_verdict(), crate::rightsize::Verdict::Over);
     assert_eq!(recs[0].mem_verdict(), crate::rightsize::Verdict::Under);

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -451,6 +451,35 @@ impl ViewSpec {
         }
     }
 
+    /// Index of `header`'s column (case-insensitive), without allocating the
+    /// header list.
+    pub fn header_index(&self, header: &str) -> Option<usize> {
+        self.columns
+            .iter()
+            .position(|c| c.header.eq_ignore_ascii_case(header))
+    }
+
+    /// The single cell at `idx` for one object. Filter comparisons read one
+    /// column of every object — extracting the full row per object per
+    /// rebuild is what this avoids.
+    pub fn cell_at(&self, obj: &DynamicObject, idx: usize) -> Option<String> {
+        let col = self.columns.get(idx)?;
+        Some(match &col.source {
+            SpecSource::User(uc) => crate::views::render_cell(obj, uc),
+            SpecSource::Curated(extract) => {
+                let name = obj.metadata.name.clone().unwrap_or_default();
+                let age = age(obj);
+                let ctx = CellContext {
+                    obj,
+                    data: &obj.data,
+                    name: &name,
+                    age: &age,
+                };
+                extract(&ctx)
+            }
+        })
+    }
+
     /// Whether `header` is a user/printer column (typed sorting applies) as
     /// opposed to a curated one.
     pub fn is_user_column(&self, header: &str) -> bool {

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -568,15 +568,7 @@ fn compact_time(raw: &str) -> String {
     }
 }
 
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let mut t: String = s.chars().take(max.saturating_sub(1)).collect();
-        t.push('…');
-        t
-    }
-}
+use crate::text::ellipsize as truncate;
 
 #[cfg(test)]
 mod tests {

--- a/src/gitops.rs
+++ b/src/gitops.rs
@@ -428,14 +428,7 @@ fn join(status: &str, reason: &str, msg: &str) -> String {
 
 /// Trim a revision/message to something that fits on a line.
 fn short(s: &str) -> String {
-    let s = s.trim();
-    if s.chars().count() <= 80 {
-        s.to_string()
-    } else {
-        let mut t: String = s.chars().take(79).collect();
-        t.push('…');
-        t
-    }
+    crate::text::ellipsize(s.trim(), 80)
 }
 
 #[cfg(test)]

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -166,10 +166,13 @@ impl Cluster {
     }
 
     /// All context names from the kubeconfig.
-    pub fn list_contexts() -> Vec<String> {
+    /// Context names from the kubeconfig. A read/parse failure is an error,
+    /// not an empty list — "no contexts" and "your kubeconfig is invalid"
+    /// must not look the same in the picker.
+    pub fn list_contexts() -> Result<Vec<String>, String> {
         Kubeconfig::read()
             .map(|k| k.contexts.into_iter().map(|c| c.name).collect())
-            .unwrap_or_default()
+            .map_err(|e| format!("reading kubeconfig: {e}"))
     }
 
     /// Merge user-defined aliases (alias -> canonical) into the registry.

--- a/src/logfilter.rs
+++ b/src/logfilter.rs
@@ -78,6 +78,16 @@ impl LogMatcher {
         }
         let base = match &self.kind {
             Kind::All => true,
+            // The whole visible buffer is re-tested per frame, so the common
+            // (ASCII) case must not allocate. ASCII bytes can't appear inside
+            // a multi-byte UTF-8 sequence, so the byte-window compare is exact
+            // on any line; only a non-ASCII *pattern* needs Unicode folding.
+            Kind::Substr(s) if s.is_ascii() => {
+                let pat = s.as_bytes();
+                line.as_bytes()
+                    .windows(pat.len())
+                    .any(|w| w.eq_ignore_ascii_case(pat))
+            }
             Kind::Substr(s) => line.to_lowercase().contains(s),
             Kind::Regex(re) => re.is_match(line),
             Kind::BadRegex => false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod providers;
 mod rightsize;
 mod snapshot;
 mod store;
+mod text;
 mod theme;
 mod thresholds;
 mod timeline;
@@ -166,10 +167,17 @@ async fn main() -> Result<()> {
     theme::set_background(cfg.skin.background);
 
     let (tx, mut rx) = mpsc::channel(EVENT_CHANNEL_CAP);
+    let panic_tx = tx.clone();
     let mut app = App::new(cluster, tx);
     // Kubeconfig contexts are stable for the session; cache them once so the
     // palette can complete `:ctx <name>` without re-reading the file per keystroke.
-    app.all_contexts = Cluster::list_contexts();
+    match Cluster::list_contexts() {
+        Ok(contexts) => app.all_contexts = contexts,
+        Err(e) => {
+            eprintln!("warning: {e}");
+            config_warnings.push(e);
+        }
+    }
     app.user_aliases = cfg.aliases.clone();
     app.namespace_favorites = cfg.favorite_namespaces.clone();
     app.plugins = cfg.plugins.clone();
@@ -258,9 +266,34 @@ async fn main() -> Result<()> {
     }
 
     let mut terminal = ratatui::init();
+    install_panic_hook(panic_tx);
     let result = run(&mut terminal, &mut app, &mut rx).await;
     ratatui::restore();
+    // `restore()` leaves the alternate screen but never re-shows the cursor
+    // that `draw` hid, so without this the user's shell prompt has no cursor.
+    let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
     result
+}
+
+/// Route background-task panics into the TUI instead of through ratatui's
+/// restore. Tokio catches a panic in a spawned task and the process survives —
+/// but ratatui's hook has already torn the terminal down by then, leaving a
+/// live TUI drawing into the primary screen with raw mode off and no usable
+/// input. Report those as an in-app error flash and keep the terminal alone.
+/// A main-thread panic is fatal, so there the ratatui hook (restore + default
+/// report) is right; we only add the cursor it forgets.
+///
+/// Must be installed after `ratatui::init()` so the previous hook is ratatui's.
+fn install_panic_hook(tx: mpsc::Sender<store::Msg>) {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if std::thread::current().name() == Some("main") {
+            prev(info);
+            let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
+        } else {
+            let _ = tx.try_send(store::Msg::Panic(info.to_string()));
+        }
+    }));
 }
 
 /// Populate the store from the watch for a short window, then render one frame
@@ -381,17 +414,28 @@ async fn snapshot(app: &mut App, rx: &mut mpsc::Receiver<store::Msg>) -> Result<
 }
 
 /// Leave the alt-screen/raw-mode TUI, run an interactive command with inherited
-/// stdio (kubectl exec/edit/port-forward), then restore the TUI.
+/// stdio (kubectl exec/edit/port-forward), then restore the TUI. Toggles the
+/// terminal modes directly rather than `ratatui::restore()`/`init()`: `init()`
+/// stacks another panic hook on every call, and the hook installed at startup
+/// must stay the outermost one.
 fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String]) {
+    use crossterm::terminal::{
+        EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+    };
     if argv.is_empty() {
         return;
     }
-    ratatui::restore();
-    let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
+    let _ = disable_raw_mode();
+    let _ = crossterm::execute!(
+        std::io::stdout(),
+        LeaveAlternateScreen,
+        crossterm::cursor::Show
+    );
     let _ = std::process::Command::new(&argv[0])
         .args(&argv[1..])
         .status();
-    *terminal = ratatui::init();
+    let _ = enable_raw_mode();
+    let _ = crossterm::execute!(std::io::stdout(), EnterAlternateScreen);
     let _ = terminal.clear();
 }
 
@@ -465,9 +509,16 @@ async fn run(
 ) -> Result<()> {
     let mut reader = crossterm::event::EventStream::new();
     let mut tick = tokio::time::interval(Duration::from_secs(1));
+    // Watch messages mark the frame dirty and the redraw waits for this
+    // interval, so a rollout storm costs at most ~60 renders a second instead
+    // of one per message. Key events still redraw immediately for input
+    // latency.
+    let mut frame = tokio::time::interval(Duration::from_millis(16));
+    frame.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut dirty = false;
 
+    terminal.draw(|f| ui::draw(f, app))?;
     loop {
-        terminal.draw(|f| ui::draw(f, app))?;
         if app.should_quit {
             return Ok(());
         }
@@ -482,9 +533,13 @@ async fn run(
                             app.flash = format!("ran: {}", argv.join(" "));
                             app.flash_err = false;
                         }
+                        terminal.draw(|f| ui::draw(f, app))?;
+                        dirty = false;
                     }
                     Some(Err(_)) | None => return Ok(()),
-                    _ => {}
+                    // Resize (and any other terminal event) still needs a
+                    // redraw, just not an urgent one.
+                    _ => dirty = true,
                 }
             }
             Some(msg) = rx.recv() => {
@@ -493,8 +548,16 @@ async fn run(
                 while let Ok(m) = rx.try_recv() {
                     app.handle_msg(m);
                 }
+                dirty = true;
             }
-            _ = tick.tick() => app.reap_port_forwards(), // age columns + drop dead forwards
+            _ = frame.tick(), if dirty => {
+                terminal.draw(|f| ui::draw(f, app))?;
+                dirty = false;
+            }
+            _ = tick.tick() => {
+                app.reap_port_forwards(); // age columns + drop dead forwards
+                dirty = true;
+            }
         }
     }
 }

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -457,13 +457,16 @@ pub(crate) fn parse_lookback(s: &str) -> Result<i64, String> {
     let n: i64 = digits
         .parse()
         .map_err(|_| format!("{s:?} is not a duration like \"30m\" or \"1h\""))?;
-    let secs = match unit {
-        "s" => n,
-        "m" => n * 60,
-        "h" => n * 3600,
-        "d" => n * 86_400,
+    let per_unit = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 3600,
+        "d" => 86_400,
         _ => return Err(format!("{s:?} has unknown unit {unit:?} (use s/m/h/d)")),
     };
+    let secs = n
+        .checked_mul(per_unit)
+        .ok_or_else(|| format!("{s:?} is too large"))?;
     if secs <= 0 {
         return Err(format!("{s:?} must be a positive duration"));
     }
@@ -692,23 +695,14 @@ impl LogProvider {
         }
     }
 
-    /// Direct-transport POST via a one-off hyper client.
+    /// Direct-transport POST via the shared process-wide hyper client.
     async fn post_direct(
         &self,
         base: &str,
         path: &str,
         params: &[(&str, &str)],
     ) -> Result<hyper::Response<hyper::body::Incoming>, String> {
-        let https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_native_roots()
-            .map_err(|e| format!("loading system TLS roots: {e}"))?
-            .https_or_http()
-            .enable_http1()
-            .build();
-        let client =
-            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                .build(https);
-
+        let client = direct_client()?;
         let url = format!("{base}{path}");
         let mut req = hyper::Request::post(&url).header(
             http::header::CONTENT_TYPE,
@@ -748,6 +742,34 @@ impl LogProvider {
         req.body(form_body(params).into_bytes())
             .map_err(|e| format!("building request: {e}"))
     }
+}
+
+type DirectHttpClient = hyper_util::client::legacy::Client<
+    hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+    Full<Bytes>,
+>;
+
+/// The hyper client for direct-transport requests, built once per process.
+/// `with_native_roots()` reads and parses the system root store from disk —
+/// per request that dwarfed the request itself — and one client also pools
+/// connections across the burst of queries right-sizing sends.
+fn direct_client() -> Result<DirectHttpClient, String> {
+    static CLIENT: std::sync::OnceLock<Result<DirectHttpClient, String>> =
+        std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            let https = hyper_rustls::HttpsConnectorBuilder::new()
+                .with_native_roots()
+                .map_err(|e| format!("loading system TLS roots: {e}"))?
+                .https_or_http()
+                .enable_http1()
+                .build();
+            Ok(
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                    .build(https),
+            )
+        })
+        .clone()
 }
 
 /// Form-urlencode `params`. Scoped helper: the serializer holds a non-`Send`
@@ -1108,16 +1130,7 @@ impl MetricsProvider {
                     .map_err(|e| format!("{}: {e}", self.location()))
             }
             Transport::Direct { url } => {
-                let https = hyper_rustls::HttpsConnectorBuilder::new()
-                    .with_native_roots()
-                    .map_err(|e| format!("loading system TLS roots: {e}"))?
-                    .https_or_http()
-                    .enable_http1()
-                    .build();
-                let http_client = hyper_util::client::legacy::Client::builder(
-                    hyper_util::rt::TokioExecutor::new(),
-                )
-                .build(https);
+                let http_client = direct_client()?;
                 let full = format!("{url}/api/v1/query");
                 let mut req = hyper::Request::post(&full).header(
                     http::header::CONTENT_TYPE,

--- a/src/rightsize.rs
+++ b/src/rightsize.rs
@@ -23,17 +23,20 @@ pub fn scalar_from_query(body: &str) -> Option<f64> {
 }
 
 /// P50/P95/P99 of one resource over the window (CPU in millicores, memory in
-/// bytes). Missing samples read as 0.
+/// bytes). `None` = no sample — the query found no data or failed. Never a
+/// zero: a recommendation must not be computed from an error.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Quantiles {
-    pub p50: f64,
-    pub p95: f64,
-    pub p99: f64,
+    pub p50: Option<f64>,
+    pub p95: Option<f64>,
+    pub p99: Option<f64>,
 }
 
 /// A right-sizing verdict for one resource.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Verdict {
+    /// No usage data for the window — can't judge anything.
+    NoData,
     /// No current request set — can't compare.
     Unset,
     /// Request is well above observed peak — wasting reservation.
@@ -47,6 +50,7 @@ pub enum Verdict {
 impl Verdict {
     pub fn label(self) -> &'static str {
         match self {
+            Verdict::NoData => "no data",
             Verdict::Unset => "no request set",
             Verdict::Over => "over-provisioned",
             Verdict::Ok => "sized about right",
@@ -63,7 +67,10 @@ pub fn suggest(p95: f64, headroom_pct: u32) -> f64 {
 /// Classify a current request against the observed P95. `Over` when the request
 /// exceeds P95 by more than half again (lots of slack); `Under` when it's below
 /// P95 (peak already breaches the request); `Ok` in between.
-pub fn verdict(current_request: Option<f64>, p95: f64) -> Verdict {
+pub fn verdict(current_request: Option<f64>, p95: Option<f64>) -> Verdict {
+    let Some(p95) = p95 else {
+        return Verdict::NoData;
+    };
     match current_request {
         None => Verdict::Unset,
         Some(req) if req <= 0.0 => Verdict::Unset,
@@ -84,12 +91,13 @@ pub struct ContainerRec {
     /// Current requests (millicores / bytes), when set.
     pub cpu_request: Option<f64>,
     pub mem_request: Option<f64>,
-    /// OOM kills and CPU-throttled periods observed over the window.
-    pub oom: f64,
-    pub throttle: f64,
-    /// Suggested requests (millicores / bytes).
-    pub suggested_cpu: f64,
-    pub suggested_mem: f64,
+    /// OOM kills and CPU-throttled periods observed over the window (`None` =
+    /// the count is unknown, not zero).
+    pub oom: Option<f64>,
+    pub throttle: Option<f64>,
+    /// Suggested requests (millicores / bytes); `None` without usage data.
+    pub suggested_cpu: Option<f64>,
+    pub suggested_mem: Option<f64>,
 }
 
 impl ContainerRec {
@@ -99,7 +107,7 @@ impl ContainerRec {
     pub fn mem_verdict(&self) -> Verdict {
         // An OOM kill in the window forces an under-provisioned verdict even if
         // the sampled working set never appeared to breach the request.
-        if self.oom > 0.0 {
+        if self.oom.unwrap_or(0.0) > 0.0 {
             return Verdict::Under;
         }
         verdict(self.mem_request, self.mem.p95)
@@ -124,14 +132,14 @@ pub fn mem_quantity(bytes: f64) -> String {
 pub fn patch_preview(recs: &[ContainerRec]) -> Option<String> {
     let containers: Vec<Value> = recs
         .iter()
-        .filter(|r| r.suggested_cpu > 0.0 || r.suggested_mem > 0.0)
+        .filter(|r| r.suggested_cpu.is_some() || r.suggested_mem.is_some())
         .map(|r| {
             let mut requests = serde_json::Map::new();
-            if r.suggested_cpu > 0.0 {
-                requests.insert("cpu".into(), json!(cpu_quantity(r.suggested_cpu)));
+            if let Some(cpu) = r.suggested_cpu {
+                requests.insert("cpu".into(), json!(cpu_quantity(cpu)));
             }
-            if r.suggested_mem > 0.0 {
-                requests.insert("memory".into(), json!(mem_quantity(r.suggested_mem)));
+            if let Some(mem) = r.suggested_mem {
+                requests.insert("memory".into(), json!(mem_quantity(mem)));
             }
             json!({ "name": r.container, "resources": { "requests": requests } })
         })
@@ -173,11 +181,13 @@ mod tests {
 
     #[test]
     fn verdict_classifies_against_p95() {
-        assert_eq!(verdict(None, 100.0), Verdict::Unset);
-        assert_eq!(verdict(Some(0.0), 100.0), Verdict::Unset);
-        assert_eq!(verdict(Some(50.0), 100.0), Verdict::Under); // peak > request
-        assert_eq!(verdict(Some(120.0), 100.0), Verdict::Ok); // a little slack
-        assert_eq!(verdict(Some(500.0), 100.0), Verdict::Over); // >1.5× P95
+        assert_eq!(verdict(None, Some(100.0)), Verdict::Unset);
+        assert_eq!(verdict(Some(0.0), Some(100.0)), Verdict::Unset);
+        assert_eq!(verdict(Some(50.0), Some(100.0)), Verdict::Under); // peak > request
+        assert_eq!(verdict(Some(120.0), Some(100.0)), Verdict::Ok); // a little slack
+        assert_eq!(verdict(Some(500.0), Some(100.0)), Verdict::Over); // >1.5× P95
+        // No usage data must never be judged as if usage were zero.
+        assert_eq!(verdict(Some(500.0), None), Verdict::NoData);
     }
 
     #[test]
@@ -186,16 +196,16 @@ mod tests {
             container: "app".into(),
             cpu: Quantiles::default(),
             mem: Quantiles {
-                p50: 10.0,
-                p95: 20.0,
-                p99: 25.0,
+                p50: Some(10.0),
+                p95: Some(20.0),
+                p99: Some(25.0),
             },
             cpu_request: Some(100.0),
             mem_request: Some(1_000_000.0), // request far above sampled p95…
-            oom: 3.0,                       // …but it was OOM-killed
-            throttle: 0.0,
-            suggested_cpu: 0.0,
-            suggested_mem: 30.0,
+            oom: Some(3.0),                 // …but it was OOM-killed
+            throttle: Some(0.0),
+            suggested_cpu: None,
+            suggested_mem: Some(30.0),
         };
         assert_eq!(rec.mem_verdict(), Verdict::Under);
     }
@@ -217,10 +227,10 @@ mod tests {
                 mem: Quantiles::default(),
                 cpu_request: None,
                 mem_request: None,
-                oom: 0.0,
-                throttle: 0.0,
-                suggested_cpu: 120.0,
-                suggested_mem: 134_217_728.0,
+                oom: Some(0.0),
+                throttle: Some(0.0),
+                suggested_cpu: Some(120.0),
+                suggested_mem: Some(134_217_728.0),
             },
             ContainerRec {
                 container: "sidecar".into(),
@@ -228,10 +238,10 @@ mod tests {
                 mem: Quantiles::default(),
                 cpu_request: None,
                 mem_request: None,
-                oom: 0.0,
-                throttle: 0.0,
-                suggested_cpu: 0.0, // no data → excluded from the patch
-                suggested_mem: 0.0,
+                oom: Some(0.0),
+                throttle: Some(0.0),
+                suggested_cpu: None, // no data → excluded from the patch
+                suggested_mem: None,
             },
         ];
         let patch = patch_preview(&recs).unwrap();

--- a/src/store.rs
+++ b/src/store.rs
@@ -48,6 +48,15 @@ pub enum Msg {
     XrayData {
         generation: u64,
         items: Vec<XrayItem>,
+        /// A list that failed during the gather — the tree may be incomplete.
+        warn: Option<String>,
+    },
+    /// The metrics poll loop failed (a broken metrics-server, not an absent
+    /// one — an absent API never starts the loop). Cleared by the next
+    /// successful [`Msg::Metrics`].
+    MetricsError {
+        generation: u64,
+        error: String,
     },
     /// Findings for the explain-unhealthy view, gathered off-thread.
     Explain {
@@ -181,6 +190,10 @@ pub enum Msg {
         generation: u64,
         error: String,
     },
+    /// A panic in a background task, reported by the process panic hook.
+    /// Deliberately generation-free: it must surface no matter which view is
+    /// current.
+    Panic(String),
 }
 
 /// Cluster-health snapshot for the pulse dashboard.
@@ -202,6 +215,8 @@ pub struct Pulse {
     pub jobs_total: usize,
     pub pvc_bound: usize,
     pub pvc_total: usize,
+    /// A list that failed during the gather — the tiles above under-count.
+    pub warn: Option<String>,
 }
 
 /// A flattened node in the xray tree (owner → children → containers).

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,50 @@
+//! Shared text helpers.
+
+/// Truncate to `max` characters, ending with an ellipsis when cut. Counts
+/// chars, never bytes: byte slicing panics on a multi-byte boundary, and the
+/// inputs here (API error messages, revisions, container names) can carry
+/// arbitrary UTF-8.
+pub fn ellipsize(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    match max {
+        0 => String::new(),
+        _ => {
+            let mut t: String = s.chars().take(max - 1).collect();
+            t.push('…');
+            t
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_strings_pass_through() {
+        assert_eq!(ellipsize("abc", 3), "abc");
+        assert_eq!(ellipsize("", 5), "");
+    }
+
+    #[test]
+    fn long_strings_end_with_ellipsis_at_max_chars() {
+        assert_eq!(ellipsize("abcdef", 4), "abc…");
+        assert_eq!(ellipsize("abcdef", 4).chars().count(), 4);
+    }
+
+    #[test]
+    fn zero_max_is_empty() {
+        assert_eq!(ellipsize("abc", 0), "");
+    }
+
+    #[test]
+    fn multibyte_input_never_panics() {
+        // Regression: a byte-sliced truncation panicked when byte 59 fell
+        // inside a multi-byte sequence.
+        let s = "é".repeat(80);
+        assert_eq!(ellipsize(&s, 60).chars().count(), 60);
+        assert_eq!(ellipsize("αβγδε", 3), "αβ…");
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -555,12 +555,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let offset = app.table_state.offset();
     let selected = app.table_state.selected();
 
-    let visible_objects: Vec<_> = app
-        .rows()
-        .into_iter()
-        .skip(offset)
-        .take(visible_rows)
-        .collect();
+    let visible_objects = app.rows_window(offset, visible_rows);
     app.ensure_table_cell_cache(&visible_objects);
     let cell_cache = app.table_cell_cache();
     let spec = app.view_spec();
@@ -2203,22 +2198,7 @@ const C_MEM: usize = 8;
 const C_MEM_PCT: usize = 9;
 const C_GAP: usize = 2;
 
-/// Truncate to `max` display columns with a trailing ellipsis (character-based;
-/// container names are ASCII in practice).
-fn truncate_cols(s: &str, max: usize) -> String {
-    let n = s.chars().count();
-    if n <= max {
-        return s.to_string();
-    }
-    match max {
-        0 => String::new(),
-        _ => {
-            let mut t: String = s.chars().take(max - 1).collect();
-            t.push('…');
-            t
-        }
-    }
-}
+use crate::text::ellipsize as truncate_cols;
 
 fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     let gap = " ".repeat(C_GAP);


### PR DESCRIPTION
## Summary

Correctness fixes and render-pipeline performance work from a code-health audit. Bin size: +8 tests (399 total), clippy clean under `-D warnings`, no `#[allow]`s added.

### Correctness

- **Background-task panic safety**: a panic in a spawned tokio task no longer restores the terminal under a still-running TUI (broken raw mode, dead input). Panics now surface as an in-app `internal error` flash via a generation-free `Msg::Panic`; main-thread panics keep the ratatui restore. The cursor is re-shown on every exit path, and `suspend_and_run` no longer stacks a fresh panic hook per `kubectl exec`/`edit`.
- **Char-safe truncation**: four hand-rolled truncate helpers consolidated into `text::ellipsize()`. The fleet one byte-sliced at index 59 and panicked on multi-byte UTF-8 in connection errors.
- **Read errors no longer render as confident answers**:
  - explain / gitops / bundle prepend an *"evidence incomplete — …"* finding when a list fails (a 403 previously diagnosed from an empty pod set)
  - pulse / xray flash *"incomplete"* instead of showing healthy-looking zero tiles
  - fleet rows show the list error instead of "0 unhealthy"
  - gitops distinguishes a read failure from a genuine 404, so the chain view stops asserting objects don't exist
  - metrics poll failures surface in `:info` (`metrics poll error`), cleared on the next success
  - an unreadable kubeconfig reports as an error instead of an empty context picker
- **Rightsize honesty**: failed PromQL queries propagate as `None` and render as `—` with a warning banner, instead of becoming `0.0` inside the recommendation math and producing authoritative-looking sizing advice built from errors.
- Smaller: `checked_mul` in config duration parsing (i64 overflow), type guard before `serde_json`'s panicking `IndexMut` on CronJob annotations, guarded `g` on an empty xray list.

### Performance

- **Frame coalescing**: watch messages mark a dirty flag drained by a 16 ms frame interval — an event storm costs at most ~60 renders/s instead of one full render per message. Key presses still draw immediately.
- **Sort-key caching**: row sort keys cached per `resourceVersion`, so one watch event no longer re-extracts sort cells (or re-gunzips Helm secrets) for all N objects. CPU/MEM sorts excluded — metrics move without a new resourceVersion. Tie-breaks borrow instead of cloning two Strings per row.
- **Viewport windowing**: `draw_table` renders via `rows_window(offset, n)` instead of materializing every filtered row per frame; `selected_ref`/`move_selection`/`G` stopped doing it too.
- **Structured filters** (`status=Running`) extract only the named column per object via `ViewSpec::header_index`/`cell_at`, instead of all cells plus a header `Vec<String>` per object.
- **Log filtering** is allocation-free for ASCII patterns (was `to_lowercase()` per line per frame over up to 100k lines); log-line sanitizing is single-pass and zero-copy for clean lines.
- **Rightsize** runs its 8 queries × N containers concurrently over a process-wide hyper client, instead of 8N sequential requests each rebuilding the TLS client and re-loading the system root store.

## Test plan

- [x] `cargo test` — 399 passed (8 new: ellipsize UTF-8 regression, panic-msg flash, sort-cache invalidation on update and column switch, pulse/xray warn flashes, metrics error store/clear)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual: run against the home cluster — verify pulse/xray under an RBAC-restricted user, `:rightsize` against VictoriaMetrics, and log filtering on a busy namespace