### PR TITLE
feat: saved port-forwards ([[forwards]]) with autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,21 @@ numbers.
   Kubernetes API patches.
 - **CronJob controls** (`t`) — trigger now (creates a Job from the jobTemplate,
   like `kubectl create job --from`), suspend, and resume.
-- **Background port-forwards** (`f`/`F` to start, `:pf` to manage).
+- **Background port-forwards** (`f`/`F` to start, `:pf` to manage), plus
+  **saved forwards** (`[[forwards]]`) — named entries that appear in `:pf`
+  even while stopped (`⏎` starts one), with optional `autostart = true` to
+  open them on connect and on matching context switches:
+
+  ```toml
+  [[forwards]]
+  name = "argocd"
+  target = "svc/argocd-server"  # kubectl syntax: pod/…, svc/…, deploy/…
+  namespace = "argocd"
+  ports = "8080:443"            # LOCAL:REMOTE
+  autostart = true              # start when sofka connects (default false)
+  contexts = ["home"]           # optional: only these contexts
+  ```
+
 - **Plugins** — shell-out commands that you define in the config file and bind
   to keys, scoped for each resource. Keys are full **chords** (`ctrl-g`,
   `alt-x`, `shift-b`, `f5`). Commands run in the **terminal**, in a captured

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1066,15 +1066,22 @@ impl App {
     /// Start `kubectl port-forward` in the background (not a foreground
     /// `Suspend::Shell` — a forward should keep running while you keep
     /// browsing). stdio is nulled since the TUI still owns the terminal.
-    pub(super) fn start_port_forward(&mut self, ns: String, target: String, ports: String) {
+    /// `config_name` links the child back to its `[[forwards]]` entry.
+    pub(super) fn start_port_forward_named(
+        &mut self,
+        ns: String,
+        target: String,
+        ports: String,
+        config_name: Option<String>,
+    ) {
         let mut argv = self.kubectl_base();
-        argv.extend([
-            "port-forward".into(),
-            "-n".into(),
-            ns.clone(),
-            target.clone(),
-            ports.clone(),
-        ]);
+        argv.push("port-forward".into());
+        if !ns.is_empty() {
+            argv.push("-n".into());
+            argv.push(ns.clone());
+        }
+        argv.push(target.clone());
+        argv.push(ports.clone());
         let mut cmd = tokio::process::Command::new(&argv[0]);
         cmd.args(&argv[1..])
             .stdin(std::process::Stdio::null())
@@ -1086,6 +1093,7 @@ impl App {
                     ns,
                     target,
                     ports,
+                    config_name,
                     child,
                 };
                 self.flash = format!("port-forwarding {} (:pf to view/stop)", pf.label());
@@ -1094,6 +1102,59 @@ impl App {
             }
             Err(e) => self.flash_warn(&format!("port-forward failed to start: {e}")),
         }
+    }
+
+    pub(super) fn start_port_forward(&mut self, ns: String, target: String, ports: String) {
+        self.start_port_forward_named(ns, target, ports, None);
+    }
+
+    /// Whether the `[[forwards]]` entry named `name` has a live child.
+    pub(super) fn forward_running(&self, name: &str) -> bool {
+        self.port_forwards
+            .iter()
+            .any(|pf| pf.config_name.as_deref() == Some(name))
+    }
+
+    /// Start one saved forward by its config index.
+    pub(super) fn start_configured_forward(&mut self, idx: usize) {
+        let Some(f) = self.forwards_cfg.get(idx).cloned() else {
+            return;
+        };
+        if self.forward_running(&f.name) {
+            self.flash_warn(&format!("forward '{}' is already running", f.name));
+            return;
+        }
+        self.start_port_forward_named(f.namespace, f.target, f.ports, Some(f.name));
+    }
+
+    /// Start every `autostart = true` saved forward that applies to the
+    /// current context and isn't already running. Called on connect and
+    /// after a context switch.
+    pub fn start_autostart_forwards(&mut self) {
+        if !self.cluster.connected {
+            return;
+        }
+        let context = self.cluster.context.clone();
+        for i in 0..self.forwards_cfg.len() {
+            let f = &self.forwards_cfg[i];
+            if f.autostart
+                && f.matches_context(&context)
+                && !f.name.is_empty()
+                && !self.forward_running(&f.name)
+            {
+                self.start_configured_forward(i);
+            }
+        }
+    }
+
+    /// Saved forwards with no live child, as `(config index, entry)` — the
+    /// "stopped" tail of the `:pf` list.
+    pub fn stopped_configured_forwards(&self) -> Vec<(usize, &crate::config::Forward)> {
+        self.forwards_cfg
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| !f.name.is_empty() && !self.forward_running(&f.name))
+            .collect()
     }
 
     /// Drop any forward whose `kubectl` process has already exited (pod
