### PR TITLE
feat: session diff — :diff works on GitOps-managed objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,11 @@ numbers.
   Open it, then press `Tab` or `Shift-Tab` to cycle its views. You stay in the
   workspace.
 - **Diff** (`:diff`) — a unified diff of the live object and its
-  `last-applied-configuration`.
+  `last-applied-configuration`. When that annotation is absent — as it is for
+  every Flux- or Helm-managed object, which nothing ever `kubectl apply`s —
+  sofka diffs against the **previous revision the session's watch saw**
+  instead, so "what just changed?" has an answer on GitOps clusters. sofka
+  keeps the last revision of up to 256 changed objects in memory for this.
 - **Events** (`:events` / `E`) — live Kubernetes Events for the selected
   object. sofka filters by UID when the UID is available.
 - **GitOps view** (`:gitops` / `:flux`) — for the selected object, the Flux

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -192,11 +192,13 @@ impl App {
             .collect()
     }
 
-    /// Diff the live object against its `last-applied-configuration` (k9s-style).
+    /// Diff the live object against its `last-applied-configuration`
+    /// (k9s-style), or — when that annotation is absent, as it is for every
+    /// Flux/Helm-managed object — against the previous revision this session's
+    /// watch saw, so "what just changed?" has an answer on GitOps clusters.
     pub fn open_diff(&mut self) {
-        use similar::{ChangeTag, TextDiff};
         self.set_return_mode();
-        let Some(mut obj) = self.selected() else {
+        let Some(obj) = self.selected() else {
             return;
         };
         let name = obj.metadata.name.clone().unwrap_or_default();
@@ -207,39 +209,37 @@ impl App {
             .as_ref()
             .and_then(|a| a.get("kubectl.kubernetes.io/last-applied-configuration"))
             .cloned();
-        let Some(last_json) = last else {
-            self.flash_warn("no last-applied-configuration (not applied via kubectl apply)");
-            return;
+
+        let (baseline_yaml, baseline_label) = match last {
+            Some(last_json) => {
+                let yaml = serde_json::from_str::<Value>(&last_json)
+                    .ok()
+                    .and_then(|v| serde_yaml::to_string(&v).ok())
+                    .unwrap_or(last_json);
+                (yaml, "last-applied")
+            }
+            None => {
+                let key = row_key(&obj);
+                let Some(prev) = self.prev_revisions.get(&self.kind_plural, &key) else {
+                    self.flash_warn(
+                        "nothing to diff: no last-applied annotation, \
+                         and no change seen this session",
+                    );
+                    return;
+                };
+                (diffable_yaml(prev.clone()), "session: previous")
+            }
         };
-        let last_yaml = serde_json::from_str::<Value>(&last_json)
-            .ok()
-            .and_then(|v| serde_yaml::to_string(&v).ok())
-            .unwrap_or(last_json);
 
-        // Clean the live object for a readable comparison.
-        if let Some(ann) = obj.metadata.annotations.as_mut() {
-            ann.remove("kubectl.kubernetes.io/last-applied-configuration");
-        }
-        obj.metadata.managed_fields = None;
-        let live_yaml = serde_yaml::to_string(&obj).unwrap_or_default();
-
-        let diff = TextDiff::from_lines(&last_yaml, &live_yaml);
-        let mut lines = Vec::new();
-        for change in diff.iter_all_changes() {
-            let sign = match change.tag() {
-                ChangeTag::Delete => '-',
-                ChangeTag::Insert => '+',
-                ChangeTag::Equal => ' ',
-            };
-            lines.push(format!("{sign}{}", change.value().trim_end_matches('\n')));
-        }
+        let live_yaml = diffable_yaml(obj);
+        let lines = diff_lines(&baseline_yaml, &live_yaml);
         if lines.iter().all(|l| l.starts_with(' ')) {
-            self.flash = "no diff: live matches last-applied".into();
+            self.flash = format!("no diff: live matches {baseline_label}");
             self.flash_err = false;
             return; // nothing to show — stay on the current view
         }
         self.detail = Scrollable {
-            title: format!("{name} — diff (last-applied → live)"),
+            title: format!("{name} — diff ({baseline_label} → live)"),
             lines: lines.into(),
             ..Default::default()
         };
@@ -352,6 +352,34 @@ impl App {
             task.abort();
         }
     }
+}
+
+/// Render an object as YAML cleaned for a readable side-by-side: no
+/// managedFields, no last-applied annotation (it *is* one of the sides), and
+/// no resourceVersion (it differs on every change — pure noise in a diff).
+fn diffable_yaml(mut obj: DynamicObject) -> String {
+    if let Some(ann) = obj.metadata.annotations.as_mut() {
+        ann.remove("kubectl.kubernetes.io/last-applied-configuration");
+    }
+    obj.metadata.managed_fields = None;
+    obj.metadata.resource_version = None;
+    serde_yaml::to_string(&obj).unwrap_or_default()
+}
+
+/// Unified-diff lines (`-`/`+`/` ` prefixed) between two documents.
+fn diff_lines(before: &str, after: &str) -> Vec<String> {
+    use similar::{ChangeTag, TextDiff};
+    let diff = TextDiff::from_lines(before, after);
+    diff.iter_all_changes()
+        .map(|change| {
+            let sign = match change.tag() {
+                ChangeTag::Delete => '-',
+                ChangeTag::Insert => '+',
+                ChangeTag::Equal => ' ',
+            };
+            format!("{sign}{}", change.value().trim_end_matches('\n'))
+        })
+        .collect()
 }
 
 /// Render one Secret `data` entry as stringData-style YAML lines: single-line

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -559,9 +559,17 @@ impl App {
                 obj,
             } if generation == self.generation => {
                 // Record state changes against the previous version before it's
-                // overwritten (session-local timeline).
-                self.timeline
-                    .observe(&self.kind_plural, &key, self.store.latest(&key), &obj);
+                // overwritten (session-local timeline), and keep that version
+                // for the session diff (`:diff` on objects with no
+                // last-applied annotation).
+                let prev = self.store.latest(&key);
+                self.timeline.observe(&self.kind_plural, &key, prev, &obj);
+                if let Some(prev) = prev
+                    && prev.metadata.resource_version != obj.metadata.resource_version
+                {
+                    self.prev_revisions
+                        .insert(&self.kind_plural, &key, prev.clone());
+                }
                 self.store.apply(key.clone(), *obj);
                 self.invalidate_row(&key);
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -725,6 +725,38 @@ impl SortKey {
     }
 }
 
+/// Maximum previous object revisions retained for the session diff.
+const PREV_REVISIONS_MAX: usize = 256;
+
+/// Previous revisions of objects the watch saw change, so `:diff` can show
+/// previous → live for GitOps-managed objects (whose
+/// `last-applied-configuration` is empty — nothing `kubectl apply`s them).
+/// Bounded FIFO keyed by (kind plural, store key); survives view switches so
+/// drilling away and back keeps the baseline.
+#[derive(Default)]
+pub(super) struct PrevRevisions {
+    map: HashMap<(String, String), DynamicObject>,
+    order: VecDeque<(String, String)>,
+}
+
+impl PrevRevisions {
+    pub(super) fn insert(&mut self, kind: &str, key: &str, obj: DynamicObject) {
+        let k = (kind.to_string(), key.to_string());
+        if self.map.insert(k.clone(), obj).is_none() {
+            self.order.push_back(k);
+            while self.order.len() > PREV_REVISIONS_MAX {
+                if let Some(oldest) = self.order.pop_front() {
+                    self.map.remove(&oldest);
+                }
+            }
+        }
+    }
+
+    pub(super) fn get(&self, kind: &str, key: &str) -> Option<&DynamicObject> {
+        self.map.get(&(kind.to_string(), key.to_string()))
+    }
+}
+
 /// The active filter string alongside its parsed form, so the grammar is
 /// reparsed only when the string actually changes — never per frame or row.
 struct FilterCache {
@@ -1035,6 +1067,8 @@ pub struct App {
     pub gitops_source: Option<DynamicObject>,
     /// Session-local per-object state-change history, fed by the table watch.
     pub timeline: crate::timeline::Timeline,
+    /// Previous object revisions for the session diff (`:diff` fallback).
+    pub(super) prev_revisions: PrevRevisions,
     /// The `(plural, row_key)` the timeline view is showing, and its cursor.
     pub timeline_target: Option<(String, String)>,
     pub timeline_state: ListState,
@@ -1206,6 +1240,7 @@ impl App {
             gitops_title: String::new(),
             gitops_source: None,
             timeline: crate::timeline::Timeline::default(),
+            prev_revisions: PrevRevisions::default(),
             timeline_target: None,
             timeline_state: ListState::default(),
             confirm_label: String::new(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -365,6 +365,88 @@ async fn skin_palette_command_opens_picker() {
 }
 
 #[tokio::test]
+async fn diff_falls_back_to_session_previous_revision() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    let dep = |rv: &str, replicas: i64| {
+        json!({
+            "apiVersion": "apps/v1", "kind": "Deployment",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": rv},
+            "spec": {"replicas": replicas}
+        })
+    };
+    apply(&mut app, dep("1", 1));
+    apply(&mut app, dep("2", 3));
+    app.table_state.select(Some(0));
+    app.open_diff();
+    assert_eq!(app.mode, Mode::Diff);
+    assert!(app.detail.title.contains("session"), "{}", app.detail.title);
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|l| l.starts_with('-') && l.contains("replicas: 1"))
+    );
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|l| l.starts_with('+') && l.contains("replicas: 3"))
+    );
+    // resourceVersion churn must not appear as diff noise.
+    assert!(
+        !app.detail
+            .lines
+            .iter()
+            .any(|l| l.contains("resourceVersion"))
+    );
+}
+
+#[tokio::test]
+async fn diff_without_any_baseline_warns() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "apps/v1", "kind": "Deployment",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"replicas": 1}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.open_diff();
+    assert_ne!(app.mode, Mode::Diff);
+    assert!(app.flash.contains("nothing to diff"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn diff_prefers_last_applied_when_present() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    let last = r#"{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"default"},"spec":{"replicas":2}}"#;
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "apps/v1", "kind": "Deployment",
+            "metadata": {
+                "name": "web", "namespace": "default", "resourceVersion": "1",
+                "annotations": {"kubectl.kubernetes.io/last-applied-configuration": last}
+            },
+            "spec": {"replicas": 3}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.open_diff();
+    assert_eq!(app.mode, Mode::Diff);
+    assert!(
+        app.detail.title.contains("last-applied"),
+        "{}",
+        app.detail.title
+    );
+}
+
+#[tokio::test]
 async fn pulse_and_xray_warns_surface_as_flash() {
     let (mut app, _rx) = test_app();
     let data = crate::store::Pulse {


### PR DESCRIPTION
## Summary
- `:diff` previously diffed live vs `last-applied-configuration` only — an annotation that is empty for every Flux/Helm-managed object, so the diff view was useless precisely for sofka's GitOps focus.
- The watch `Applied` handler now keeps the previous revision of changed objects (bounded FIFO, 256 entries, keyed by kind + store key; survives view switches) next to the existing timeline observation.
- When the annotation is absent, `:diff` shows **previous → live** from the session watch, titled `(session: previous → live)`. When neither baseline exists, it says so explicitly.
- `resourceVersion` is stripped from both sides of every diff (it changes on every write — pure noise), and the diff rendering is extracted into shared `diffable_yaml`/`diff_lines` helpers.
- README documents the fallback.

## Test plan
- [x] New tests: session fallback produces `-replicas: 1`/`+replicas: 3` with no `resourceVersion` noise; no-baseline case warns; last-applied still takes priority when present
- [x] `cargo test` — 402 passed; clippy `-D warnings` + fmt clean
- [x] Manual: `:diff` a Flux-managed Deployment after a reconcile touches it