### PR TITLE
Restore text selection in the log view

### DIFF
--- a/src/altscroll.rs
+++ b/src/altscroll.rs
@@ -1,0 +1,236 @@
+//! Repairs cursor-key escape sequences split at a read boundary.
+//!
+//! While mouse capture is released — document and log views release it so
+//! click-drag uses the terminal's native text selection (#133) — terminals
+//! translate the wheel into cursor-key escape sequences in the alternate
+//! screen ("alternate scroll"): `ESC [ A`/`ESC [ B`, or `ESC O A`/`ESC O B`
+//! in application cursor mode.
+//!
+//! Under a fast scroll burst a read can end exactly on the `ESC` byte. With
+//! nothing else buffered the parser has to commit, so it reports a bare `Esc`
+//! and then re-starts on the tail, which no longer looks like a sequence and
+//! comes through as plain `[` and `B` characters. In the log view that stray
+//! `Esc` closed the view and the tail then hit table bindings, landing on some
+//! unrelated resource (#152).
+//!
+//! [`Repair`] puts the sequence back together: an `Esc` is held back for one
+//! event (or a few milliseconds — see [`Repair::TIMEOUT`]), and if the
+//! introducer and a final letter follow, the three are turned back into the
+//! cursor key they came from.
+
+use std::time::Duration;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// What the repair has consumed so far and is waiting to interpret.
+enum State {
+    /// Nothing held: keys pass straight through.
+    Idle,
+    /// A bare `Esc` is held, waiting to see whether a sequence follows it.
+    Esc(KeyEvent),
+    /// `Esc` plus a `[`/`O` introducer; the next letter finishes the sequence.
+    Intro(KeyEvent),
+}
+
+/// Escape-sequence reassembly for one input stream.
+///
+/// Feed every key press through [`push`](Self::push) and dispatch whatever it
+/// returns. When [`pending`](Self::pending) is true the caller must call
+/// [`flush`](Self::flush) after [`TIMEOUT`](Self::TIMEOUT) so a real `Esc`
+/// press is not held forever waiting for a sequence that will never arrive.
+pub struct Repair {
+    state: State,
+}
+
+impl Default for Repair {
+    fn default() -> Self {
+        Self { state: State::Idle }
+    }
+}
+
+impl Repair {
+    /// How long a held `Esc` may wait for the rest of a sequence. Split reads
+    /// arrive back-to-back, so this only has to outlast one poll — short
+    /// enough that a real `Esc` press still feels instant.
+    pub const TIMEOUT: Duration = Duration::from_millis(15);
+
+    /// Whether an `Esc` is currently held back and needs a timeout flush.
+    pub fn pending(&self) -> bool {
+        !matches!(self.state, State::Idle)
+    }
+
+    /// Feed one key press; returns the keys to dispatch, in order.
+    pub fn push(&mut self, key: KeyEvent) -> Vec<KeyEvent> {
+        // Only the bare, unmodified forms below can come from a split
+        // sequence; anything carrying modifiers is a real chord.
+        let plain = key.modifiers.is_empty();
+        match std::mem::replace(&mut self.state, State::Idle) {
+            State::Idle => {
+                if plain && key.code == KeyCode::Esc {
+                    self.state = State::Esc(key);
+                    return Vec::new();
+                }
+                vec![key]
+            }
+            State::Esc(esc) => {
+                if plain && matches!(key.code, KeyCode::Char('[') | KeyCode::Char('O')) {
+                    self.state = State::Intro(esc);
+                    return Vec::new();
+                }
+                // A second `Esc` starts a fresh wait; the first one was real.
+                if plain && key.code == KeyCode::Esc {
+                    self.state = State::Esc(key);
+                    return vec![esc];
+                }
+                vec![esc, key]
+            }
+            State::Intro(esc) => {
+                if plain && let Some(code) = final_byte(key.code) {
+                    return vec![KeyEvent::new(code, KeyModifiers::NONE)];
+                }
+                // Not a sequence after all: replay what was swallowed. The
+                // introducer is regenerated rather than stored — the only two
+                // it can be are indistinguishable here in effect, and `[` is
+                // what a user typing `Esc [` actually pressed.
+                vec![
+                    esc,
+                    KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
+                    key,
+                ]
+            }
+        }
+    }
+
+    /// Give up on a held `Esc` and release what was swallowed.
+    pub fn flush(&mut self) -> Vec<KeyEvent> {
+        match std::mem::replace(&mut self.state, State::Idle) {
+            State::Idle => Vec::new(),
+            State::Esc(esc) => vec![esc],
+            State::Intro(esc) => vec![esc, KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE)],
+        }
+    }
+}
+
+/// The cursor key a `CSI`/`SS3` final byte stands for.
+fn final_byte(code: KeyCode) -> Option<KeyCode> {
+    match code {
+        KeyCode::Char('A') => Some(KeyCode::Up),
+        KeyCode::Char('B') => Some(KeyCode::Down),
+        KeyCode::Char('C') => Some(KeyCode::Right),
+        KeyCode::Char('D') => Some(KeyCode::Left),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn codes(keys: Vec<KeyEvent>) -> Vec<KeyCode> {
+        keys.into_iter().map(|k| k.code).collect()
+    }
+
+    #[test]
+    fn ordinary_keys_pass_straight_through() {
+        let mut r = Repair::default();
+        for code in [KeyCode::Char('j'), KeyCode::Down, KeyCode::Enter] {
+            assert_eq!(codes(r.push(press(code))), vec![code]);
+            assert!(!r.pending());
+        }
+    }
+
+    #[test]
+    fn split_csi_and_ss3_sequences_become_cursor_keys() {
+        for intro in ['[', 'O'] {
+            for (final_byte, want) in [
+                ('A', KeyCode::Up),
+                ('B', KeyCode::Down),
+                ('C', KeyCode::Right),
+                ('D', KeyCode::Left),
+            ] {
+                let mut r = Repair::default();
+                assert!(r.push(press(KeyCode::Esc)).is_empty());
+                assert!(r.pending(), "esc is held while the tail is awaited");
+                assert!(r.push(press(KeyCode::Char(intro))).is_empty());
+                assert_eq!(codes(r.push(press(KeyCode::Char(final_byte)))), vec![want]);
+                assert!(!r.pending());
+            }
+        }
+    }
+
+    #[test]
+    fn a_burst_of_split_scrolls_never_yields_an_esc() {
+        let mut r = Repair::default();
+        let mut out = Vec::new();
+        for _ in 0..50 {
+            for code in [KeyCode::Esc, KeyCode::Char('['), KeyCode::Char('B')] {
+                out.extend(codes(r.push(press(code))));
+            }
+        }
+        assert_eq!(out, vec![KeyCode::Down; 50]);
+        assert!(!r.pending());
+    }
+
+    #[test]
+    fn a_real_esc_press_survives_the_timeout_flush() {
+        let mut r = Repair::default();
+        assert!(r.push(press(KeyCode::Esc)).is_empty());
+        assert_eq!(codes(r.flush()), vec![KeyCode::Esc]);
+        assert!(!r.pending());
+        assert!(r.flush().is_empty(), "flushing twice is a no-op");
+    }
+
+    #[test]
+    fn esc_followed_by_another_key_releases_both_in_order() {
+        let mut r = Repair::default();
+        assert!(r.push(press(KeyCode::Esc)).is_empty());
+        assert_eq!(
+            codes(r.push(press(KeyCode::Char('j')))),
+            vec![KeyCode::Esc, KeyCode::Char('j')]
+        );
+        assert!(!r.pending());
+    }
+
+    #[test]
+    fn repeated_esc_presses_all_get_through() {
+        let mut r = Repair::default();
+        assert!(r.push(press(KeyCode::Esc)).is_empty());
+        assert_eq!(codes(r.push(press(KeyCode::Esc))), vec![KeyCode::Esc]);
+        assert_eq!(codes(r.flush()), vec![KeyCode::Esc]);
+    }
+
+    #[test]
+    fn an_unfinished_sequence_replays_what_it_swallowed() {
+        let mut r = Repair::default();
+        assert!(r.push(press(KeyCode::Esc)).is_empty());
+        assert!(r.push(press(KeyCode::Char('['))).is_empty());
+        assert_eq!(
+            codes(r.push(press(KeyCode::Char('x')))),
+            vec![KeyCode::Esc, KeyCode::Char('['), KeyCode::Char('x')]
+        );
+
+        let mut r = Repair::default();
+        assert!(r.push(press(KeyCode::Esc)).is_empty());
+        assert!(r.push(press(KeyCode::Char('['))).is_empty());
+        assert_eq!(codes(r.flush()), vec![KeyCode::Esc, KeyCode::Char('[')]);
+    }
+
+    #[test]
+    fn modified_keys_are_never_mistaken_for_a_sequence() {
+        let mut r = Repair::default();
+        let ctrl_esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::CONTROL);
+        assert_eq!(codes(r.push(ctrl_esc)), vec![KeyCode::Esc]);
+        assert!(!r.pending());
+
+        assert!(r.push(press(KeyCode::Esc)).is_empty());
+        let alt_bracket = KeyEvent::new(KeyCode::Char('['), KeyModifiers::ALT);
+        assert_eq!(
+            codes(r.push(alt_bracket)),
+            vec![KeyCode::Esc, KeyCode::Char('[')]
+        );
+    }
+}

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -42,14 +42,24 @@ impl App {
     }
 
     /// Whether the run loop should keep terminal mouse capture on right now.