@@ -1113,21 +1174,36 @@ impl App {
     }
 
     pub(super) fn open_port_forwards(&mut self) {
-        self.pf_state.select(if self.port_forwards.is_empty() {
-            None
-        } else {
-            Some(0)
-        });
+        let len = self.port_forwards.len() + self.stopped_configured_forwards().len();
+        self.pf_state.select(if len == 0 { None } else { Some(0) });
         self.mode = Mode::PortForwards;
     }
 
+    /// The `:pf` list is the running forwards followed by the saved-but-
+    /// stopped `[[forwards]]` entries; `x`/`s` stops a running one, `⏎`/`s`
+    /// starts a stopped one.
     pub(super) fn key_port_forwards(&mut self, key: KeyEvent) {
-        let len = self.port_forwards.len();
+        let running = self.port_forwards.len();
+        let len = running + self.stopped_configured_forwards().len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
             KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.pf_state, len, true),
             KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.pf_state, len, false),
-            KeyCode::Char('x') | KeyCode::Char('s') => self.stop_selected_port_forward(),
+            KeyCode::Char('x') | KeyCode::Char('s') | KeyCode::Enter => {
+                let Some(i) = self.pf_state.selected() else {
+                    return;
+                };
+                if i < running {
+                    // Enter on a running forward is a no-op, not a stop — a
+                    // reflexive ⏎ shouldn't kill a tunnel.
+                    if key.code != KeyCode::Enter {
+                        self.stop_selected_port_forward();
+                    }
+                } else if let Some(&(idx, _)) = self.stopped_configured_forwards().get(i - running)
+                {
+                    self.start_configured_forward(idx);
+                }
+            }
             _ => {}
         }
     }
