### PR TITLE
feat: enter on a Flux HelmRelease opens its Helm release history

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,12 @@ numbers.
 - **Xray tree** (`:xray`) — a hierarchical view from the current kind down
   through owner references to pods and containers.
 - **Flux CD controls** (`t`) — a suspend/resume/reconcile menu that uses native
-  Kubernetes API patches.
+  Kubernetes API patches. Press `⏎` on a **HelmRelease** to open the revision
+  history of the Helm release it manages (resolved the way helm-controller
+  composes `releaseName`/`storageNamespace`): from there `⏎` shows a
+  revision's values, `y` the rendered manifest, `d` the NOTES, and `r` rolls
+  back — the Flux object and the Helm storage inspector are one keystroke
+  apart.
 - **CronJob controls** (`t`) — trigger now (creates a Job from the jobTemplate,
   like `kubectl create job --from`), suspend, and resume.
 - **Background port-forwards** (`f`/`F` to start, `:pf` to manage).

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -37,8 +37,41 @@ impl App {
             // Helm: release -> every revision, revision -> its values.
             "helm" => self.drill_into_helm_history(&obj),
             "helmhistory" => self.open_helm_values(&obj),
+            // A Flux HelmRelease bridges into the same native inspector:
+            // enter opens the history of the Helm release it manages.
+            "helmreleases" => self.drill_into_helmrelease(&obj),
             _ => self.open_detail(),
         }
