### PR TITLE
feat: global fuzzy find (:find <text>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ numbers.
   label and field selectors (the API server evaluates them on ⏎), and typed
   column comparisons (`status=CrashLoopBackOff`, `cpu>500m`, `memory>1Gi`,
   `restarts>=5`, `age<2h`). Terms with a space between them use AND.
+- **Global fuzzy find** (`:find <text>`) — search object names across the
+  common kinds (workloads, pods, services, config, ingresses, jobs, storage,
+  nodes, namespaces, Flux objects) in every namespace at once, concurrently.
+  Results rank by fuzzy score; `⏎` jumps straight to the object. When a kind
+  can't be listed (RBAC), the result says it's incomplete instead of
+  pretending otherwise.
 - **Multiselect** (`space`) for bulk delete/kill/suspend/resume/reconcile.
 - **Pulse dashboard** (`:pulse`) — cluster-health tiles. sofka refreshes them
   every 5 seconds.

--- a/src/app/find.rs
+++ b/src/app/find.rs
@@ -1,0 +1,151 @@
+use super::*;
+
+/// The kinds `:find` sweeps. A curated set rather than the whole discovery
+/// catalog: listing every CRD across all namespaces on each keypress would
+/// hammer the API server for kinds nobody names things in.
+const FIND_KINDS: &[&str] = &[
+    "pods",
+    "deployments",
+    "statefulsets",
+    "daemonsets",
+    "services",
+    "configmaps",
+    "secrets",
+    "ingresses",
+    "jobs",
+    "cronjobs",
+    "persistentvolumeclaims",
+    "nodes",
+    "namespaces",
+    "kustomizations",
+    "helmreleases",
+];
+
+/// Bound on how many hits are kept (best scores first).
+const FIND_MAX_RESULTS: usize = 200;
+
+impl App {
+    /// `:find <text>` — fuzzy-search object names across the common kinds,
+    /// all namespaces, concurrently. Results open in a picker; `⏎` jumps to
+    /// the object as a name-filtered view of its kind.
+    pub(super) fn start_find(&mut self, query: &str) {
+        let query = query.trim().to_string();
+        if query.is_empty() {
+            self.flash_warn("usage: :find <text>");
+            return;
+        }
+        if !self.cluster.connected {
+            self.flash_warn("not connected to a cluster");
+            return;
+        }
+        self.find_query = query.clone();
+        self.find_items.clear();
+        self.find_state.select(None);
+        self.mode = Mode::Find;
+        self.flash = format!("finding '{query}'…");
+        self.flash_err = false;
+
+        let kinds: Vec<(String, ApiResource)> = FIND_KINDS
+            .iter()
+            .filter_map(|p| {
+                self.cluster
+                    .resolve(p)
+                    .map(|k| (k.ar.plural.to_lowercase(), k.ar))
+            })
+            .collect();
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+
+        tokio::spawn(async move {
+            let lists = futures_util::future::join_all(kinds.into_iter().map(|(plural, ar)| {
+                let client = client.clone();
+                async move {
+                    let api: Api<DynamicObject> = Api::all_with(client, &ar);
+                    (plural, api.list(&ListParams::default()).await)
+                }
+            }))
+            .await;
+
+            // Score after gathering: the matcher isn't Send, so it must not
+            // live across the await above.
+            let matcher = SkimMatcherV2::default();
+            let mut failed = 0usize;
+            let mut scored: Vec<(i64, crate::store::FindItem)> = Vec::new();
+            for (plural, res) in lists {
+                match res {
+                    Ok(list) => {
+                        for o in list.items {
+                            let name = o.metadata.name.unwrap_or_default();
+                            if let Some(score) = matcher.fuzzy_match(&name, &query) {
+                                scored.push((
+                                    score,
+                                    crate::store::FindItem {
+                                        plural: plural.clone(),
+                                        ns: o.metadata.namespace.unwrap_or_default(),
+                                        name,
+                                    },
+                                ));
+                            }
+                        }
+                    }
+                    Err(_) => failed += 1,
+                }
+            }
+            scored.sort_by(|a, b| {
+                b.0.cmp(&a.0)
+                    .then_with(|| a.1.name.cmp(&b.1.name))
+                    .then_with(|| a.1.plural.cmp(&b.1.plural))
+            });
+            let items: Vec<crate::store::FindItem> = scored
+                .into_iter()
+                .take(FIND_MAX_RESULTS)
+                .map(|(_, i)| i)
+                .collect();
+            let warn = (failed > 0).then(|| format!("{failed} kind(s) could not be listed"));
+            let _ = tx
+                .send(Msg::FindResults {
+                    generation: genr,
+                    query,
+                    items,
+                    warn,
+                })
+                .await;
+        });
+    }
+
+    pub(super) fn key_find(&mut self, key: KeyEvent) {
+        let len = self.find_items.len();
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
+            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.find_state, len, true),
+            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.find_state, len, false),
+            KeyCode::Char('g') | KeyCode::Home => {
+                if len > 0 {
+                    self.find_state.select(Some(0));
+                }
+            }
+            KeyCode::Char('G') | KeyCode::End => {
+                if len > 0 {
+                    self.find_state.select(Some(len - 1));
+                }
+            }
+            KeyCode::Enter => {
+                let Some(item) = self
+                    .find_state
+                    .selected()
+                    .and_then(|i| self.find_items.get(i))
+                else {
+                    return;
+                };
+                let target = crate::explain::Target {
+                    plural: item.plural.clone(),
+                    namespace: (!item.ns.is_empty()).then(|| item.ns.clone()),
+                    name: item.name.clone(),
+                };
+                self.navigate_to_target(&target);
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -75,6 +75,7 @@ impl App {
             Mode::Skins => self.key_skins(key),
             Mode::Snapshots => self.key_snapshots(key),
             Mode::Fleet => self.key_fleet(key),
+            Mode::Find => self.key_find(key),
         }
         Ok(())
     }
@@ -549,6 +550,7 @@ impl App {
             PaletteAction::Info => self.open_info(),
             PaletteAction::Fleet => self.open_fleet(),
             PaletteAction::Rightsize => self.open_rightsize(),
+            PaletteAction::Find => self.flash_warn("usage: :find <text>"),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.open_events(),
             PaletteAction::PortForwards => self.open_port_forwards(),
@@ -590,6 +592,19 @@ impl App {
         {
             let rest = parts.collect::<Vec<_>>().join(" ");
             self.take_snapshot(&rest);
+            return true;
+        }
+        // `:find <text>` sweeps object names across the common kinds.
+        let mut parts = cmd.split_whitespace();
+        if let Some(first) = parts.next()
+            && matches!(first.to_ascii_lowercase().as_str(), "find" | "fd")
+        {
+            let rest = parts.collect::<Vec<_>>().join(" ");
+            if rest.is_empty() {
+                self.flash_warn("usage: :find <text>");
+            } else {
+                self.start_find(&rest);
+            }
             return true;
         }
         // `:can-i <verb> <resource> [ns]` checks one action; bare `:can-i`

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -640,6 +640,24 @@ impl App {
                     self.refresh_view_spec();
                 }
             }
+            Msg::FindResults {
+                generation,
+                query,
+                items,
+                warn,
+            } if generation == self.generation => {
+                if let Some(w) = warn {
+                    self.flash = format!("find is incomplete — {w}");
+                    self.flash_err = true;
+                } else {
+                    self.flash = format!("{} hit(s) for '{query}'", items.len());
+                    self.flash_err = false;
+                }
+                self.find_query = query;
+                self.find_items = items;
+                self.find_state
+                    .select((!self.find_items.is_empty()).then_some(0));
+            }
             Msg::PulseData { generation, data } if generation == self.generation => {
                 if let Some(w) = &data.warn {
                     self.flash = format!("pulse is incomplete — {w}");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -126,6 +126,8 @@ pub enum Mode {
     Snapshots,
     /// Cross-context fleet health dashboard (`:fleet`).
     Fleet,
+    /// Global fuzzy-find results picker (`:find <text>`).
+    Find,
 }
 
 /// A request for the run loop to suspend the TUI and run an interactive
@@ -417,6 +419,7 @@ enum PaletteAction {
     Info,
     Fleet,
     Rightsize,
+    Find,
     Diff,
     Events,
     PortForwards,
@@ -487,6 +490,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Snapshots,
         names: &["snapshots", "dumps"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Find,
+        names: &["find", "fd"],
     },
     PaletteCommand {
         action: PaletteAction::Diff,
@@ -935,6 +942,10 @@ pub struct App {
     /// context's summary lands.
     pub fleet_rows: Vec<crate::fleet::FleetRow>,
     pub fleet_state: ListState,
+    /// Global fuzzy-find (`:find`) results and picker cursor.
+    pub find_items: Vec<crate::store::FindItem>,
+    pub find_state: ListState,
+    pub find_query: String,
     /// The last bundle assembled by `:bundle`, previewed in the detail view and
     /// written to disk by `:bundle-save`: `(filename, text)`.
     pub pending_bundle: Option<(String, String)>,
@@ -1158,6 +1169,9 @@ impl App {
             fleet_cfg: crate::config::FleetConfig::default(),
             fleet_rows: Vec::new(),
             fleet_state: ListState::default(),
+            find_items: Vec::new(),
+            find_state: ListState::default(),
+            find_query: String::new(),
             pending_bundle: None,
             journal: crate::journal::Journal::default(),
             watch_errors: 0,
@@ -1265,6 +1279,7 @@ mod dashboards;
 mod details;
 mod diagnostics;
 mod explain;
+mod find;
 mod fleet;
 mod gitops;
 mod guardrails;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -406,6 +406,55 @@ async fn metrics_error_is_stored_and_cleared_by_next_success() {
 }
 
 #[tokio::test]
+async fn find_opens_picker_and_enter_navigates_to_the_object() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+
+    // Bare :find is a usage hint, not a search.
+    assert!(app.run_palette_command("find"));
+    assert!(app.flash.contains("usage"), "{}", app.flash);
+
+    assert!(app.run_palette_command("find web"));
+    assert_eq!(app.mode, Mode::Find);
+    assert_eq!(app.find_query, "web");
+
+    app.handle_msg(Msg::FindResults {
+        generation: app.generation,
+        query: "web".into(),
+        items: vec![
+            crate::store::FindItem {
+                plural: "pods".into(),
+                ns: "default".into(),
+                name: "web-1".into(),
+            },
+            crate::store::FindItem {
+                plural: "deployments".into(),
+                ns: "default".into(),
+                name: "web".into(),
+            },
+        ],
+        warn: None,
+    });
+    assert_eq!(app.find_state.selected(), Some(0));
+    assert!(app.flash.contains("2 hit(s)"), "{}", app.flash);
+
+    app.key_find(press(KeyCode::Enter));
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.fields.as_deref(), Some("metadata.name=web-1"));
+
+    // Incomplete sweeps say so instead of pretending the list is exhaustive.
+    app.handle_msg(Msg::FindResults {
+        generation: app.generation,
+        query: "web".into(),
+        items: Vec::new(),
+        warn: Some("2 kind(s) could not be listed".into()),
+    });
+    assert!(app.flash_err);
+    assert!(app.flash.contains("incomplete"), "{}", app.flash);
+}
+
+#[tokio::test]
 async fn panic_msg_flashes_regardless_of_generation() {
     let (mut app, _rx) = test_app();
     app.generation = 7; // a Panic has no generation tag and must never be dropped as stale

--- a/src/store.rs
+++ b/src/store.rs
@@ -186,6 +186,14 @@ pub enum Msg {
         generation: u64,
         row: Box<crate::fleet::FleetRow>,
     },
+    /// Results of a `:find <text>` sweep across kinds.
+    FindResults {
+        generation: u64,
+        query: String,
+        items: Vec<FindItem>,
+        /// Kinds that failed to list — the results may be incomplete.
+        warn: Option<String>,
+    },
     Error {
         generation: u64,
         error: String,
@@ -194,6 +202,14 @@ pub enum Msg {
     /// Deliberately generation-free: it must surface no matter which view is
     /// current.
     Panic(String),
+}
+
+/// One hit from the global fuzzy find (`:find <text>`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FindItem {
+    pub plural: String,
+    pub ns: String,
+    pub name: String,
 }
 
 /// Cluster-health snapshot for the pulse dashboard.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -151,6 +151,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Timeline => draw_timeline(frame, app, chunks[1]),
         Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
         Mode::Fleet => draw_fleet(frame, app, chunks[1]),
+        Mode::Find => draw_find(frame, app, chunks[1]),
         _ => draw_table(frame, app, chunks[1]),
     }
 
@@ -2108,6 +2109,36 @@ fn draw_port_forwards(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+fn draw_find(frame: &mut Frame, app: &mut App, area: Rect) {
+    let items: Vec<ListItem> = app
+        .find_items
+        .iter()
+        .map(|it| {
+            let location = if it.ns.is_empty() {
+                it.name.clone()
+            } else {
+                format!("{}/{}", it.ns, it.name)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{:<22} ", it.plural), theme::dim()),
+                Span::styled(location, Style::default().fg(theme::text())),
+            ]))
+        })
+        .collect();
+    let title = format!(
+        " Find '{}' [{}]  (⏎ open · esc close) ",
+        app.find_query,
+        app.find_items.len()
+    );
+    render_framed_list(
+        frame,
+        area,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.find_state,
+    );
+}
+
 fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
     let items: Vec<ListItem> = app
         .skin_list
@@ -2979,6 +3010,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Mode::Fleet => Line::from(Span::styled(
             "  j/k: move   ⏎: switch to context   r: refresh   esc: back",
+            theme::dim(),
+        )),
+        Mode::Find => Line::from(Span::styled(
+            "  j/k: move   ⏎: open the object   esc: close",
             theme::dim(),
         )),
         _ => {


### PR DESCRIPTION
## Summary
- `:find <text>` (alias `:fd`) answers "where is the thing called *payments*" without guessing its kind first: it lists a curated set of common kinds — workloads, pods, services, configmaps, secrets, ingresses, jobs, cronjobs, PVCs, nodes, namespaces, Kustomizations, HelmReleases — across **all namespaces concurrently**, fuzzy-matches names, and opens a ranked picker (top 200).
- `⏎` on a hit jumps straight to the object via the existing `navigate_to_target` path (a name-filtered view of its kind), so logs/YAML/events are one more keystroke away.
- Kinds the user can't list (RBAC) make the result flash "find is incomplete — N kind(s) could not be listed" instead of silently pretending the sweep was exhaustive. Bare `:find` prints usage.
- Deliberately a curated kind set rather than the full discovery catalog — listing every CRD in the cluster per search would hammer the API server for kinds nobody names things in.

## Test plan
- [x] New test: bare `:find` → usage; `:find web` opens the picker; results select the top hit and flash the count; `⏎` lands on `pods` with `metadata.name=web-1`; a warn flashes "incomplete"
- [x] `cargo test` — 400 passed; clippy `-D warnings` + fmt clean
- [x] Manual: `:find` against the home cluster with and without RBAC restrictions