### PR TITLE
feat: toggle fleet membership from the context switcher

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -138,7 +138,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   usage in a Prometheus or VictoriaMetrics backend, with a patch preview. Never
   mutates. See [Providers](providers.md#right-sizing-metrics-provider).
 - **Fleet dashboard** (`:fleet`) - an opt-in health summary across contexts,
-  side by side. See [Providers](providers.md#fleet-dashboard).
+  side by side. Contexts come from config or `space` in the `:ctx` switcher.
+  See [Providers](providers.md#fleet-dashboard).
 - **YAML view** (`y`), **describe** (`d`, via `kubectl`), **events**
   (`:events` / `E`, filtered by UID when available), and **diff** (`:diff`).
 - **Diff on GitOps clusters** - `:diff` shows a unified diff of the live object

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -29,9 +29,9 @@ plugin, bookmark, and workspace chords.
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
 | `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                             |
-| `:ctx` / `:ctx <name>`                        | context switcher popup (`/` filters, `r` renames) / switch directly (the name tab-completes)                                          |
+| `:ctx` / `:ctx <name>`                        | context switcher popup (`/` filters, `r` renames, `space` toggles fleet membership) / switch directly (the name tab-completes)        |
 | `:helm`                                       | Helm releases (native storage-Secret decode): ⏎ history → values · `y` manifest · `d` notes · `r` rollback                            |
-| `:fleet`                                      | cross-context health dashboard (opt-in `[fleet]` contexts; `⏎` switches, `r` refreshes)                                               |
+| `:fleet`                                      | cross-context health dashboard (opt-in: `[fleet]` contexts or `space` in `:ctx`; `⏎` switches, `r` refreshes)                         |
 | `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
 | `:reload` / `:config` / `:info`               | reload config from disk · config sources + warnings · runtime diagnostics                                                             |
 | `l` / `p`                                     | logs (workload = all matching pods) / previous-container logs                                                                         |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -78,6 +78,14 @@ through them. It's **opt-in** - sofka queries only the contexts you list.
 contexts = ["prod-eu", "prod-us", "staging"]
 ```
 
+You can also build or edit the fleet from inside the TUI: in the `:ctx`
+switcher, `space` toggles the highlighted context in or out of the fleet
+(members show a `✓`). These marks are saved to `<state-dir>/fleet.toml`
+(`~/.local/state/sofka/fleet.toml` by default; see `sofka --info`) and overlay
+the `[fleet] contexts` list on every start - sofka never rewrites your config
+file, so the config stays the hand-edited base list and marks can both add to
+it and mask entries out.
+
 Contexts are gathered concurrently with a per-context timeout, so an unreachable
 or slow cluster shows an error on its own row instead of blocking the others.
 Each row shows connectivity, Kubernetes version, node readiness, the unhealthy

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -10,12 +10,67 @@ const FLEET_CONCURRENCY: usize = 4;
 const FLEET_TIMEOUT_SECS: u64 = 8;
 
 impl App {
+    /// The fleet contexts in effect: the `[fleet] contexts` config list plus
+    /// contexts marked with `space` in the context switcher, minus config
+    /// entries unmarked the same way. Marks persist across restarts (see
+    /// [`crate::fleet::FleetMarks`]); the config file is never rewritten.
+    pub fn fleet_contexts(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .fleet_cfg
+            .contexts
+            .iter()
+            .filter(|c| !self.fleet_marks.removed.contains(c))
+            .cloned()
+            .collect();
+        for c in &self.fleet_marks.added {
+            if !out.contains(c) {
+                out.push(c.clone());
+            }
+        }
+        out
+    }
+
+    /// Whether `ctx` is currently part of the fleet (config + marks).
+    pub fn is_fleet_context(&self, ctx: &str) -> bool {
+        self.fleet_contexts().iter().any(|c| c == ctx)
+    }
+
+    /// Toggle a context in/out of the fleet (`space` in the context
+    /// switcher), saving the marks so the fleet survives restarts.
+    pub(super) fn toggle_fleet_context(&mut self, ctx: &str) {
+        if self.is_fleet_context(ctx) {
+            self.fleet_marks.added.retain(|c| c != ctx);
+            // A config-listed context can't be dropped from the config Vec
+            // (it comes back on every re-resolve), so it's masked instead.
+            if self.fleet_cfg.contexts.iter().any(|c| c == ctx)
+                && !self.fleet_marks.removed.iter().any(|c| c == ctx)
+            {
+                self.fleet_marks.removed.push(ctx.to_string());
+            }
+            self.flash = format!("fleet − {ctx}");
+        } else {
+            self.fleet_marks.removed.retain(|c| c != ctx);
+            self.fleet_marks.added.push(ctx.to_string());
+            self.flash = format!("fleet + {ctx}");
+        }
+        self.flash_err = false;
+        if let Some(path) = self.fleet_marks_path.clone()
+            && let Err(e) = self.fleet_marks.save(&path)
+        {
+            self.flash_warn(&format!("fleet mark not saved: {e}"));
+        }
+    }
+
     /// `:fleet` — open the opt-in cross-context health dashboard. Only the
-    /// contexts in `[fleet].contexts` are queried; each is gathered off-thread
-    /// with its own timeout so one slow context never blocks the rest.
+    /// contexts in `[fleet].contexts` (plus session `space`-marks) are
+    /// queried; each is gathered off-thread with its own timeout so one slow
+    /// context never blocks the rest.
     pub(super) fn open_fleet(&mut self) {
-        if self.fleet_cfg.contexts.is_empty() {
-            self.flash_warn("no fleet contexts — set [fleet] contexts = [\"ctx-a\", …]");
+        let contexts = self.fleet_contexts();
+        if contexts.is_empty() {
+            self.flash_warn(
+                "no fleet contexts — set [fleet] contexts = [\"ctx-a\", …] or mark them with space in :ctx",
+            );
             return;
         }
         // Leaving the table view: stop its watches (like the pulse dashboard),
@@ -27,9 +82,7 @@ impl App {
 
         // Seed a "connecting" row per context, resolving each one's read-only
         // policy up front (the CLI flag wins; else the per-context config).
-        self.fleet_rows = self
-            .fleet_cfg
-            .contexts
+        self.fleet_rows = contexts
             .iter()
             .map(|ctx| {
                 let cluster = crate::k8s::cluster_name_for_context(ctx);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -996,6 +996,12 @@ pub struct App {
     /// context's summary lands.
     pub fleet_rows: Vec<crate::fleet::FleetRow>,
     pub fleet_state: ListState,
+    /// Fleet membership marks (`space` in the context switcher), overlaying
+    /// `[fleet] contexts`. Persisted to `fleet_marks_path` on every toggle.
+    pub fleet_marks: crate::fleet::FleetMarks,
+    /// Where fleet marks persist (`<state-dir>/fleet.toml`, set at startup);
+    /// `None` (tests) keeps them in memory only.
+    pub fleet_marks_path: Option<std::path::PathBuf>,
     /// Global fuzzy-find (`:find`) results and picker cursor.
     pub find_items: Vec<crate::store::FindItem>,
     pub find_state: ListState,
@@ -1245,6 +1251,8 @@ impl App {
             fleet_cfg: crate::config::FleetConfig::default(),
             fleet_rows: Vec::new(),
             fleet_state: ListState::default(),
+            fleet_marks: crate::fleet::FleetMarks::default(),
+            fleet_marks_path: None,
             find_items: Vec::new(),
             find_state: ListState::default(),
             find_query: String::new(),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -447,6 +447,17 @@ impl App {
             }
             KeyCode::Char('/') => self.ctx_filtering = true,
             KeyCode::Char('r') | KeyCode::Char('R') => self.open_rename_context(),
+            // Space toggles the highlighted context in/out of the `:fleet`
+            // dashboard for this session (the bulk-mark idiom).
+            KeyCode::Char(' ') => {
+                if let Some(name) = self
+                    .ctx_state
+                    .selected()
+                    .and_then(|i| self.filtered_contexts().get(i).cloned())
+                {
+                    self.toggle_fleet_context(&name);
+                }
+            }
             KeyCode::Down | KeyCode::Char('j') => list_step(&mut self.ctx_state, len, true),
             KeyCode::Up | KeyCode::Char('k') => list_step(&mut self.ctx_state, len, false),
             KeyCode::Enter => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5114,6 +5114,75 @@ async fn fleet_without_configured_contexts_warns() {
 }
 
 #[tokio::test]
+async fn fleet_toggle_in_context_switcher_edits_marks() {
+    let (mut app, _rx) = test_app();
+    app.fleet_cfg = crate::config::FleetConfig {
+        contexts: vec!["prod".into()],
+    };
+
+    // Space on a non-member adds it after the config entries.
+    app.ctx_list = vec!["prod".into(), "staging".into()];
+    app.ctx_state.select(Some(1));
+    app.mode = Mode::Contexts;
+    app.key_contexts(press(KeyCode::Char(' ')));
+    assert_eq!(app.fleet_contexts(), vec!["prod", "staging"]);
+    assert!(app.is_fleet_context("staging"));
+    assert!(app.flash.contains("fleet + staging"), "{}", app.flash);
+    assert_eq!(app.mode, Mode::Contexts, "toggling stays in the switcher");
+
+    // Space again removes it.
+    app.key_contexts(press(KeyCode::Char(' ')));
+    assert_eq!(app.fleet_contexts(), vec!["prod"]);
+    assert!(app.flash.contains("fleet − staging"), "{}", app.flash);
+
+    // A config-listed context can be masked out for the session too…
+    app.ctx_state.select(Some(0));
+    app.key_contexts(press(KeyCode::Char(' ')));
+    assert!(app.fleet_contexts().is_empty());
+    // …and re-added.
+    app.key_contexts(press(KeyCode::Char(' ')));
+    assert_eq!(app.fleet_contexts(), vec!["prod"]);
+}
+
+#[tokio::test]
+async fn fleet_opens_with_marked_contexts_only() {
+    let (mut app, _rx) = test_app();
+    assert!(app.fleet_cfg.contexts.is_empty());
+    app.fleet_marks.added.push("staging".into());
+    app.open_fleet();
+    assert_eq!(app.mode, Mode::Fleet);
+    assert_eq!(app.fleet_rows.len(), 1);
+    assert_eq!(app.fleet_rows[0].context, "staging");
+}
+
+#[tokio::test]
+async fn fleet_marks_persist_across_restarts() {
+    let dir = std::env::temp_dir().join(format!("sofka-fleet-test-{}", std::process::id()));
+    let path = dir.join("fleet.toml");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // Toggling with a persist path saves the marks…
+    let (mut app, _rx) = test_app();
+    app.fleet_marks_path = Some(path.clone());
+    app.ctx_list = vec!["prod".into(), "staging".into()];
+    app.ctx_state.select(Some(1));
+    app.mode = Mode::Contexts;
+    app.key_contexts(press(KeyCode::Char(' ')));
+    assert!(path.exists(), "marks file written on toggle");
+    assert!(!app.flash_err, "{}", app.flash);
+
+    // …and a fresh app (a restart) loads them back.
+    let loaded = crate::fleet::FleetMarks::load(&path);
+    assert_eq!(loaded, app.fleet_marks);
+    assert_eq!(loaded.added, vec!["staging".to_string()]);
+
+    // A missing or corrupt file degrades to empty marks, never an error.
+    std::fs::write(&path, "not toml [[[").unwrap();
+    assert_eq!(crate::fleet::FleetMarks::load(&path), Default::default());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn fleet_seeds_connecting_rows_and_applies_summaries() {
     let (mut app, _rx) = test_app();
     app.fleet_cfg = crate::config::FleetConfig {

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -7,6 +7,49 @@
 //! each is gathered independently so one slow cluster never blocks the rest.
 //! Only these non-sensitive summaries are held in memory.
 
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Fleet membership edits made with `space` in the context switcher,
+/// persisted to `<state-dir>/fleet.toml` so marks survive restarts. This is
+/// deliberately a separate state file: sofka never rewrites the user's config,
+/// so `[fleet] contexts` stays the hand-edited base list and these marks
+/// overlay it.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FleetMarks {
+    /// Contexts added on top of `[fleet] contexts`, in toggle order.
+    pub added: Vec<String>,
+    /// Config-listed contexts masked out with `space`.
+    pub removed: Vec<String>,
+}
+
+impl FleetMarks {
+    /// Where marks live: `<state-dir>/fleet.toml`.
+    pub fn default_path() -> PathBuf {
+        crate::diagnostics::state_dir().join("fleet.toml")
+    }
+
+    /// Load persisted marks. A missing or unparsable file is an empty set —
+    /// the dashboard must still open when state was never written or got
+    /// hand-mangled.
+    pub fn load(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        let text = toml::to_string(self).map_err(|e| e.to_string())?;
+        std::fs::write(path, text).map_err(|e| e.to_string())
+    }
+}
+
 /// Where a context's summary stands.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FleetStatus {

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,11 @@ async fn main() -> Result<()> {
     let (tx, mut rx) = mpsc::channel(EVENT_CHANNEL_CAP);
     let panic_tx = tx.clone();
     let mut app = App::new(cluster, tx);
+    // Fleet marks (`space` in `:ctx`) persist under the state dir, overlaying
+    // the `[fleet] contexts` config list across restarts.
+    let fleet_marks_path = fleet::FleetMarks::default_path();
+    app.fleet_marks = fleet::FleetMarks::load(&fleet_marks_path);
+    app.fleet_marks_path = Some(fleet_marks_path);
     // Kubeconfig contexts are stable for the session; cache them once so the
     // palette can complete `:ctx <name>` without re-reading the file per keystroke.
     match Cluster::list_contexts() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1755,7 +1755,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind(":ctx · :pulse", "switch context · cluster-health dashboard"),
         bind(
             ":fleet",
-            "cross-context health dashboard (opt-in [fleet] contexts; ⏎ switches)",
+            "cross-context health dashboard ([fleet] contexts or space in :ctx; ⏎ switches)",
         ),
         bind(
             ":xray · :diff",
@@ -2023,14 +2023,23 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
         .iter()
         .map(|c| {
             let marker = if *c == current { "● " } else { "  " };
-            ListItem::new(Span::styled(
-                format!("{marker}{c}"),
-                Style::default().fg(if *c == current {
-                    theme::green()
-                } else {
-                    theme::text()
-                }),
-            ))
+            // Fleet membership (`space` toggles) in the bulk-mark style.
+            let fleet = if app.is_fleet_context(c) {
+                "✓ "
+            } else {
+                "  "
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(fleet, Style::default().fg(theme::mark())),
+                Span::styled(
+                    format!("{marker}{c}"),
+                    Style::default().fg(if *c == current {
+                        theme::green()
+                    } else {
+                        theme::text()
+                    }),
+                ),
+            ]))
         })
         .collect();
     // While typing, show the filter buffer in the title so it reads like an
@@ -2040,7 +2049,7 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
     } else if !app.ctx_filter.is_empty() {
         format!(" Contexts · /{} ", app.ctx_filter)
     } else {
-        " Contexts (/ filter · r rename · ⏎ switch) ".to_string()
+        " Contexts (/ filter · r rename · space fleet · ⏎ switch) ".to_string()
     };
     render_popup_list(
         frame,


### PR DESCRIPTION
## Summary
- `space` in the `:ctx` switcher toggles the highlighted context in/out of the `:fleet` dashboard; members show a `✓` in the bulk-mark style
- Marks persist to `<state-dir>/fleet.toml` (`~/.local/state/sofka/fleet.toml`) and overlay `[fleet] contexts` on every start — the config file is never rewritten, so it stays the hand-edited base list that marks can extend or mask
- `:fleet` now queries the effective list (config minus removed marks, plus added marks); the empty-fleet warning points at both ways to opt in
- A missing or unparsable marks file degrades to empty marks; a failed save flashes a warning
- Docs updated (keys, features, providers) and palette/picker hints mention the new key

## Test plan
- [x] `cargo test` — 436 passed, including new coverage for toggle add/remove/mask, opening `:fleet` from marks alone, and the save/load round-trip with a corrupt-file fallback
- [x] `cargo clippy --all-targets` and `cargo fmt --check` clean
- [ ] Manual: mark a context with `space` in `:ctx`, restart, confirm `:fleet` opens with it