+    }
+
+    /// Drill from a Flux `HelmRelease` row into the revision history of the
+    /// Helm release it manages — the same view `:helm` → enter reaches, so
+    /// values (`⏎`), manifest (`y`), notes (`d`), and rollback (`r`) all work
+    /// without leaving the Flux object. Resolves the storage coordinates the
+    /// way helm-controller composes them (releaseName/storageNamespace).
+    pub(super) fn drill_into_helmrelease(&mut self, obj: &DynamicObject) {
+        let Some(secrets) = self.cluster.resolve("secrets") else {
+            self.flash_warn("secrets kind unavailable");
+            return;
+        };
+        let (release, ns) = crate::helm::helmrelease_storage(obj);
+        if release.is_empty() {
+            self.flash_warn("HelmRelease has no resolvable release name");
+            return;
+        }
+        self.push_frame();
+        self.kind = Some(secrets);
+        self.kind_plural = "helmhistory".into();
+        self.namespace = ns;
+        self.labels = Some(format!("owner=helm,name={release}"));
+        self.fields = Some("type=helm.sh/release.v1".into());
+        self.scope_label = Some(format!("helm/{release}"));
+        self.filter.clear();
+        self.reset_sort();
+        self.table_state.select(Some(0));
+        self.flash = format!("↳ {release} history");
+        self.flash_err = false;
+        self.start_watch();
     }
 
     /// Drill from an aggregated Helm release row into every revision of that

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2588,6 +2588,63 @@ async fn namespace_switch_is_recorded_in_history() {
 
 // ----- Helm ---------------------------------------------------------------
 
+#[test]
+fn helmrelease_storage_resolves_like_helm_controller() {
+    use crate::helm::helmrelease_storage;
+    let hr = |spec: serde_json::Value| {
+        obj(json!({
+            "apiVersion": "helm.toolkit.fluxcd.io/v2", "kind": "HelmRelease",
+            "metadata": {"name": "podinfo", "namespace": "flux-system"},
+            "spec": spec
+        }))
+    };
+    // Defaults: metadata name, object namespace.
+    assert_eq!(
+        helmrelease_storage(&hr(json!({}))),
+        ("podinfo".to_string(), "flux-system".to_string())
+    );
+    // Explicit releaseName + storageNamespace win.
+    assert_eq!(
+        helmrelease_storage(&hr(
+            json!({"releaseName": "custom", "storageNamespace": "apps"})
+        )),
+        ("custom".to_string(), "apps".to_string())
+    );
+    // targetNamespace without releaseName composes `<target>-<name>`.
+    assert_eq!(
+        helmrelease_storage(&hr(json!({"targetNamespace": "prod"}))),
+        ("prod-podinfo".to_string(), "flux-system".to_string())
+    );
+}
+
+#[tokio::test]
+async fn enter_on_helmrelease_opens_helm_history() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("helmreleases");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "helm.toolkit.fluxcd.io/v2", "kind": "HelmRelease",
+            "metadata": {"name": "podinfo", "namespace": "flux-system"},
+            "spec": {"storageNamespace": "apps"}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.drill();
+    assert_eq!(app.kind_plural, "helmhistory");
+    assert_eq!(app.namespace, "apps");
+    assert_eq!(app.labels.as_deref(), Some("owner=helm,name=podinfo"));
+    assert_eq!(app.fields.as_deref(), Some("type=helm.sh/release.v1"));
+    // The backing kind must be the secrets watch, not the HelmRelease CRD.
+    assert_eq!(
+        app.kind.as_ref().map(|k| k.ar.plural.as_str()),
+        Some("secrets")
+    );
+    // Esc returns to the HelmRelease list.
+    assert!(app.pop_frame());
+    assert_eq!(app.kind_plural, "helmreleases");
+}
+
 #[tokio::test]
 async fn helm_list_shows_only_latest_revision_per_release() {
     let (mut app, _rx) = test_app();

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -132,6 +132,27 @@ pub fn release_name(secret: &DynamicObject) -> Option<&str> {
         .map(String::as_str)
 }
 
+/// Where helm-controller stores a Flux `HelmRelease`'s underlying Helm
+/// release: `(release name, storage namespace)`. The release name is
+/// `spec.releaseName`, defaulting to helm-controller's own composition
+/// `[<targetNamespace>-]<name>`; storage is `spec.storageNamespace`,
+/// defaulting to the object's namespace.
+pub fn helmrelease_storage(obj: &DynamicObject) -> (String, String) {
+    let name = obj.metadata.name.clone().unwrap_or_default();
+    let field = |p: &str| obj.data.pointer(p).and_then(Value::as_str);
+    let release = match field("/spec/releaseName") {
+        Some(r) => r.to_string(),
+        None => match field("/spec/targetNamespace") {
+            Some(t) => format!("{t}-{name}"),
+            None => name,
+        },
+    };
+    let ns = field("/spec/storageNamespace")
+        .map(str::to_string)
+        .unwrap_or_else(|| obj.metadata.namespace.clone().unwrap_or_default());
+    (release, ns)
+}
+
 /// The revision number from the secret's `version` label — cheap, no decode
 /// needed. Used to pick the latest revision per release without decoding
 /// every revision's payload.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -460,6 +460,9 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
     if app.flux_suspendable() {
         lines.push(hint_line(&[("t", "flux menu")]));
     }
+    if app.kind_plural == "helmreleases" {
+        lines.push(hint_line(&[("⏎", "helm history")]));
+    }
     if app.cronjob_kind() {
         lines.push(hint_line(&[("t", "trigger/suspend")]));
     }


### PR DESCRIPTION
## Summary
- sofka has a full native Helm storage inspector (`:helm` → history → values / manifest / NOTES / rollback), but it was unreachable from the `HelmRelease` objects a Flux user actually browses — `t` gave Flux controls, and the rendered values/manifest were a separate manual `:helm` trip away.
- `⏎` on a `helmreleases` row now drills straight into the `helmhistory` view for the Helm release that object manages. All existing history-view keys work from there (`⏎` values, `y` manifest, `d` NOTES, `r` rollback), and `esc` returns to the HelmRelease list.
- Storage coordinates are resolved exactly the way helm-controller composes them: `spec.releaseName` (defaulting to `[<targetNamespace>-]<name>`) and `spec.storageNamespace` (defaulting to the object's namespace) — covered by a unit test.
- Header hints show `⏎ helm history` on the helmreleases view; README's Flux bullet documents the bridge.

## Test plan
- [x] New tests: resolution defaults / explicit fields / targetNamespace composition; drill lands on `helmhistory` backed by the `secrets` kind with the right labels+namespace; `esc` pops back
- [x] `cargo test` — 401 passed; clippy `-D warnings` + fmt clean
- [x] Manual: `⏎` on a HelmRelease in the home cluster, roll through values/manifest/notes