### PR TITLE
fix: let CRDs own their palette name over built-in commands

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -494,10 +494,17 @@ impl App {
                             self.open_workspace_named(&s.label);
                         }
                     }
-                    // An exact typed built-in wins (stable muscle memory), then
-                    // the highlighted suggestion, then the raw text as a resource.
+                    // A name owned by a CRD resolves to the CRD even when a
+                    // built-in command shares it — the cluster's vocabulary
+                    // outranks ours, and the suggestion list already ranks the
+                    // resource first. After that an exact typed built-in wins
+                    // (stable muscle memory), then the highlighted suggestion,
+                    // then the raw text as a resource.
                     _ => {
-                        if self.run_palette_command(&typed) {
+                        let crd_owned = self.cluster.resolve(&head).is_some_and(|k| k.is_custom());
+                        if crd_owned {
+                            self.switch_kind_ns(&head, ns_arg);
+                        } else if self.run_palette_command(&typed) {
                             // handled
                         } else if let Some(s) = picked {
                             match s.kind {
@@ -729,17 +736,42 @@ impl App {
         // An exact alias/kind/plural hit (e.g. `hr` → helmreleases) outranks
         // every fuzzy match, so a shorthand lands on its target instead of an
         // alphabetically-earlier lookalike (hr → horizontalpodautoscalers).
+        // Compared by resolved identity so any of a kind's names hits.
         let alias_target = if q.is_empty() {
             None
         } else {
-            self.cluster.resolve(q).map(|k| k.ar.plural.to_lowercase())
+            self.cluster.resolve(q).map(|k| k.title().to_lowercase())
         };
 
-        // Resource catalog (RBAC-filtered).
-        for c in self.cluster.catalog.iter().filter(|c| self.rbac_visible(c)) {
+        // Resource catalog (RBAC-filtered; the allow-list carries bare
+        // plurals, so group-qualified entries are checked by their plural).
+        // A qualified entry (`snapshots.kopiur…`) is listed only when it adds
+        // something: it's dropped while the bare plural also matches the query
+        // and resolves to the same kind, and kept when the plural is shadowed
+        // (`pods.metrics.k8s.io`) or only the group part matches (`kopiur`).
+        for c in &self.cluster.catalog {
+            let (plural, group) = match c.split_once('.') {
+                Some((p, g)) => (p, Some(g)),
+                None => (c.as_str(), None),
+            };
+            if !self.rbac_visible(plural) {
+                continue;
+            }
+            if let Some(group) = group {
+                let bare_matches = q.is_empty() || self.matcher.fuzzy_match(plural, q).is_some();
+                let same_kind = self
+                    .cluster
+                    .resolve(plural)
+                    .is_some_and(|k| k.ar.group.eq_ignore_ascii_case(group));
+                if bare_matches && same_kind {
+                    continue;
+                }
+            }
             let score = if q.is_empty() {
                 Some(0)
-            } else if alias_target.as_deref() == Some(c.as_str()) {
+            } else if alias_target.is_some()
+                && self.cluster.resolve(c).map(|k| k.title().to_lowercase()) == alias_target
+            {
                 Some(i64::MAX)
             } else {
                 self.matcher.fuzzy_match(c, q)

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1615,6 +1615,100 @@ async fn pf_palette_command_opens_the_view() {
 }
 
 #[tokio::test]
+async fn crd_plural_outranks_builtin_command() {
+    let (mut app, _rx) = test_app();
+    // The fake cluster serves snapshots.kopiur.home-operations.com, which
+    // collides with the `:snapshots` built-in — the CRD must win.
+    app.mode = Mode::Command;
+    for c in "snapshots".chars() {
+        app.key_command(press(KeyCode::Char(c)));
+    }
+    app.key_command(press(KeyCode::Enter));
+    assert_eq!(app.mode, Mode::Table);
+    assert!(
+        app.flash.contains("snapshots.kopiur.home-operations.com"),
+        "{}",
+        app.flash
+    );
+
+    // `:kind namespace` still works for the shadowed plural.
+    app.mode = Mode::Command;
+    for c in "snapshots media".chars() {
+        app.key_command(press(KeyCode::Char(c)));
+    }
+    app.key_command(press(KeyCode::Enter));
+    assert_eq!(app.namespace, "media");
+}
+
+#[tokio::test]
+async fn qualified_names_surface_without_doubling_the_list() {
+    let (mut app, _rx) = test_app();
+
+    // A group fragment finds the CRD by its qualified name even though the
+    // bare plural doesn't match.
+    app.command = "kopiur".into();
+    app.update_suggestions();
+    assert_eq!(
+        app.cmd_suggestions[0].label,
+        "snapshots.kopiur.home-operations.com"
+    );
+
+    // When the bare plural matches and means the same kind, the qualified
+    // twin stays hidden.
+    app.command = "deploy".into();
+    app.update_suggestions();
+    let labels: Vec<_> = app.cmd_suggestions.iter().map(|s| &s.label).collect();
+    assert!(labels.contains(&&"deployments".to_string()), "{labels:?}");
+    assert!(
+        !labels.contains(&&"deployments.apps".to_string()),
+        "{labels:?}"
+    );
+
+    // Browsing with `:` lists each kind once, under its bare plural.
+    app.command.clear();
+    app.update_suggestions();
+    assert!(
+        app.cmd_suggestions.iter().all(|s| !s.label.contains('.')),
+        "{:?}",
+        app.cmd_suggestions
+            .iter()
+            .map(|s| &s.label)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn typed_qualified_name_opens_the_kind() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Command;
+    for c in "snapshots.kopiur.home-operations.com".chars() {
+        app.key_command(press(KeyCode::Char(c)));
+    }
+    app.key_command(press(KeyCode::Enter));
+    assert_eq!(app.mode, Mode::Table);
+    assert!(
+        app.flash.contains("snapshots.kopiur.home-operations.com"),
+        "{}",
+        app.flash
+    );
+}
+
+#[tokio::test]
+async fn shadowed_builtin_stays_reachable_via_alias() {
+    let (mut app, _rx) = test_app();
+    // `snapshots` now resolves to the CRD; the snapshot browser keeps its
+    // `dumps` alias. Depending on the machine's state dir it either opens
+    // the browser or warns that none are saved — both are the built-in.
+    assert!(app.run_palette_command("dumps"));
+    assert!(
+        app.mode == Mode::Snapshots || app.flash.contains("no snapshots yet"),
+        "mode={:?} flash={}",
+        app.mode,
+        app.flash
+    );
+}
+
+#[tokio::test]
 async fn events_palette_command_dispatches() {
     let (mut app, _rx) = test_app();
     assert!(app.run_palette_command("events"));

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -31,6 +31,21 @@ impl Kind {
             format!("{}.{}", self.ar.plural, self.ar.group)
         }
     }
+
+    /// Whether this kind comes from a custom API group (a CRD or third-party
+    /// aggregated API) rather than one Kubernetes ships with. Custom kinds own
+    /// their name in the command palette even when a built-in command shares
+    /// it (`:snapshots` with a snapshots.* CRD installed); vanilla kinds don't
+    /// get that priority, so `:events` keeps opening the built-in view.
+    pub fn is_custom(&self) -> bool {
+        let group = self.ar.group.as_str();
+        !group.is_empty()
+            && !group.ends_with(".k8s.io")
+            && !matches!(
+                group,
+                "apps" | "batch" | "policy" | "autoscaling" | "extensions"
+            )
+    }
 }
 
 /// Connection + discovery context for a cluster.
@@ -217,10 +232,13 @@ impl Cluster {
                 let plural = ar.plural.to_lowercase();
                 let kind_lc = ar.kind.to_lowercase();
                 catalog.push(plural.clone());
-                // Group-qualified keys are unambiguous; insert directly.
+                // Group-qualified keys are unambiguous; insert directly. They
+                // join the catalog too, so completion can surface a kind whose
+                // bare plural is shadowed (or find it by its group name).
                 if !ar.group.is_empty() {
-                    self.registry
-                        .insert(format!("{}.{}", plural, ar.group), kind.clone());
+                    let qualified = format!("{}.{}", plural, ar.group);
+                    self.registry.insert(qualified.clone(), kind.clone());
+                    catalog.push(qualified);
                 }
                 entries.push((kind, plural, kind_lc));
             }
@@ -518,6 +536,39 @@ impl Cluster {
             "certificates".to_string(),
             mk("cert-manager.io", "Certificate", "certificates", true),
         );
+        // A CRD whose plural collides with the `:snapshots` built-in command,
+        // for palette-priority tests (CRD names outrank built-ins).
+        registry.insert(
+            "snapshots".to_string(),
+            mk("kopiur.home-operations.com", "Snapshot", "snapshots", true),
+        );
+        // Mirror discover(): catalogued kinds with a group also resolve by
+        // (and are listed under) their group-qualified name.
+        let mut catalog: Vec<String> = [
+            "certificates",
+            "deployments",
+            "helmreleases",
+            "horizontalpodautoscalers",
+            "kustomizations",
+            "namespaces",
+            "nodes",
+            "pods",
+            "services",
+            "snapshots",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        for plural in catalog.clone() {
+            let kind = registry[&plural].clone();
+            if kind.ar.group.is_empty() {
+                continue;
+            }
+            let qualified = format!("{plural}.{}", kind.ar.group);
+            registry.insert(qualified.clone(), kind);
+            catalog.push(qualified);
+        }
+        catalog.sort();
         Self {
             client,
             context: "test".into(),
@@ -527,17 +578,7 @@ impl Cluster {
             cli_context: Some("test".into()),
             connected: true,
             registry,
-            catalog: vec![
-                "certificates".to_string(),
-                "deployments".to_string(),
-                "helmreleases".to_string(),
-                "horizontalpodautoscalers".to_string(),
-                "kustomizations".to_string(),
-                "namespaces".to_string(),
-                "nodes".to_string(),
-                "pods".to_string(),
-                "services".to_string(),
-            ],
+            catalog,
         }
     }
 }


### PR DESCRIPTION
## Summary
- A CRD whose plural collides with a built-in command name (`snapshots.kopiur.home-operations.com` vs `:snapshots`) was unreachable from the palette: the exact typed built-in always won on Enter, even while the suggestion popup ranked the resource first.
- `:name` now resolves to the resource when it's owned by a custom API group (`Kind::is_custom` — not core, not `*.k8s.io`, not `apps`/`batch`/`policy`/`autoscaling`/`extensions`). Vanilla kinds keep the old priority, so `:events` still opens the built-in view, and shadowed built-ins stay reachable via their aliases (`:dumps` for the snapshot browser).
- Group-qualified names join the completion catalog (mirroring their registry keys), so a kind is findable by its group fragment (`kopiur`) and reachable when its bare plural is shadowed (`pods.metrics.k8s.io`). A qualified entry is hidden while the bare plural also matches the query and resolves to the same kind, so the browse list doesn't double.
- RBAC filtering of suggestions checks the bare plural for qualified entries, and the exact-alias top-ranking compares resolved kinds instead of plural strings.

## Test plan
- [x] `cargo test` — new coverage: CRD plural beats the built-in on Enter (incl. `:kind namespace`), shadowed built-in reachable via alias, group fragment surfaces the qualified name, no doubled entries on browse/fuzzy, typed qualified name opens the kind
- [x] `cargo clippy --all-targets` clean
- [x] On a cluster with the kopiur Snapshot CRD: `:snapshots` opens the CRD table, `:dumps` opens the snapshot browser, `:kopiur` suggests `snapshots.kopiur.home-operations.com`