### PR TITLE
docs: sync README and in-app docs with the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,10 @@ numbers.
   node → its pods, pod → containers, namespace → re-scope, CRD → its custom
   resources. Press `esc` to go back.
 - **Command palette** (`:`) — fuzzy search over the full resource catalog, the
-  built-in commands (`ctx`, `pulse`, `xray`, `explain`, `timeline`, `gitops`,
-  `can-i`, `journal`, `diff`, `events`, `pf`), and your saved
+  built-in commands (`ctx`, `helm`, `pulse`, `xray`, `explain`, `timeline`,
+  `gitops`, `can-i`, `journal`, `debug`, `debug-clean`, `bundle`,
+  `bundle-save`, `snapshot`, `snapshots`, `diff`, `events`, `pf`, `vlogs`,
+  `rightsize`, `fleet`, `skin`, `reload`, `config`, `info`), and your saved
   bookmarks/workspaces together. It also does row **filtering** (`/`) with
   matched-character highlighting: fuzzy text, `!text` inverse match, `-l`/`-f`
   label and field selectors (the API server evaluates them on ⏎), and typed
@@ -165,6 +167,18 @@ numbers.
   Kubernetes API patches.
 - **CronJob controls** (`t`) — trigger now (creates a Job from the jobTemplate,
   like `kubectl create job --from`), suspend, and resume.
