### PR TITLE
feat: horizontal column scrolling in table view

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -53,6 +53,7 @@ plugin, bookmark, and workspace chords.
 | `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                      |
 | `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
 | `w`                                           | toggle wide-only columns (kubectl `-o wide`)                                                                                          |
+| `←` / `→`                                     | scroll columns horizontally (NAMESPACE/NAME stay anchored) — for narrow panes                                                         |
 | `:q`, `ctrl-c`                                | quit                                                                                                                                  |
 | `?`                                           | help                                                                                                                                  |
 | _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                           |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -114,6 +114,11 @@ impl App {
             }
             KeyCode::PageDown => self.move_selection(10),
             KeyCode::PageUp => self.move_selection(-10),
+            // Horizontal column scroll for narrow panes: the NAMESPACE/NAME
+            // prefix stays anchored, → hides the next column after it, ←
+            // brings one back.
+            KeyCode::Right => self.scroll_columns(1),
+            KeyCode::Left => self.scroll_columns(-1),
             // k9s: SPACE marks/unmarks the current row for bulk actions, then
             // advances so a range can be marked with repeated taps.
             KeyCode::Char(' ') => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -907,6 +907,11 @@ pub struct App {
     /// `None` for the natural namespace/name order.
     pub sort_column: Option<usize>,
     pub sort_desc: bool,
+    /// Horizontal column scroll: how many columns after the anchored
+    /// NAMESPACE/NAME prefix are hidden off the left edge (←/→ in the
+    /// table). Clamped by `draw_table`, since the header set can change
+    /// underneath it; reset when the view spec is rebuilt.
+    pub col_offset: usize,
     pub filter: String,
     /// Parsed form of `filter`, refreshed lazily when the string changes so
     /// neither row matching nor rendering reparses it per frame.
@@ -1195,6 +1200,7 @@ impl App {
             marked: HashSet::new(),
             sort_column: None,
             sort_desc: false,
+            col_offset: 0,
             filter: String::new(),
             filter_cache: RefCell::new(FilterCache {
                 raw: String::new(),

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -13,14 +13,15 @@ pub(crate) struct TableHit {
     /// Inner x extent (inside the borders).
     pub x_min: u16,
     pub x_max: u16,
-    /// Per-column `[start, end)` x ranges, aligned with `display_headers()`.
-    pub cols: Vec<(u16, u16)>,
+    /// Per-column `[start, end)` x ranges plus the `display_headers()` index
+    /// each range shows (columns can be scrolled out of view horizontally).
+    pub cols: Vec<(u16, u16, usize)>,
 }
 
 impl App {
     /// Record the table geometry the renderer just used, so clicks can be
     /// mapped back to rows and header columns. `cols` are `[start, end)` x
-    /// ranges aligned with `display_headers()`.
+    /// ranges tagged with the `display_headers()` index they show.
     pub fn record_table_hit(
         &self,
         header_y: u16,
@@ -28,7 +29,7 @@ impl App {
         rows_h: u16,
         x_min: u16,
         x_max: u16,
-        cols: Vec<(u16, u16)>,
+        cols: Vec<(u16, u16, usize)>,
     ) {
         *self.table_hit.borrow_mut() = Some(TableHit {
             header_y,
@@ -94,7 +95,7 @@ impl App {
         }
         // Header row: sort by the clicked column (again = flip direction).
         if y == hit.header_y {
-            let Some(idx) = hit.cols.iter().position(|(s, e)| x >= *s && x < *e) else {
+            let Some(&(_, _, idx)) = hit.cols.iter().find(|(s, e, _)| x >= *s && x < *e) else {
                 return;
             };
             if self.sort_column == Some(idx) {

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -373,6 +373,7 @@ impl App {
             }
         }
         self.clear_rows_cache();
+        self.col_offset = 0;
     }
 
     /// The user-configured view matching the current kind, if any. Synthetic
@@ -411,6 +412,21 @@ impl App {
         self.refresh_view_spec();
         self.flash = format!("wide columns: {}", if self.wide { "on" } else { "off" });
         self.flash_err = false;
+    }
+
+    /// Scroll the table columns horizontally (←/→): the NAMESPACE/NAME
+    /// prefix stays anchored while the columns after it shift. Clamped so
+    /// the last column can always be reached and at least one scrollable
+    /// column stays visible.
+    pub(super) fn scroll_columns(&mut self, delta: isize) {
+        let anchored = usize::from(self.show_namespace_column()) + 1;
+        let scrollable = self.display_headers().len().saturating_sub(anchored);
+        let max = scrollable.saturating_sub(1);
+        self.col_offset = self
+            .col_offset
+            .min(max)
+            .saturating_add_signed(delta)
+            .min(max);
     }
 
     pub fn show_namespace_column(&self) -> bool {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -621,7 +621,12 @@ async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
         .iter()
         .position(|h| h == "RESTARTS")
         .unwrap();
-    let (sx, _) = hit.cols[ridx];
+    let (sx, _, _) = hit
+        .cols
+        .iter()
+        .copied()
+        .find(|(_, _, i)| *i == ridx)
+        .unwrap();
     app.handle_mouse(click(sx, hit.header_y)).unwrap();
     assert_eq!(app.sort_column, Some(ridx));
     assert!(!app.sort_desc);
@@ -642,6 +647,52 @@ async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
     // A click outside the table (e.g. the header panel) is ignored.
     app.handle_mouse(click(0, 0)).unwrap();
     assert_eq!(app.table_state.selected(), Some(1));
+}
+
+#[tokio::test]
+async fn horizontal_column_scroll_anchors_name_and_clamps() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "a", "namespace": "default"},
+            "status": {"phase": "Running"}
+        }),
+    );
+    app.table_state.select(Some(0));
+
+    let headers = app.display_headers();
+    assert_eq!(headers[0], "NAME");
+    let scrollable = headers.len() - 1;
+
+    // ← at the left edge is a no-op; → hides the column after NAME.
+    app.handle_key(press(KeyCode::Left)).unwrap();
+    assert_eq!(app.col_offset, 0);
+    app.handle_key(press(KeyCode::Right)).unwrap();
+    assert_eq!(app.col_offset, 1);
+
+    // → clamps so the last scrollable column stays visible.
+    for _ in 0..headers.len() {
+        app.handle_key(press(KeyCode::Right)).unwrap();
+    }
+    assert_eq!(app.col_offset, scrollable - 1);
+
+    // The rendered geometry skips the hidden columns: NAME (0) stays
+    // anchored, then only the last scrollable column follows.
+    let mut term = Terminal::new(TestBackend::new(120, 32)).unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let hit = app.table_hit.borrow().clone().expect("geometry recorded");
+    let cols: Vec<usize> = hit.cols.iter().map(|&(_, _, i)| i).collect();
+    assert_eq!(cols, vec![0, headers.len() - 1]);
+
+    // Rebuilding the view spec (view switch, wide toggle) resets the scroll.
+    app.refresh_view_spec();
+    assert_eq!(app.col_offset, 0);
 }
 
 #[tokio::test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -491,6 +491,15 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // Offset from a displayed column index back to the view spec's (the spec
     // doesn't know about the prepended NAMESPACE or appended CPU/MEM).
     let ns_off = usize::from(show_ns);
+    // Horizontal column scroll: everything after the anchored NAMESPACE/NAME
+    // prefix can be shifted off the left edge with ←/→. Clamped here (not
+    // only in the key handler) because the header set can change underneath
+    // the offset (wide toggle, printer columns arriving).
+    let name_col = if show_ns { 1 } else { 0 };
+    let scrollable_cols = headers.len().saturating_sub(name_col + 1);
+    app.col_offset = app.col_offset.min(scrollable_cols.saturating_sub(1));
+    let col_offset = app.col_offset;
+    let col_visible = move |i: usize| i <= name_col || i >= name_col + 1 + col_offset;
     // Per-column custom alignment, precomputed so cells don't re-borrow app.
     let aligns: Vec<Option<Alignment>> = (0..headers.len())
         .map(|i| {
@@ -505,6 +514,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         headers
             .iter()
             .enumerate()
+            .filter(|(i, _)| col_visible(*i))
             .map(|(i, h)| {
                 // Active sort column gets a direction arrow in the sorter color
                 // (sky, bold), matching k9s; the label inherits the header color.
@@ -536,7 +546,6 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // Column indices (fixed for the whole table) for the columns that get
     // their own visibility treatment below, computed once rather than
     // string-compared per cell.
-    let name_col = if show_ns { 1 } else { 0 };
     let age_idx = headers.iter().position(|h| h == "AGE");
     let ready_idx = headers.iter().position(|h| h == "READY");
     let restarts_idx = headers.iter().position(|h| h == "RESTARTS");
@@ -650,6 +659,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             let render_cells: Vec<Cell> = cells
                 .into_iter()
                 .enumerate()
+                .filter(|(i, _)| col_visible(*i))
                 .map(|(i, c)| {
                     let align = align_of(i);
                     if marked_row {
@@ -706,6 +716,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let widths: Vec<Constraint> = headers
         .iter()
         .enumerate()
+        .filter(|(i, _)| col_visible(*i))
         .map(|(i, h)| {
             // A custom column's configured width wins over the curated rules.
             if let Some(w) = i
@@ -752,6 +763,10 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         Span::styled(format!(" {kind_label} "), theme::title()),
         Span::styled(format!("[{count}]"), Style::default().fg(theme::counter())),
     ];
+    // Horizontal scroll indicator: how many columns are hidden off the left.
+    if col_offset > 0 {
+        title.push(Span::styled(format!(" ‹{col_offset}"), theme::dim()));
+    }
     if !app.marked.is_empty() {
         title.push(Span::styled(
             format!(" ✓{}", app.marked.len()),
@@ -789,7 +804,9 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // Record the geometry for mouse hit-testing (click-to-select, header-click
     // sort). Mirrors the Table widget's own column layout: the area inside the
     // borders, the always-reserved 2-cell highlight symbol, then a horizontal
-    // layout with the same widths, spacing, and default Start flex.
+    // layout with the same widths, spacing, and default Start flex. Each range
+    // carries the display-header index it shows, since columns can be
+    // scrolled out of view.
     {
         use ratatui::layout::{Flex, Margin};
         let inner = area.inner(Margin::new(1, 1));
@@ -810,7 +827,11 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             inner.height.saturating_sub(1),
             inner.x,
             inner.x.saturating_add(inner.width),
-            rects.iter().map(|r| (r.x, r.x + r.width)).collect(),
+            rects
+                .iter()
+                .zip((0..headers.len()).filter(|&i| col_visible(i)))
+                .map(|(r, i)| (r.x, r.x + r.width, i))
+                .collect(),
         );
     }
 
@@ -1757,6 +1778,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind("shift-j", "jump to owner (controller)"),
         bind("o", "show node hosting the pod"),
+        bind("←/→", "scroll columns (NAMESPACE/NAME stay anchored)"),
         bind("esc", "go back / pop view / clear filter"),
         bind("j/k g/G", "move · top/bottom"),
         bind("S · I", "sort by column (fuzzy picker) · invert direction"),


### PR DESCRIPTION
## Summary
- `←`/`→` in the table view scroll columns horizontally: the NAMESPACE/NAME prefix stays anchored while the columns after it shift off the left edge one at a time (fixes #137)
- Title shows a dim `‹N` indicator with the hidden-column count when scrolled
- Offset clamps so the last column is always reachable and at least one scrollable column stays visible; resets whenever the column set changes (view switch, drill, `w` wide toggle, printer columns arriving)
- Mouse hit-test ranges now carry the `display_headers()` index they show, so header-click sort maps to the right column while scrolled
- Help (`?`) and `docs/keys.md` document the new keys

## Test plan
- [x] New test `horizontal_column_scroll_anchors_name_and_clamps`: left-edge no-op, clamping, hit geometry skips hidden columns, reset on spec rebuild
- [x] Updated mouse click/sort test for index-tagged hit ranges
- [x] Full suite: 430 passed; `cargo fmt --check` and `cargo clippy --all-targets` clean
- [x] Live smoke test against a real cluster: `→`×2 showed `‹1`/`‹2` and hid READY then STATUS with NAME anchored; `←`×2 restored them