### PR TITLE
feat: rename contexts in the context switcher

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -29,7 +29,7 @@ plugin, bookmark, and workspace chords.
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
 | `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                             |
-| `:ctx` / `:ctx <name>`                        | context switcher popup / switch directly (the name tab-completes)                                                                     |
+| `:ctx` / `:ctx <name>`                        | context switcher popup (`/` filters, `r` renames) / switch directly (the name tab-completes)                                          |
 | `:helm`                                       | Helm releases (native storage-Secret decode): ⏎ history → values · `y` manifest · `d` notes · `r` rollback                            |
 | `:fleet`                                      | cross-context health dashboard (opt-in `[fleet]` contexts; `⏎` switches, `r` refreshes)                                               |
 | `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -916,6 +916,37 @@ impl App {
                     self.ctx_state.select(Some(idx));
                 }
             }
+            Msg::ContextRenamed {
+                generation,
+                old,
+                new,
+                result,
+            } if generation == self.generation => match result {
+                Ok(()) => {
+                    // Patch the cached lists in place — kubectl already
+                    // rewrote the kubeconfig, so a re-read would say the same.
+                    for list in [&mut self.ctx_list, &mut self.all_contexts] {
+                        if let Some(c) = list.iter_mut().find(|c| **c == old) {
+                            *c = new.clone();
+                        }
+                        list.sort();
+                    }
+                    if self.mode == Mode::Contexts {
+                        let idx = self.filtered_contexts().iter().position(|c| *c == new);
+                        self.ctx_state.select(Some(idx.unwrap_or(0)));
+                    }
+                    // The live connection is unaffected; only the name moves.
+                    if self.cluster.context == old {
+                        self.cluster.context = new.clone();
+                        if let Some(recents) = self.recent_namespaces.remove(&old) {
+                            self.recent_namespaces.insert(new.clone(), recents);
+                        }
+                    }
+                    self.flash = format!("renamed context {old} → {new}");
+                    self.flash_err = false;
+                }
+                Err(e) => self.flash_warn(&format!("rename failed: {e}")),
+            },
             Msg::ContextSwitched {
                 generation,
                 name,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -344,6 +344,11 @@ enum PromptKind {
         expected: String,
         action: Box<ConfirmAction>,
     },
+    /// New name for a kubeconfig context (`r` in the context switcher) —
+    /// opened from (and returning to) [`Mode::Contexts`].
+    RenameContext {
+        old: String,
+    },
 }
 
 #[derive(Default)]