-    /// Most document-style views release capture so click-drag uses the
-    /// terminal's native text selection. Logs keep it because rapid alternate
-    /// scroll emits cursor-key escape sequences that can be split under load;
-    /// captured wheel events stay atomic and are clamped by `key_logs`.
+    /// Document-style views (YAML/describe, diff, events, logs, help) release
+    /// capture so click-drag uses the terminal's native text selection —
+    /// nothing in them uses clicks, and scrolling still works because with
+    /// reporting off terminals translate the wheel into arrow keys in the
+    /// alternate screen ("alternate scroll"), which these views all handle.
+    /// The filter-typing overlays keep the same document on screen, so they
+    /// release too. A wheel burst can split one of those escape sequences
+    /// mid-read; `crate::altscroll` reassembles them before they reach us.
     pub fn wants_mouse_capture(&self) -> bool {
         !matches!(
             self.mode,
-            Mode::Detail | Mode::Diff | Mode::Events | Mode::Help | Mode::DocFilter
+            Mode::Detail
+                | Mode::Diff
+                | Mode::Events
+                | Mode::Logs
+                | Mode::Help
+                | Mode::DocFilter
+                | Mode::LogFilter
         )
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -826,24 +826,21 @@ async fn document_views_release_mouse_capture_for_text_selection() {
     let (mut app, _rx) = test_app();
     assert!(app.wants_mouse_capture(), "table keeps capture");
 
-    // Full-screen text views release capture so click-drag selects text
-    // natively (#133), including the document filter overlay.
+    // Every full-screen text view releases capture so click-drag selects text
+    // natively (#133), including the filter overlays that keep it on screen.
+    // Logs included: the alternate-scroll bursts that used to throw the view
+    // off (#152) are repaired in `crate::altscroll`, not by holding capture.
     for mode in [
         Mode::Detail,
         Mode::Diff,
         Mode::Events,
+        Mode::Logs,
         Mode::Help,
         Mode::DocFilter,
+        Mode::LogFilter,
     ] {
         app.mode = mode;
         assert!(!app.wants_mouse_capture(), "{mode:?} releases capture");
-    }
-
-    // Logs keep capture so rapid wheel input arrives as atomic mouse events
-    // rather than alternate-scroll escape sequences (#152).
-    for mode in [Mode::Logs, Mode::LogFilter] {
-        app.mode = mode;
-        assert!(app.wants_mouse_capture(), "{mode:?} keeps capture");
     }
 
     // Interactive pickers and dashboards still want clicks/wheel captured.
@@ -1149,10 +1146,12 @@ async fn logs_pause_freezes_and_survives_new_lines() {
     assert_eq!(app.logs.view.scroll, 60);
 }
 
+/// A fast wheel-down burst in the log view reaches us as alternate-scroll
+/// escape sequences, split at the `ESC` byte when a read boundary lands there.
+/// Repaired (as the run loop does) they must stay Down keys clamped to the
+/// bottom of the buffer, never a stray Esc that closes the view (#152).
 #[tokio::test]
 async fn rapid_log_wheel_down_clamps_without_leaving_logs() {
-    use crossterm::event::{MouseEvent, MouseEventKind};
-
     let (mut app, _rx) = test_app();
     app.mode = Mode::Logs;
     app.return_mode = Mode::Table;
@@ -1165,20 +1164,23 @@ async fn rapid_log_wheel_down_clamps_without_leaving_logs() {
     app.handle_key(press(KeyCode::Up)).unwrap();
     assert!(!app.logs.follow);
     assert_eq!(app.logs.view.scroll, 59);
-    assert!(app.wants_mouse_capture());
+    assert!(
+        !app.wants_mouse_capture(),
+        "logs release capture for selection"
+    );
 
-    let wheel_down = MouseEvent {
-        kind: MouseEventKind::ScrollDown,
-        column: 0,
-        row: 0,
-        modifiers: KeyModifiers::NONE,
-    };
+    let mut repair = crate::altscroll::Repair::default();
     for _ in 0..100 {
-        app.handle_mouse(wheel_down).unwrap();
+        for code in [KeyCode::Esc, KeyCode::Char('['), KeyCode::Char('B')] {
+            for key in repair.push(press(code)) {
+                app.handle_key(key).unwrap();
+            }
+        }
         assert_eq!(app.mode, Mode::Logs);
         assert!(app.logs.view.scroll <= 60);
     }
     assert_eq!(app.logs.view.scroll, 60);
+    assert!(!repair.pending());
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 //!
 //! A from-scratch reimagining of k9s built on kube-rs + ratatui, async-first.
 
+mod altscroll;
 mod app;
 mod bundle;
 mod columns;
@@ -543,6 +544,29 @@ fn print_info(loader: &config::ConfigLoader, warnings: &[String]) {
     }
 }
 
+/// Feed keys to the app and redraw. Returns whether anything was dispatched,
+/// so a repair that swallowed its input costs no frame.
+fn dispatch(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut App,
+    keys: Vec<crossterm::event::KeyEvent>,
+    captured: bool,
+) -> Result<bool> {
+    if keys.is_empty() {
+        return Ok(false);
+    }
+    for key in keys {
+        app.handle_key(key)?;
+        if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
+            suspend_and_run(terminal, &argv, captured);
+            app.flash = format!("ran: {}", argv.join(" "));
+            app.flash_err = false;
+        }
+    }
+    terminal.draw(|f| ui::draw(f, app))?;
+    Ok(true)
+}
+
 async fn run(
     terminal: &mut ratatui::DefaultTerminal,
     app: &mut App,
@@ -562,6 +586,9 @@ async fn run(
     // document views release it for native text selection (see
     // `wants_mouse_capture`). Always false when the config disabled the mouse.
     let mut captured = mouse;
+    // Reassembles cursor-key escape sequences split mid-read; only ever fed
+    // while capture is released, which is the only time they can arrive.
+    let mut repair = altscroll::Repair::default();
 
     terminal.draw(|f| ui::draw(f, app))?;
     loop {
@@ -578,20 +605,30 @@ async fn run(
                 let _ =
                     crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
             }
+            // No more alternate-scroll sequences either way: release any Esc
+            // still waiting for a tail that can no longer come.
+            if dispatch(terminal, app, repair.flush(), captured)? {
+                dirty = false;
+            }
         }
 
         tokio::select! {
             maybe_event = reader.next() => {
                 match maybe_event {
                     Some(Ok(Event::Key(key))) if key.kind == KeyEventKind::Press => {
-                        app.handle_key(key)?;
-                        if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
-                            suspend_and_run(terminal, &argv, captured);
-                            app.flash = format!("ran: {}", argv.join(" "));
-                            app.flash_err = false;
+                        // With capture released the wheel reaches us as
+                        // cursor-key escape sequences, and a fast burst can
+                        // split one across reads; `altscroll` puts those back
+                        // together. Nothing to repair while capture is on, so
+                        // the key goes straight through.
+                        let keys = if captured {
+                            vec![key]
+                        } else {
+                            repair.push(key)
+                        };
+                        if dispatch(terminal, app, keys, captured)? {
+                            dirty = false;
                         }
-                        terminal.draw(|f| ui::draw(f, app))?;
-                        dirty = false;
                     }
                     Some(Ok(Event::Mouse(m))) => {
                         app.handle_mouse(m)?;
@@ -627,6 +664,13 @@ async fn run(
             _ = tick.tick() => {
                 app.reap_port_forwards(); // age columns + drop dead forwards
                 dirty = true;
+            }
+            // A held Esc was a real keypress after all, not the head of a
+            // split escape sequence: act on it.
+            _ = tokio::time::sleep(altscroll::Repair::TIMEOUT), if repair.pending() => {
+                if dispatch(terminal, app, repair.flush(), captured)? {
+                    dirty = false;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Mouse text selection stopped working in the log view. #159 fixed the rapid-scroll havoc of #152 by keeping terminal mouse capture **on** in `Mode::Logs`/`Mode::LogFilter` — with capture on the terminal never sees a click-drag, so the native selection that #133 deliberately enabled for these views was gone.

This fixes #152 at the layer where it actually breaks, so logs can release capture again like every other document view.

**Root cause of #152.** With capture released, terminals translate the wheel into cursor-key escape sequences in the alternate screen (`ESC [ B`, or `ESC O B` in application cursor mode). A fast burst can end a read exactly on the `ESC` byte; with nothing else buffered the parser has to commit, so it reports a bare `Esc` and then re-starts on the tail, which no longer looks like a sequence and arrives as plain `[` and `B` characters. That stray `Esc` closed the log view, and the tail then hit table bindings — landing on some unrelated resource.

**The fix.** New `altscroll::Repair` reassembles those split sequences before they reach the app:

- An `Esc` is held back for one event, or 15 ms — short enough that a real `Esc` press still feels instant, long enough to outlast one poll.
- If the `[`/`O` introducer and an `A`–`D` final byte follow, the three become the cursor key they came from.
- Anything else replays exactly what was swallowed, in order. Modified keys are never mistaken for a sequence.
- The run loop only feeds keys through it while capture is released, which is the only time such sequences can arrive.

`wants_mouse_capture` then puts `Mode::Logs` and `Mode::LogFilter` back on the release list.

## Test plan

- [x] `cargo test` — 454 pass, `cargo clippy --all-targets` clean
- [x] 8 new unit tests in `altscroll`: split CSI and SS3 for all four arrows, a 50-notch burst yielding only `Down` and never an `Esc`, a real `Esc` surviving the timeout flush, `Esc` + another key releasing both in order, repeated `Esc` presses, unfinished sequences replaying their input, modified keys passing through
- [x] `rapid_log_wheel_down_clamps_without_leaving_logs` rewritten to drive the actual split-sequence path rather than synthetic mouse events — stays in `Mode::Logs`, clamps at the buffer bottom
- [x] Manually: open logs (`l`), `s` to pause, scroll up ~15 lines, then scroll down as fast as possible — stays in the log view
- [x] Manually: click-drag to select log text, including under the filter overlay (`/`) and in fullscreen (`F`)
- [x] Manually: `Esc` still leaves the log view promptly

Fixes #152