### PR TITLE
fix: discover kinds served outside a group's preferred version

### DIFF
--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -223,7 +223,14 @@ impl Cluster {
         let mut entries: Vec<(Kind, String, String)> = Vec::new(); // (kind, plural, kind_lc)
         let mut catalog = Vec::new();
         for group in discovery.groups() {
-            for (ar, caps) in group.recommended_resources() {
+            // All served versions of the group, most stable version per kind.
+            // NOT `recommended_resources()`: that only returns resources at
+            // the group's *preferred* version, silently dropping kinds served
+            // solely at other versions — e.g. a CRD group whose preferred
+            // version is v1 while half its kinds only exist at v1alpha1
+            // (netbird.io does this; kube-rs docs call it the "ApiGroup
+            // Common Pitfall").
+            for (ar, caps) in group.resources_by_stability() {
                 let namespaced = matches!(caps.scope, Scope::Namespaced);
                 let kind = Kind {
                     ar: ar.clone(),
@@ -621,11 +628,17 @@ mod tests {
         fn route(path: &str, aggregated: bool, include_broken: bool) -> (&'static str, String) {
             let broken_legacy = r#",{"name":"broken.example.com","versions":[{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}}"#;
             let broken_v2 = r#",{"metadata":{"name":"broken.example.com"},"versions":[{"version":"v1beta1","resources":[],"freshness":"Stale"}]}"#;
+            // A mixed-version group modeled on the netbird.io operator: the
+            // preferred version (v1) serves `widgets`, while `gadgets` is
+            // only served at v1alpha1 — a preferred-version-only walk never
+            // sees gadgets.
+            let mixed_v2 = r#",{"metadata":{"name":"mixed.example.com"},"versions":[{"version":"v1","resources":[{"resource":"widgets","responseKind":{"group":"mixed.example.com","version":"v1","kind":"Widget"},"scope":"Namespaced","singularResource":"widget","verbs":["get","list","watch"]}],"freshness":"Current"},{"version":"v1alpha1","resources":[{"resource":"gadgets","responseKind":{"group":"mixed.example.com","version":"v1alpha1","kind":"Gadget"},"scope":"Namespaced","singularResource":"gadget","verbs":["get","list","watch"]}],"freshness":"Current"}]}"#;
+            let mixed_legacy = r#",{"name":"mixed.example.com","versions":[{"groupVersion":"mixed.example.com/v1","version":"v1"},{"groupVersion":"mixed.example.com/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"mixed.example.com/v1","version":"v1"}}"#;
             match (path, aggregated) {
                 ("/apis", true) => (
                     "200 OK",
                     format!(
-                        r#"{{"kind":"APIGroupDiscoveryList","apiVersion":"apidiscovery.k8s.io/v2","metadata":{{}},"items":[{{"metadata":{{"name":"apps"}},"versions":[{{"version":"v1","resources":[{{"resource":"deployments","responseKind":{{"group":"apps","version":"v1","kind":"Deployment"}},"scope":"Namespaced","singularResource":"deployment","verbs":["get","list","watch"]}}],"freshness":"Current"}}]}}{}]}}"#,
+                        r#"{{"kind":"APIGroupDiscoveryList","apiVersion":"apidiscovery.k8s.io/v2","metadata":{{}},"items":[{{"metadata":{{"name":"apps"}},"versions":[{{"version":"v1","resources":[{{"resource":"deployments","responseKind":{{"group":"apps","version":"v1","kind":"Deployment"}},"scope":"Namespaced","singularResource":"deployment","verbs":["get","list","watch"]}}],"freshness":"Current"}}]}}{mixed_v2}{}]}}"#,
                         if include_broken { broken_v2 } else { "" }
                     ),
                 ),
@@ -636,7 +649,7 @@ mod tests {
                 ("/apis", false) => (
                     "200 OK",
                     format!(
-                        r#"{{"kind":"APIGroupList","apiVersion":"v1","groups":[{{"name":"apps","versions":[{{"groupVersion":"apps/v1","version":"v1"}}],"preferredVersion":{{"groupVersion":"apps/v1","version":"v1"}}}}{}]}}"#,
+                        r#"{{"kind":"APIGroupList","apiVersion":"v1","groups":[{{"name":"apps","versions":[{{"groupVersion":"apps/v1","version":"v1"}}],"preferredVersion":{{"groupVersion":"apps/v1","version":"v1"}}}}{mixed_legacy}{}]}}"#,
                         if include_broken { broken_legacy } else { "" }
                     ),
                 ),
@@ -651,6 +664,14 @@ mod tests {
                 ("/api/v1", _) => (
                     "200 OK",
                     r#"{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"v1","resources":[{"name":"pods","singularName":"pod","namespaced":true,"kind":"Pod","verbs":["get","list","watch"]}]}"#.into(),
+                ),
+                ("/apis/mixed.example.com/v1", _) => (
+                    "200 OK",
+                    r#"{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"mixed.example.com/v1","resources":[{"name":"widgets","singularName":"widget","namespaced":true,"kind":"Widget","verbs":["get","list","watch"]}]}"#.into(),
+                ),
+                ("/apis/mixed.example.com/v1alpha1", _) => (
+                    "200 OK",
+                    r#"{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"mixed.example.com/v1alpha1","resources":[{"name":"gadgets","singularName":"gadget","namespaced":true,"kind":"Gadget","verbs":["get","list","watch"]}]}"#.into(),
                 ),
                 ("/apis/broken.example.com/v1beta1", _) => (
                     "503 Service Unavailable",
@@ -747,6 +768,37 @@ mod tests {
             .expect("connect via legacy discovery walk");
         assert!(cluster.resolve("deployments").is_some());
         assert!(cluster.resolve("pods").is_some());
+    }
+
+    /// Asserts every kind of the mixed-version group resolved: `widgets` at
+    /// the preferred v1, `gadgets` only served at v1alpha1. A discovery walk
+    /// limited to each group's preferred version loses gadgets entirely
+    /// (the netbird.io bug: `:sidecarprofiles.netbird.io` -> no match).
+    fn assert_mixed_group(cluster: &Cluster) {
+        let widgets = cluster.resolve("widgets").expect("widgets resolves");
+        assert_eq!(widgets.ar.version, "v1");
+        let gadgets = cluster.resolve("gadgets").expect("gadgets resolves");
+        assert_eq!(gadgets.ar.version, "v1alpha1");
+        assert!(cluster.resolve("gadgets.mixed.example.com").is_some());
+        assert!(
+            cluster
+                .catalog
+                .contains(&"gadgets.mixed.example.com".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregated_discovery_includes_non_preferred_versions() {
+        let url = mock_apiserver(true, false).await;
+        let cluster = connect_mock(url).await.expect("connect aggregated");
+        assert_mixed_group(&cluster);
+    }
+
+    #[tokio::test]
+    async fn legacy_discovery_includes_non_preferred_versions() {
+        let url = mock_apiserver(false, false).await;
+        let cluster = connect_mock(url).await.expect("connect legacy");
+        assert_mixed_group(&cluster);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `discover()` used kube-rs `recommended_resources()`, which only returns resources served at each API group's **preferred version**. Kinds served solely at another version never entered the registry or catalog, so they couldn't be resolved (`:sidecarprofiles.netbird.io` → "No resource matches") or completed — even though k9s/kubectl see them.
- Real-world trigger: the netbird operator's `netbird.io` group is mixed-version — 5 CRDs at `v1` (preferred), 7 at `v1alpha1` (`sidecarprofiles`, `clusterproxies`, `setupkeys`, `networkrouters`, …). kube-rs documents this as the "ApiGroup Common Pitfall".
- Switch to `resources_by_stability()`: merges all served versions of the group and picks the most stable version per kind (kubectl semantics). Works on both the aggregated and legacy discovery paths, since both retain all versions.
- Behavioral note: kinds served at multiple versions now use the most *stable* version rather than the group's preferred one (e.g. a group preferring `v2beta1` while also serving `v1` now watches `v1`) — matches kubectl.

## Test plan
- [x] Extended the mock apiserver with a mixed-version group (`widgets`@v1 preferred, `gadgets`@v1alpha1 only) modeled on netbird.io
- [x] New `aggregated_discovery_includes_non_preferred_versions` and `legacy_discovery_includes_non_preferred_versions` tests fail on the old code (`gadgets resolves` panic) and pass with the fix; assert resolved versions, group-qualified keys, and catalog presence
- [x] Full suite: 433 passed, 0 failed
- [x] Live repro: applied the 12 netbird CRDs to a real cluster (apiserver reports `preferred: v1`), confirmed `sofka --snapshot sidecarprofiles.netbird.io` resolves and renders the view