### PR TITLE
feat: node %CPU/%MEM of allocatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ numbers.
   resource uses its CRD `additionalPrinterColumns` automatically. Press `w` to
   show or hide the wide-only columns (kubectl `-o wide`).
 - **Live CPU and MEM columns** for pods and nodes from the metrics API, with
-  color for unusual values. The pod container picker also shows CPU and memory
+  color for unusual values. Nodes also get **%CPU and %MEM of allocatable**
+  (`status.allocatable` — the pool the scheduler hands out), colored by the
+  configurable `utilization` thresholds and sortable, so "which node is full"
+  is one glance and one `S`. The pod container picker also shows CPU and memory
   for each container, each container usage as a percent of its request and its
   limit (`-` marks an unset request or limit), and the pod QoS class. All of it
   works correctly when metrics-server is not present.

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -615,7 +615,7 @@ impl App {
                         let headers = self.display_headers();
                         headers.get(i).cloned()
                     })
-                    .is_some_and(|h| matches!(h.as_str(), "CPU" | "MEM"));
+                    .is_some_and(|h| matches!(h.as_str(), "CPU" | "MEM" | "%CPU" | "%MEM"));
                 if !data.is_empty() || !containers.is_empty() {
                     self.metrics_seen = true;
                 }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -154,9 +154,10 @@ impl App {
         let sort_header = self
             .sort_column
             .and_then(|i| headers.get(i).map(String::as_str));
-        // CPU/MEM sort by the live metrics snapshot, which moves without a new
-        // resourceVersion, so those keys can never be cached.
-        let volatile_sort = matches!(sort_header, Some("CPU" | "MEM"));
+        // CPU/MEM (and the node capacity percentages) sort by the live metrics
+        // snapshot, which moves without a new resourceVersion, so those keys
+        // can never be cached.
+        let volatile_sort = matches!(sort_header, Some("CPU" | "MEM" | "%CPU" | "%MEM"));
         // The aggregated Helm release list (`helm list` semantics) shows only
         // the latest revision per release; `helmhistory` (one release's full
         // history) shows every revision, so it skips this.
@@ -318,7 +319,18 @@ impl App {
             h.push("CPU".into());
             h.push("MEM".into());
         }
+        if self.node_capacity_columns() {
+            h.push("%CPU".into());
+            h.push("%MEM".into());
+        }
         h
+    }
+
+    /// Nodes get usage as a percentage of `status.allocatable` next to the
+    /// absolute CPU/MEM — "how full is this node" is the number a nodes view
+    /// is opened for.
+    pub fn node_capacity_columns(&self) -> bool {
+        self.kind_plural == "nodes"
     }
 
     pub(crate) fn view_spec(&self) -> &crate::columns::ViewSpec {
@@ -445,6 +457,23 @@ impl App {
             "AGE" => SortKey::Num(crate::columns::age_secs(o).unwrap_or(i64::MAX) as f64),
             "CPU" => SortKey::Num(self.metrics_for(o).0 as f64),
             "MEM" => SortKey::Num(self.metrics_for(o).1 as f64),
+            // Unknown allocatable sorts below every real percentage.
+            "%CPU" if self.node_capacity_columns() => SortKey::Num(
+                crate::columns::usage_pct(
+                    self.metrics_for(o).0,
+                    crate::columns::node_allocatable(o).0,
+                )
+                .map(|p| p as f64)
+                .unwrap_or(-1.0),
+            ),
+            "%MEM" if self.node_capacity_columns() => SortKey::Num(
+                crate::columns::usage_pct(
+                    self.metrics_for(o).1,
+                    crate::columns::node_allocatable(o).1,
+                )
+                .map(|p| p as f64)
+                .unwrap_or(-1.0),
+            ),
             // Humanized time cells ("5d23h") must sort by the underlying
             // timestamp, never the rendered string. Negated epoch seconds so
             // ascending = most recent first, matching AGE; unknowns last.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1650,6 +1650,65 @@ async fn metrics_update_invalidates_metric_sorted_rows() {
     assert_eq!(names, ["b", "a"]);
 }
 
+#[tokio::test]
+async fn node_capacity_percent_columns_render_and_sort() {
+    let (mut app, _rx) = test_app();
+    // Pods must not grow the node columns.
+    app.switch_kind("pods");
+    assert!(!app.display_headers().contains(&"%CPU".to_string()));
+
+    app.switch_kind("nodes");
+    let node = |name: &str, cpu: &str| {
+        json!({"apiVersion": "v1", "kind": "Node",
+               "metadata": {"name": name, "resourceVersion": "1"},
+               "status": {"allocatable": {"cpu": cpu, "memory": "8Gi"}}})
+    };
+    apply(&mut app, node("big", "4"));
+    apply(&mut app, node("small", "2"));
+
+    let headers = app.display_headers();
+    assert!(headers.contains(&"%CPU".to_string()), "{headers:?}");
+    assert!(headers.contains(&"%MEM".to_string()), "{headers:?}");
+
+    // Same absolute usage, different allocatable → percent sort differs from
+    // absolute sort: 1000m is 25% of big (4 cores) but 50% of small (2).
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::from([
+            ("big".to_string(), (1000, 0)),
+            ("small".to_string(), (1000, 0)),
+        ]),
+        containers: HashMap::new(),
+    });
+    let pct_idx = app
+        .display_headers()
+        .iter()
+        .position(|h| *h == "%CPU")
+        .unwrap();
+    app.sort_column = Some(pct_idx);
+    app.sort_desc = true;
+    app.invalidate_rows();
+    let names: Vec<String> = app
+        .rows()
+        .iter()
+        .map(|o| o.metadata.name.clone().unwrap())
+        .collect();
+    assert_eq!(names, ["small", "big"]);
+}
+
+#[test]
+fn node_allocatable_reads_status_quantities() {
+    let node = obj(json!({"apiVersion": "v1", "kind": "Node",
+        "metadata": {"name": "n"},
+        "status": {"allocatable": {"cpu": "3900m", "memory": "8Gi"}}}));
+    assert_eq!(
+        crate::columns::node_allocatable(&node),
+        (Some(3900), Some(8 * 1024 * 1024 * 1024))
+    );
+    let bare = obj(json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "n"}}));
+    assert_eq!(crate::columns::node_allocatable(&bare), (None, None));
+}
+
 #[test]
 fn pod_metrics_are_split_by_container() {
     let metrics = obj(json!({

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1491,6 +1491,23 @@ pub fn parse_mem_bytes(s: &str) -> i64 {
     s.parse::<f64>().unwrap_or(0.0) as i64
 }
 
+/// A node's allocatable CPU (millicores) and memory (bytes) from
+/// `status.allocatable` — the pool the scheduler actually hands out, i.e. the
+/// right denominator for "how full is this node".
+pub fn node_allocatable(o: &DynamicObject) -> (Option<i64>, Option<i64>) {
+    let read = |field: &str, parse: fn(&str) -> i64| {
+        o.data
+            .pointer(&format!("/status/allocatable/{field}"))
+            .and_then(Value::as_str)
+            .map(parse)
+            .filter(|v| *v > 0)
+    };
+    (
+        read("cpu", parse_cpu_milli),
+        read("memory", parse_mem_bytes),
+    )
+}
+
 pub fn fmt_cpu(milli: i64) -> String {
     if milli <= 0 {
         "-".into()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -532,6 +532,8 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let restarts_idx = headers.iter().position(|h| h == "RESTARTS");
     let cpu_idx = headers.iter().position(|h| h == "CPU");
     let mem_idx = headers.iter().position(|h| h == "MEM");
+    let pct_cpu_idx = headers.iter().position(|h| h == "%CPU");
+    let pct_mem_idx = headers.iter().position(|h| h == "%MEM");
 
     let count = app.row_count();
     let visible_rows = area.height.saturating_sub(3).max(1) as usize;
@@ -585,6 +587,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
             }
             let mut metrics_raw = None;
+            let mut node_pcts: (Option<i64>, Option<i64>) = (None, None);
             if metrics_cols {
                 let name = obj.metadata.name.as_deref().unwrap_or_default();
                 let key = if pods_view {
@@ -600,6 +603,15 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 metrics_raw = Some((cpu, mem));
                 cells.push(TableCellText::Owned(columns::fmt_cpu(cpu)));
                 cells.push(TableCellText::Owned(columns::fmt_mem(mem)));
+                if app.node_capacity_columns() {
+                    let (alloc_cpu, alloc_mem) = columns::node_allocatable(obj);
+                    node_pcts = (
+                        columns::usage_pct(cpu, alloc_cpu),
+                        columns::usage_pct(mem, alloc_mem),
+                    );
+                    cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.0)));
+                    cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.1)));
+                }
             }
             // Combined colorer: the whole row takes a k9s-style status tint
             // (errors red, pending peach, completed/terminating dimmed, healthy