@@ -941,8 +946,12 @@ pub struct App {
 
     pub ctx_list: Vec<String>,
     pub ctx_state: ListState,
-    /// Type-to-filter buffer for the context switcher.
+    /// Filter buffer for the context switcher (typed after `/`, like the
+    /// table filter — plain letters are action keys, e.g. `r` rename).
     pub ctx_filter: String,
+    /// Whether the context switcher is in filter-typing mode (`/` pressed;
+    /// esc/enter leave it).
+    pub ctx_filtering: bool,
     pub sort_picker_state: ListState,
     /// Type-to-filter buffer for the sort-column picker.
     pub sort_picker_filter: String,
@@ -1211,6 +1220,7 @@ impl App {
             ctx_list: Vec::new(),
             ctx_state: ListState::default(),
             ctx_filter: String::new(),
+            ctx_filtering: false,
             sort_picker_state: ListState::default(),
             sort_picker_filter: String::new(),
             all_contexts: Vec::new(),
@@ -1328,6 +1338,12 @@ impl App {
     /// renderer keeps the logs (not the table) underneath it.
     pub fn prompt_over_logs(&self) -> bool {
         matches!(self.prompt_kind, Some(PromptKind::ProviderLookback))
+    }
+
+    /// Whether the active prompt was opened from the context switcher, so the
+    /// renderer keeps the picker underneath it and esc/enter return there.
+    pub fn prompt_over_contexts(&self) -> bool {
+        matches!(self.prompt_kind, Some(PromptKind::RenameContext { .. }))
     }
 
     /// Whether the logs view is showing the external log provider (enables

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -225,10 +225,13 @@ impl App {
         }
         match key.code {
             KeyCode::Esc => {
-                // The lookback prompt is the one prompt opened from the logs
-                // view; every other prompt starts at (and returns to) the table.
+                // Most prompts start at (and return to) the table; the
+                // lookback and rename-context prompts return to the view
+                // they were opened from.
                 self.mode = if self.prompt_over_logs() {
                     Mode::Logs
+                } else if self.prompt_over_contexts() {
+                    Mode::Contexts
                 } else {
                     Mode::Table
                 };
@@ -238,6 +241,8 @@ impl App {
                 let input = self.prompt_input.trim().to_string();
                 self.mode = if self.prompt_over_logs() {
                     Mode::Logs
+                } else if self.prompt_over_contexts() {
+                    Mode::Contexts
                 } else {
                     Mode::Table
                 };
@@ -335,6 +340,11 @@ impl App {
                             self.flash_warn("guardrail: input did not match — cancelled");
                         }
                     }
+                    // Empty input = cancel, keep the old name.
+                    Some(PromptKind::RenameContext { old }) if !input.is_empty() => {
+                        self.rename_context(old, input);
+                    }
+                    Some(PromptKind::RenameContext { .. }) => {}
                     None => {}
                 }
             }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -351,6 +351,7 @@ impl App {
 
     pub(super) fn open_contexts(&mut self) {
         self.ctx_filter.clear();
+        self.ctx_filtering = false;
         self.ctx_list.clear();
         self.ctx_state.select(None);
         self.mode = Mode::Contexts;
@@ -400,24 +401,54 @@ impl App {
         scored.into_iter().map(|(_, c)| c.clone()).collect()
     }
 
+    /// Unlike the other pickers, the switcher is not type-to-filter: `/`
+    /// starts the filter (like the table filter), which frees plain letters
+    /// for actions (`r` rename, `j`/`k` movement).
     pub(super) fn key_contexts(&mut self, key: KeyEvent) {
-        if edit_chord(&key, &mut self.ctx_filter) {
-            self.ctx_state.select(Some(0));
+        let len = self.filtered_contexts().len();
+        if self.ctx_filtering {
+            if edit_chord(&key, &mut self.ctx_filter) {
+                self.ctx_state.select(Some(0));
+                return;
+            }
+            match key.code {
+                // Esc cancels the filter, enter keeps it applied (the table
+                // filter's semantics); both return to browsing.
+                KeyCode::Esc => {
+                    self.ctx_filter.clear();
+                    self.ctx_filtering = false;
+                    self.select_current_context();
+                }
+                KeyCode::Enter => self.ctx_filtering = false,
+                KeyCode::Down => list_step(&mut self.ctx_state, len, true),
+                KeyCode::Up => list_step(&mut self.ctx_state, len, false),
+                KeyCode::Backspace => {
+                    self.ctx_filter.pop();
+                    self.ctx_state.select(Some(0));
+                }
+                KeyCode::Char(c) => {
+                    self.ctx_filter.push(c);
+                    self.ctx_state.select(Some(0));
+                }
+                _ => {}
+            }
             return;
         }
-        let len = self.filtered_contexts().len();
         match key.code {
             KeyCode::Esc => {
-                // First esc clears the filter, second closes the switcher.
+                // First esc clears an applied filter, second closes the
+                // switcher.
                 if self.ctx_filter.is_empty() {
                     self.mode = Mode::Table;
                 } else {
                     self.ctx_filter.clear();
-                    self.ctx_state.select(Some(0));
+                    self.select_current_context();
                 }
             }
-            KeyCode::Down => list_step(&mut self.ctx_state, len, true),
-            KeyCode::Up => list_step(&mut self.ctx_state, len, false),
+            KeyCode::Char('/') => self.ctx_filtering = true,
+            KeyCode::Char('r') | KeyCode::Char('R') => self.open_rename_context(),
+            KeyCode::Down | KeyCode::Char('j') => list_step(&mut self.ctx_state, len, true),
+            KeyCode::Up | KeyCode::Char('k') => list_step(&mut self.ctx_state, len, false),
             KeyCode::Enter => {
                 if let Some(name) = self
                     .ctx_state
@@ -428,16 +459,71 @@ impl App {
                     self.switch_context(name);
                 }
             }
-            KeyCode::Backspace => {
-                self.ctx_filter.pop();
-                self.ctx_state.select(Some(0));
-            }
-            KeyCode::Char(c) => {
-                self.ctx_filter.push(c);
-                self.ctx_state.select(Some(0));
-            }
             _ => {}
         }
+    }
+
+    /// Put the switcher cursor on the active context (fallback: the top).
+    fn select_current_context(&mut self) {
+        let idx = self
+            .filtered_contexts()
+            .iter()
+            .position(|c| *c == self.cluster.context)
+            .unwrap_or(0);
+        self.ctx_state.select(Some(idx));
+    }
+
+    /// Prompt for a new name for the selected context (`r` in the switcher),
+    /// prefilled with the current name.
+    fn open_rename_context(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
+        let Some(old) = self
+            .ctx_state
+            .selected()
+            .and_then(|i| self.filtered_contexts().get(i).cloned())
+        else {
+            return;
+        };
+        self.prompt_label = format!("Rename context {old} to:");
+        self.prompt_input = old.clone();
+        self.prompt_kind = Some(PromptKind::RenameContext { old });
+        self.mode = Mode::Prompt;
+    }
+
+    /// Rename a kubeconfig context off-thread via `kubectl config
+    /// rename-context` (which also updates `current-context` when it pointed
+    /// at the old name); the outcome arrives as `Msg::ContextRenamed`.
+    pub(super) fn rename_context(&mut self, old: String, new: String) {
+        if new == old {
+            return;
+        }
+        if self.ctx_list.contains(&new) {
+            self.flash_warn(&format!("context '{new}' already exists"));
+            return;
+        }
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let out = tokio::process::Command::new("kubectl")
+                .args(["config", "rename-context", &old, &new])
+                .output()
+                .await;
+            let result = match out {
+                Ok(o) if o.status.success() => Ok(()),
+                Ok(o) => Err(String::from_utf8_lossy(&o.stderr).trim().to_string()),
+                Err(e) => Err(format!("kubectl failed to start: {e}")),
+            };
+            let _ = tx
+                .send(Msg::ContextRenamed {
+                    generation: genr,
+                    old,
+                    new,
+                    result,
+                })
+                .await;
+        });
     }
 
     /// Rebuild the cluster connection against a different kubeconfig context.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2916,6 +2916,160 @@ async fn context_list_result_selects_current_context() {
 }
 
 #[tokio::test]
+async fn context_picker_filters_only_after_slash() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Contexts;
+    app.handle_msg(Msg::Contexts {
+        generation: app.generation,
+        list: vec!["dev".into(), "prod".into(), "test".into()],
+    });
+
+    // Plain letters are action keys, not filter input.
+    app.key_contexts(press(KeyCode::Char('p')));
+    assert!(app.ctx_filter.is_empty());
+    assert!(!app.ctx_filtering);
+
+    // `/` starts the filter; typing narrows the list live.
+    app.key_contexts(press(KeyCode::Char('/')));
+    assert!(app.ctx_filtering);
+    app.key_contexts(press(KeyCode::Char('p')));
+    assert_eq!(app.ctx_filter, "p");
+    assert_eq!(app.filtered_contexts(), vec!["prod".to_string()]);
+
+    // Enter keeps the filter applied and returns to browsing.
+    app.key_contexts(press(KeyCode::Enter));
+    assert!(!app.ctx_filtering);
+    assert_eq!(app.ctx_filter, "p");
+    assert_eq!(app.mode, Mode::Contexts);
+
+    // First esc clears the applied filter (cursor back on the current
+    // context), second closes the switcher.
+    app.key_contexts(press(KeyCode::Esc));
+    assert!(app.ctx_filter.is_empty());
+    assert_eq!(app.mode, Mode::Contexts);
+    assert_eq!(app.ctx_state.selected(), Some(2), "cursor on 'test'");
+    app.key_contexts(press(KeyCode::Esc));
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn context_picker_esc_while_typing_cancels_filter() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Contexts;
+    app.handle_msg(Msg::Contexts {
+        generation: app.generation,
+        list: vec!["dev".into(), "test".into()],
+    });
+    app.key_contexts(press(KeyCode::Char('/')));
+    app.key_contexts(press(KeyCode::Char('d')));
+    app.key_contexts(press(KeyCode::Esc));
+    assert!(!app.ctx_filtering);
+    assert!(app.ctx_filter.is_empty());
+    assert_eq!(
+        app.mode,
+        Mode::Contexts,
+        "esc cancels the filter, not the picker"
+    );
+}
+
+#[tokio::test]
+async fn context_rename_prompt_opens_prefilled_and_returns_to_picker() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Contexts;
+    app.handle_msg(Msg::Contexts {
+        generation: app.generation,
+        list: vec!["prod".into(), "test".into()],
+    });
+
+    app.key_contexts(press(KeyCode::Char('r')));
+    assert_eq!(app.mode, Mode::Prompt);
+    assert!(app.prompt_over_contexts());
+    assert_eq!(app.prompt_input, "test", "prefilled with the selected name");
+    assert!(app.prompt_label.contains("Rename context test"));
+
+    // Esc abandons the rename and lands back in the picker.
+    app.key_prompt(press(KeyCode::Esc));
+    assert_eq!(app.mode, Mode::Contexts);
+    assert!(!app.prompt_over_contexts());
+}
+
+#[tokio::test]
+async fn context_rename_to_existing_name_warns() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Contexts;
+    app.handle_msg(Msg::Contexts {
+        generation: app.generation,
+        list: vec!["prod".into(), "test".into()],
+    });
+
+    app.key_contexts(press(KeyCode::Char('r')));
+    app.prompt_input = "prod".into();
+    app.key_prompt(press(KeyCode::Enter));
+    assert_eq!(app.mode, Mode::Contexts);
+    assert!(app.flash_err);
+    assert!(app.flash.contains("already exists"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn context_renamed_updates_lists_and_current_context() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Contexts;
+    app.handle_msg(Msg::Contexts {
+        generation: app.generation,
+        list: vec!["prod".into(), "test".into()],
+    });
+    app.all_contexts = vec!["prod".into(), "test".into()];
+    app.note_recent_namespace("shop");
+
+    app.handle_msg(Msg::ContextRenamed {
+        generation: app.generation,
+        old: "test".into(),
+        new: "staging".into(),
+        result: Ok(()),
+    });
+    assert_eq!(
+        app.ctx_list,
+        vec!["prod".to_string(), "staging".to_string()]
+    );
+    assert_eq!(
+        app.all_contexts,
+        vec!["prod".to_string(), "staging".to_string()]
+    );
+    assert_eq!(
+        app.cluster.context, "staging",
+        "live connection follows the rename"
+    );
+    assert_eq!(
+        app.recent_namespaces.get("staging").map(|dq| dq.len()),
+        Some(1),
+        "per-context recents follow the rename"
+    );
+    assert_eq!(
+        app.ctx_state.selected(),
+        Some(1),
+        "cursor lands on the new name"
+    );
+    assert!(
+        app.flash.contains("renamed context test → staging"),
+        "{}",
+        app.flash
+    );
+
+    // A failed rename only flashes.
+    app.handle_msg(Msg::ContextRenamed {
+        generation: app.generation,
+        old: "prod".into(),
+        new: "live".into(),
+        result: Err("no context exists with the name".into()),
+    });
+    assert!(app.flash_err);
+    assert_eq!(
+        app.ctx_list,
+        vec!["prod".to_string(), "staging".to_string()]
+    );
+}
+
+#[tokio::test]
 async fn rbac_for_old_generation_is_dropped() {
     let (mut app, _rx) = test_app();
     let stale = app.generation;

--- a/src/store.rs
+++ b/src/store.rs
@@ -140,6 +140,14 @@ pub enum Msg {
         name: String,
         result: Result<Box<crate::k8s::Cluster>, String>,
     },
+    /// Result of an off-thread `kubectl config rename-context` (`r` in the
+    /// context switcher).
+    ContextRenamed {
+        generation: u64,
+        old: String,
+        new: String,
+        result: Result<(), String>,
+    },
     /// Resource plurals the user may `list`, computed for namespace `ns`
     /// (empty = cluster default). Dropped if the active namespace has since
     /// changed. "*" = all.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -162,6 +162,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Containers => draw_containers(frame, app, chunks[1]),
         Mode::SetImage => draw_set_image(frame, app, chunks[1]),
         Mode::Confirm => draw_confirm(frame, app, chunks[1]),
+        // The rename prompt opens from the context switcher — keep the
+        // picker visible underneath it.
+        Mode::Prompt if app.prompt_over_contexts() => {
+            draw_contexts(frame, app, chunks[1]);
+            draw_prompt_popup(frame, app, chunks[1]);
+        }
         Mode::Prompt => draw_prompt_popup(frame, app, chunks[1]),
         Mode::Command => draw_palette(frame, app, chunks[1]),
         Mode::FluxMenu => draw_flux_menu(frame, app, chunks[1]),
@@ -2005,11 +2011,14 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
             ))
         })
         .collect();
