### PR TITLE
feat: :notify via notifier subprocess + herdr toast auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,13 @@ numbers.
   title+body, the form Ghostty recommends; also kitty, WezTerm, foot, urxvt)
   or `osc9` (iTerm2-style body-only, for iTerm2 and Windows Terminal, which
   speak only that), plus `both` and `off`. Terminals ignore protocols they
-  don't speak. Each notify is its own bounded single-object watch, so it keeps
+  don't speak. Inside a **terminal multiplexer** — which swallows escape
+  sequences from its panes — set `command` to run a local notifier
+  subprocess instead (`$MESSAGE` substitutes as a whole argument, never via
+  a shell). In a **herdr** pane no config is needed at all: sofka detects
+  the pane environment and delivers through `herdr notification show`, so
+  the toast follows herdr's own `ui.toast` delivery (in-app, outer
+  terminal, or system). Each notify is its own bounded single-object watch, so it keeps
   firing while you browse other views — "tell me when this rollout finishes"
   and keep working. Toggle it off with `:notify` on the same row; everything
   is session-local.
@@ -242,6 +248,8 @@ numbers.
   [notify]
   bell = true         # ring the terminal bell
   desktop = "osc777"  # "osc777" | "osc9" | "both" | "off"
+  # command = ["notify-send", "sofka", "$MESSAGE"]     # Linux, inside tmux
+  # command = ["terminal-notifier", "-title", "sofka"] # macOS ($MESSAGE appended)
   ```
 
 - **Diff** (`:diff`) — a unified diff of the live object and its

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -597,6 +597,7 @@ impl App {
             Msg::Notify(text) => {
                 self.flash = format!("🔔 {text}");
                 self.flash_err = false;
+                self.run_notify_command(&text);
                 self.pending_notify = Some(text);
             }
             Msg::LogLines { generation, lines } if generation == self.log_gen => {

--- a/src/app/notify.rs
+++ b/src/app/notify.rs
@@ -111,6 +111,74 @@ impl App {
     pub fn take_notification(&mut self) -> Option<String> {
         self.pending_notify.take()
     }
+
+    /// Deliver one `:notify` event through the notifier subprocess, when one
+    /// applies (`[notify] command`, or the herdr auto-detection) — the route
+    /// that survives terminal multiplexers, which swallow pane escape
+    /// sequences. Fire-and-forget with nulled stdio; a notifier that can't
+    /// even start is worth one warning, not a broken TUI.
+    pub(super) fn run_notify_command(&mut self, text: &str) {
+        let Some(argv) = notification_command(&self.notify_cfg, in_herdr_pane(), text) else {
+            return;
+        };
+        let mut cmd = tokio::process::Command::new(&argv[0]);
+        cmd.args(&argv[1..])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        if let Err(e) = cmd.spawn() {
+            self.flash_warn(&format!("notify command '{}' failed: {e}", argv[0]));
+        }
+    }
+}
+
+/// Whether this process runs inside a herdr pane (herdr exports its socket
+/// path into every pane's environment). Always false under test, so a suite
+/// run inside a herdr pane doesn't pop real toasts.
+fn in_herdr_pane() -> bool {
+    !cfg!(test) && std::env::var_os("HERDR_SOCKET_PATH").is_some()
+}
+
+/// The notifier argv for one notification, if any applies. An explicit
+/// `[notify] command` wins: `$MESSAGE` substitutes as whole arguments (never
+/// spliced into a shell string), and with no placeholder the message is
+/// appended. With no command configured, a herdr pane auto-routes through
+/// `herdr notification show`, which delivers via herdr's own `ui.toast`
+/// setting — pane escape sequences would be swallowed there anyway.
+pub fn notification_command(
+    cfg: &crate::config::NotifyConfig,
+    in_herdr: bool,
+    text: &str,
+) -> Option<Vec<String>> {
+    let explicit = cfg
+        .command
+        .first()
+        .is_some_and(|exe| !exe.trim().is_empty());
+    if explicit {
+        let mut argv: Vec<String> = cfg.command.clone();
+        let mut substituted = false;
+        for arg in argv.iter_mut().skip(1) {
+            if arg.contains("$MESSAGE") {
+                *arg = arg.replace("$MESSAGE", text);
+                substituted = true;
+            }
+        }
+        if !substituted {
+            argv.push(text.to_string());
+        }
+        return Some(argv);
+    }
+    if in_herdr {
+        return Some(vec![
+            "herdr".into(),
+            "notification".into(),
+            "show".into(),
+            "sofka".into(),
+            "--body".into(),
+            text.to_string(),
+        ]);
+    }
+    None
 }
 
 /// The terminal escape sequences that deliver one `:notify` event, per the

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -715,11 +715,13 @@ fn notification_sequences_follow_the_configured_protocol() {
     let osc9 = NotifyConfig {
         bell: false,
         desktop: "osc9".into(),
+        ..NotifyConfig::default()
     };
     assert_eq!(notification_sequence("hi", &osc9), "\x1b]9;sofka: hi\x07");
     let osc777 = NotifyConfig {
         bell: false,
         desktop: "osc777".into(),
+        ..NotifyConfig::default()
     };
     assert_eq!(
         notification_sequence("hi", &osc777),
@@ -729,6 +731,7 @@ fn notification_sequences_follow_the_configured_protocol() {
     let both = NotifyConfig {
         bell: false,
         desktop: "both".into(),
+        ..NotifyConfig::default()
     };
     let seq = notification_sequence("hi", &both);
     assert!(seq.contains("]9;") && seq.contains("]777;"), "{seq:?}");
@@ -736,6 +739,7 @@ fn notification_sequences_follow_the_configured_protocol() {
     let off = NotifyConfig {
         bell: false,
         desktop: "off".into(),
+        ..NotifyConfig::default()
     };
     assert!(notification_sequence("hi", &off).is_empty());
 
@@ -749,10 +753,67 @@ fn notification_sequences_follow_the_configured_protocol() {
     let bad = NotifyConfig {
         bell: false,
         desktop: "growl".into(),
+        ..NotifyConfig::default()
     };
     assert!(notification_sequence("hi", &bad).contains("]777;"));
     assert_eq!(notify_warnings(&bad).len(), 1);
     assert!(notify_warnings(&dflt).is_empty());
+}
+
+#[test]
+fn notify_command_resolution_prefers_explicit_then_herdr() {
+    use super::notify::notification_command;
+    use crate::config::{NotifyConfig, notify_warnings};
+
+    // No command, not in herdr → nothing to run.
+    let dflt = NotifyConfig::default();
+    assert_eq!(notification_command(&dflt, false, "hi"), None);
+
+    // In a herdr pane, notifications auto-route through herdr's toast CLI.
+    assert_eq!(
+        notification_command(&dflt, true, "pod/web: Ready"),
+        Some(vec![
+            "herdr".into(),
+            "notification".into(),
+            "show".into(),
+            "sofka".into(),
+            "--body".into(),
+            "pod/web: Ready".into(),
+        ])
+    );
+
+    // An explicit command wins over herdr; $MESSAGE substitutes as a whole
+    // argument (never spliced into a shell string).
+    let explicit = NotifyConfig {
+        command: vec!["notify-send".into(), "sofka".into(), "$MESSAGE".into()],
+        ..NotifyConfig::default()
+    };
+    assert_eq!(
+        notification_command(&explicit, true, "a; rm -rf /"),
+        Some(vec![
+            "notify-send".into(),
+            "sofka".into(),
+            "a; rm -rf /".into(),
+        ])
+    );
+
+    // Without a $MESSAGE placeholder, the message appends as the last arg.
+    let bare = NotifyConfig {
+        command: vec!["terminal-notifier".into(), "-title".into(), "sofka".into()],
+        ..NotifyConfig::default()
+    };
+    let argv = notification_command(&bare, false, "hi").unwrap();
+    assert_eq!(argv.last().map(String::as_str), Some("hi"));
+
+    // An empty executable is invalid: warned at load, ignored at delivery
+    // (herdr auto-detection still applies).
+    let empty = NotifyConfig {
+        command: vec!["".into()],
+        ..NotifyConfig::default()
+    };
+    assert_eq!(notify_warnings(&empty).len(), 1);
+    assert!(notification_command(&empty, false, "hi").is_none());
+    assert!(notification_command(&empty, true, "hi").is_some_and(|v| v[0] == "herdr"));
 }
 
 #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,7 @@ pub struct Config {
 /// [notify]
 /// bell = true         # ring the terminal bell
 /// desktop = "osc777"  # "osc777" | "osc9" | "both" | "off"
+/// # command = ["notify-send", "sofka", "$MESSAGE"]   # optional subprocess
 /// ```
 ///
 /// `osc777` (the default) is the rxvt-style title+body form Ghostty
