### PR TITLE
fix: prefer shorter labels on palette fuzzy-score ties

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -809,7 +809,7 @@ impl App {
             }
         }
 
-        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.label.cmp(&b.1.label)));
+        rank_completions(&mut scored, |s| s.label.as_str(), !q.is_empty());
         self.cmd_suggestions = scored.into_iter().take(100).map(|(_, s)| s).collect();
         self.cmd_sel = 0;
     }
@@ -838,7 +838,7 @@ impl App {
             };
             scored.push((score, n));
         }
-        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        rank_completions(&mut scored, |s| s.as_str(), !arg.is_empty());
         self.cmd_suggestions = scored
             .into_iter()
             .take(100)
@@ -864,7 +864,7 @@ impl App {
             };
             scored.push((score, c.clone()));
         }
-        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        rank_completions(&mut scored, |s| s.as_str(), !arg.is_empty());
         self.cmd_suggestions = scored
             .into_iter()
             .take(100)
@@ -1383,4 +1383,25 @@ fn plugin_flash(name: &str, n: usize, suffix: &str) -> String {
     } else {
         format!("plugin: {name}{suffix}…")
     }
+}
+
+/// Order scored palette completions: score descending, then label length,
+/// then alphabetical. Skim scores only the matched characters — unmatched
+/// trailing ones cost nothing — so short queries tie constantly (`serv`
+/// scores `services` and `serviceaccounts` identically; issue #164), and a
+/// purely alphabetical tie-break buried the shorter, denser match. Browse
+/// lists (empty query: everything ties at one score) skip the length
+/// tie-break so they stay alphabetical.
+fn rank_completions<T>(scored: &mut [(i64, T)], label: fn(&T) -> &str, by_len: bool) {
+    scored.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| {
+                if by_len {
+                    label(&a.1).len().cmp(&label(&b.1).len())
+                } else {
+                    std::cmp::Ordering::Equal
+                }
+            })
+            .then_with(|| label(&a.1).cmp(label(&b.1)))
+    });
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -113,6 +113,34 @@ async fn exact_alias_outranks_fuzzy_suggestions() {
 }
 
 #[tokio::test]
+async fn shorter_label_wins_fuzzy_score_ties() {
+    // Issue #164: skim scores only the matched characters, so `serv` scores
+    // `services` and `serviceaccounts` identically; the alphabetical
+    // tie-break buried `services`. Shorter label (denser match) wins ties.
+    let (mut app, _rx) = test_app();
+    app.cluster
+        .catalog
+        .extend(["serviceaccounts", "servicemonitors"].map(str::to_string));
+    app.cluster.catalog.sort();
+
+    app.command = "serv".into();
+    app.update_suggestions();
+    assert_eq!(app.cmd_suggestions[0].label, "services");
+
+    // The empty browse list stays purely alphabetical.
+    app.command.clear();
+    app.update_suggestions();
+    let labels: Vec<_> = app
+        .cmd_suggestions
+        .iter()
+        .map(|s| s.label.as_str())
+        .collect();
+    let mut sorted = labels.clone();
+    sorted.sort_unstable();
+    assert_eq!(labels, sorted);
+}
+
+#[tokio::test]
 async fn explicit_palette_search_bypasses_rbac_filter() {
     let (mut app, _rx) = test_app();
     app.cluster


### PR DESCRIPTION
## Summary
- Skim scores only the matched characters — unmatched trailing ones cost nothing — so short palette queries tie constantly: `serv` scores `services`, `serviceaccounts`, and `servicemonitors` identically, and the purely alphabetical tie-break buried `services` (#164).
- Break score ties by label length (denser match first), then alphabetically, via a shared `rank_completions` helper used by the palette and the `:<kind> <ns>` / `:ctx <name>` argument completions.
- Empty-query browse lists (everything ties at one score) skip the length tie-break and stay purely alphabetical.
- Length is a tie-break only: genuinely different fuzzy scores, exact-alias hits (`:svc`, `:hr`), and bookmark/workspace boosts are unaffected.

## Test plan
- [x] New regression test `shorter_label_wins_fuzzy_score_ties`: `serv` ranks `services` first ahead of `serviceaccounts`/`servicemonitors`; empty browse list remains alphabetical
- [x] `just check` — fmt, clippy `-D warnings`, 456 tests pass

Fixes #164