### PR TITLE
feat: mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ numbers.
   sofka queries only the contexts in `[fleet]`, and gathers each one at the same
   time with its own timeout, so one slow cluster never blocks the rest. Press
   `⏎` to switch to a context. Press `r` to refresh.
+- **Mouse support** — the wheel scrolls every view (table, logs, documents,
+  pickers — one notch is three steps of that view's own up/down), clicking a
+  table row selects it, and clicking a column header sorts by it (click again
+  to flip the direction). Set `mouse = false` in the config to keep the
+  terminal's native mouse behavior (text selection) instead; sofka releases
+  the mouse while a suspended command (`kubectl exec`, `$EDITOR`) runs.
 - **Compact mode** (`ctrl-e`) — collapse the seven-line header and the footer
   into one info line (kind · count · namespace · context, with a flash and the
   live indicator). So a tiled or multiplexed pane is almost all table.
@@ -330,6 +336,8 @@ default_namespace = "kube-system"
 default_resource  = "deployments"
 readonly          = false  # true disables every mutating action (delete, edit,
                            # scale, shell, plugins, …); --readonly/--write win
+mouse             = true   # false keeps the terminal's native mouse behavior
+                           # (text selection) instead of scroll/click/sort
 
 # Namespaces pinned to the top of the `n` switcher (★); session recents (·)
 # follow them.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1035,6 +1035,9 @@ pub struct App {
     pub gitops_source: Option<DynamicObject>,
     /// Session-local per-object state-change history, fed by the table watch.
     pub timeline: crate::timeline::Timeline,
+    /// Table geometry from the last frame, for mouse hit-testing. A RefCell
+    /// because the renderer records it while the frame still borrows rows.
+    pub(super) table_hit: RefCell<Option<mouse::TableHit>>,
     /// The `(plural, row_key)` the timeline view is showing, and its cursor.
     pub timeline_target: Option<(String, String)>,
     pub timeline_state: ListState,
@@ -1206,6 +1209,7 @@ impl App {
             gitops_title: String::new(),
             gitops_source: None,
             timeline: crate::timeline::Timeline::default(),
+            table_hit: RefCell::new(None),
             timeline_target: None,
             timeline_state: ListState::default(),
             confirm_label: String::new(),
@@ -1273,6 +1277,7 @@ mod input;
 mod journal;
 mod lifecycle;
 mod logs;
+mod mouse;
 mod navigation;
 mod overlays;
 mod pickers;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -1,0 +1,106 @@
+use super::*;
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+/// Where the table landed on screen last frame, for mouse hit-testing.
+/// Recorded by `draw_table`; coordinates are terminal cells.
+#[derive(Clone, Default)]
+pub(crate) struct TableHit {
+    /// The header row's y.
+    pub header_y: u16,
+    /// First data row's y and how many rows are visible.
+    pub rows_y: u16,
+    pub rows_h: u16,
+    /// Inner x extent (inside the borders).
+    pub x_min: u16,
+    pub x_max: u16,
+    /// Per-column `[start, end)` x ranges, aligned with `display_headers()`.
+    pub cols: Vec<(u16, u16)>,
+}
+
+impl App {
+    /// Record the table geometry the renderer just used, so clicks can be
+    /// mapped back to rows and header columns. `cols` are `[start, end)` x
+    /// ranges aligned with `display_headers()`.
+    pub fn record_table_hit(
+        &self,
+        header_y: u16,
+        rows_y: u16,
+        rows_h: u16,
+        x_min: u16,
+        x_max: u16,
+        cols: Vec<(u16, u16)>,
+    ) {
+        *self.table_hit.borrow_mut() = Some(TableHit {
+            header_y,
+            rows_y,
+            rows_h,
+            x_min,
+            x_max,
+            cols,
+        });
+    }
+
+    /// Route a mouse event. The wheel is synthesized into the mode's own
+    /// up/down keys, so scrolling works identically in every view (table,
+    /// logs, documents, pickers) without a second navigation code path;
+    /// clicks are table-specific (select a row, sort by a header).
+    pub fn handle_mouse(&mut self, m: MouseEvent) -> Result<()> {
+        match m.kind {
+            MouseEventKind::ScrollUp => self.wheel(KeyCode::Up),
+            MouseEventKind::ScrollDown => self.wheel(KeyCode::Down),
+            MouseEventKind::Down(MouseButton::Left) if self.mode == Mode::Table => {
+                self.table_click(m.column, m.row);
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// One wheel notch = three steps, like most list UIs.
+    fn wheel(&mut self, code: KeyCode) -> Result<()> {
+        for _ in 0..3 {
+            self.handle_key(KeyEvent::new(code, KeyModifiers::NONE))?;
+        }
+        Ok(())
+    }
+
+    fn table_click(&mut self, x: u16, y: u16) {
+        let Some(hit) = self.table_hit.borrow().clone() else {
+            return;
+        };
+        if x < hit.x_min || x >= hit.x_max {
+            return;
+        }
+        // Header row: sort by the clicked column (again = flip direction).
+        if y == hit.header_y {
+            let Some(idx) = hit.cols.iter().position(|(s, e)| x >= *s && x < *e) else {
+                return;
+            };
+            if self.sort_column == Some(idx) {
+                self.sort_desc = !self.sort_desc;
+            } else {
+                self.sort_column = Some(idx);
+                self.sort_desc = false;
+            }
+            self.invalidate_rows();
+            let label = self.display_headers().get(idx).cloned().unwrap_or_default();
+            self.flash = format!(
+                "sort by {label} {}",
+                if self.sort_desc {
+                    "↓ desc"
+                } else {
+                    "↑ asc"
+                }
+            );
+            self.flash_err = false;
+            return;
+        }
+        // Data rows: select what was clicked.
+        if y >= hit.rows_y && y < hit.rows_y + hit.rows_h {
+            let idx = self.table_state.offset() + (y - hit.rows_y) as usize;
+            if idx < self.row_count() {
+                self.table_state.select(Some(idx));
+            }
+        }
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -406,6 +406,72 @@ async fn metrics_error_is_stored_and_cleared_by_next_success() {
 }
 
 #[tokio::test]
+async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let pod = |name: &str, restarts: i64| {
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": name, "namespace": "default"},
+            "status": {"phase": "Running", "containerStatuses":
+                [{"ready": true, "restartCount": restarts, "state": {"running": {}}}]}
+        })
+    };
+    apply(&mut app, pod("a", 5));
+    apply(&mut app, pod("b", 1));
+    app.table_state.select(Some(0));
+
+    // A frame must render first — that's what records the hit geometry.
+    let mut term = Terminal::new(TestBackend::new(120, 32)).unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let hit = app.table_hit.borrow().clone().expect("geometry recorded");
+
+    let click = |column: u16, row: u16| MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    };
+
+    // Click the second data row → it becomes the selection.
+    app.handle_mouse(click(hit.x_min + 3, hit.rows_y + 1))
+        .unwrap();
+    assert_eq!(app.table_state.selected(), Some(1));
+
+    // Click the RESTARTS header → sort by it; again → flip direction.
+    let ridx = app
+        .display_headers()
+        .iter()
+        .position(|h| h == "RESTARTS")
+        .unwrap();
+    let (sx, _) = hit.cols[ridx];
+    app.handle_mouse(click(sx, hit.header_y)).unwrap();
+    assert_eq!(app.sort_column, Some(ridx));
+    assert!(!app.sort_desc);
+    app.handle_mouse(click(sx, hit.header_y)).unwrap();
+    assert!(app.sort_desc);
+
+    // Wheel scroll maps to the mode's own up/down keys (3 per notch).
+    app.table_state.select(Some(0));
+    app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    })
+    .unwrap();
+    assert_eq!(app.table_state.selected(), Some(1), "clamped at the end");
+
+    // A click outside the table (e.g. the header panel) is ignored.
+    app.handle_mouse(click(0, 0)).unwrap();
+    assert_eq!(app.table_state.selected(), Some(1));
+}
+
+#[tokio::test]
 async fn panic_msg_flashes_regardless_of_generation() {
     let (mut app, _rx) = test_app();
     app.generation = 7; // a Panic has no generation tag and must never be dropped as stale

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,10 @@ pub struct Config {
     pub logs: LogsConfig,
     /// Cross-context fleet dashboard (`:fleet`) — see [`FleetConfig`].
     pub fleet: FleetConfig,
+    /// Mouse support (wheel scroll, click-to-select, header-click sort).
+    /// `None` = on. Set `mouse = false` to keep the terminal's native mouse
+    /// behavior (text selection) instead.
+    pub mouse: Option<bool>,
 }
 
 /// The opt-in cross-context fleet dashboard (`:fleet`). Only the kubeconfig

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,9 +265,16 @@ async fn main() -> Result<()> {
         return snapshot(&mut app, &mut rx).await;
     }
 
+    let mouse = cfg.mouse.unwrap_or(true);
     let mut terminal = ratatui::init();
+    if mouse {
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture);
+    }
     install_panic_hook(panic_tx);
-    let result = run(&mut terminal, &mut app, &mut rx).await;
+    let result = run(&mut terminal, &mut app, &mut rx, mouse).await;
+    // Disable before leaving the alternate screen so the shell never sees
+    // mouse-report sequences (harmless if capture was never enabled).
+    let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
     ratatui::restore();
     // `restore()` leaves the alternate screen but never re-shows the cursor
     // that `draw` hid, so without this the user's shell prompt has no cursor.
@@ -288,6 +295,10 @@ fn install_panic_hook(tx: mpsc::Sender<store::Msg>) {
     let prev = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         if std::thread::current().name() == Some("main") {
+            // Mouse capture must go first: ratatui's restore leaves the
+            // alternate screen, and stray mouse reports would land in the
+            // shell after a crash.
+            let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
             prev(info);
             let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
         } else {
@@ -418,12 +429,16 @@ async fn snapshot(app: &mut App, rx: &mut mpsc::Receiver<store::Msg>) -> Result<
 /// terminal modes directly rather than `ratatui::restore()`/`init()`: `init()`
 /// stacks another panic hook on every call, and the hook installed at startup
 /// must stay the outermost one.
-fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String]) {
+fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String], mouse: bool) {
+    use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
     use crossterm::terminal::{
         EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     };
     if argv.is_empty() {
         return;
+    }
+    if mouse {
+        let _ = crossterm::execute!(std::io::stdout(), DisableMouseCapture);
     }
     let _ = disable_raw_mode();
     let _ = crossterm::execute!(
@@ -436,6 +451,9 @@ fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String]) {
         .status();
     let _ = enable_raw_mode();
     let _ = crossterm::execute!(std::io::stdout(), EnterAlternateScreen);
+    if mouse {
+        let _ = crossterm::execute!(std::io::stdout(), EnableMouseCapture);
+    }
     let _ = terminal.clear();
 }
 