@@ -111,6 +112,15 @@ pub struct Config {
 /// Terminals ignore protocols they don't speak, but one that speaks both
 /// would show two notifications under `both` — hence a choice, not a
 /// broadcast.
+///
+/// `command` runs a local notifier subprocess instead of relying on escape
+/// sequences — the route that works inside terminal multiplexers, which
+/// swallow OSC sequences from their panes. `$MESSAGE` substitutes as a whole
+/// argument (never spliced into a shell string); without a `$MESSAGE`
+/// placeholder the message is appended as the final argument. Inside
+/// **herdr** no configuration is needed: sofka detects the pane environment
+/// and delivers through `herdr notification show`, which honours herdr's own
+/// `ui.toast` delivery (in-app, outer terminal, or system).
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct NotifyConfig {
@@ -118,6 +128,9 @@ pub struct NotifyConfig {
     pub bell: bool,
     /// Desktop-notification escape protocol: `osc777`, `osc9`, `both`, `off`.
     pub desktop: String,
+    /// Notifier subprocess (argv). Empty = none configured (herdr panes
+    /// auto-detect). `$MESSAGE` substitutes the notification text.
+    pub command: Vec<String>,
 }
 
 impl Default for NotifyConfig {
@@ -125,19 +138,26 @@ impl Default for NotifyConfig {
         Self {
             bell: true,
             desktop: "osc777".into(),
+            command: Vec::new(),
         }
     }
 }
 
 /// Validate `[notify]`: an unknown `desktop` value warns and behaves as the
-/// default (`osc777`).
+/// default (`osc777`); a `command` with an empty executable warns and is
+/// ignored.
 pub fn notify_warnings(cfg: &NotifyConfig) -> Vec<String> {
+    let mut warnings = Vec::new();
     match cfg.desktop.as_str() {
-        "osc9" | "osc777" | "both" | "off" => Vec::new(),
-        other => vec![format!(
+        "osc9" | "osc777" | "both" | "off" => {}
+        other => warnings.push(format!(
             "notify: desktop '{other}' is not osc777/osc9/both/off; using osc777"
-        )],
+        )),
     }
+    if cfg.command.first().is_some_and(|exe| exe.trim().is_empty()) {
+        warnings.push("notify: command has an empty executable; ignored".into());
+    }
+    warnings
 }
 
 /// A named, saved port-forward. Shows up in `:pf` even when stopped, so one


### PR DESCRIPTION
## Summary
Escape-sequence notifications (OSC 9/777) can't cross a terminal multiplexer — tmux and herdr consume their panes' escape sequences, so the outer terminal never sees them. Two additions:

- **`[notify] command`** — run a local notifier subprocess instead of (or alongside) the escape sequences: `notify-send` on Linux, `terminal-notifier` on macOS, anything. `$MESSAGE` substitutes as a **whole argument** (the plugins-style placeholder rule — never spliced into a shell string); with no placeholder the message is appended as the final argument. Fire-and-forget with nulled stdio; a notifier that fails to spawn is one flash-warning, never a broken TUI. An empty executable warns at load and is ignored.
- **herdr auto-detection** — herdr exports `HERDR_SOCKET_PATH` into every pane and ships a toast CLI (`herdr notification show <title> --body …`) that delivers via the user's `ui.toast` setting (in-app toast, outer-terminal notification, or the OS notification service). When sofka finds itself in a herdr pane and no explicit `command` is set, `:notify` events route through that automatically — **zero config**. An explicit `command` always wins.

Background: herdr has no OSC 9/777 passthrough (its Claude Code notifications come from its own agent-state detection, not from forwarding the agent's escape sequences), so the subprocess route is the only reliable delivery from inside a pane.

## Test plan
- [x] New test pins the resolution order: none → herdr auto-CLI argv (exact) → explicit command wins over herdr; `$MESSAGE` whole-argument substitution (shell metacharacters stay inert); append-when-no-placeholder; empty executable ignored with a load warning
- [x] herdr detection is env-based (`HERDR_SOCKET_PATH`) and forced off under `cfg!(test)` so suites run inside herdr stay hermetic
- [x] `cargo test` — 417 passed; clippy `-D warnings` + fmt clean
- [ ] Manual: `:notify` a deployment inside a herdr pane → toast via herdr; same in tmux with `command = ["terminal-notifier", "-title", "sofka"]`

Sources: [herdr CLI reference](https://herdr.dev/docs/cli-reference/), [herdr config reference](https://herdr.dev/docs/config-reference/)