### PR TITLE
feat: show pod count per node in the nodes view

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -271,6 +271,7 @@ impl App {
         self.watch_key = Some(key);
         self.metrics.clear();
         self.container_metrics.clear();
+        self.node_pods = None;
         self.marked.clear();
         self.clear_rows_cache();
         if self.table_state.selected().is_none() {
@@ -291,6 +292,9 @@ impl App {
 
         if matches!(self.kind_plural.as_str(), "pods" | "nodes") {
             self.spawn_metrics_poll();
+        }
+        if self.kind_plural == "nodes" {
+            self.spawn_node_pods_poll();
         }
 
         // Refresh RBAC allow-list when the namespace changes.
@@ -534,6 +538,56 @@ impl App {
         self.tasks.push(handle);
     }
 
+    /// Poll the pods API for the nodes view: pod count per node (the PODS
+    /// column). Counts non-terminated pods — Succeeded/Failed pods hold no
+    /// node resources — mirroring `kubectl describe node`. List failures
+    /// (e.g. no cluster-wide pod list permission) leave the column at "-".
+    pub(super) fn spawn_node_pods_poll(&mut self) {
+        let Some(pkind) = self.cluster.resolve("pods") else {
+            return;
+        };
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        let flag = self.gen_flag.clone();
+        let ar = pkind.ar.clone();
+
+        let handle = tokio::spawn(async move {
+            let params =
+                ListParams::default().fields("status.phase!=Succeeded,status.phase!=Failed");
+            loop {
+                if flag.load(Ordering::SeqCst) != genr {
+                    break;
+                }
+                let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
+                if let Ok(list) = api.list(&params).await {
+                    let mut counts: HashMap<String, usize> = HashMap::new();
+                    for item in list {
+                        if let Some(node) = item
+                            .data
+                            .pointer("/spec/nodeName")
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            *counts.entry(node.to_string()).or_insert(0) += 1;
+                        }
+                    }
+                    if tx
+                        .send(Msg::NodePods {
+                            generation: genr,
+                            counts,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        });
+        self.tasks.push(handle);
+    }
+
     pub(super) fn bump_generation(&mut self) {
         self.stop_event_stream();
         self.generation += 1;
@@ -638,6 +692,16 @@ impl App {
                 self.metrics = data;
                 self.container_metrics = containers;
                 if sort_uses_metrics {
+                    self.invalidate_rows();
+                }
+            }
+            Msg::NodePods { generation, counts } if generation == self.generation => {
+                let sort_uses_pods = self
+                    .sort_column
+                    .and_then(|i| self.display_headers().get(i).cloned())
+                    .is_some_and(|h| h == "PODS");
+                self.node_pods = Some(counts);
+                if sort_uses_pods {
                     self.invalidate_rows();
                 }
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1092,6 +1092,10 @@ pub struct App {
     pub metrics: HashMap<String, (i64, i64)>,
     /// Latest pod-container metrics: "ns/pod/container" -> (cpu_m, mem_bytes).
     pub container_metrics: HashMap<String, (i64, i64)>,
+    /// Latest pod count per node (nodes view PODS column). `None` until the
+    /// first successful pods list, so "no data yet" renders as "-" instead of
+    /// a misleading 0.
+    pub node_pods: Option<HashMap<String, usize>>,
 
     pub pulse: Pulse,
     pub xray_items: Vec<XrayItem>,
@@ -1294,6 +1298,7 @@ impl App {
             image_target: None,
             metrics: HashMap::new(),
             container_metrics: HashMap::new(),
+            node_pods: None,
             pulse: Pulse::default(),
             xray_items: Vec::new(),
             xray_state: ListState::default(),

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -154,10 +154,10 @@ impl App {
         let sort_header = self
             .sort_column
             .and_then(|i| headers.get(i).map(String::as_str));
-        // CPU/MEM (and the node capacity percentages) sort by the live metrics
-        // snapshot, which moves without a new resourceVersion, so those keys
-        // can never be cached.
-        let volatile_sort = matches!(sort_header, Some("CPU" | "MEM" | "%CPU" | "%MEM"));
+        // CPU/MEM (and the node capacity percentages and pod counts) sort by
+        // live poll snapshots, which move without a new resourceVersion, so
+        // those keys can never be cached.
+        let volatile_sort = matches!(sort_header, Some("CPU" | "MEM" | "%CPU" | "%MEM" | "PODS"));
         // The aggregated Helm release list (`helm list` semantics) shows only
         // the latest revision per release; `helmhistory` (one release's full
         // history) shows every revision, so it skips this.
@@ -315,6 +315,9 @@ impl App {
         if self.show_namespace_column() {
             h.insert(0, "NAMESPACE".into());
         }
+        if self.node_capacity_columns() {
+            h.push("PODS".into());
+        }
         if self.metrics_columns() {
             h.push("CPU".into());
             h.push("MEM".into());
@@ -451,6 +454,24 @@ impl App {
         self.metrics.get(&key).copied().unwrap_or((0, 0))
     }
 
+    /// Latest pod count for a node from the pods poll; `None` before the
+    /// first successful list (renders "-", distinct from a genuinely empty
+    /// node).
+    pub fn node_pods_for(&self, o: &DynamicObject) -> Option<usize> {
+        let name = o.metadata.name.as_deref().unwrap_or_default();
+        self.node_pods
+            .as_ref()
+            .map(|m| m.get(name).copied().unwrap_or(0))
+    }
+
+    /// The PODS cell for a node as displayed.
+    pub fn node_pods_cell(&self, o: &DynamicObject) -> String {
+        match self.node_pods_for(o) {
+            Some(n) => n.to_string(),
+            None => "-".into(),
+        }
+    }
+
     /// Comparable value of `header`'s cell for object `o`.
     pub(super) fn column_sort_key(&self, o: &DynamicObject, header: &str) -> SortKey {
         // User/printer columns sort by their declared type (quantity, number,
@@ -473,6 +494,10 @@ impl App {
             "AGE" => SortKey::Num(crate::columns::age_secs(o).unwrap_or(i64::MAX) as f64),
             "CPU" => SortKey::Num(self.metrics_for(o).0 as f64),
             "MEM" => SortKey::Num(self.metrics_for(o).1 as f64),
+            // Unknown counts (poll hasn't landed) sort below every real count.
+            "PODS" if self.node_capacity_columns() => {
+                SortKey::Num(self.node_pods_for(o).map(|c| c as f64).unwrap_or(-1.0))
+            }
             // Unknown allocatable sorts below every real percentage.
             "%CPU" if self.node_capacity_columns() => SortKey::Num(
                 crate::columns::usage_pct(

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -73,6 +73,9 @@ impl App {
                         }
                     }
                 }
+                if self.node_capacity_columns() {
+                    cells.push(self.node_pods_cell(obj));
+                }
                 if metrics_cols {
                     let name = obj.metadata.name.as_deref().unwrap_or_default();
                     let key = if pods_view {
@@ -87,6 +90,17 @@ impl App {
                     let (cpu, mem) = self.metrics.get(&key).copied().unwrap_or((0, 0));
                     cells.push(crate::columns::fmt_cpu(cpu));
                     cells.push(crate::columns::fmt_mem(mem));
+                    // Nodes also carry %CPU/%MEM headers — the capture must
+                    // stay one cell per column.
+                    if self.node_capacity_columns() {
+                        let (alloc_cpu, alloc_mem) = crate::columns::node_allocatable(obj);
+                        cells.push(crate::columns::fmt_pct(crate::columns::usage_pct(
+                            cpu, alloc_cpu,
+                        )));
+                        cells.push(crate::columns::fmt_pct(crate::columns::usage_pct(
+                            mem, alloc_mem,
+                        )));
+                    }
                 }
                 cells
             })

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2397,6 +2397,94 @@ async fn node_capacity_percent_columns_render_and_sort() {
     assert_eq!(names, ["small", "big"]);
 }
 
+#[tokio::test]
+async fn nodes_view_pods_column_counts_and_sorts() {
+    let (mut app, _rx) = test_app();
+    // Pods must not grow a PODS column.
+    app.switch_kind("pods");
+    assert!(!app.display_headers().contains(&"PODS".to_string()));
+
+    app.switch_kind("nodes");
+    let headers = app.display_headers();
+    let pods_idx = headers.iter().position(|h| *h == "PODS").unwrap();
+    // PODS sits right before the CPU/MEM usage columns, k9s-style.
+    assert_eq!(headers[pods_idx + 1], "CPU", "{headers:?}");
+
+    for n in ["node-a", "node-b"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node",
+                   "metadata": {"name": n, "resourceVersion": "1"}}),
+        );
+    }
+
+    // Before the first pods list lands the column reads "-", not a fake 0,
+    // and the capture stays one cell per column (nodes carry PODS and
+    // %CPU/%MEM headers beyond the base spec).
+    let (cols, rows) = app.snapshot_table();
+    assert!(rows.iter().all(|r| r.len() == cols.len()), "{rows:?}");
+    assert!(rows.iter().all(|r| r[pods_idx] == "-"), "{rows:?}");
+
+    app.handle_msg(Msg::NodePods {
+        generation: app.generation,
+        counts: HashMap::from([("node-b".to_string(), 7)]),
+    });
+    // node-a has no entry → genuinely zero pods once data exists.
+    let (_, rows) = app.snapshot_table();
+    let cell = |name: &str| {
+        rows.iter()
+            .find(|r| r[0] == name)
+            .map(|r| r[pods_idx].clone())
+            .unwrap()
+    };
+    assert_eq!(cell("node-a"), "0");
+    assert_eq!(cell("node-b"), "7");
+
+    app.sort_column = Some(pods_idx);
+    app.sort_desc = true;
+    app.invalidate_rows();
+    let names: Vec<String> = app
+        .rows()
+        .iter()
+        .map(|o| o.metadata.name.clone().unwrap())
+        .collect();
+    assert_eq!(names, ["node-b", "node-a"]);
+}
+
+#[tokio::test]
+async fn node_pods_update_invalidates_pods_sorted_rows() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("nodes");
+    for n in ["node-a", "node-b"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node",
+                   "metadata": {"name": n, "resourceVersion": "1"}}),
+        );
+    }
+    let pods_idx = app
+        .display_headers()
+        .iter()
+        .position(|h| *h == "PODS")
+        .unwrap();
+    app.sort_column = Some(pods_idx);
+    app.sort_desc = true;
+    app.invalidate_rows();
+    let _ = app.rows(); // warm the sorted row cache
+
+    // A fresh count snapshot must resort without any other invalidation.
+    app.handle_msg(Msg::NodePods {
+        generation: app.generation,
+        counts: HashMap::from([("node-a".to_string(), 2), ("node-b".to_string(), 9)]),
+    });
+    let names: Vec<String> = app
+        .rows()
+        .iter()
+        .map(|o| o.metadata.name.clone().unwrap())
+        .collect();
+    assert_eq!(names, ["node-b", "node-a"]);
+}
+
 #[test]
 fn node_allocatable_reads_status_quantities() {
     let node = obj(json!({"apiVersion": "v1", "kind": "Node",

--- a/src/store.rs
+++ b/src/store.rs
@@ -34,6 +34,12 @@ pub enum Msg {
         /// Per-container usage keyed by `namespace/pod/container`.
         containers: HashMap<String, (i64, i64)>,
     },
+    /// Pod count per node from the pods poll on the nodes view, keyed by node
+    /// name. Counts non-terminated pods, mirroring `kubectl describe node`.
+    NodePods {
+        generation: u64,
+        counts: HashMap<String, usize>,
+    },
     /// CRD `additionalPrinterColumns` fallback for a custom-resource plural,
     /// fetched off-thread (`None` = CRD had nothing usable for the version).
     PrinterColumns {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -605,6 +605,9 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     cells.push(TableCellText::Borrowed(cell));
                 }
             }
+            if app.node_capacity_columns() {
+                cells.push(TableCellText::Owned(app.node_pods_cell(obj)));
+            }
             let mut metrics_raw = None;
             let mut node_pcts: (Option<i64>, Option<i64>) = (None, None);
             if metrics_cols {
@@ -735,6 +738,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 "AGE" => Constraint::Length(7),
                 "CPU" | "MEM" => Constraint::Length(8),
                 "%CPU" | "%MEM" => Constraint::Length(5),
+                "PODS" => Constraint::Length(5),
                 // Wide enough for the long pod reasons (ContainerCreating,
                 // CrashLoopBackOff, ImagePullBackOff…) so status is never clipped.
                 "STATUS" => Constraint::Length(19),


### PR DESCRIPTION
## Summary
- Adds a `PODS` column to the nodes view (between `AGE` and `CPU`, k9s-style) showing the pod count per node.
- Counts come from a 10s pods poll (`Msg::NodePods`) that lists non-terminated pods (`status.phase!=Succeeded,status.phase!=Failed`) and groups by `spec.nodeName` — the same set `kubectl describe node` counts.
- `-` until the first list lands, so "no data yet" never reads as an empty node; a node absent from the counts after that is genuinely `0`. List failures (e.g. no cluster-wide pod list RBAC) leave the column at `-`.
- Sortable: `PODS` joins the volatile sort set (CPU/MEM/%CPU/%MEM) since counts move without a new `resourceVersion`, so a fresh poll resorts a PODS-sorted view.

## Bug fix included
`:snapshot` captures of the nodes view were two cells short per row — `display_headers` appends `%CPU`/`%MEM` for nodes but `snapshot_table` never emitted those cells. The capture now emits one cell per column (PODS and the capacity percentages), covered by an assertion in the new test.

## Testing
- `nodes_view_pods_column_counts_and_sorts`: header placement, `-` before data, `0` vs real counts after, sort order, snapshot row/column alignment.
- `node_pods_update_invalidates_pods_sorted_rows`: a fresh count snapshot resorts a PODS-sorted view (caught the resourceVersion sort-key cache reusing stale keys).
- `just check` (fmt, clippy `-D warnings`, 439 tests) passes.

Closes #145
