### PR TITLE
fix: release mouse capture in document views so text selection works

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -43,9 +43,13 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   session recents (·) above the rest, plus a context switcher (`:ctx`).
 - **Mouse support** - the wheel scrolls every view (one notch is three steps of
   that view's own up/down), clicking a row selects it, clicking a column header
-  sorts by it (click again to flip). Set `mouse = false` to keep the terminal's
-  native text selection instead. sofka releases the mouse while a suspended
-  command (`kubectl exec`, `$EDITOR`) runs.
+  sorts by it (click again to flip). Document views (YAML/describe, diff,
+  events, logs, help) release the mouse automatically so click-drag selects
+  text natively; the wheel still scrolls them in terminals that translate it to
+  arrow keys in the alternate screen (kitty, Ghostty, iTerm2, ...). Set
+  `mouse = false` to keep the terminal's native mouse behavior everywhere.
+  sofka also releases the mouse while a suspended command (`kubectl exec`,
+  `$EDITOR`) runs.
 - **Compact mode** (`ctrl-e`) - collapse the seven-line header and the footer
   into one info line (kind · count · namespace · context, with a flash and the
   live indicator), so a tiled pane is almost all table.

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -40,6 +40,27 @@ impl App {
         });
     }
 
+    /// Whether the run loop should keep terminal mouse capture on right now.
+    /// Document-style views (YAML/describe, diff, events, logs, help) release
+    /// capture so click-drag uses the terminal's native text selection —
+    /// nothing in them uses clicks, and scrolling still works because with
+    /// reporting off terminals translate the wheel into arrow keys in the
+    /// alternate screen ("alternate scroll"), which these views all handle.
+    /// The filter-typing overlays keep the same document on screen, so they
+    /// release too.
+    pub fn wants_mouse_capture(&self) -> bool {
+        !matches!(
+            self.mode,
+            Mode::Detail
+                | Mode::Diff
+                | Mode::Events
+                | Mode::Logs
+                | Mode::Help
+                | Mode::DocFilter
+                | Mode::LogFilter
+        )
+    }
+
     /// Route a mouse event. The wheel is synthesized into the mode's own
     /// up/down keys, so scrolling works identically in every view (table,
     /// logs, documents, pickers) without a second navigation code path;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -645,6 +645,33 @@ async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
 }
 
 #[tokio::test]
