### PR TITLE
Search full discovery catalog on explicit palette queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ get distracted. She is, in effect, a cluster watchman that is a cat.
 TUI and a good cat both watch things closely, and both know when something is
 wrong.
 
+<br clear="right">
+
 ## What it does
 
 sofka is a reimagining of [k9s](https://github.com/derailed/k9s) with one generic

--- a/docs/features.md
+++ b/docs/features.md
@@ -38,7 +38,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   rank by fuzzy score, `⏎` jumps to the object. When a kind can't be listed
   (RBAC), the result says it's incomplete instead of pretending otherwise.
 - **Multiselect** (`space`) for bulk delete/kill/suspend/resume/reconcile.
-- **RBAC-aware palette** - kinds you can't `list` are hidden.
+- **RBAC-aware palette browse** - the empty `:` list hides kinds you cannot
+  `list`. An explicit search checks the full discovery catalog, because some
+  delegated authorizers return incomplete rule reviews.
 - **Namespace switcher** (`n`) with pinned favourites (★) and per-context
   session recents (·) above the rest, plus a context switcher (`:ctx`).
 - **Mouse support** - the wheel scrolls every view (one notch is three steps of

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -61,7 +61,9 @@ fighting the controller.
 namespace. `:can-i <verb> <resource> [ns]` checks a single action before you try
 it. Same answer as `kubectl auth can-i`, inside the TUI.
 
-The command palette is RBAC-aware too: kinds you can't `list` are hidden.
+The empty command-palette browse list hides kinds you cannot `list`. An explicit
+search includes every discovered kind because delegated authorizers can return
+incomplete rule reviews. The API still enforces access when you open the kind.
 
 ## Action journal
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -748,18 +748,17 @@ impl App {
             self.cluster.resolve(q).map(|k| k.title().to_lowercase())
         };
 
-        // Resource catalog (RBAC-filtered; the allow-list carries bare
-        // plurals, so group-qualified entries are checked by their plural).
-        // A qualified entry (`snapshots.kopiur…`) is listed only when it adds
-        // something: it's dropped while the bare plural also matches the query
-        // and resolves to the same kind, and kept when the plural is shadowed
-        // (`pods.metrics.k8s.io`) or only the group part matches (`kopiur`).
+        // Resource catalog. The empty browse list is RBAC-filtered, but an
+        // explicit query searches every discovered kind. Authorizers can return
+        // an incomplete SelfSubjectRulesReview without marking it incomplete,
+        // so using that result for search can hide resources the user can open.
+        // Qualified entries are checked by their bare plural when browsing.
         for c in &self.cluster.catalog {
             let (plural, group) = match c.split_once('.') {
                 Some((p, g)) => (p, Some(g)),
                 None => (c.as_str(), None),
             };
-            if !self.rbac_visible(plural) {
+            if q.is_empty() && !self.rbac_visible(plural) {
                 continue;
             }
             if let Some(group) = group {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -112,6 +112,51 @@ async fn exact_alias_outranks_fuzzy_suggestions() {
     assert_eq!(app.cmd_suggestions[0].label, "pods");
 }
 
+#[tokio::test]
+async fn explicit_palette_search_bypasses_rbac_filter() {
+    let (mut app, _rx) = test_app();
+    app.cluster
+        .catalog
+        .extend(["nbgroups.netbird.io", "networkresources.netbird.io"].map(str::to_string));
+    app.cluster.catalog.sort();
+    app.cluster.catalog.dedup();
+    app.rbac_allowed = Some(HashSet::from(["nbgroups".to_string()]));
+
+    // Explicit group and shorthand queries search discovery even when a rules
+    // review omits a resource that the authorizer still lets the user open.
+    for query in ["netbird", "nb"] {
+        app.command = query.into();
+        app.update_suggestions();
+        let labels: Vec<_> = app
+            .cmd_suggestions
+            .iter()
+            .map(|s| s.label.as_str())
+            .collect();
+        assert!(
+            labels.contains(&"nbgroups.netbird.io"),
+            "{query}: {labels:?}"
+        );
+        assert!(
+            labels.contains(&"networkresources.netbird.io"),
+            "{query}: {labels:?}"
+        );
+    }
+
+    // The empty browse list remains RBAC-filtered.
+    app.command.clear();
+    app.update_suggestions();
+    let labels: Vec<_> = app
+        .cmd_suggestions
+        .iter()
+        .map(|s| s.label.as_str())
+        .collect();
+    assert!(labels.contains(&"nbgroups.netbird.io"), "{labels:?}");
+    assert!(
+        !labels.contains(&"networkresources.netbird.io"),
+        "{labels:?}"
+    );
+}
+
 #[test]
 fn list_step_clamps_both_ends() {
     let mut s = ListState::default();


### PR DESCRIPTION
## Summary
- Explicit `:` palette queries now search the full discovery catalog instead of the RBAC allow-list; the empty browse list stays RBAC-filtered. Delegated authorizers can return incomplete `SelfSubjectRulesReview` results, which hid kinds the user could actually open.
- Updated docs (`features.md`, `safety.md`) to describe the browse-vs-search RBAC behavior.
- README: added `<br clear="right">` after the "Why sofka" section so the "What it does" heading underline no longer crosses the floated cat image.

## Test plan
- [x] `explicit_palette_search_bypasses_rbac_filter` — explicit queries surface kinds missing from the rules review; empty browse list remains filtered
- [x] Verify README rendering on GitHub after merge