@@ -506,6 +524,7 @@ async fn run(
     terminal: &mut ratatui::DefaultTerminal,
     app: &mut App,
     rx: &mut mpsc::Receiver<store::Msg>,
+    mouse: bool,
 ) -> Result<()> {
     let mut reader = crossterm::event::EventStream::new();
     let mut tick = tokio::time::interval(Duration::from_secs(1));
@@ -529,12 +548,21 @@ async fn run(
                     Some(Ok(Event::Key(key))) if key.kind == KeyEventKind::Press => {
                         app.handle_key(key)?;
                         if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
-                            suspend_and_run(terminal, &argv);
+                            suspend_and_run(terminal, &argv, mouse);
                             app.flash = format!("ran: {}", argv.join(" "));
                             app.flash_err = false;
                         }
                         terminal.draw(|f| ui::draw(f, app))?;
                         dirty = false;
+                    }
+                    Some(Ok(Event::Mouse(m))) => {
+                        app.handle_mouse(m)?;
+                        if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
+                            suspend_and_run(terminal, &argv, mouse);
+                            app.flash = format!("ran: {}", argv.join(" "));
+                            app.flash_err = false;
+                        }
+                        dirty = true;
                     }
                     Some(Err(_)) | None => return Ok(()),
                     // Resize (and any other terminal event) still needs a

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -757,6 +757,34 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         None
     };
     render_state.select(render_selected);
