### PR TITLE
Fix rapid log scroll overshoot

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -42,23 +42,14 @@ impl App {
     }
 
     /// Whether the run loop should keep terminal mouse capture on right now.
-    /// Document-style views (YAML/describe, diff, events, logs, help) release
-    /// capture so click-drag uses the terminal's native text selection —
-    /// nothing in them uses clicks, and scrolling still works because with
-    /// reporting off terminals translate the wheel into arrow keys in the
-    /// alternate screen ("alternate scroll"), which these views all handle.
-    /// The filter-typing overlays keep the same document on screen, so they
-    /// release too.
+    /// Most document-style views release capture so click-drag uses the
+    /// terminal's native text selection. Logs keep it because rapid alternate
+    /// scroll emits cursor-key escape sequences that can be split under load;
+    /// captured wheel events stay atomic and are clamped by `key_logs`.
     pub fn wants_mouse_capture(&self) -> bool {
         !matches!(
             self.mode,
-            Mode::Detail
-                | Mode::Diff
-                | Mode::Events
-                | Mode::Logs
-                | Mode::Help
-                | Mode::DocFilter
-                | Mode::LogFilter
+            Mode::Detail | Mode::Diff | Mode::Events | Mode::Help | Mode::DocFilter
         )
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -826,19 +826,24 @@ async fn document_views_release_mouse_capture_for_text_selection() {
     let (mut app, _rx) = test_app();
     assert!(app.wants_mouse_capture(), "table keeps capture");
 
-    // Every full-screen text view releases capture so click-drag selects text
-    // natively (#133), including the filter overlays that keep it on screen.
+    // Full-screen text views release capture so click-drag selects text
+    // natively (#133), including the document filter overlay.
     for mode in [
         Mode::Detail,
         Mode::Diff,
         Mode::Events,
-        Mode::Logs,
         Mode::Help,
         Mode::DocFilter,
-        Mode::LogFilter,
     ] {
         app.mode = mode;
         assert!(!app.wants_mouse_capture(), "{mode:?} releases capture");
+    }
+
+    // Logs keep capture so rapid wheel input arrives as atomic mouse events
+    // rather than alternate-scroll escape sequences (#152).
+    for mode in [Mode::Logs, Mode::LogFilter] {
+        app.mode = mode;
+        assert!(app.wants_mouse_capture(), "{mode:?} keeps capture");
     }
 
     // Interactive pickers and dashboards still want clicks/wheel captured.
@@ -1141,6 +1146,38 @@ async fn logs_pause_freezes_and_survives_new_lines() {
     app.logs.view.scroll = 60;
     app.handle_key(press(KeyCode::Char('j'))).unwrap();
     assert!(!app.logs.follow);
+    assert_eq!(app.logs.view.scroll, 60);
+}
+
+#[tokio::test]
+async fn rapid_log_wheel_down_clamps_without_leaving_logs() {
+    use crossterm::event::{MouseEvent, MouseEventKind};
+
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.return_mode = Mode::Table;
+    app.logs.follow = true;
+    app.logs.view.scroll = 60;
+    app.logs.viewport_rows = 100;
+    app.logs.viewport_h = 40;
+
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    app.handle_key(press(KeyCode::Up)).unwrap();
+    assert!(!app.logs.follow);
+    assert_eq!(app.logs.view.scroll, 59);
+    assert!(app.wants_mouse_capture());
+
+    let wheel_down = MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    };
+    for _ in 0..100 {
+        app.handle_mouse(wheel_down).unwrap();
+        assert_eq!(app.mode, Mode::Logs);
+        assert!(app.logs.view.scroll <= 60);
+    }
     assert_eq!(app.logs.view.scroll, 60);
 }
 


### PR DESCRIPTION
## Summary
- keep mouse capture enabled in log and log-filter modes so rapid wheel input arrives as atomic mouse events instead of terminal alternate-scroll escape sequences
- route repeated wheel-down events through the existing clamped log navigation without changing the active mode
- add a regression test covering paused logs, upward movement, and 100 wheel-down events past the bottom

Fixes #152

## Test plan
- [x] `cargo test rapid_log_wheel_down_clamps_without_leaving_logs`
- [x] `cargo test document_views_release_mouse_capture_for_text_selection`
- [x] `cargo test logs_pause_freezes_and_survives_new_lines`