### PR TITLE
fix: search matches all visible columns, not just name

### DIFF
--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -43,15 +43,29 @@ impl App {
         }
         let parsed = self.parsed_filter();
         match &*parsed {
-            ParsedFilter::Fuzzy(pat) => {
-                pat.is_empty() || self.matcher.fuzzy_match(&self.fuzzy_hay(o), pat).is_some()
-            }
+            ParsedFilter::Fuzzy(pat) => pat.is_empty() || self.fuzzy_match_row(o, pat),
             ParsedFilter::Structured(s) => s.terms.iter().all(|t| match t {
-                Term::Fuzzy(pat) => self.matcher.fuzzy_match(&self.fuzzy_hay(o), pat).is_some(),
-                Term::NotFuzzy(pat) => self.matcher.fuzzy_match(&self.fuzzy_hay(o), pat).is_none(),
+                Term::Fuzzy(pat) => self.fuzzy_match_row(o, pat),
+                Term::NotFuzzy(pat) => !self.fuzzy_match_row(o, pat),
                 Term::Cmp(cmp) => self.eval_cmp(o, cmp),
             }),
         }
+    }
+
+    /// Does one fuzzy pattern match this row? "namespace name" first (the
+    /// original haystack — cheap, and by far the most common hit), then each
+    /// rendered column cell individually, so `/10.96` finds a Service by its
+    /// CLUSTER-IP. Cells are matched one at a time rather than joined so a
+    /// pattern can't match across cell boundaries; the full row is only
+    /// rendered when the name haystack missed.
+    fn fuzzy_match_row(&self, o: &DynamicObject, pat: &str) -> bool {
+        if self.matcher.fuzzy_match(&self.fuzzy_hay(o), pat).is_some() {
+            return true;
+        }
+        let (cells, _) = self.spec.cells(o);
+        cells
+            .iter()
+            .any(|c| self.matcher.fuzzy_match(c, pat).is_some())
     }
 
     /// What fuzzy terms match against: "namespace name". Helm rows are backed

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5514,6 +5514,34 @@ async fn inverse_filter_hides_fuzzy_matches() {
 }
 
 #[tokio::test]
+async fn fuzzy_filter_matches_any_column_cell() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    for (n, ip) in [("api", "10.96.13.5"), ("web", "172.20.44.9")] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Service",
+                   "metadata": {"name": n, "namespace": "default"},
+                   "spec": {"type": "ClusterIP", "clusterIP": ip,
+                            "ports": [{"port": 80, "protocol": "TCP"}]}}),
+        );
+    }
+    // An IP substring matches via the CLUSTER-IP cell, not the name.
+    type_filter(&mut app, "10.96");
+    assert_eq!(row_names(&app), ["api"]);
+
+    // Name matching still works exactly as before.
+    app.filter = "web".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["web"]);
+
+    // Inverse terms see the cells too: hide the 10.96 service.
+    app.filter = "!10.96".into();
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["web"]);
+}
+
+#[tokio::test]
 async fn status_filter_matches_status_column() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,11 +1,12 @@
 //! Structured row-filter grammar.
 //!
-//! Plain text with no structured markers stays exactly what it always was:
-//! one fuzzy pattern over "namespace name". Once any structured marker
+//! Plain text with no structured markers stays what it always was: one fuzzy
+//! pattern over "namespace name", falling back to each rendered column cell
+//! (so `/10.96` finds a Service by its CLUSTER-IP). Once any structured marker
 //! appears, the input is split on whitespace and every term must match
 //! (terms are AND-ed; there is no OR/grouping — deliberately small):
 //!
-//! - `text`                   fuzzy match (namespace + name)
+//! - `text`                   fuzzy match (namespace + name + any column cell)
 //! - `!text`                  inverse fuzzy match
 //! - `-l app=api,env=prod`    Kubernetes label selector (sent server-side)
 //! - `-f spec.nodeName=n1`    Kubernetes field selector (sent server-side)


### PR DESCRIPTION
## Summary
- The `/` row filter only matched the "namespace name" haystack, so searching a services listing by IP (e.g. `/10.96`) found nothing even though CLUSTER-IP was on screen.
- Fuzzy terms (positive and `!inverse`) now fall back to matching each rendered column cell individually when the name haystack misses — cells are matched one at a time so a pattern can't match across cell boundaries, and the full row is only rendered on a name miss (no extra allocation on the common name-match path).
- Structured column comparisons (`status=…`, `cpu>…`) and `-l`/`-f` selectors are untouched, as are palette/picker searches.

Fixes #149

## Test plan
- [x] `cargo test fuzzy_filter_matches_any_column_cell` — new test: `/10.96` matches a Service via its CLUSTER-IP cell, name filtering still works, and `!10.96` hides it.
- [x] `cargo test filter` — all 48 existing filter tests pass.