@@ -665,6 +677,12 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                             .map(theme::severity_fg)
                             .unwrap_or(row_color);
                         c.into_cell_aligned(align).style(Style::default().fg(color))
+                    } else if Some(i) == pct_cpu_idx {
+                        let color = util_color(node_pcts.0, thresholds.utilization);
+                        c.into_cell_aligned(align).style(Style::default().fg(color))
+                    } else if Some(i) == pct_mem_idx {
+                        let color = util_color(node_pcts.1, thresholds.utilization);
+                        c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else {
                         c.into_cell_aligned(align)
                             .style(Style::default().fg(row_color))
@@ -695,6 +713,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 "NODE" | "CLAIM" | "VOLUME" | "HOSTS" => Constraint::Fill(1),
                 "AGE" => Constraint::Length(7),
                 "CPU" | "MEM" => Constraint::Length(8),
+                "%CPU" | "%MEM" => Constraint::Length(5),
                 // Wide enough for the long pod reasons (ContainerCreating,
                 // CrashLoopBackOff, ImagePullBackOff…) so status is never clipped.
                 "STATUS" => Constraint::Length(19),


### PR DESCRIPTION
## Summary
- The nodes view showed absolute CPU/MEM usage only — `status.allocatable` was never read, so the number a nodes view is actually opened for ("how full is this node") didn't exist.
- Nodes now get `%CPU` / `%MEM` columns: metrics usage as a percentage of allocatable, rendered `57%` (or `-` when allocatable is unknown), colored by the existing configurable `utilization` thresholds (green / peach ≥ warn / red ≥ critical).
- Both columns sort by value via the sort picker; they're treated as volatile sorts like CPU/MEM (metrics move without a resourceVersion bump, so they're excluded from the sort-key cache and re-sorted on each metrics poll).
- Reuses the existing `usage_pct`/`fmt_pct`/`util_color` helpers from the container picker; adds `node_allocatable()` for quantity parsing.

## Test plan
- [x] New tests: `%CPU`/`%MEM` appear on nodes and not pods; percent sort orders by fullness, not absolute usage (same usage, different allocatable); `node_allocatable` parses `3900m`/`8Gi` and returns `None` when absent
- [x] `cargo test` — 401 passed; clippy `-D warnings` + fmt clean
- [x] Manual: nodes view against the home cluster with metrics-server present and absent