+- **A native Helm inspector** (`:helm` / `:hm`) — sofka decodes Helm's release
+  storage Secrets directly (double base64 → gunzip → JSON, like Helm itself)
+  and shows one row per release at its latest revision, like `helm list`.
+  Press `⏎` on a release for its full revision history (`helm history`); on a
+  revision, `⏎` shows the user-supplied values, `y` the rendered chart
+  manifest, and `d` the NOTES.txt. `r` on a history row rolls back and
+  `ctrl-d` uninstalls — those two shell out to the real `helm` binary; all
+  the inspection is native, no `helm` needed.
+- **File transfer** (`t` on a pod, or `t` in the container picker for one
+  container) — download from or upload to a pod via `kubectl cp`, run
+  off-thread with a completion flash. Uploads are gated by the `transfer`
+  guardrail action and read-only mode.
 - **Background port-forwards** (`f`/`F` to start, `:pf` to manage).
 - **Plugins** — shell-out commands that you define in the config file and bind
   to keys, scoped for each resource. Keys are full **chords** (`ctrl-g`,
@@ -203,7 +217,8 @@ numbers.
 - **Declarative guardrails** (`[[guardrails]]`) — rules in the config file that
   match on context/namespace/resource/action globs. A rule can **deny** a
   destructive action outright
-  (`delete`/`force-delete`/`drain`/`restart`/`shell`/`debug`/`node-debug`),
+  (`delete`/`force-delete`/`drain`/`restart`/`shell`/`debug`/`node-debug`/
+  `transfer` — a file upload into a pod),
   force **type-to-confirm** (the resource name or `context/name`), or cap
   **bulk** operations. So rules like "never delete in prod", "always confirm a
   prod shell", and "no more than one at a time" are enforced, not remembered.
@@ -534,7 +549,8 @@ remember them. Each rule matches on `contexts`, `namespaces`, `resources`, and
 applies the strictest of these: `deny` (block the action), `confirmation` (type
 to confirm), and `max_bulk` (a maximum number of rows for one action). The
 gated `actions` are the destructive verbs that sofka does directly — `delete`,
-`force-delete`, `drain`, `restart`, `shell` (exec), `debug`, and `node-debug`.
+`force-delete`, `drain`, `restart`, `shell` (exec), `debug`, `node-debug`, and
+`transfer` (a file upload into a pod).
 The first rule that matches wins. sofka shows the `reason` when a rule fires.
 
 ```toml
@@ -635,6 +651,7 @@ tail, the buffer size, and an optional `since` lookback:
 tail = 300       # initial lines fetched per stream (kubectl --tail)
 buffer = 5000    # max lines kept while following (oldest dropped)
 since = "1h"     # optional: only logs newer than this — replaces tail
+fullscreen = false # open log views fullscreen (F toggles per session)
 ```
 
 In the view, `/` filters with a case-insensitive substring, a `/regex/`, or a
@@ -816,12 +833,14 @@ A switch away from it restores write mode.
 | `o`                                           | show the node hosting the selected pod                                                                                                |
 | `ctrl-r`                                      | refresh the watch                                                                                                                     |
 | `y` / `d` / `E`                               | view YAML / describe (`kubectl`) / live events                                                                                        |
+| `x`                                           | secrets: show `data` base64-decoded (as `stringData`)                                                                                 |
 | `X` / `T`                                     | explain why the selection is unhealthy / session-local state-change timeline                                                          |
 | `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                  |
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
 | `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                             |
 | `:ctx` / `:ctx <name>`                        | context switcher popup / switch directly (the name tab-completes)                                                                     |
+| `:helm`                                       | Helm releases (native storage-Secret decode): ⏎ history → values · `y` manifest · `d` notes · `r` rollback                            |
 | `:fleet`                                      | cross-context health dashboard (opt-in `[fleet]` contexts; `⏎` switches, `r` refreshes)                                               |
 | `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
 | `:reload` / `:config` / `:info`               | reload config from disk · config sources + warnings · runtime diagnostics                                                             |
@@ -835,19 +854,24 @@ A switch away from it restores write mode.
 | `:bundle` / `:bundle-save`                    | assemble a redacted diagnostic bundle for the selection · write the previewed bundle to a file                                        |
 | `:snapshot [text\|json\|yaml]` / `:snapshots` | capture the current view to a file · browse, open, and delete saved snapshots                                                         |
 | `i`                                           | set container image                                                                                                                   |
-| `r`                                           | rollout restart (workloads) / refresh (elsewhere)                                                                                     |
+| `r`                                           | rollout restart (workloads) / force-sync (ExternalSecrets/PushSecrets) / refresh (elsewhere)                                          |
 | `f` / `shift-f`                               | port-forward (pods/services) - runs in the background                                                                                 |
-| `t`                                           | Flux: suspend/resume/reconcile menu · CronJobs: trigger/suspend/resume menu                                                           |
+| `t`                                           | Flux: suspend/resume/reconcile menu · CronJobs: trigger/suspend/resume · pods: file transfer (`kubectl cp`)                           |
 | `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                      |
 | `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
 | `:q`, `ctrl-c`                                | quit                                                                                                                                  |
 | `?`                                           | help                                                                                                                                  |
 | _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                           |
 
-**Logs view:** `/` filter (substring · `/regex/` · `!invert`) · `s` autoscroll
-· `w` wrap · `t` timestamps · `x` stop/resume stream · `z` clear buffer · `c`
-copy buffer · `ctrl-s` save to file · `esc` back. The newest line anchors to
-the bottom of the viewport.
+**Logs view:** `/` filter (substring · `/regex/` · `!invert`) · `s`/`f`
+autoscroll · `w` wrap · `t` timestamps · `x` stop/resume stream · `z` clear
+buffer · `c` copy buffer · `ctrl-s` save to file · `F` fullscreen (no chrome,
+clean text selection) · `0`–`5` time anchors (tail · 1m · 5m · 15m · 30m ·
+1h) · `T` provider lookback (VictoriaLogs views) · `esc` back. The newest
+line anchors to the bottom of the viewport.
+
+**Text inputs** (palette, filters, prompts): `ctrl-u` clears the line,
+`ctrl-w` / `alt-⌫` delete the previous word.
 
 **Document views** (YAML, describe, diff, events): `/` searches like vim. The
 whole document stays on screen, and sofka highlights every match. Press `n` or

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,8 +696,8 @@ pub struct Guardrail {
     pub namespaces: Vec<String>,
     /// Resource plurals/kinds this applies to (globs). Empty = any.
     pub resources: Vec<String>,
-    /// Actions this applies to: `delete`, `force-delete`, `drain`, `shell`,
-    /// `debug`, `node-debug`. Empty = any.
+    /// Actions this applies to: `delete`, `force-delete`, `drain`, `restart`,
+    /// `shell`, `debug`, `node-debug`, `transfer`. Empty = any.
     pub actions: Vec<String>,
     /// Block the action outright.
     pub deny: bool,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1716,7 +1716,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "ctrl-u · ctrl-w",
             "text inputs: clear line (cmd-⌫) · delete word (opt-⌫)",
         ),
-        bind("n · 0-9", "namespace switcher · 0 = all namespaces"),
+        bind("n · 0", "namespace switcher · 0 = all namespaces"),
         bind("ctrl-r", "refresh watch"),
         Line::from(""),
         Line::from(Span::styled("  Inspect", theme::title())),


### PR DESCRIPTION
## Summary
Documentation-only PR closing the README-vs-code drift found in an audit — the in-app `?` help was more accurate than the README in several places.

**Previously undocumented features, now documented:**
- The entire **native Helm inspector**: `:helm` release list (storage-Secret decode, `helm list` semantics), history drill-down, values / rendered manifest / NOTES views, `r` rollback and `ctrl-d` uninstall — plus a key-table row
- **File transfer** (`t` on a pod / in the container picker, via `kubectl cp`), gated by the `transfer` guardrail
- **Secret decode** (`x` shows `data` as `stringData`)
- **External Secrets force-sync** (`r` on externalsecrets/pushsecrets)
- Logs-view keys `F` (fullscreen), `0`–`5` (time anchors), `T` (provider lookback), `f` as a follow alias; the `[logs] fullscreen` config option
- Text-input line editing (`ctrl-u`, `ctrl-w`/`alt-⌫`)

**Inaccuracies fixed:**
- The guardrail action list was wrong in three mutually disagreeing places: README (×2) now includes `transfer`, and the `config.rs` docstring gains both `restart` and `transfer` — verified against the `guard(...)` call sites
- The palette command list claimed 11 commands; it lists all 26 now
- In-app help claimed `0-9` switch namespaces; only `0` is bound (`n · 0-9` → `n · 0`)

## Test plan
- [x] `cargo test` (399) + clippy `-D warnings` + fmt clean (one string changed in `ui.rs`, one docstring in `config.rs`)
- [x] Every documented key cross-checked against `input.rs`/`actions.rs` bindings and the `guard()` call sites