### PR TITLE
Fix context switcher type-to-filter

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -29,7 +29,7 @@ plugin, bookmark, and workspace chords.
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
 | `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                             |
-| `:ctx` / `:ctx <name>`                        | context switcher popup (`/` filters, `r` renames, `space` toggles fleet membership) / switch directly (the name tab-completes)        |
+| `:ctx` / `:ctx <name>`                        | context switcher popup (type to filter, `r` renames, `space` toggles fleet membership) / switch directly (the name tab-completes)     |
 | `:helm`                                       | Helm releases (native storage-Secret decode): ⏎ history → values · `y` manifest · `d` notes · `r` rollback                            |
 | `:fleet`                                      | cross-context health dashboard (opt-in: `[fleet]` contexts or `space` in `:ctx`; `⏎` switches, `r` refreshes)                         |
 | `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -958,11 +958,11 @@ pub struct App {
 
     pub ctx_list: Vec<String>,
     pub ctx_state: ListState,
-    /// Filter buffer for the context switcher (typed after `/`, like the
-    /// table filter — plain letters are action keys, e.g. `r` rename).
+    /// Type-to-filter buffer for the context switcher. Plain action keys remain
+    /// available until filtering starts.
     pub ctx_filter: String,
-    /// Whether the context switcher is in filter-typing mode (`/` pressed;
-    /// esc/enter leave it).
+    /// Whether the context switcher is accepting filter input (started by
+    /// typing or explicitly with `/` for names that begin with an action key).
     pub ctx_filtering: bool,
     pub sort_picker_state: ListState,
     /// Type-to-filter buffer for the sort-column picker.

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -499,34 +499,32 @@ impl App {
         scored.into_iter().map(|(_, c)| c.clone()).collect()
     }
 
-    /// Unlike the other pickers, the switcher is not type-to-filter: `/`
-    /// starts the filter (like the table filter), which frees plain letters
-    /// for actions (`r` rename, `j`/`k` movement).
+    /// Contexts type-to-filter like the namespace picker. Existing action keys
+    /// remain available while browsing; `/` explicitly starts filter input
+    /// when a context name begins with one of those keys.
     pub(super) fn key_contexts(&mut self, key: KeyEvent) {
         let len = self.filtered_contexts().len();
         if self.ctx_filtering {
             if edit_chord(&key, &mut self.ctx_filter) {
-                self.ctx_state.select(Some(0));
+                self.select_best_context_match();
                 return;
             }
             match key.code {
-                // Esc cancels the filter, enter keeps it applied (the table
-                // filter's semantics); both return to browsing.
                 KeyCode::Esc => {
                     self.ctx_filter.clear();
                     self.ctx_filtering = false;
                     self.select_current_context();
                 }
-                KeyCode::Enter => self.ctx_filtering = false,
+                KeyCode::Enter => self.switch_selected_context(),
                 KeyCode::Down => list_step(&mut self.ctx_state, len, true),
                 KeyCode::Up => list_step(&mut self.ctx_state, len, false),
                 KeyCode::Backspace => {
                     self.ctx_filter.pop();
-                    self.ctx_state.select(Some(0));
+                    self.select_best_context_match();
                 }
                 KeyCode::Char(c) => {
                     self.ctx_filter.push(c);
-                    self.ctx_state.select(Some(0));
+                    self.select_best_context_match();
                 }
                 _ => {}
             }
@@ -534,8 +532,6 @@ impl App {
         }
         match key.code {
             KeyCode::Esc => {
-                // First esc clears an applied filter, second closes the
-                // switcher.
                 if self.ctx_filter.is_empty() {
                     self.mode = Mode::Table;
                 } else {
@@ -558,17 +554,31 @@ impl App {
             }
             KeyCode::Down | KeyCode::Char('j') => list_step(&mut self.ctx_state, len, true),
             KeyCode::Up | KeyCode::Char('k') => list_step(&mut self.ctx_state, len, false),
-            KeyCode::Enter => {
-                if let Some(name) = self
-                    .ctx_state
-                    .selected()
-                    .and_then(|i| self.filtered_contexts().get(i).cloned())
-                {
-                    self.mode = Mode::Table;
-                    self.switch_context(name);
-                }
+            KeyCode::Enter => self.switch_selected_context(),
+            KeyCode::Char(c) => {
+                self.ctx_filtering = true;
+                self.ctx_filter.push(c);
+                self.select_best_context_match();
             }
             _ => {}
+        }
+    }
+
+    fn select_best_context_match(&mut self) {
+        let selected = (!self.filtered_contexts().is_empty()).then_some(0);
+        self.ctx_state.select(selected);
+    }
+
+    fn switch_selected_context(&mut self) {
+        if let Some(name) = self
+            .ctx_state
+            .selected()
+            .and_then(|i| self.filtered_contexts().get(i).cloned())
+        {
+            self.mode = Mode::Table;
+            self.ctx_filter.clear();
+            self.ctx_filtering = false;
+            self.switch_context(name);
         }
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3262,7 +3262,7 @@ async fn context_list_result_selects_current_context() {
 }
 
 #[tokio::test]
-async fn context_picker_filters_only_after_slash() {
+async fn context_picker_typing_filters_and_backspace_widens() {
     let (mut app, _rx) = test_app();
     app.mode = Mode::Contexts;
     app.handle_msg(Msg::Contexts {
@@ -3270,32 +3270,55 @@ async fn context_picker_filters_only_after_slash() {
         list: vec!["dev".into(), "prod".into(), "test".into()],
     });
 
-    // Plain letters are action keys, not filter input.
-    app.key_contexts(press(KeyCode::Char('p')));
-    assert!(app.ctx_filter.is_empty());
-    assert!(!app.ctx_filtering);
+    app.handle_key(press(KeyCode::Char('k'))).unwrap();
+    assert_eq!(app.ctx_state.selected(), Some(1));
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    assert_eq!(app.ctx_state.selected(), Some(2));
+    assert!(app.ctx_filter.is_empty(), "navigation keys still browse");
 
-    // `/` starts the filter; typing narrows the list live.
-    app.key_contexts(press(KeyCode::Char('/')));
+    app.handle_key(press(KeyCode::Char('p'))).unwrap();
     assert!(app.ctx_filtering);
-    app.key_contexts(press(KeyCode::Char('p')));
     assert_eq!(app.ctx_filter, "p");
     assert_eq!(app.filtered_contexts(), vec!["prod".to_string()]);
+    assert_eq!(app.ctx_state.selected(), Some(0));
 
-    // Enter keeps the filter applied and returns to browsing.
-    app.key_contexts(press(KeyCode::Enter));
-    assert!(!app.ctx_filtering);
-    assert_eq!(app.ctx_filter, "p");
-    assert_eq!(app.mode, Mode::Contexts);
-
-    // First esc clears the applied filter (cursor back on the current
-    // context), second closes the switcher.
-    app.key_contexts(press(KeyCode::Esc));
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
     assert!(app.ctx_filter.is_empty());
-    assert_eq!(app.mode, Mode::Contexts);
-    assert_eq!(app.ctx_state.selected(), Some(2), "cursor on 'test'");
-    app.key_contexts(press(KeyCode::Esc));
+    assert_eq!(
+        app.filtered_contexts(),
+        vec!["dev".to_string(), "prod".to_string(), "test".to_string()]
+    );
+    assert_eq!(app.ctx_state.selected(), Some(0));
+
+    app.handle_key(press(KeyCode::Char('z'))).unwrap();
+    assert!(app.filtered_contexts().is_empty());
+    assert_eq!(app.ctx_state.selected(), None);
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    assert_eq!(app.ctx_state.selected(), Some(0));
+}
+
+#[tokio::test]
+async fn context_picker_enter_switches_to_filtered_selection() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Contexts;
+    app.handle_msg(Msg::Contexts {
+        generation: app.generation,
+        list: vec!["prod-east".into(), "prod-west".into(), "test".into()],
+    });
+
+    app.handle_key(press(KeyCode::Char('p'))).unwrap();
+    assert_eq!(
+        app.filtered_contexts(),
+        vec!["prod-east".to_string(), "prod-west".to_string()]
+    );
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    assert_eq!(app.ctx_state.selected(), Some(1));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+
     assert_eq!(app.mode, Mode::Table);
+    assert!(app.ctx_filter.is_empty());
+    assert!(!app.ctx_filtering);
+    assert_eq!(app.flash, "switching to prod-west…");
 }
 
 #[tokio::test]
@@ -3306,9 +3329,8 @@ async fn context_picker_esc_while_typing_cancels_filter() {
         generation: app.generation,
         list: vec!["dev".into(), "test".into()],
     });
-    app.key_contexts(press(KeyCode::Char('/')));
-    app.key_contexts(press(KeyCode::Char('d')));
-    app.key_contexts(press(KeyCode::Esc));
+    app.handle_key(press(KeyCode::Char('d'))).unwrap();
+    app.handle_key(press(KeyCode::Esc)).unwrap();
     assert!(!app.ctx_filtering);
     assert!(app.ctx_filter.is_empty());
     assert_eq!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2061,13 +2061,13 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
     // While typing, show the filter buffer in the title so it reads like an
-    // input; an applied filter stays visible without the cursor.
+    // input.
     let title = if app.ctx_filtering {
         format!(" Contexts · /{}_ ", app.ctx_filter)
     } else if !app.ctx_filter.is_empty() {
         format!(" Contexts · /{} ", app.ctx_filter)
     } else {
-        " Contexts (/ filter · r rename · space fleet · ⏎ switch) ".to_string()
+        " Contexts (type to filter · r rename · space fleet · ⏎ switch) ".to_string()
     };
     render_popup_list(
         frame,


### PR DESCRIPTION
## Summary
- make the `:ctx` switcher start filtering when users type, matching the namespace picker
- keep browsing actions available before filtering and clamp selection as matches narrow or widen
- switch directly to the highlighted filtered context on Enter
- update the picker hint and key reference

Fixes #150

## Test plan
- [x] `cargo test context_picker_`