### PR TITLE
fix: route :events to the Events resource list

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -582,7 +582,7 @@ impl App {
             PaletteAction::Rightsize => self.open_rightsize(),
             PaletteAction::Find => self.flash_warn("usage: :find <text>"),
             PaletteAction::Diff => self.open_diff(),
-            PaletteAction::Events => self.open_events(),
+            PaletteAction::Events => self.switch_kind("events.events.k8s.io"),
             PaletteAction::PortForwards => self.open_port_forwards(),
             PaletteAction::ProviderLogs => self.open_provider_logs(),
             PaletteAction::Skin => self.open_skins(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1913,12 +1913,41 @@ async fn shadowed_builtin_stays_reachable_via_alias() {
 }
 
 #[tokio::test]
-async fn events_palette_command_dispatches() {
+async fn events_palette_opens_resource_and_e_stays_contextual() {
     let (mut app, _rx) = test_app();
-    assert!(app.run_palette_command("events"));
+    app.switch_kind("pods");
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "events".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+
     assert_eq!(app.mode, Mode::Table);
-    assert!(app.flash_err);
-    assert!(app.flash.contains("events"), "{}", app.flash);
+    let kind = app.kind.as_ref().expect("events resource selected");
+    assert_eq!(kind.ar.group, "events.k8s.io");
+    assert_eq!(kind.title(), "events.events.k8s.io");
+    assert!(!app.flash_err);
+
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "web",
+                "namespace": "default",
+                "uid": "pod-uid"
+            }
+        }),
+    );
+    app.handle_key(press(KeyCode::Char('E'))).unwrap();
+
+    assert_eq!(app.mode, Mode::Events);
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.detail.title, "web — events");
+    app.stop_event_stream();
 }
 
 #[test]

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -35,8 +35,8 @@ impl Kind {
     /// Whether this kind comes from a custom API group (a CRD or third-party
     /// aggregated API) rather than one Kubernetes ships with. Custom kinds own
     /// their name in the command palette even when a built-in command shares
-    /// it (`:snapshots` with a snapshots.* CRD installed); vanilla kinds don't
-    /// get that priority, so `:events` keeps opening the built-in view.
+    /// it (`:snapshots` with a snapshots.* CRD installed); built-in Kubernetes
+    /// API groups don't get that priority.
     pub fn is_custom(&self) -> bool {
         let group = self.ar.group.as_str();
         !group.is_empty()
@@ -495,6 +495,7 @@ impl Cluster {
             "namespaces".to_string(),
             mk("", "Namespace", "namespaces", false),
         );
+        registry.insert("events".to_string(), mk("", "Event", "events", true));
         registry.insert("jobs".to_string(), mk("batch", "Job", "jobs", true));
         registry.insert(
             "cronjobs".to_string(),
@@ -554,6 +555,7 @@ impl Cluster {
         let mut catalog: Vec<String> = [
             "certificates",
             "deployments",
+            "events",
             "helmreleases",
             "horizontalpodautoscalers",
             "kustomizations",
@@ -575,6 +577,10 @@ impl Cluster {
             registry.insert(qualified.clone(), kind);
             catalog.push(qualified);
         }
+        registry.insert(
+            "events.events.k8s.io".to_string(),
+            mk("events.k8s.io", "Event", "events", true),
+        );
         catalog.sort();
         Self {
             client,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1775,7 +1775,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             ":xray · :diff",
             "hierarchical tree · live-vs-last-applied diff",
         ),
-        bind(":events · E", "events for the selected object"),
+        bind(
+            ":events · E",
+            "browse all events · events for the selected object",
+        ),
         bind(":pf", "view/stop background port-forwards"),
         bind(":skin", "switch color skin live"),
         bind(


### PR DESCRIPTION
## Summary
- route `:events` through the discovered `events.events.k8s.io` resource instead of the selected-object event stream
- keep `E` scoped to the selected object and clarify the help entry
- cover both navigation paths with a focused regression test

Fixes #154

## Test plan
- [x] `cargo test events_palette_opens_resource_and_e_stays_contextual`
- [x] `cargo test qualified_names_surface_without_doubling_the_list`
- [x] `cargo test event`