+async fn document_views_release_mouse_capture_for_text_selection() {
+    let (mut app, _rx) = test_app();
+    assert!(app.wants_mouse_capture(), "table keeps capture");
+
+    // Every full-screen text view releases capture so click-drag selects text
+    // natively (#133), including the filter overlays that keep it on screen.
+    for mode in [
+        Mode::Detail,
+        Mode::Diff,
+        Mode::Events,
+        Mode::Logs,
+        Mode::Help,
+        Mode::DocFilter,
+        Mode::LogFilter,
+    ] {
+        app.mode = mode;
+        assert!(!app.wants_mouse_capture(), "{mode:?} releases capture");
+    }
+
+    // Interactive pickers and dashboards still want clicks/wheel captured.
+    for mode in [Mode::Table, Mode::Namespaces, Mode::Pulse, Mode::Confirm] {
+        app.mode = mode;
+        assert!(app.wants_mouse_capture(), "{mode:?} keeps capture");
+    }
+}
+
+#[tokio::test]
 async fn notify_toggles_a_background_watch_per_object() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,8 @@ pub struct Config {
     pub forwards: Vec<Forward>,
     /// Mouse support (wheel scroll, click-to-select, header-click sort).
     /// `None` = on. Set `mouse = false` to keep the terminal's native mouse
-    /// behavior (text selection) instead.
+    /// behavior (text selection) everywhere. Document views release capture
+    /// on their own regardless — see [`crate::app::App::wants_mouse_capture`].
     pub mouse: Option<bool>,
     /// How `:notify` events are delivered — see [`NotifyConfig`].
     pub notify: NotifyConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,8 +444,10 @@ fn ring_notification(text: &str, cfg: &config::NotifyConfig) {
 /// stdio (kubectl exec/edit/port-forward), then restore the TUI. Toggles the
 /// terminal modes directly rather than `ratatui::restore()`/`init()`: `init()`
 /// stacks another panic hook on every call, and the hook installed at startup
-/// must stay the outermost one.
-fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String], mouse: bool) {
+/// must stay the outermost one. `captured` is whether mouse capture is on
+/// right now (not just the config flag), so the pre-suspend state is restored
+/// exactly.
+fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String], captured: bool) {
     use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
     use crossterm::terminal::{
         EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -453,7 +455,7 @@ fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String], mou
     if argv.is_empty() {
         return;
     }
-    if mouse {
+    if captured {
         let _ = crossterm::execute!(std::io::stdout(), DisableMouseCapture);
     }
     let _ = disable_raw_mode();
@@ -467,7 +469,7 @@ fn suspend_and_run(terminal: &mut ratatui::DefaultTerminal, argv: &[String], mou
         .status();
     let _ = enable_raw_mode();
     let _ = crossterm::execute!(std::io::stdout(), EnterAlternateScreen);
-    if mouse {
+    if captured {
         let _ = crossterm::execute!(std::io::stdout(), EnableMouseCapture);
     }
     let _ = terminal.clear();
@@ -551,11 +553,26 @@ async fn run(
     let mut frame = tokio::time::interval(Duration::from_millis(16));
     frame.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut dirty = false;
+    // Tracks whether mouse capture is currently on, so it can follow the mode:
+    // document views release it for native text selection (see
+    // `wants_mouse_capture`). Always false when the config disabled the mouse.
+    let mut captured = mouse;
 
     terminal.draw(|f| ui::draw(f, app))?;
     loop {
         if app.should_quit {
             return Ok(());
+        }
+
+        if mouse && app.wants_mouse_capture() != captured {
+            captured = !captured;
+            if captured {
+                let _ =
+                    crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture);
+            } else {
+                let _ =
+                    crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
+            }
         }
 
         tokio::select! {
@@ -564,7 +581,7 @@ async fn run(
                     Some(Ok(Event::Key(key))) if key.kind == KeyEventKind::Press => {
                         app.handle_key(key)?;
                         if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
-                            suspend_and_run(terminal, &argv, mouse);
+                            suspend_and_run(terminal, &argv, captured);
                             app.flash = format!("ran: {}", argv.join(" "));
                             app.flash_err = false;
                         }
@@ -574,7 +591,7 @@ async fn run(
                     Some(Ok(Event::Mouse(m))) => {
                         app.handle_mouse(m)?;
                         if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
-                            suspend_and_run(terminal, &argv, mouse);
+                            suspend_and_run(terminal, &argv, captured);
                             app.flash = format!("ran: {}", argv.join(" "));
                             app.flash_err = false;
                         }


### PR DESCRIPTION
Fixes #133

Mouse capture stayed on in every mode, so click-drag in the YAML/describe view (and other full-screen text views) went to the app — which ignores clicks outside the table — instead of the terminal's native text selection.

The run loop now tracks the mode's capture preference each iteration and toggles `EnableMouseCapture`/`DisableMouseCapture` when it changes. Document-style views release capture: `Detail` (YAML/describe), `Diff`, `Events`, `Logs`, `Help`, and the `DocFilter`/`LogFilter` overlays that keep the same document on screen. The table, pickers, dashboards, and dialogs keep capture for row clicks, header-sort clicks, and wheel scroll.

Wheel scrolling still works in the released views: with mouse reporting off, terminals translate the wheel into arrow keys in the alternate screen (alternate scroll — kitty, Ghostty, iTerm2, etc., including both emulators from the report), and all of these views scroll on Up/Down.

`suspend_and_run` now receives the *current* capture state rather than the config flag, so suspending from a doc view (e.g. `e` edit) no longer re-enables capture on return while the doc view is still up. `mouse = false` still disables capture globally, as before.

Docs updated (`features.md`, config field comment) and a test covers the mode → capture mapping.