### PR TITLE
feat: pre-fill port-forward prompt with default ports

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1057,8 +1057,24 @@ impl App {
         }
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        // Pre-fill `p:p` from the first exposed port (service `spec.ports`,
+        // pod container ports) so the common case is Enter-only; still
+        // editable, and empty when the object declares no ports.
+        let port = match self.kind_plural.as_str() {
+            "services" => obj
+                .data
+                .pointer("/spec/ports/0/port")
+                .and_then(Value::as_i64),
+            _ => obj
+                .data
+                .pointer("/spec/containers")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .find_map(|c| c.pointer("/ports/0/containerPort").and_then(Value::as_i64)),
+        };
         self.prompt_label = format!("Port-forward {name} (LOCAL:REMOTE, e.g. 8080:80):");
-        self.prompt_input.clear();
+        self.prompt_input = port.map(|p| format!("{p}:{p}")).unwrap_or_default();
         self.prompt_kind = Some(PromptKind::PortForward { ns, name });
         self.mode = Mode::Prompt;
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -618,6 +618,55 @@ async fn saved_forwards_show_as_stopped_until_running() {
     assert_eq!(app.pf_state.selected(), Some(0), "clamped to combined list");
 }
 
+#[tokio::test]
+async fn port_forward_prompt_prefills_first_exposed_port() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Service",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"ports": [{"port": 8080}, {"port": 9090}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.request_port_forward();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert_eq!(
+        app.prompt_input, "8080:8080",
+        "first service port, LOCAL:REMOTE"
+    );
+
+    // Pods take the first declared container port.
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "db", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"containers": [{"name": "pg", "ports": [{"containerPort": 5432}]}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.request_port_forward();
+    assert_eq!(app.prompt_input, "5432:5432");
+
+    // No declared ports: the prompt stays empty as before.
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "aux", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"containers": [{"name": "c"}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.request_port_forward();
+    assert_eq!(app.prompt_input, "");
+}
+
 #[test]
 fn forward_context_matching_and_validation() {
     let f = crate::config::Forward {


### PR DESCRIPTION
## Summary
- `f` on a pod/service now pre-fills the port-forward prompt with `PORT:PORT` from the target's first exposed port (service `spec.ports[0].port`, first pod container port), so the common case is Enter-only
- The input stays fully editable; objects that declare no ports keep the previous empty prompt

Fixes #153

## Test plan
- [x] `cargo test port_forward_prompt_prefills_first_exposed_port` — service pre-fills `8080:8080`, pod pre-fills `5432:5432`, port-less pod leaves the prompt empty
- [x] `cargo test saved_forwards_show_as_stopped_until_running` — adjacent forward tests still pass