-    // Show the type-to-filter buffer in the title so it reads like an input.
-    let title = if app.ctx_filter.is_empty() {
-        " Contexts (type to filter · ⏎ switch) ".to_string()
-    } else {
+    // While typing, show the filter buffer in the title so it reads like an
+    // input; an applied filter stays visible without the cursor.
+    let title = if app.ctx_filtering {
         format!(" Contexts · /{}_ ", app.ctx_filter)
+    } else if !app.ctx_filter.is_empty() {
+        format!(" Contexts · /{} ", app.ctx_filter)
+    } else {
+        " Contexts (/ filter · r rename · ⏎ switch) ".to_string()
     };
     render_popup_list(
         frame,


### PR DESCRIPTION
## Summary
- The context switcher is no longer type-to-filter: `/` starts the filter with the same semantics as the table filter — typing narrows live, enter keeps the filter applied, esc cancels it. While browsing, a first esc clears an applied filter and a second closes the popup.
- With plain letters freed up, `r`/`R` prompts for a new name for the selected context (prefilled, drawn over the picker) and `j`/`k` move the cursor.
- The rename shells out to `kubectl config rename-context` off-thread, consistent with the existing cp/debug/port-forward delegation; kubectl also updates `current-context` when it pointed at the old name.
- On success the cached context lists are patched in place and re-sorted, the cursor lands on the new name, and renaming the connected context carries `cluster.context` and its per-context namespace recents over — the live connection is untouched.
- Duplicate names are rejected up front, failures flash kubectl's error, and read-only mode blocks the rename like every other mutating action.
- Popup title now hints `(/ filter · r rename · ⏎ switch)`; `docs/keys.md` updated.

Note one flow change: the old fast path `:ctx prod⏎` is now `:ctx /prod⏎⏎` (filter, commit, switch).

Closes #129

## Test plan
- [x] `cargo test` — 427 passing, including six new tests covering `/`-gated filtering, esc semantics, the prefilled rename prompt round-trip, duplicate-name rejection, and state updates after a successful/failed rename
- [x] Manual: `:ctx`, `/` to filter, `r` to rename a context; verify the kubeconfig entry, the picker cursor, and (for the active context) the header/context name follow