### PR TITLE
feat: allow rebinding palette completion keys

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,7 @@ Each of these is documented where the feature itself is:
 | `[[guardrails]]`      | enforced rules on destructive actions       | [Safety](safety.md#guardrails)                             |
 | `[logs]`              | log tail, follow buffer, `since` lookback   | [Log controls](debugging.md#log-controls)                  |
 | `[notify]`            | bell and desktop notification delivery      | [Notifications](debugging.md#notifications)                |
+| `[keys]`              | palette completion key rebinds              | [Key reference](keys.md#palette-completion-keys)           |
 | `[debug]`             | ephemeral and node debug images             | [Debug containers](debugging.md#debug-containers-and-pods) |
 | `[bundle]`            | redaction and size caps for `:bundle`       | [Diagnostic bundles](debugging.md#diagnostic-bundles)      |
 | `[providers.metrics]` | Prometheus/VictoriaMetrics for `:rightsize` | [Providers](providers.md#right-sizing-metrics-provider)    |

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -85,6 +85,24 @@ drill into has a trailing `→`.
 
 `ctrl-u` clears the line, `ctrl-w` / `alt-⌫` delete the previous word.
 
+## Palette completion keys
+
+In the `:` palette, `tab`/`↓` and `shift-tab`/`↑` move through the suggestion
+list and `⏎` runs the highlighted one. Rebind them under `[keys]` in
+`config.toml` — emacs/cmp style, for example:
+
+```toml
+[keys]
+palette_next   = "ctrl-n"
+palette_prev   = "ctrl-p"
+palette_accept = ["ctrl-y", "enter"]
+```
+
+Each value is one [key chord](plugins.md) or a list of chords, and replaces
+the default set for that action (`["tab", "down"]`, `["backtab", "up"]`,
+`["enter"]`) — include a default in the list to keep it too. `ctrl-c` (quit)
+and `ctrl-e` (compact mode) are reserved by built-ins and can't be bound.
+
 ## What suspends the TUI
 
 Interactive actions (`e`, `s` for shell, `a`) suspend the TUI and shell out to

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1330,6 +1330,10 @@ impl App {
         warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
         warnings.extend(crate::config::forward_warnings(&self.forwards_cfg));
         warnings.extend(crate::config::notify_warnings(&self.notify_cfg));
+        let (palette_keys, key_warnings) =
+            crate::config::compile_palette_keys(&resolved.config.keys);
+        self.palette_keys = palette_keys;
+        warnings.extend(key_warnings);
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -444,98 +444,35 @@ impl App {
     }
 
     pub(super) fn key_command(&mut self, key: KeyEvent) {
+        // Configured completion chords win over everything else (including
+        // the shared line-editing chords), so a `[keys]` rebind like ctrl-w
+        // always does what the user asked. Defaults: tab/down, backtab/up,
+        // enter — see [`crate::config::PaletteKeys`].
+        if self.palette_keys.next.iter().any(|c| c.matches(&key)) {
+            if !self.cmd_suggestions.is_empty() {
+                self.cmd_sel = (self.cmd_sel + 1) % self.cmd_suggestions.len();
+            }
+            return;
+        }
+        if self.palette_keys.prev.iter().any(|c| c.matches(&key)) {
+            if !self.cmd_suggestions.is_empty() {
+                self.cmd_sel = self
+                    .cmd_sel
+                    .checked_sub(1)
+                    .unwrap_or(self.cmd_suggestions.len() - 1);
+            }
+            return;
+        }
+        if self.palette_keys.accept.iter().any(|c| c.matches(&key)) {
+            self.palette_accept();
+            return;
+        }
         if edit_chord(&key, &mut self.command) {
             self.update_suggestions();
             return;
         }
         match key.code {
             KeyCode::Esc => self.mode = self.palette_return,
-            KeyCode::Down | KeyCode::Tab => {
-                if !self.cmd_suggestions.is_empty() {
-                    self.cmd_sel = (self.cmd_sel + 1) % self.cmd_suggestions.len();
-                }
-            }
-            KeyCode::Up | KeyCode::BackTab => {
-                if !self.cmd_suggestions.is_empty() {
-                    self.cmd_sel = self
-                        .cmd_sel
-                        .checked_sub(1)
-                        .unwrap_or(self.cmd_suggestions.len() - 1);
-                }
-            }
-            KeyCode::Enter => {
-                let typed = self.command.trim().to_string();
-                let picked = self.cmd_suggestions.get(self.cmd_sel).cloned();
-                self.mode = Mode::Table;
-                self.command.clear();
-                // Dispatch leaves the view the palette was opened from behind,
-                // so run the cleanup its own esc path would have done.
-                match self.palette_return {
-                    Mode::Logs => self.stop_log_stream(),
-                    Mode::Events => self.stop_event_stream(),
-                    _ => {}
-                }
-                self.palette_return = Mode::Table;
-                // `:kind namespace` switches both at once (`:deploy social`,
-                // `:cephclusters all`); only the first word selects the kind.
-                let (head, ns_arg) = match typed.split_once(char::is_whitespace) {
-                    Some((h, rest)) => (h.to_string(), rest.split_whitespace().next()),
-                    None => (typed.clone(), None),
-                };
-                match picked.as_ref().map(|s| s.kind) {
-                    // Argument completions act on the highlighted suggestion:
-                    // apply the completed namespace/context, not the partial
-                    // text still in the buffer.
-                    Some(SuggestKind::Namespace) => {
-                        if let Some(s) = picked {
-                            self.switch_kind_ns(&head, Some(s.label.as_str()));
-                        }
-                    }
-                    Some(SuggestKind::Context) => {
-                        if let Some(s) = picked {
-                            self.switch_context(s.label);
-                        }
-                    }
-                    Some(SuggestKind::Bookmark) => {
-                        if let Some(s) = picked {
-                            self.apply_bookmark_named(&s.label);
-                        }
-                    }
-                    Some(SuggestKind::Workspace) => {
-                        if let Some(s) = picked {
-                            self.open_workspace_named(&s.label);
-                        }
-                    }
-                    // A name owned by a CRD resolves to the CRD even when a
-                    // built-in command shares it — the cluster's vocabulary
-                    // outranks ours, and the suggestion list already ranks the
-                    // resource first. After that an exact typed built-in wins
-                    // (stable muscle memory), then the highlighted suggestion,
-                    // then the raw text as a resource.
-                    _ => {
-                        let crd_owned = self.cluster.resolve(&head).is_some_and(|k| k.is_custom());
-                        if crd_owned {
-                            self.switch_kind_ns(&head, ns_arg);
-                        } else if self.run_palette_command(&typed) {
-                            // handled
-                        } else if let Some(s) = picked {
-                            match s.kind {
-                                SuggestKind::Command => {
-                                    self.run_palette_command(&s.label);
-                                }
-                                SuggestKind::Resource => self.switch_kind_ns(&s.label, ns_arg),
-                                // Handled by the outer match arms above.
-                                SuggestKind::Namespace
-                                | SuggestKind::Context
-                                | SuggestKind::Bookmark
-                                | SuggestKind::Workspace => {}
-                            }
-                        } else if !head.is_empty() {
-                            self.switch_kind_ns(&head, ns_arg);
-                        }
-                    }
-                }
-            }
             KeyCode::Backspace => {
                 self.command.pop();
                 self.update_suggestions();
@@ -545,6 +482,81 @@ impl App {
                 self.update_suggestions();
             }
             _ => {}
+        }
+    }
+
+    /// Run the highlighted palette suggestion (or the raw typed text).
+    fn palette_accept(&mut self) {
+        let typed = self.command.trim().to_string();
+        let picked = self.cmd_suggestions.get(self.cmd_sel).cloned();
+        self.mode = Mode::Table;
+        self.command.clear();
+        // Dispatch leaves the view the palette was opened from behind,
+        // so run the cleanup its own esc path would have done.
+        match self.palette_return {
+            Mode::Logs => self.stop_log_stream(),
+            Mode::Events => self.stop_event_stream(),
+            _ => {}
+        }
+        self.palette_return = Mode::Table;
+        // `:kind namespace` switches both at once (`:deploy social`,
+        // `:cephclusters all`); only the first word selects the kind.
+        let (head, ns_arg) = match typed.split_once(char::is_whitespace) {
+            Some((h, rest)) => (h.to_string(), rest.split_whitespace().next()),
+            None => (typed.clone(), None),
+        };
+        match picked.as_ref().map(|s| s.kind) {
+            // Argument completions act on the highlighted suggestion:
+            // apply the completed namespace/context, not the partial
+            // text still in the buffer.
+            Some(SuggestKind::Namespace) => {
+                if let Some(s) = picked {
+                    self.switch_kind_ns(&head, Some(s.label.as_str()));
+                }
+            }
+            Some(SuggestKind::Context) => {
+                if let Some(s) = picked {
+                    self.switch_context(s.label);
+                }
+            }
+            Some(SuggestKind::Bookmark) => {
+                if let Some(s) = picked {
+                    self.apply_bookmark_named(&s.label);
+                }
+            }
+            Some(SuggestKind::Workspace) => {
+                if let Some(s) = picked {
+                    self.open_workspace_named(&s.label);
+                }
+            }
+            // A name owned by a CRD resolves to the CRD even when a
+            // built-in command shares it — the cluster's vocabulary
+            // outranks ours, and the suggestion list already ranks the
+            // resource first. After that an exact typed built-in wins
+            // (stable muscle memory), then the highlighted suggestion,
+            // then the raw text as a resource.
+            _ => {
+                let crd_owned = self.cluster.resolve(&head).is_some_and(|k| k.is_custom());
+                if crd_owned {
+                    self.switch_kind_ns(&head, ns_arg);
+                } else if self.run_palette_command(&typed) {
+                    // handled
+                } else if let Some(s) = picked {
+                    match s.kind {
+                        SuggestKind::Command => {
+                            self.run_palette_command(&s.label);
+                        }
+                        SuggestKind::Resource => self.switch_kind_ns(&s.label, ns_arg),
+                        // Handled by the outer match arms above.
+                        SuggestKind::Namespace
+                        | SuggestKind::Context
+                        | SuggestKind::Bookmark
+                        | SuggestKind::Workspace => {}
+                    }
+                } else if !head.is_empty() {
+                    self.switch_kind_ns(&head, ns_arg);
+                }
+            }
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1068,6 +1068,8 @@ pub struct App {
     pub forwards_cfg: Vec<crate::config::Forward>,
     /// `[notify]` delivery options (bell, desktop-notification protocol).
     pub notify_cfg: crate::config::NotifyConfig,
+    /// Compiled `[keys]` palette-completion bindings.
+    pub palette_keys: crate::config::PaletteKeys,
 
     pub skin_list: Vec<String>,
     pub skin_state: ListState,
@@ -1296,6 +1298,7 @@ impl App {
             port_forwards: Vec::new(),
             forwards_cfg: Vec::new(),
             notify_cfg: crate::config::NotifyConfig::default(),
+            palette_keys: crate::config::PaletteKeys::default(),
             pf_state: ListState::default(),
             skin_list: crate::theme::BUILTIN_NAMES
                 .iter()

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -702,6 +702,10 @@ impl App {
         plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         plugin_warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
+        let (palette_keys, key_warnings) =
+            crate::config::compile_palette_keys(&resolved.config.keys);
+        self.palette_keys = palette_keys;
+        plugin_warnings.extend(key_warnings);
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1912,6 +1912,53 @@ async fn crd_plural_outranks_builtin_command() {
 }
 
 #[tokio::test]
+async fn palette_completion_keys_are_rebindable() {
+    let (mut app, _rx) = test_app();
+    let keys_cfg: crate::config::Config = toml::from_str(
+        r#"
+        [keys]
+        palette_next = "ctrl-n"
+        palette_prev = "ctrl-p"
+        palette_accept = ["ctrl-y", "enter"]
+    "#,
+    )
+    .unwrap();
+    let (palette_keys, warnings) = crate::config::compile_palette_keys(&keys_cfg.keys);
+    assert!(warnings.is_empty(), "{warnings:?}");
+    app.palette_keys = palette_keys;
+
+    app.mode = Mode::Command;
+    app.update_suggestions();
+    assert!(app.cmd_suggestions.len() > 1);
+    assert_eq!(app.cmd_sel, 0);
+
+    // ctrl-n / ctrl-p move the highlight; the overridden tab/arrows don't.
+    app.key_command(ctrl(KeyCode::Char('n')));
+    assert_eq!(app.cmd_sel, 1);
+    app.key_command(press(KeyCode::Tab));
+    app.key_command(press(KeyCode::Down));
+    assert_eq!(app.cmd_sel, 1, "tab/down were overridden away");
+    app.key_command(ctrl(KeyCode::Char('p')));
+    assert_eq!(app.cmd_sel, 0);
+
+    // ctrl-y runs the command line exactly like enter does by default.
+    for c in "snapshots media".chars() {
+        app.key_command(press(KeyCode::Char(c)));
+    }
+    app.key_command(ctrl(KeyCode::Char('y')));
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.namespace, "media");
+
+    // Enter stays usable because the config listed it too.
+    app.mode = Mode::Command;
+    for c in "pods".chars() {
+        app.key_command(press(KeyCode::Char(c)));
+    }
+    app.key_command(press(KeyCode::Enter));
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
 async fn qualified_names_surface_without_doubling_the_list() {
     let (mut app, _rx) = test_app();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crossterm::event::KeyCode;
 use serde::Deserialize;
+
+use crate::keys::KeyChord;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
@@ -95,6 +98,9 @@ pub struct Config {
     pub mouse: Option<bool>,
     /// How `:notify` events are delivered — see [`NotifyConfig`].
     pub notify: NotifyConfig,
+    /// Command-palette completion key rebinds — see [`KeysConfig`]. Compiled
+    /// and validated by [`compile_palette_keys`].
+    pub keys: KeysConfig,
 }
 
 /// Delivery for `:notify` events, besides the status-line flash.
@@ -159,6 +165,117 @@ pub fn notify_warnings(cfg: &NotifyConfig) -> Vec<String> {
         warnings.push("notify: command has an empty executable; ignored".into());
     }
     warnings
+}
+
+/// Key overrides for the `:` command-palette completion popup — emacs/cmp
+/// style rebinds, for example:
+///
+/// ```toml
+/// [keys]
+/// palette_next   = "ctrl-n"            # default: ["tab", "down"]
+/// palette_prev   = "ctrl-p"            # default: ["backtab", "up"]
+/// palette_accept = ["ctrl-y", "enter"] # default: ["enter"]
+/// ```
+///
+/// Each value is one key chord (see [`crate::keys::KeyChord`]) or a list of
+/// them, and *replaces* the default set for that action — include a default
+/// chord in the list to keep it too. Compiled and validated by
+/// [`compile_palette_keys`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct KeysConfig {
+    /// Move the suggestion highlight down.
+    pub palette_next: Option<Chords>,
+    /// Move the suggestion highlight up.
+    pub palette_prev: Option<Chords>,
+    /// Run the highlighted suggestion (or the typed text).
+    pub palette_accept: Option<Chords>,
+}
+
+/// One key chord, or a list of chords that all trigger the same action.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum Chords {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl Chords {
+    fn as_slice(&self) -> &[String] {
+        match self {
+            Chords::One(s) => std::slice::from_ref(s),
+            Chords::Many(v) => v,
+        }
+    }
+}
+
+/// Compiled `[keys]` palette bindings, with defaults filled in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaletteKeys {
+    pub next: Vec<KeyChord>,
+    pub prev: Vec<KeyChord>,
+    pub accept: Vec<KeyChord>,
+}
+
+impl Default for PaletteKeys {
+    fn default() -> Self {
+        let plain = |code| KeyChord {
+            code,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        };
+        Self {
+            next: vec![plain(KeyCode::Tab), plain(KeyCode::Down)],
+            prev: vec![plain(KeyCode::BackTab), plain(KeyCode::Up)],
+            accept: vec![plain(KeyCode::Enter)],
+        }
+    }
+}
+
+impl PaletteKeys {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// Compile `[keys]` palette bindings. A chord that doesn't parse, or that
+/// collides with a reserved global (`ctrl-c` quit, `ctrl-e` compact toggle),
+/// warns and is dropped; an action left with no usable chord falls back to
+/// its default so the palette never becomes unusable.
+pub fn compile_palette_keys(cfg: &KeysConfig) -> (PaletteKeys, Vec<String>) {
+    let mut warnings = Vec::new();
+    let defaults = PaletteKeys::default();
+    let mut action = |name: &str, spec: &Option<Chords>, default: &[KeyChord]| {
+        let Some(spec) = spec else {
+            return default.to_vec();
+        };
+        let mut out = Vec::new();
+        for s in spec.as_slice() {
+            match KeyChord::parse(s) {
+                Ok(c) if c.ctrl && matches!(c.code, KeyCode::Char('c' | 'e')) => {
+                    warnings.push(format!(
+                        "keys: {name}: {} is reserved by a built-in; ignored",
+                        c.label()
+                    ));
+                }
+                Ok(c) => out.push(c),
+                Err(e) => warnings.push(format!("keys: {name}: {e}")),
+            }
+        }
+        if out.is_empty() {
+            warnings.push(format!("keys: {name} has no usable chord; using default"));
+            default.to_vec()
+        } else {
+            out
+        }
+    };
+    let keys = PaletteKeys {
+        next: action("palette_next", &cfg.palette_next, &defaults.next),
+        prev: action("palette_prev", &cfg.palette_prev, &defaults.prev),
+        accept: action("palette_accept", &cfg.palette_accept, &defaults.accept),
+    };
+    (keys, warnings)
 }
 
 /// A named, saved port-forward. Shows up in `:pf` even when stopped, so one
@@ -1166,6 +1283,63 @@ fn config_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn palette_keys_default_when_unset() {
+        let cfg: Config = toml::from_str("").unwrap();
+        let (keys, warnings) = compile_palette_keys(&cfg.keys);
+        assert!(warnings.is_empty());
+        assert!(keys.is_default());
+    }
+
+    #[test]
+    fn palette_keys_accept_string_or_list() {
+        let toml = r#"
+            [keys]
+            palette_next = "ctrl-n"
+            palette_prev = "ctrl-p"
+            palette_accept = ["ctrl-y", "enter"]
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        let (keys, warnings) = compile_palette_keys(&cfg.keys);
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert_eq!(keys.next, vec![KeyChord::parse("ctrl-n").unwrap()]);
+        assert_eq!(keys.prev, vec![KeyChord::parse("ctrl-p").unwrap()]);
+        assert_eq!(
+            keys.accept,
+            vec![
+                KeyChord::parse("ctrl-y").unwrap(),
+                KeyChord::parse("enter").unwrap()
+            ]
+        );
+        assert!(!keys.is_default());
+    }
+
+    #[test]
+    fn palette_keys_bad_chord_warns_and_falls_back() {
+        let toml = r#"
+            [keys]
+            palette_next = "hyper-n"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        let (keys, warnings) = compile_palette_keys(&cfg.keys);
+        assert_eq!(warnings.len(), 2, "{warnings:?}"); // parse error + fallback
+        assert!(warnings[0].contains("palette_next"), "{warnings:?}");
+        assert_eq!(keys.next, PaletteKeys::default().next);
+    }
+
+    #[test]
+    fn palette_keys_reserved_chord_is_dropped() {
+        let toml = r#"
+            [keys]
+            palette_accept = ["ctrl-c", "ctrl-y"]
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        let (keys, warnings) = compile_palette_keys(&cfg.keys);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("reserved"), "{warnings:?}");
+        assert_eq!(keys.accept, vec![KeyChord::parse("ctrl-y").unwrap()]);
+    }
 
     #[test]
     fn parses_full_config() {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -72,6 +72,12 @@ impl KeyChord {
             shift = false;
         }
 
+        // Terminals deliver shift-tab as its own key, not tab+shift.
+        if let (true, KeyCode::Tab) = (shift, code) {
+            code = KeyCode::BackTab;
+            shift = false;
+        }
+
         Ok(KeyChord {
             code,
             ctrl,
@@ -97,6 +103,8 @@ impl KeyChord {
                     a == b
                 }
             }
+            // Terminals disagree on whether BackTab carries a SHIFT modifier.
+            (KeyCode::BackTab, KeyCode::BackTab) => true,
             (a, b) => a == b && self.shift == event.modifiers.contains(KeyModifiers::SHIFT),
         }
     }
@@ -134,6 +142,7 @@ fn parse_key(token: &str) -> Option<KeyCode> {
     Some(match lower.as_str() {
         "enter" | "return" | "ret" => KeyCode::Enter,
         "tab" => KeyCode::Tab,
+        "backtab" => KeyCode::BackTab,
         "esc" | "escape" => KeyCode::Esc,
         "space" => KeyCode::Char(' '),
         "backspace" | "bs" => KeyCode::Backspace,
@@ -158,6 +167,7 @@ fn key_label(code: KeyCode) -> String {
         KeyCode::F(n) => format!("f{n}"),
         KeyCode::Enter => "enter".into(),
         KeyCode::Tab => "tab".into(),
+        KeyCode::BackTab => "backtab".into(),
         KeyCode::Esc => "esc".into(),
         KeyCode::Backspace => "backspace".into(),
         KeyCode::Delete => "delete".into(),
@@ -280,6 +290,18 @@ mod tests {
         assert!(upper.matches(&ev(KeyCode::Char('B'), KeyModifiers::NONE)));
         // But not the lowercase.
         assert!(!upper.matches(&ev(KeyCode::Char('b'), KeyModifiers::NONE)));
+    }
+
+    #[test]
+    fn backtab_and_shift_tab_are_the_same_key() {
+        let named = KeyChord::parse("backtab").unwrap();
+        assert_eq!(named.code, KeyCode::BackTab);
+        assert_eq!(named, KeyChord::parse("shift-tab").unwrap());
+        assert_eq!(named.label(), "backtab");
+        // Terminals disagree on whether BackTab carries SHIFT — match both.
+        assert!(named.matches(&ev(KeyCode::BackTab, KeyModifiers::SHIFT)));
+        assert!(named.matches(&ev(KeyCode::BackTab, KeyModifiers::NONE)));
+        assert!(!named.matches(&ev(KeyCode::Tab, KeyModifiers::NONE)));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,12 @@ async fn main() -> Result<()> {
         eprintln!("warning: {w}");
         config_warnings.push(w);
     }
+    let (palette_keys, key_warnings) = config::compile_palette_keys(&cfg.keys);
+    for w in key_warnings {
+        eprintln!("warning: {w}");
+        config_warnings.push(w);
+    }
+    app.palette_keys = palette_keys;
     let (user_views, view_warnings) = views::compile(&cfg.views);
     for w in &view_warnings {
         eprintln!("warning: {w}");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2807,11 +2807,26 @@ fn draw_palette(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     let mut state = ListState::default();
     state.select(Some(app.cmd_sel));
+    // The hint mirrors the user's `[keys]` rebinds (first chord of each
+    // action); the default set keeps its compact symbols.
+    let hint = if app.palette_keys.is_default() {
+        " commands & resources (tab/↑↓ · ⏎) ".to_string()
+    } else {
+        let first = |chords: &[crate::keys::KeyChord]| {
+            chords.first().map(|c| c.label()).unwrap_or_default()
+        };
+        format!(
+            " commands & resources ({}/{} · {}) ",
+            first(&app.palette_keys.next),
+            first(&app.palette_keys.prev),
+            first(&app.palette_keys.accept),
+        )
+    };
     render_framed_list(
         frame,
         rect,
         items,
-        Span::styled(" commands & resources (tab/↑↓ · ⏎) ", theme::title()),
+        Span::styled(hint, theme::title()),
         &mut state,
     );
 }


### PR DESCRIPTION
## Summary

Closes #169.

Adds a `[keys]` config section to rebind the `:` command-palette completion keys, emacs/cmp style:

```toml
[keys]
palette_next   = "ctrl-n"            # default: ["tab", "down"]
palette_prev   = "ctrl-p"            # default: ["backtab", "up"]
palette_accept = ["ctrl-y", "enter"] # default: ["enter"]
```

- Each value is one key chord or a list, and replaces the default set for that action — include a default in the list to keep it.
- Invalid chords warn (stderr + `:config`) and fall back to the default so the palette never becomes unusable; `ctrl-c`/`ctrl-e` are rejected as reserved built-ins.
- Configured chords are checked before the shared line-editing chords, so rebinds like `ctrl-w` win.
- Rebinds follow per-cluster/per-context overrides, `:reload`, and context switches like every other config section.
- The suggestion-popup hint shows the rebound chords instead of the default `tab/↑↓ · ⏎`.
- `KeyChord` gains `backtab` (with `shift-tab` folding into it, matching regardless of the SHIFT modifier terminals may or may not attach).

## Test plan

- [x] `just check` (fmt, clippy, 466 tests)
- [x] New unit tests: chord parsing for `backtab`/`shift-tab`, `[keys]` compile (string/list, bad chord fallback, reserved chords), end-to-end palette navigation and accept with `ctrl-n`/`ctrl-p`/`ctrl-y`