+    // Record the geometry for mouse hit-testing (click-to-select, header-click
+    // sort). Mirrors the Table widget's own column layout: the area inside the
+    // borders, the always-reserved 2-cell highlight symbol, then a horizontal
+    // layout with the same widths, spacing, and default Start flex.
+    {
+        use ratatui::layout::{Flex, Margin};
+        let inner = area.inner(Margin::new(1, 1));
+        let sel_w = 2u16; // "▌ " with HighlightSpacing::Always
+        let cols_area = Rect {
+            x: inner.x.saturating_add(sel_w),
+            y: inner.y,
+            width: inner.width.saturating_sub(sel_w),
+            height: inner.height,
+        };
+        let rects = Layout::horizontal(widths.clone())
+            .flex(Flex::Start)
+            .spacing(2)
+            .split(cols_area);
+        app.record_table_hit(
+            inner.y,
+            inner.y.saturating_add(1),
+            inner.height.saturating_sub(1),
+            inner.x,
+            inner.x.saturating_add(inner.width),
+            rects.iter().map(|r| (r.x, r.x + r.width)).collect(),
+        );
+    }
+
     let table = Table::new(rows, widths)
         .header(header_row)
         .row_highlight_style(theme::selected_row())


### PR DESCRIPTION
## Summary
- **Wheel** scrolls every view — table, logs, documents, pickers — by synthesizing the mode's own up/down keys (3 per notch), so mouse navigation can never disagree with keyboard navigation and there's no second code path.
- **Click** on a table row selects it. **Click on a column header** sorts by that column; clicking it again flips the direction — the natural complement to the `S` sort picker.
- Hit-testing mirrors the Table widget's actual layout (block borders, the always-reserved 2-cell highlight column, `column_spacing(2)`, `Flex::Start`), recorded by `draw_table` each frame into a `RefCell` — verified by a test that renders a real frame and clicks the RESTARTS header.
- `mouse = false` in config opts out entirely and keeps the terminal's native text selection. Capture is released while a suspended command runs (`kubectl exec`, `$EDITOR`), on normal exit, and in the panic hook — a crash can't leave the shell eating mouse reports.

## Test plan
- [x] New test renders a frame via TestBackend, then: row click selects, header click sorts + flips, wheel moves selection, out-of-table click is ignored
- [x] `cargo test` — 400 passed; clippy `-D warnings` + fmt clean
- [x] Manual: scroll/click/sort in kitty and tmux; confirm text selection works with `mouse = false`; exec into a pod and verify the mouse hands back cleanly