### PR TITLE
fix: open command palette from detail, diff, events, and logs views

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -83,12 +83,7 @@ impl App {
 
     pub(super) fn key_table(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Char(':') => {
-                self.mode = Mode::Command;
-                self.command.clear();
-                self.ensure_namespace_cache();
-                self.update_suggestions();
-            }
+            KeyCode::Char(':') => self.open_palette(),
             KeyCode::Char('/') => self.mode = Mode::Filter,
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Esc => {
@@ -454,7 +449,7 @@ impl App {
             return;
         }
         match key.code {
-            KeyCode::Esc => self.mode = Mode::Table,
+            KeyCode::Esc => self.mode = self.palette_return,
             KeyCode::Down | KeyCode::Tab => {
                 if !self.cmd_suggestions.is_empty() {
                     self.cmd_sel = (self.cmd_sel + 1) % self.cmd_suggestions.len();
@@ -473,6 +468,14 @@ impl App {
                 let picked = self.cmd_suggestions.get(self.cmd_sel).cloned();
                 self.mode = Mode::Table;
                 self.command.clear();
+                // Dispatch leaves the view the palette was opened from behind,
+                // so run the cleanup its own esc path would have done.
+                match self.palette_return {
+                    Mode::Logs => self.stop_log_stream(),
+                    Mode::Events => self.stop_event_stream(),
+                    _ => {}
+                }
+                self.palette_return = Mode::Table;
                 // `:kind namespace` switches both at once (`:deploy social`,
                 // `:cephclusters all`); only the first word selects the kind.
                 let (head, ns_arg) = match typed.split_once(char::is_whitespace) {
@@ -543,6 +546,17 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    /// Open the `:` command palette. Bound in the table and the document
+    /// views (detail/diff/events/logs); `palette_return` remembers where it
+    /// was opened so esc goes back there.
+    pub(super) fn open_palette(&mut self) {
+        self.palette_return = self.mode;
+        self.mode = Mode::Command;
+        self.command.clear();
+        self.ensure_namespace_cache();
+        self.update_suggestions();
     }
 
     /// Run a built-in palette action.
@@ -928,6 +942,9 @@ impl App {
                 self.doc_filter_return = self.mode;
                 self.mode = Mode::DocFilter;
             }
+            // The command palette works from document views too — switching
+            // away doesn't require backing out to the table first.
+            KeyCode::Char(':') => self.open_palette(),
             // Jump to the next / previous search match (vim `n`/`N`). No-op
             // when no search is active.
             KeyCode::Char('n') if detail => target.step_match(true),
@@ -968,6 +985,11 @@ impl App {
             return;
         }
         match key.code {
+            // The command palette works from the logs view too.
+            KeyCode::Char(':') => {
+                self.open_palette();
+                return;
+            }
             // k9s: `s` toggles autoscroll/follow (we also accept `f`).
             KeyCode::Char('s') | KeyCode::Char('f') => {
                 self.logs.follow = !self.logs.follow;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -938,6 +938,10 @@ pub struct App {
     /// was opened from, so the renderer keeps drawing it underneath and
     /// enter/esc return to it.
     pub doc_filter_return: Mode,
+    /// Which view the `:` command palette was opened from (the table or a
+    /// document view — detail/diff/events/logs), so esc returns there and the
+    /// renderer keeps drawing it underneath the suggestion popup.
+    pub palette_return: Mode,
     pub logs: LogsView,
 
     pub ns_list: Vec<String>,
@@ -1236,6 +1240,7 @@ impl App {
             detail: Scrollable::empty(),
             help_filter: String::new(),
             doc_filter_return: Mode::Detail,
+            palette_return: Mode::Table,
             logs: LogsView::default(),
             ns_list: Vec::new(),
             ns_state: ListState::default(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -393,6 +393,38 @@ async fn palette_command_dispatch() {
 }
 
 #[tokio::test]
+async fn palette_opens_from_document_views() {
+    // Issue #148: `:` in a describe/YAML view did nothing — the palette was
+    // only bound in the table.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.set_return_mode();
+    app.mode = Mode::Detail;
+
+    // `:` opens the palette; esc returns to the detail view, not the table.
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert_eq!(app.mode, Mode::Command);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+
+    // Dispatching a kind switch leaves the detail view for the new table.
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "deployments".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.kind_plural, "deployments");
+
+    // Logs view binds `:` too, and esc from the palette lands back on it.
+    app.mode = Mode::Logs;
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert_eq!(app.mode, Mode::Command);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Logs);
+}
+
+#[tokio::test]
 async fn skin_palette_command_opens_picker() {
     let (mut app, _rx) = test_app();
     assert!(app.run_palette_command("skin"));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -152,6 +152,15 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
         Mode::Fleet => draw_fleet(frame, app, chunks[1]),
         Mode::Find => draw_find(frame, app, chunks[1]),
+        // While the palette is open, keep drawing the view it was opened
+        // from, so `:` from a document view doesn't flash the table.
+        Mode::Command => match app.palette_return {
+            Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
+            Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
+            Mode::Detail => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
+            Mode::Logs => draw_logs(frame, app, chunks[1]),
+            _ => draw_table(frame, app, chunks[1]),
+        },
         _ => draw_table(frame, app, chunks[1]),
     }
 


### PR DESCRIPTION
## Summary
- `:` was only bound in the table view, so the command palette could not be opened while inspecting a resource (describe/YAML, diff, events, or logs) — you had to esc back to the table first
- New shared `App::open_palette()` bound in `key_table`, `key_scroll` (detail/diff/events), and `key_logs`; it records the origin mode in a new `palette_return` field
- Palette esc now returns to the view it was opened from instead of always landing on the table
- The renderer keeps drawing the origin view underneath the suggestion popup (same pattern as the `/` doc-search prompt), so opening the palette from a document no longer flashes the table
- Dispatching a command from a logs/events view runs the same stream cleanup its esc path does (`stop_log_stream` / `stop_event_stream`), so no stream keeps running behind the new view
- Table behavior is unchanged (`palette_return` defaults to `Table`)

Fixes #148

## Test plan
- [x] `cargo test --locked` — 442 passed, including new regression test `palette_opens_from_document_views` (`:` from Detail opens the palette, esc returns to Detail, `:deployments`⏎ switches views; same round-trip from Logs)
- [x] `cargo fmt` + `cargo clippy --all-targets` clean
- [ ] Manual: select a pod, press `d`, press `:` — palette opens; esc returns to describe; `:svc`⏎ switches view