### PR TITLE
feat: copy any cell of the selected row via a field picker (Y)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -38,6 +38,11 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   rank by fuzzy score, `⏎` jumps to the object. When a kind can't be listed
   (RBAC), the result says it's incomplete instead of pretending otherwise.
 - **Multiselect** (`space`) for bulk delete/kill/suspend/resume/reconcile.
+- **Copy to clipboard** - `c` copies the selected resource's name; `Y` opens a
+  field picker over the selected row's displayed columns (full values, never
+  the width-truncated cell text) - type to match a column name or its value
+  (an IP, an image, a node), `⏎` copies it. Falls back to OSC 52 on remote
+  terminals without a local clipboard tool.
 - **RBAC-aware palette browse** - the empty `:` list hides kinds you cannot
   `list`. An explicit search checks the full discovery catalog, because some
   delegated authorizers return incomplete rule reviews.

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -37,6 +37,7 @@ plugin, bookmark, and workspace chords.
 | `l` / `p`                                     | logs (workload = all matching pods) / previous-container logs                                                                         |
 | `L` / `:vlogs`                                | VictoriaLogs history for the selection (pod, container, workload, service, namespace)                                                 |
 | `c`                                           | copy resource name to clipboard                                                                                                       |
+| `Y`                                           | copy any cell of the selected row: picker over the displayed columns (type to match a column name or value), `⏎` copies               |
 | `e`                                           | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |
 | `s`                                           | shell into pod / scale a workload (context-dependent)                                                                                 |
 | `a`                                           | attach to pod                                                                                                                         |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -60,6 +60,7 @@ impl App {
             Mode::Namespaces => self.key_namespaces(key),
             Mode::Contexts => self.key_contexts(key),
             Mode::SortPicker => self.key_sort_picker(key),
+            Mode::CopyPicker => self.key_copy_picker(key),
             Mode::Containers => self.key_containers(key),
             Mode::SetImage => self.key_set_image(key),
             Mode::Confirm => self.key_confirm(key),
@@ -149,6 +150,9 @@ impl App {
             KeyCode::Char('i') => self.request_set_image(),
             KeyCode::Char('o') => self.show_node(),
             KeyCode::Char('c') => self.copy_name(),
+            // Copy any displayed cell of the row via a field picker (`c`
+            // above copies just the name).
+            KeyCode::Char('Y') => self.open_copy_picker(),
             KeyCode::Char('J') => self.jump_owner(),
             // `X` — explain why the selection is unhealthy (evidence-backed).
             KeyCode::Char('X') => self.open_explain(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -103,6 +103,9 @@ pub enum Mode {
     Contexts,
     /// Fuzzy sort-column picker (`S`).
     SortPicker,
+    /// Fuzzy field picker over the selected row's cells (`Y`): pick a column
+    /// value to copy to the clipboard.
+    CopyPicker,
     Containers,
     SetImage,
     Confirm,
@@ -960,6 +963,12 @@ pub struct App {
     pub sort_picker_state: ListState,
     /// Type-to-filter buffer for the sort-column picker.
     pub sort_picker_filter: String,
+    pub copy_picker_state: ListState,
+    /// Type-to-filter buffer for the copy-field picker.
+    pub copy_picker_filter: String,
+    /// The selected row's `(header, value)` pairs, captured when the copy
+    /// picker opens so a watch update can't shift entries mid-pick.
+    pub copy_picker_fields: Vec<(String, String)>,
     /// All kubeconfig context names, cached once at startup for `:ctx <name>`
     /// palette completion (the switcher popup uses `ctx_list`).
     pub all_contexts: Vec<String>,
@@ -1239,6 +1248,9 @@ impl App {
             ctx_filtering: false,
             sort_picker_state: ListState::default(),
             sort_picker_filter: String::new(),
+            copy_picker_state: ListState::default(),
+            copy_picker_filter: String::new(),
+            copy_picker_fields: Vec::new(),
             all_contexts: Vec::new(),
             user_aliases: HashMap::new(),
             plugins: Vec::new(),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -263,6 +263,104 @@ impl App {
         self.flash_err = false;
     }
 
+    /// Open the copy-field picker (`Y`): every displayed column of the
+    /// selected row with its full (untruncated) value, ⏎ copies the value to
+    /// the clipboard. The fields are captured here so a watch update can't
+    /// shift entries while the picker is open.
+    pub(super) fn open_copy_picker(&mut self) {
+        let fields = self.selected_row_fields();
+        if fields.is_empty() {
+            self.flash_warn("no row selected");
+            return;
+        }
+        self.copy_picker_fields = fields;
+        self.copy_picker_filter.clear();
+        self.copy_picker_state.select(Some(0));
+        self.mode = Mode::CopyPicker;
+    }
+
+    /// Entries for the copy picker: the captured `(header, value)` pairs,
+    /// fuzzy-matched against both the header and the value (so typing part
+    /// of an IP finds it as readily as typing the column name).
+    pub fn filtered_copy_entries(&self) -> Vec<(String, String)> {
+        if self.copy_picker_filter.is_empty() {
+            return self.copy_picker_fields.clone();
+        }
+        let mut scored: Vec<(i64, (String, String))> = self
+            .copy_picker_fields
+            .iter()
+            .filter_map(|(h, v)| {
+                self.matcher
+                    .fuzzy_match(&format!("{h} {v}"), &self.copy_picker_filter)
+                    .map(|s| (s, (h.clone(), v.clone())))
+            })
+            .collect();
+        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.0.cmp(&b.1.0)));
+        scored.into_iter().map(|(_, e)| e).collect()
+    }
+
+    pub(super) fn key_copy_picker(&mut self, key: KeyEvent) {
+        if edit_chord(&key, &mut self.copy_picker_filter) {
+            self.select_best_copy_match();
+            return;
+        }
+        let len = self.filtered_copy_entries().len();
+        match key.code {
+            KeyCode::Esc => {
+                // First esc clears the filter, second closes the picker.
+                if self.copy_picker_filter.is_empty() {
+                    self.mode = Mode::Table;
+                } else {
+                    self.copy_picker_filter.clear();
+                    self.select_best_copy_match();
+                }
+            }
+            KeyCode::Down => list_step(&mut self.copy_picker_state, len, true),
+            KeyCode::Up => list_step(&mut self.copy_picker_state, len, false),
+            KeyCode::Enter => {
+                if let Some((header, value)) = self
+                    .copy_picker_state
+                    .selected()
+                    .and_then(|i| self.filtered_copy_entries().get(i).cloned())
+                {
+                    self.copy_field(&header, value);
+                }
+            }
+            KeyCode::Backspace => {
+                self.copy_picker_filter.pop();
+                self.select_best_copy_match();
+            }
+            KeyCode::Char(c) => {
+                self.copy_picker_filter.push(c);
+                self.select_best_copy_match();
+            }
+            _ => {}
+        }
+    }
+
+    /// Keep the cursor on the best fuzzy match while typing (see
+    /// `select_best_sort_match` — same idiom, no pinned entry here).
+    fn select_best_copy_match(&mut self) {
+        self.copy_picker_state.select(Some(0));
+    }
+
+    /// Copy a picked field's value to the clipboard and close the picker.
+    /// The flash echoes what was copied, truncated so a long value (a list
+    /// of ports, a node selector) can't flood the one-line status bar.
+    fn copy_field(&mut self, header: &str, value: String) {
+        self.mode = Mode::Table;
+        self.copy_picker_filter.clear();
+        let mut shown: String = value.chars().take(60).collect();
+        if shown.len() < value.len() {
+            shown.push('…');
+        }
+        self.copy_to_clipboard_async(
+            value,
+            format!("copied {header}: {shown}"),
+            "no clipboard target found (pbcopy/xclip/wl-copy/OSC 52)",
+        );
+    }
+
     pub(super) fn key_namespaces(&mut self, key: KeyEvent) {
         if edit_chord(&key, &mut self.ns_filter) {
             self.select_best_namespace_match();

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -580,6 +580,51 @@ impl App {
         self.selected_ref().cloned()
     }
 
+    /// `(header, value)` pairs for the selected row, mirroring the table's
+    /// displayed columns (NAMESPACE prefix, view-spec cells with volatile
+    /// overrides, PODS/CPU/MEM suffixes) — but with the full cell values,
+    /// never the width-truncated text the renderer shows. Empty cells are
+    /// dropped: there is nothing to copy from them.
+    pub fn selected_row_fields(&self) -> Vec<(String, String)> {
+        let Some(obj) = self.selected_ref() else {
+            return Vec::new();
+        };
+        let mut values: Vec<String> = Vec::new();
+        if self.show_namespace_column() {
+            values.push(obj.metadata.namespace.clone().unwrap_or_default());
+        }
+        let (cells, _) = self.spec.cells(obj);
+        for (i, cell) in cells.into_iter().enumerate() {
+            values.push(
+                self.spec
+                    .volatile(obj, &self.kind_plural, i)
+                    .unwrap_or(cell),
+            );
+        }
+        if self.node_capacity_columns() {
+            values.push(self.node_pods_cell(obj));
+        }
+        if self.metrics_columns() {
+            let (cpu, mem) = self.metrics_for(obj);
+            values.push(crate::columns::fmt_cpu(cpu));
+            values.push(crate::columns::fmt_mem(mem));
+            if self.node_capacity_columns() {
+                let (alloc_cpu, alloc_mem) = crate::columns::node_allocatable(obj);
+                values.push(crate::columns::fmt_pct(crate::columns::usage_pct(
+                    cpu, alloc_cpu,
+                )));
+                values.push(crate::columns::fmt_pct(crate::columns::usage_pct(
+                    mem, alloc_mem,
+                )));
+            }
+        }
+        self.display_headers()
+            .into_iter()
+            .zip(values)
+            .filter(|(_, v)| !v.is_empty())
+            .collect()
+    }
+
     pub fn confirm_allows_force_toggle(&self) -> bool {
         matches!(self.confirm_action, Some(ConfirmAction::Delete { .. }))
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2309,6 +2309,60 @@ async fn sort_picker_esc_clears_filter_then_closes() {
 }
 
 #[tokio::test]
+async fn copy_picker_lists_full_row_fields_and_filters_on_values() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Service",
+               "metadata": {"name": "web", "namespace": "default"},
+               "spec": {"type": "ClusterIP", "clusterIP": "10.96.13.5",
+                        "ports": [{"port": 80, "protocol": "TCP"}]}}),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Char('Y'))).unwrap();
+    assert_eq!(app.mode, Mode::CopyPicker);
+    let fields = app.copy_picker_fields.clone();
+    assert!(
+        fields.contains(&("NAME".into(), "web".into())),
+        "{fields:?}"
+    );
+    assert!(
+        fields.contains(&("CLUSTER-IP".into(), "10.96.13.5".into())),
+        "{fields:?}"
+    );
+    // AGE has no creationTimestamp here — empty cells carry nothing to copy.
+    assert!(fields.iter().all(|(_, v)| !v.is_empty()), "{fields:?}");
+
+    // Typing part of the *value* (not the header) finds the IP, and the
+    // cursor tracks the best match.
+    for c in "96.13".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    let entries = app.filtered_copy_entries();
+    assert_eq!(entries[0], ("CLUSTER-IP".into(), "10.96.13.5".into()));
+    assert_eq!(app.copy_picker_state.selected(), Some(0));
+
+    // First esc clears the filter and stays open; second esc closes.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::CopyPicker);
+    assert!(app.copy_picker_filter.is_empty());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn copy_picker_without_a_selection_warns_and_stays_in_table() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    app.handle_key(press(KeyCode::Char('Y'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash_err);
+    assert!(app.flash.contains("no row selected"));
+}
+
+#[tokio::test]
 async fn metrics_update_invalidates_metric_sorted_rows() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -159,6 +159,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Namespaces => draw_namespaces(frame, app, chunks[1]),
         Mode::Contexts => draw_contexts(frame, app, chunks[1]),
         Mode::SortPicker => draw_sort_picker(frame, app, chunks[1]),
+        Mode::CopyPicker => draw_copy_picker(frame, app, chunks[1]),
         Mode::Containers => draw_containers(frame, app, chunks[1]),
         Mode::SetImage => draw_set_image(frame, app, chunks[1]),
         Mode::Confirm => draw_confirm(frame, app, chunks[1]),
@@ -430,7 +431,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
         "services" => vec![
             hint_line(&[("⏎", "pods"), ("f", "port-fwd")]),
             hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
-            hint_line(&[("^d", "delete")]),
+            hint_line(&[("Y", "copy cell"), ("^d", "delete")]),
         ],
         "nodes" => vec![
             hint_line(&[("⏎", "pods"), ("y", "yaml"), ("d", "describe")]),
@@ -460,7 +461,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
         ],
         _ => vec![
             hint_line(&[("⏎", "yaml"), ("d", "describe"), ("E", "events")]),
-            hint_line(&[("e", "edit"), ("c", "copy name")]),
+            hint_line(&[("e", "edit"), ("c", "copy name"), ("Y", "copy cell")]),
             hint_line(&[("^d", "delete")]),
         ],
     };
@@ -1811,6 +1812,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind("c", "copy resource name · in doc views: copy the document"),
         bind(
+            "shift-y",
+            "copy any cell of the selected row (picker: type to match a column or value)",
+        ),
+        bind(
             "/ · n/N",
             "search within YAML/describe/diff/events (highlight in place, n/N to jump); filters help",
         ),
@@ -2106,6 +2111,42 @@ fn draw_sort_picker(frame: &mut Frame, app: &mut App, area: Rect) {
         items,
         Span::styled(title, theme::title()),
         &mut app.sort_picker_state,
+    );
+}
+
+/// Copy-field picker (`Y`): each displayed column of the selected row with
+/// its full value; ⏎ copies the value to the clipboard. Headers are padded
+/// to a common width so the values read as a column.
+fn draw_copy_picker(frame: &mut Frame, app: &mut App, area: Rect) {
+    let entries = app.filtered_copy_entries();
+    let pad = entries
+        .iter()
+        .map(|(h, _)| h.chars().count())
+        .max()
+        .unwrap_or(0);
+    let items: Vec<ListItem> = entries
+        .iter()
+        .map(|(h, v)| {
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{h:<pad$}  "), Style::default().fg(theme::teal())),
+                Span::styled(v.clone(), Style::default().fg(theme::text())),
+            ]))
+        })
+        .collect();
+    // Show the type-to-filter buffer in the title so it reads like an input.
+    let title = if app.copy_picker_filter.is_empty() {
+        " Copy (⏎ copies the value) ".to_string()
+    } else {
+        format!(" Copy · /{}_ ", app.copy_picker_filter)
+    };
+    render_popup_list(
+        frame,
+        area,
+        60,
+        60,
+        items,
+        Span::styled(title, theme::title()),
+        &mut app.copy_picker_state,
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #147.

`Y` in any table view opens a fuzzy field picker over the selected row's displayed columns. Typing matches against both the column header and the value (so typing part of an IP finds it as readily as typing `CLUSTER-IP`), and `⏎` copies the value through the existing clipboard path (pbcopy/wl-copy/xclip/xsel, OSC 52 fallback for remote terminals).

Key properties:

- The picker shows **full cell values**, never the width-truncated text the table renders — a `CLUSTER-IP` the table clips to `10.120.48.` copies as `10.120.48.1`.
- Fields mirror the displayed layout exactly: NAMESPACE prefix, view-spec cells with volatile (AGE-style) overrides, and the PODS/CPU/MEM/%CPU/%MEM suffixes. Empty cells are dropped.
- Fields are captured when the picker opens, so a watch update can't shift entries mid-pick.
- Esc semantics match the sort picker: first esc clears the filter, second closes.
- The success flash truncates long values (port lists, selectors) to keep the one-line status bar readable; the clipboard always gets the full value.

`c` (copy resource name) is unchanged; `Y` was previously unbound in table mode.

## Test plan

- `just check` — fmt, clippy, 441 tests pass.
- New tests: `copy_picker_lists_full_row_fields_and_filters_on_values`, `copy_picker_without_a_selection_warns_and_stays_in_table`.
- Smoke-tested against a live cluster: services view → `Y` → typed `48.1` → `⏎` → flash `copied CLUSTER-IP: 10.120.48.1`, `pbpaste` confirms the clipboard.