### PR TITLE
fix: coalesce :notify bursts into one delivery

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -597,8 +597,9 @@ impl App {
             Msg::Notify(text) => {
                 self.flash = format!("🔔 {text}");
                 self.flash_err = false;
-                self.run_notify_command(&text);
-                self.pending_notify = Some(text);
+                // Delivery happens once per frame in the run loop (see
+                // `take_notification`), so a batch of these coalesces.
+                self.pending_notify.push(text);
             }
             Msg::LogLines { generation, lines } if generation == self.log_gen => {
                 self.push_log_lines(lines);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1099,9 +1099,11 @@ pub struct App {
     /// a notify must survive `bump_generation` (view switches) and fire from
     /// anywhere until toggled off.
     pub(super) notify_tasks: HashMap<String, tokio::task::JoinHandle<()>>,
-    /// A notification waiting for the main loop to ring the terminal bell and
-    /// emit an OSC 9 desktop notification for.
-    pub(super) pending_notify: Option<String>,
+    /// Notifications waiting for the main loop to deliver (bell, desktop
+    /// escape sequence, notifier subprocess). Drained once per frame and
+    /// joined, so a burst arriving in one batch is one delivery — sinks
+    /// rate-limit rapid-fire notifications.
+    pub(super) pending_notify: Vec<String>,
     /// Previous object revisions for the session diff (`:diff` fallback).
     pub(super) prev_revisions: PrevRevisions,
     /// The `(plural, row_key)` the timeline view is showing, and its cursor.
@@ -1282,7 +1284,7 @@ impl App {
             timeline: crate::timeline::Timeline::default(),
             table_hit: RefCell::new(None),
             notify_tasks: HashMap::new(),
-            pending_notify: None,
+            pending_notify: Vec::new(),
             prev_revisions: PrevRevisions::default(),
             timeline_target: None,
             timeline_state: ListState::default(),

--- a/src/app/notify.rs
+++ b/src/app/notify.rs
@@ -65,15 +65,22 @@ impl App {
             while let Some(event) = stream.next().await {
                 match event {
                     Ok(watcher::Event::Apply(o)) | Ok(watcher::Event::InitApply(o)) => {
-                        let news: Vec<String> = match &prev {
+                        // One watch event → ONE notification. A single change
+                        // often carries several transitions (phase + Ready +
+                        // restarts); separate notifications land microseconds
+                        // apart, and notification sinks rate-limit such bursts
+                        // (herdr drops all but the first), so joining is what
+                        // keeps them deliverable — and more readable.
+                        let items: Vec<String> = match &prev {
                             Some(p) => crate::timeline::transitions(p, &o, &plural)
                                 .into_iter()
-                                .map(|(_, text)| format!("{label}: {text}"))
+                                .map(|(_, text)| text)
                                 .collect(),
-                            None if synced => vec![format!("{label}: created")],
+                            None if synced => vec!["created".into()],
                             None => Vec::new(),
                         };
-                        for text in news {
+                        if !items.is_empty() {
+                            let text = format!("{label}: {}", items.join(" · "));
                             if tx.send(Msg::Notify(text)).await.is_err() {
                                 return;
                             }
@@ -106,10 +113,17 @@ impl App {
         self.flash_err = false;
     }
 
-    /// The message the main loop should ring the bell / emit a desktop
-    /// notification for, if one arrived since the last frame.
+    /// The message the main loop should deliver (bell, escape sequence,
+    /// notifier subprocess), if any arrived since the last frame. Multiple
+    /// pending notifications join into one message — one delivery per frame,
+    /// bounded, so bursts survive sink rate limiting.
     pub fn take_notification(&mut self) -> Option<String> {
-        self.pending_notify.take()
+        if self.pending_notify.is_empty() {
+            return None;
+        }
+        let text = self.pending_notify.join(" · ");
+        self.pending_notify.clear();
+        Some(crate::text::ellipsize(&text, 300))
     }
 
     /// Deliver one `:notify` event through the notifier subprocess, when one
@@ -117,7 +131,7 @@ impl App {
     /// that survives terminal multiplexers, which swallow pane escape
     /// sequences. Fire-and-forget with nulled stdio; a notifier that can't
     /// even start is worth one warning, not a broken TUI.
-    pub(super) fn run_notify_command(&mut self, text: &str) {
+    pub fn run_notify_command(&mut self, text: &str) {
         let Some(argv) = notification_command(&self.notify_cfg, in_herdr_pane(), text) else {
             return;
         };

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -699,6 +699,27 @@ async fn notify_msg_flashes_and_queues_bell() {
     assert_eq!(app.take_notification(), None, "consumed once");
 }
 
+#[tokio::test]
+async fn notification_bursts_coalesce_into_one_delivery() {
+    // Notification sinks rate-limit rapid-fire messages (herdr drops all but
+    // the first of a burst) — everything pending in one frame batch must
+    // leave as a single bounded delivery.
+    let (mut app, _rx) = test_app();
+    app.handle_msg(Msg::Notify("pod/a: Ready True → False".into()));
+    app.handle_msg(Msg::Notify("pod/a: deleted".into()));
+    assert_eq!(
+        app.take_notification().as_deref(),
+        Some("pod/a: Ready True → False · pod/a: deleted")
+    );
+    assert_eq!(app.take_notification(), None);
+
+    for i in 0..100 {
+        app.handle_msg(Msg::Notify(format!("pod/pod-{i}: restarts 0 → 1")));
+    }
+    let text = app.take_notification().unwrap();
+    assert!(text.chars().count() <= 300, "bounded: {}", text.len());
+}
+
 #[test]
 fn notification_sequences_follow_the_configured_protocol() {
     use crate::config::{NotifyConfig, notify_warnings};

--- a/src/main.rs
+++ b/src/main.rs
@@ -593,6 +593,7 @@ async fn run(
                     app.handle_msg(m);
                 }
                 if let Some(text) = app.take_notification() {
+                    app.run_notify_command(&text);
                     ring_notification(&text, &app.notify_cfg);
                 }
                 dirty = true;


### PR DESCRIPTION
## Summary
Debugged live inside a herdr pane: sofka's herdr delivery was working (env present, spawn succeeding, `herdr notification show` verified end-to-end from the CLI), yet `:notify` toasts never appeared — while single CLI calls did. The tell was herdr's response to two back-to-back calls: `{"reason":"rate_limited","shown":false}`. **herdr rate-limits toast bursts**, and sofka was a burst machine:

- one watch event frequently carries several transitions (phase + Ready + restarts on a pod kill), each sent as its own notification → its own `herdr` spawn, microseconds apart
- multiple `Msg::Notify` in one frame batch each spawned their own notifier too

Fix is two-level coalescing:
- **Per watch event**: all transitions from one object change join into one message — `pod/web: phase Running → Failed · Ready True → False`
- **Per frame**: the run loop drains everything pending as a single delivery (bell + escape sequence + notifier subprocess), bounded to 300 chars via `ellipsize`

One notification per moment-of-change survives any sink's rate limiter, and reads better everywhere (Ghostty, herdr, `notify-send`) than three fragments.

## Test plan
- [x] New test: two queued notifications drain as one joined message, consumed once; a 100-message burst leaves as a single bounded (≤300 chars) delivery
- [x] `cargo test` — 418 passed; clippy `-D warnings` + fmt clean
- [ ] Manual: `:notify` a pod in a herdr pane, delete it — one toast with the joined transitions