@@ -1229,10 +1305,13 @@ impl App {
         self.bundle_cfg = resolved.config.bundle;
         self.logs_cfg = resolved.config.logs;
         self.fleet_cfg = resolved.config.fleet;
+        // Running forwards keep running; :reload only refreshes what's saved.
+        self.forwards_cfg = resolved.config.forwards;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
+        warnings.extend(crate::config::forward_warnings(&self.forwards_cfg));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.
@@ -1348,11 +1427,11 @@ impl App {
         let pf = self.port_forwards.remove(i); // dropped -> Drop kills the child
         self.flash = format!("stopped port-forward {}", pf.label());
         self.flash_err = false;
-        self.pf_state.select(if self.port_forwards.is_empty() {
-            None
-        } else {
-            Some(i.min(self.port_forwards.len() - 1))
-        });
+        // A stopped configured forward reappears in the stopped tail, so
+        // clamp against the combined list.
+        let len = self.port_forwards.len() + self.stopped_configured_forwards().len();
+        self.pf_state
+            .select(if len == 0 { None } else { Some(i.min(len - 1)) });
     }
 
     pub(super) fn do_scale(&mut self, ns: String, name: String, replicas: i32) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -143,6 +143,9 @@ pub struct PortForward {
     ns: String,
     target: String,
     ports: String,
+    /// The `[[forwards]]` entry this instance was started from, if any —
+    /// links a running child back to its saved config in `:pf`.
+    pub(super) config_name: Option<String>,
     child: tokio::process::Child,
 }
 
@@ -979,6 +982,9 @@ pub struct App {
     /// Viewed/stopped via `:pf`; killed automatically on drop.
     pub port_forwards: Vec<PortForward>,
     pub pf_state: ListState,
+    /// Saved `[[forwards]]` from config: shown in `:pf` even while stopped,
+    /// startable with one keystroke, autostarted on connect when configured.
+    pub forwards_cfg: Vec<crate::config::Forward>,
 
     pub skin_list: Vec<String>,
     pub skin_state: ListState,
@@ -1175,6 +1181,7 @@ impl App {
             transfer_menu_state: ListState::default(),
             transfer_target: None,
             port_forwards: Vec::new(),
+            forwards_cfg: Vec::new(),
             pf_state: ListState::default(),
             skin_list: crate::theme::BUILTIN_NAMES
                 .iter()

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -570,5 +570,10 @@ impl App {
                 .unwrap_or_else(|| "pods".into());
             self.switch_kind(&kind);
         }
+        // Saved forwards for the new context. Running ones from the previous
+        // context are deliberately left alone (kubectl pinned their context
+        // at spawn); autostart only adds what's missing here.
+        self.forwards_cfg = resolved.config.forwards;
+        self.start_autostart_forwards();
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -406,6 +406,97 @@ async fn metrics_error_is_stored_and_cleared_by_next_success() {
 }
 
 #[tokio::test]
+async fn saved_forwards_show_as_stopped_until_running() {
+    let (mut app, _rx) = test_app();
+    app.forwards_cfg = vec![
+        crate::config::Forward {
+            name: "argocd".into(),
+            target: "svc/argocd-server".into(),
+            namespace: "argocd".into(),
+            ports: "8080:443".into(),
+            autostart: false,
+            contexts: vec![],
+        },
+        crate::config::Forward {
+            name: "db".into(),
+            target: "svc/postgres".into(),
+            namespace: "data".into(),
+            ports: "5432:5432".into(),
+            autostart: false,
+            contexts: vec![],
+        },
+    ];
+    let stopped: Vec<&str> = app
+        .stopped_configured_forwards()
+        .iter()
+        .map(|(_, f)| f.name.as_str())
+        .collect();
+    assert_eq!(stopped, ["argocd", "db"]);
+
+    // A live child linked by name moves the entry out of the stopped tail.
+    app.port_forwards.push(PortForward {
+        config_name: Some("argocd".into()),
+        ns: "argocd".into(),
+        target: "svc/argocd-server".into(),
+        ports: "8080:443".into(),
+        child: spawn_test_child("sleep", "5"),
+    });
+    assert!(app.forward_running("argocd"));
+    let stopped: Vec<&str> = app
+        .stopped_configured_forwards()
+        .iter()
+        .map(|(_, f)| f.name.as_str())
+        .collect();
+    assert_eq!(stopped, ["db"]);
+
+    // The :pf list is running + stopped; x on the running entry stops it and
+    // the entry reappears in the stopped tail.
+    app.open_port_forwards();
+    assert_eq!(app.pf_state.selected(), Some(0));
+    app.key_port_forwards(press(KeyCode::Char('x')));
+    assert!(app.port_forwards.is_empty());
+    assert_eq!(app.stopped_configured_forwards().len(), 2);
+    assert_eq!(app.pf_state.selected(), Some(0), "clamped to combined list");
+}
+
+#[test]
+fn forward_context_matching_and_validation() {
+    let f = crate::config::Forward {
+        name: "x".into(),
+        target: "svc/x".into(),
+        namespace: "ns".into(),
+        ports: "8080:80".into(),
+        autostart: true,
+        contexts: vec!["home".into()],
+    };
+    assert!(f.matches_context("home"));
+    assert!(!f.matches_context("prod"));
+    let all = crate::config::Forward {
+        contexts: vec![],
+        ..f.clone()
+    };
+    assert!(all.matches_context("anything"));
+
+    let warnings = crate::config::forward_warnings(&[
+        crate::config::Forward {
+            name: "".into(),
+            ..f.clone()
+        },
+        crate::config::Forward {
+            name: "badports".into(),
+            ports: "eighty:80".into(),
+            ..f.clone()
+        },
+        f.clone(),
+        f.clone(), // duplicate name
+    ]);
+    assert_eq!(warnings.len(), 3, "{warnings:?}");
+    assert!(warnings.iter().any(|w| w.contains("empty name")));
+    assert!(warnings.iter().any(|w| w.contains("not LOCAL:REMOTE")));
+    assert!(warnings.iter().any(|w| w.contains("duplicate name")));
+}
+
+#[tokio::test]
 async fn panic_msg_flashes_regardless_of_generation() {
     let (mut app, _rx) = test_app();
     app.generation = 7; // a Panic has no generation tag and must never be dropped as stale
@@ -1176,12 +1267,14 @@ fn spawn_test_child(argv0: &str, arg: &str) -> tokio::process::Child {
 async fn stopping_a_forward_kills_only_that_one() {
     let (mut app, _rx) = test_app();
     app.port_forwards.push(PortForward {
+        config_name: None,
         ns: "default".into(),
         target: "pod/a".into(),
         ports: "8080:80".into(),
         child: spawn_test_child("sleep", "30"),
     });
     app.port_forwards.push(PortForward {
+        config_name: None,
         ns: "default".into(),
         target: "pod/b".into(),
         ports: "8081:81".into(),
@@ -1207,6 +1300,7 @@ async fn reap_drops_exited_forwards_and_flashes() {
     let mut child = spawn_test_child("true", "");
     child.wait().await.unwrap(); // let it exit before reaping
     app.port_forwards.push(PortForward {
+        config_name: None,
         ns: "default".into(),
         target: "pod/a".into(),
         ports: "8080:80".into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,81 @@ pub struct Config {
     pub logs: LogsConfig,
     /// Cross-context fleet dashboard (`:fleet`) — see [`FleetConfig`].
     pub fleet: FleetConfig,
+    /// Saved port-forwards — see [`Forward`]. Validated by
+    /// [`forward_warnings`].
+    pub forwards: Vec<Forward>,
+}
+
+/// A named, saved port-forward. Shows up in `:pf` even when stopped, so one
+/// keystroke starts it; `autostart = true` also starts it on connect (and on
+/// every context switch, when its `contexts` list matches).
+///
+/// ```toml
+/// [[forwards]]
+/// name = "argocd"
+/// target = "svc/argocd-server"   # kubectl syntax: pod/…, svc/…, deploy/…
+/// namespace = "argocd"
+/// ports = "8080:443"             # LOCAL:REMOTE
+/// autostart = true               # start when sofka connects (default false)
+/// contexts = ["home"]            # optional: only in these contexts (exact)
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct Forward {
+    pub name: String,
+    /// Forward target in kubectl syntax (`pod/web`, `svc/api`, `deploy/api`).
+    pub target: String,
+    pub namespace: String,
+    /// `LOCAL:REMOTE` port pair (kubectl also accepts a bare port).
+    pub ports: String,
+    /// Start automatically when sofka connects / switches to a matching
+    /// context.
+    pub autostart: bool,
+    /// Kubeconfig context names this forward applies to (exact match).
+    /// Empty = every context.
+    pub contexts: Vec<String>,
+}
+
+impl Forward {
+    /// Whether this forward applies to `context`.
+    pub fn matches_context(&self, context: &str) -> bool {
+        self.contexts.is_empty() || self.contexts.iter().any(|c| c == context)
+    }
+}
+
+/// Validate `[[forwards]]`, returning one warning per problem (the entries
+/// stay usable where possible; unusable ones are flagged, not fatal).
+pub fn forward_warnings(forwards: &[Forward]) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for f in forwards {
+        let label = if f.name.is_empty() {
+            "<unnamed>"
+        } else {
+            &f.name
+        };
+        if f.name.trim().is_empty() {
+            warnings.push("forwards: entry with empty name".to_string());
+        } else if !seen.insert(f.name.clone()) {
+            warnings.push(format!("forwards.{label}: duplicate name"));
+        }
+        if f.target.trim().is_empty() {
+            warnings.push(format!("forwards.{label}: empty target"));
+        }
+        if f.ports.trim().is_empty()
+            || !f
+                .ports
+                .split(':')
+                .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+            || f.ports.split(':').count() > 2
+        {
+            warnings.push(format!(
+                "forwards.{label}: ports '{}' is not LOCAL:REMOTE (e.g. 8080:80)",
+                f.ports
+            ));
+        }
+    }
+    warnings
 }
 
 /// The opt-in cross-context fleet dashboard (`:fleet`). Only the kubeconfig

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,11 +191,13 @@ async fn main() -> Result<()> {
     // reloads) don't fight the user's in-session choice.
     app.logs.fullscreen = cfg.logs.fullscreen;
     app.fleet_cfg = cfg.fleet.clone();
+    app.forwards_cfg = cfg.forwards.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))
         .chain(config::workspace_warnings(&app.workspaces))
         .chain(config::guardrail_warnings(&app.guardrails))
+        .chain(config::forward_warnings(&app.forwards_cfg))
     {
         eprintln!("warning: {w}");
         config_warnings.push(w);
@@ -252,7 +254,10 @@ async fn main() -> Result<()> {
         // No cluster to watch — open the context picker over the empty table;
         // a successful pick connects and lands on the default resource.
         Some(err) => app.start_disconnected(err),
-        None => app.switch_kind(&resource),
+        None => {
+            app.switch_kind(&resource);
+            app.start_autostart_forwards();
+        }
     }
     // View config problems must be visible inside the TUI, not only on the
     // (about-to-be-hidden) stderr.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2085,18 +2085,40 @@ fn draw_transfer_menu(frame: &mut Frame, app: &mut App, area: Rect) {
 /// Background port-forwards (`:pf`). A full-width view, not a popup — closing
 /// it (`esc`) does not stop the forwards; only `x`/`s` on a row does.
 fn draw_port_forwards(frame: &mut Frame, app: &mut App, area: Rect) {
-    let items: Vec<ListItem> = app
+    // Running forwards first, then the saved-but-stopped [[forwards]]
+    // entries — one keystroke away instead of retyped.
+    let mut items: Vec<ListItem> = app
         .port_forwards
         .iter()
         .map(|pf| {
+            let name = pf
+                .config_name
+                .as_ref()
+                .map(|n| format!("{n}: "))
+                .unwrap_or_default();
             ListItem::new(Line::from(vec![
                 Span::styled("● ", Style::default().fg(theme::green())),
-                Span::styled(pf.label(), Style::default().fg(theme::text())),
+                Span::styled(
+                    format!("{name}{}", pf.label()),
+                    Style::default().fg(theme::text()),
+                ),
             ]))
         })
         .collect();
+    for (_, f) in app.stopped_configured_forwards() {
+        items.push(ListItem::new(Line::from(vec![
+            Span::styled("○ ", theme::dim()),
+            Span::styled(
+                format!(
+                    "{}: {} {} -n {} (stopped)",
+                    f.name, f.target, f.ports, f.namespace
+                ),
+                theme::dim(),
+            ),
+        ])));
+    }
     let title = format!(
-        " Port-forwards [{}]  (x/s stop · esc close — others keep running) ",
+        " Port-forwards [{}]  (x/s stop · ⏎ start · esc close) ",
         app.port_forwards.len()
     );
     render_framed_list(


### PR DESCRIPTION
## Summary
- Port-forwards previously lived only as session children — killed on quit, retyped every morning. `[[forwards]]` saves them: `name`, `target` (kubectl syntax), `namespace`, `ports`, optional `autostart` and a `contexts` allowlist.
- `:pf` now lists running forwards (●) followed by saved-but-stopped entries (○ dimmed); `⏎`/`s` starts a stopped one, `x`/`s` stops a running one (`⏎` on a running forward is deliberately a no-op — a reflexive enter shouldn't kill a tunnel).
- `autostart = true` starts the forward on connect and after a context switch when `contexts` matches (empty = everywhere). Already-running entries are never duplicated; forwards from the previous context are left alone since kubectl pinned their `--context` at spawn.
- `:reload` refreshes the saved list without touching live tunnels; validation warnings (empty/duplicate names, malformed `ports`) surface in `:config` like every other section.

## Test plan
- [x] New tests: stopped tail lists saved entries, a live child linked by name moves its entry out, stopping via `x` returns it, selection clamps to the combined list; context matching; validation warnings for empty name / bad ports / duplicates
- [x] `cargo test` — 401 passed; clippy `-D warnings` + fmt clean
- [x] Manual: autostart against the home cluster, context switch, `:pf` start/stop round-trip