### PR TITLE
feat: configurable :notify delivery ([notify] bell + desktop protocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ numbers.
   watch sees (the same transitions the timeline records — rollout progress,
   readiness, phase, restarts, waiting reasons, conditions) flashes in the
   status line, rings the terminal bell, and emits a **desktop notification**.
-  The protocol is configurable (`[notify]`): `osc9` (default — iTerm2-style;
-  iTerm2, Ghostty, kitty, WezTerm, foot, Windows Terminal) or `osc777`
-  (rxvt-style title+body — Ghostty recommends this form; also kitty, WezTerm,
-  foot, urxvt), plus `both` and `off`. Terminals ignore protocols they don't
-  speak. Each notify is its own bounded single-object watch, so it keeps
+  The protocol is configurable (`[notify]`): `osc777` (default — rxvt-style
+  title+body, the form Ghostty recommends; also kitty, WezTerm, foot, urxvt)
+  or `osc9` (iTerm2-style body-only, for iTerm2 and Windows Terminal, which
+  speak only that), plus `both` and `off`. Terminals ignore protocols they
+  don't speak. Each notify is its own bounded single-object watch, so it keeps
   firing while you browse other views — "tell me when this rollout finishes"
   and keep working. Toggle it off with `:notify` on the same row; everything
   is session-local.
@@ -241,7 +241,7 @@ numbers.
   ```toml
   [notify]
   bell = true         # ring the terminal bell
-  desktop = "osc9"    # "osc9" | "osc777" | "both" | "off"
+  desktop = "osc777"  # "osc777" | "osc9" | "both" | "off"
   ```
 
 - **Diff** (`:diff`) — a unified diff of the live object and its

--- a/README.md
+++ b/README.md
@@ -228,12 +228,22 @@ numbers.
   object. Sophie watches it so you don't have to: every state change the
   watch sees (the same transitions the timeline records — rollout progress,
   readiness, phase, restarts, waiting reasons, conditions) flashes in the
-  status line, rings the terminal bell, and emits an OSC 9 desktop
-  notification (iTerm2, kitty, WezTerm, foot; terminals without OSC 9 ignore
-  it). Each notify is its own bounded single-object watch, so it keeps firing
-  while you browse other views — "tell me when this rollout finishes" and
-  keep working. Toggle it off with `:notify` on the same row; everything is
-  session-local.
+  status line, rings the terminal bell, and emits a **desktop notification**.
+  The protocol is configurable (`[notify]`): `osc9` (default — iTerm2-style;
+  iTerm2, Ghostty, kitty, WezTerm, foot, Windows Terminal) or `osc777`
+  (rxvt-style title+body — Ghostty recommends this form; also kitty, WezTerm,
+  foot, urxvt), plus `both` and `off`. Terminals ignore protocols they don't
+  speak. Each notify is its own bounded single-object watch, so it keeps
+  firing while you browse other views — "tell me when this rollout finishes"
+  and keep working. Toggle it off with `:notify` on the same row; everything
+  is session-local.
+
+  ```toml
+  [notify]
+  bell = true         # ring the terminal bell
+  desktop = "osc9"    # "osc9" | "osc777" | "both" | "off"
+  ```
+
 - **Diff** (`:diff`) — a unified diff of the live object and its
   `last-applied-configuration`. When that annotation is absent — as it is for
   every Flux- or Helm-managed object, which nothing ever `kubectl apply`s —

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1307,11 +1307,13 @@ impl App {
         self.fleet_cfg = resolved.config.fleet;
         // Running forwards keep running; :reload only refreshes what's saved.
         self.forwards_cfg = resolved.config.forwards;
+        self.notify_cfg = resolved.config.notify;
         warnings.extend(crate::config::plugin_warnings(&self.plugins));
         warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
         warnings.extend(crate::config::forward_warnings(&self.forwards_cfg));
+        warnings.extend(crate::config::notify_warnings(&self.notify_cfg));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1033,6 +1033,8 @@ pub struct App {
     /// Saved `[[forwards]]` from config: shown in `:pf` even while stopped,
     /// startable with one keystroke, autostarted on connect when configured.
     pub forwards_cfg: Vec<crate::config::Forward>,
+    /// `[notify]` delivery options (bell, desktop-notification protocol).
+    pub notify_cfg: crate::config::NotifyConfig,
 
     pub skin_list: Vec<String>,
     pub skin_state: ListState,
@@ -1246,6 +1248,7 @@ impl App {
             transfer_target: None,
             port_forwards: Vec::new(),
             forwards_cfg: Vec::new(),
+            notify_cfg: crate::config::NotifyConfig::default(),
             pf_state: ListState::default(),
             skin_list: crate::theme::BUILTIN_NAMES
                 .iter()
@@ -1361,6 +1364,7 @@ mod timeline;
 mod workspaces;
 
 use helpers::*;
+pub use notify::notification_sequence;
 pub use pickers::DEFAULT_SORT_LABEL;
 
 #[cfg(test)]

--- a/src/app/notify.rs
+++ b/src/app/notify.rs
@@ -5,7 +5,7 @@ impl App {
     /// active, every state change the watch sees for it (the same transitions
     /// the timeline records: rollout progress, readiness, phase, restarts,
     /// waiting reasons, conditions) flashes, rings the terminal bell, and
-    /// emits an OSC 9 desktop notification. Each notify is its own bounded
+    /// emits a desktop notification (`[notify]`). Each notify is its own bounded
     /// single-object watch, so it keeps firing no matter which view is open,
     /// until toggled off or the session ends. Nothing touches disk.
     pub(super) fn toggle_notify(&mut self) {
@@ -124,7 +124,7 @@ impl App {
 /// - `osc777` — rxvt-style `notify;title;body`: Ghostty (which recommends
 ///   it), kitty, WezTerm, foot, urxvt.
 ///
-/// An unknown `desktop` value behaves as the default `osc9` (it warned at
+/// An unknown `desktop` value behaves as the default `osc777` (it warned at
 /// config load).
 pub fn notification_sequence(text: &str, cfg: &crate::config::NotifyConfig) -> String {
     let clean: String = text.chars().filter(|c| !c.is_control()).collect();
@@ -134,7 +134,7 @@ pub fn notification_sequence(text: &str, cfg: &crate::config::NotifyConfig) -> S
     }
     let desktop = match cfg.desktop.as_str() {
         d @ ("osc9" | "osc777" | "both" | "off") => d,
-        _ => "osc9",
+        _ => "osc777",
     };
     if matches!(desktop, "osc9" | "both") {
         seq.push_str(&format!("\x1b]9;sofka: {clean}\x07"));

--- a/src/app/notify.rs
+++ b/src/app/notify.rs
@@ -106,9 +106,41 @@ impl App {
         self.flash_err = false;
     }
 
-    /// The message the main loop should ring the bell / emit OSC 9 for, if a
-    /// notification arrived since the last frame.
+    /// The message the main loop should ring the bell / emit a desktop
+    /// notification for, if one arrived since the last frame.
     pub fn take_notification(&mut self) -> Option<String> {
         self.pending_notify.take()
     }
+}
+
+/// The terminal escape sequences that deliver one `:notify` event, per the
+/// `[notify]` config: an optional BEL, then the chosen desktop-notification
+/// protocol(s). Control characters are stripped so object content can't
+/// smuggle sequences; BEL-terminated OSC matches every terminal's documented
+/// examples.
+///
+/// - `osc9` — iTerm2-style, body only: iTerm2, Ghostty, kitty, WezTerm,
+///   foot, Windows Terminal.
+/// - `osc777` — rxvt-style `notify;title;body`: Ghostty (which recommends
+///   it), kitty, WezTerm, foot, urxvt.
+///
+/// An unknown `desktop` value behaves as the default `osc9` (it warned at
+/// config load).
+pub fn notification_sequence(text: &str, cfg: &crate::config::NotifyConfig) -> String {
+    let clean: String = text.chars().filter(|c| !c.is_control()).collect();
+    let mut seq = String::new();
+    if cfg.bell {
+        seq.push('\x07');
+    }
+    let desktop = match cfg.desktop.as_str() {
+        d @ ("osc9" | "osc777" | "both" | "off") => d,
+        _ => "osc9",
+    };
+    if matches!(desktop, "osc9" | "both") {
+        seq.push_str(&format!("\x1b]9;sofka: {clean}\x07"));
+    }
+    if matches!(desktop, "osc777" | "both") {
+        seq.push_str(&format!("\x1b]777;notify;sofka;{clean}\x07"));
+    }
+    seq
 }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -574,6 +574,7 @@ impl App {
         // context are deliberately left alone (kubectl pinned their context
         // at spawn); autostart only adds what's missing here.
         self.forwards_cfg = resolved.config.forwards;
+        self.notify_cfg = resolved.config.notify;
         self.start_autostart_forwards();
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -706,9 +706,17 @@ fn notification_sequences_follow_the_configured_protocol() {
     let dflt = NotifyConfig::default();
     let seq = notification_sequence("pod/web: Ready", &dflt);
     assert!(seq.starts_with('\x07'), "bell on by default");
-    assert!(seq.contains("\x1b]9;sofka: pod/web: Ready\x07"), "{seq:?}");
-    assert!(!seq.contains("]777;"), "one protocol by default: {seq:?}");
+    assert!(
+        seq.contains("\x1b]777;notify;sofka;pod/web: Ready\x07"),
+        "titled osc777 is the default: {seq:?}"
+    );
+    assert!(!seq.contains("]9;"), "one protocol by default: {seq:?}");
 
+    let osc9 = NotifyConfig {
+        bell: false,
+        desktop: "osc9".into(),
+    };
+    assert_eq!(notification_sequence("hi", &osc9), "\x1b]9;sofka: hi\x07");
     let osc777 = NotifyConfig {
         bell: false,
         desktop: "osc777".into(),
@@ -742,7 +750,7 @@ fn notification_sequences_follow_the_configured_protocol() {
         bell: false,
         desktop: "growl".into(),
     };
-    assert!(notification_sequence("hi", &bad).contains("]9;"));
+    assert!(notification_sequence("hi", &bad).contains("]777;"));
     assert_eq!(notify_warnings(&bad).len(), 1);
     assert!(notify_warnings(&dflt).is_empty());
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -699,6 +699,54 @@ async fn notify_msg_flashes_and_queues_bell() {
     assert_eq!(app.take_notification(), None, "consumed once");
 }
 
+#[test]
+fn notification_sequences_follow_the_configured_protocol() {
+    use crate::config::{NotifyConfig, notify_warnings};
+
+    let dflt = NotifyConfig::default();
+    let seq = notification_sequence("pod/web: Ready", &dflt);
+    assert!(seq.starts_with('\x07'), "bell on by default");
+    assert!(seq.contains("\x1b]9;sofka: pod/web: Ready\x07"), "{seq:?}");
+    assert!(!seq.contains("]777;"), "one protocol by default: {seq:?}");
+
+    let osc777 = NotifyConfig {
+        bell: false,
+        desktop: "osc777".into(),
+    };
+    assert_eq!(
+        notification_sequence("hi", &osc777),
+        "\x1b]777;notify;sofka;hi\x07"
+    );
+
+    let both = NotifyConfig {
+        bell: false,
+        desktop: "both".into(),
+    };
+    let seq = notification_sequence("hi", &both);
+    assert!(seq.contains("]9;") && seq.contains("]777;"), "{seq:?}");
+
+    let off = NotifyConfig {
+        bell: false,
+        desktop: "off".into(),
+    };
+    assert!(notification_sequence("hi", &off).is_empty());
+
+    // Control characters in object-derived text can't smuggle sequences.
+    assert_eq!(
+        notification_sequence("a\x1b]0;evil\x07b", &osc777),
+        "\x1b]777;notify;sofka;a]0;evilb\x07"
+    );
+
+    // Unknown protocol behaves as the default (it warned at config load).
+    let bad = NotifyConfig {
+        bell: false,
+        desktop: "growl".into(),
+    };
+    assert!(notification_sequence("hi", &bad).contains("]9;"));
+    assert_eq!(notify_warnings(&bad).len(), 1);
+    assert!(notify_warnings(&dflt).is_empty());
+}
+
 #[tokio::test]
 async fn find_opens_picker_and_enter_navigates_to_the_object() {
     let (mut app, _rx) = test_app();

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,51 @@ pub struct Config {
     /// `None` = on. Set `mouse = false` to keep the terminal's native mouse
     /// behavior (text selection) instead.
     pub mouse: Option<bool>,
+    /// How `:notify` events are delivered — see [`NotifyConfig`].
+    pub notify: NotifyConfig,
+}
+
+/// Delivery for `:notify` events, besides the status-line flash.
+///
+/// ```toml
+/// [notify]
+/// bell = true         # ring the terminal bell
+/// desktop = "osc9"    # "osc9" | "osc777" | "both" | "off"
+/// ```
+///
+/// `osc9` is the iTerm2-style body-only notification (iTerm2, Ghostty,
+/// kitty, WezTerm, foot, Windows Terminal). `osc777` is the rxvt-style
+/// title+body form (Ghostty — which recommends it — kitty, WezTerm, foot,
+/// urxvt). Terminals ignore protocols they don't speak, but one that speaks
+/// both would show two notifications under `both` — hence a choice, not a
+/// broadcast.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct NotifyConfig {
+    /// Ring the terminal bell on a notification.
+    pub bell: bool,
+    /// Desktop-notification escape protocol: `osc9`, `osc777`, `both`, `off`.
+    pub desktop: String,
+}
+
+impl Default for NotifyConfig {
+    fn default() -> Self {
+        Self {
+            bell: true,
+            desktop: "osc9".into(),
+        }
+    }
+}
+
+/// Validate `[notify]`: an unknown `desktop` value warns and behaves as the
+/// default (`osc9`).
+pub fn notify_warnings(cfg: &NotifyConfig) -> Vec<String> {
+    match cfg.desktop.as_str() {
+        "osc9" | "osc777" | "both" | "off" => Vec::new(),
+        other => vec![format!(
+            "notify: desktop '{other}' is not osc9/osc777/both/off; using osc9"
+        )],
+    }
 }
 
 /// A named, saved port-forward. Shows up in `:pf` even when stopped, so one

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,21 +101,22 @@ pub struct Config {
 /// ```toml
 /// [notify]
 /// bell = true         # ring the terminal bell
-/// desktop = "osc9"    # "osc9" | "osc777" | "both" | "off"
+/// desktop = "osc777"  # "osc777" | "osc9" | "both" | "off"
 /// ```
 ///
-/// `osc9` is the iTerm2-style body-only notification (iTerm2, Ghostty,
-/// kitty, WezTerm, foot, Windows Terminal). `osc777` is the rxvt-style
-/// title+body form (Ghostty — which recommends it — kitty, WezTerm, foot,
-/// urxvt). Terminals ignore protocols they don't speak, but one that speaks
-/// both would show two notifications under `both` — hence a choice, not a
+/// `osc777` (the default) is the rxvt-style title+body form Ghostty
+/// recommends (Ghostty, kitty, WezTerm, foot, urxvt). `osc9` is the
+/// iTerm2-style body-only notification for terminals that speak only that
+/// (iTerm2, Windows Terminal; also Ghostty, kitty, WezTerm, foot).
+/// Terminals ignore protocols they don't speak, but one that speaks both
+/// would show two notifications under `both` — hence a choice, not a
 /// broadcast.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct NotifyConfig {
     /// Ring the terminal bell on a notification.
     pub bell: bool,
-    /// Desktop-notification escape protocol: `osc9`, `osc777`, `both`, `off`.
+    /// Desktop-notification escape protocol: `osc777`, `osc9`, `both`, `off`.
     pub desktop: String,
 }
 
@@ -123,18 +124,18 @@ impl Default for NotifyConfig {
     fn default() -> Self {
         Self {
             bell: true,
-            desktop: "osc9".into(),
+            desktop: "osc777".into(),
         }
     }
 }
 
 /// Validate `[notify]`: an unknown `desktop` value warns and behaves as the
-/// default (`osc9`).
+/// default (`osc777`).
 pub fn notify_warnings(cfg: &NotifyConfig) -> Vec<String> {
     match cfg.desktop.as_str() {
         "osc9" | "osc777" | "both" | "off" => Vec::new(),
         other => vec![format!(
-            "notify: desktop '{other}' is not osc9/osc777/both/off; using osc9"
+            "notify: desktop '{other}' is not osc777/osc9/both/off; using osc777"
         )],
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,12 +192,14 @@ async fn main() -> Result<()> {
     app.logs.fullscreen = cfg.logs.fullscreen;
     app.fleet_cfg = cfg.fleet.clone();
     app.forwards_cfg = cfg.forwards.clone();
+    app.notify_cfg = cfg.notify.clone();
     for w in config::plugin_warnings(&app.plugins)
         .into_iter()
         .chain(config::bookmark_warnings(&app.bookmarks))
         .chain(config::workspace_warnings(&app.workspaces))
         .chain(config::guardrail_warnings(&app.guardrails))
         .chain(config::forward_warnings(&app.forwards_cfg))
+        .chain(config::notify_warnings(&app.notify_cfg))
     {
         eprintln!("warning: {w}");
         config_warnings.push(w);
@@ -429,16 +431,13 @@ async fn snapshot(app: &mut App, rx: &mut mpsc::Receiver<store::Msg>) -> Result<
     Ok(())
 }
 
-/// Ring the terminal bell and emit an OSC 9 desktop notification for a
-/// `:notify` event. OSC 9 pops a system notification on terminals that
-/// support it (iTerm2, kitty, WezTerm, foot…) and is ignored by the rest;
-/// control characters are stripped so log content can't smuggle sequences.
-fn ring_notification(text: &str) {
-    let clean: String = text.chars().filter(|c| !c.is_control()).collect();
-    let _ = crossterm::execute!(
-        std::io::stdout(),
-        crossterm::style::Print(format!("\x07\x1b]9;sofka: {clean}\x1b\\"))
-    );
+/// Emit the configured bell + desktop-notification sequences for a `:notify`
+/// event (see [`config::NotifyConfig`] and `app::notify::notification_sequence`).
+fn ring_notification(text: &str, cfg: &config::NotifyConfig) {
+    let seq = app::notification_sequence(text, cfg);
+    if !seq.is_empty() {
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::style::Print(seq));
+    }
 }
 
 /// Leave the alt-screen/raw-mode TUI, run an interactive command with inherited
@@ -594,7 +593,7 @@ async fn run(
                     app.handle_msg(m);
                 }
                 if let Some(text) = app.take_notification() {
-                    ring_notification(&text);
+                    ring_notification(&text, &app.notify_cfg);
                 }
                 dirty = true;
             }


### PR DESCRIPTION
## Summary
- `:notify` hardcoded bell + OSC 9. A new `[notify]` config section makes delivery configurable:
  - `desktop = "osc777"` (**default**) — rxvt-style `notify;title;body`, the form [Ghostty recommends](https://ghostty.org/docs/vt/osc/9) and renders with a proper "sofka" title: Ghostty, kitty, WezTerm, foot, urxvt
  - `desktop = "osc9"` — iTerm2-style body-only notification, for iTerm2 and Windows Terminal (which speak only that); also understood by Ghostty, kitty, WezTerm, foot
  - `desktop = "both"` / `"off"`, and `bell = true|false`
- One protocol by default on purpose: terminals that speak several (Ghostty, kitty, WezTerm, foot) would show **duplicate** notifications if sofka broadcast them all.
- OSC sequences are now BEL-terminated (matches every terminal's documented examples; the previous ST terminator worked in most but not all). Control characters are still stripped so object-derived text can't smuggle escape sequences.
- Unknown `desktop` values warn at config load (`:config`) and behave as the default; the section re-applies on `:reload` and per-context on context switches like every other config section.
- Sequence building is a pure function (`notification_sequence`) so the exact bytes are unit-tested.

Note: iTerm2/Windows Terminal users need one line (`desktop = "osc9"`) to keep desktop notifications — called out in the README.

## Test plan
- [x] Test pins the exact emitted bytes per protocol: default (bell + titled OSC 777 only), osc9, both, off, control-character stripping, unknown-value fallback + load warning
- [x] `cargo test` — 416 passed; clippy `-D warnings` + fmt clean
- [ ] Manual: smoke in Ghostty with the default and kitty/iTerm2 with `osc9`

Sources: [Ghostty OSC 9 docs](https://ghostty.org/docs/vt/osc/9), [kitty desktop notifications](https://sw.kovidgoyal.net/kitty/desktop-notifications/)