### PR TITLE
feat: remember sort column and direction per kind, persisted across restarts

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -14,7 +14,7 @@ plugin, bookmark, and workspace chords.
 | `enter`                                       | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources)                               |
 | `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                             |
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                              |
-| `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction                                                    |
+| `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction — remembered per kind across views and restarts    |
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                              |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                      |
 | `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |

--- a/docs/views.md
+++ b/docs/views.md
@@ -9,7 +9,9 @@ lowercase kind. The most specific key wins.
 
 ```toml
 [views."cert-manager.io/v1/certificates"]
-sort = "EXPIRES:desc"     # initial sort column, ":asc" (default) or ":desc"
+sort = "EXPIRES:desc"     # initial sort column, ":asc" (default) or ":desc";
+                          # a sort you pick in the TUI (S/I/header click) is
+                          # remembered per kind and wins over this
 # replace = true          # replace the curated columns instead of overlaying
 
 [[views."cert-manager.io/v1/certificates".columns]]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -278,6 +278,9 @@ impl App {
             self.table_state.select(Some(0));
         }
         self.refresh_view_spec();
+        // The remembered per-kind sort wins over a view's configured initial
+        // sort: the memory *is* the user's last explicit choice for this kind.
+        self.apply_remembered_sort();
         self.apply_view_sort();
         self.maybe_fetch_printer_columns(&kind);
         let handle = self.cluster.spawn_watch(
@@ -717,6 +720,9 @@ impl App {
                 self.crd_views.insert(plural, *view);
                 if for_current {
                     self.refresh_view_spec();
+                    // A remembered sort on a printer column only becomes
+                    // resolvable now that the CRD's columns are known.
+                    self.apply_remembered_sort();
                 }
             }
             Msg::FindResults {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1015,6 +1015,12 @@ pub struct App {
     /// Where fleet marks persist (`<state-dir>/fleet.toml`, set at startup);
     /// `None` (tests) keeps them in memory only.
     pub fleet_marks_path: Option<std::path::PathBuf>,
+    /// Remembered sort per kind (`S`/`I`/header click), restored on every
+    /// view start. Persisted to `sort_memory_path` on every change.
+    pub sort_memory: crate::sortmem::SortMemory,
+    /// Where remembered sorts persist (`<state-dir>/sort.toml`, set at
+    /// startup); `None` (tests) keeps them in memory only.
+    pub sort_memory_path: Option<std::path::PathBuf>,
     /// Global fuzzy-find (`:find`) results and picker cursor.
     pub find_items: Vec<crate::store::FindItem>,
     pub find_state: ListState,
@@ -1276,6 +1282,8 @@ impl App {
             fleet_state: ListState::default(),
             fleet_marks: crate::fleet::FleetMarks::default(),
             fleet_marks_path: None,
+            sort_memory: crate::sortmem::SortMemory::default(),
+            sort_memory_path: None,
             find_items: Vec::new(),
             find_state: ListState::default(),
             find_query: String::new(),

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -106,6 +106,7 @@ impl App {
                 self.sort_desc = false;
             }
             self.invalidate_rows();
+            self.remember_sort();
             let label = self.display_headers().get(idx).cloned().unwrap_or_default();
             self.flash = format!(
                 "sort by {label} {}",

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -241,6 +241,7 @@ impl App {
         self.sort_picker_filter.clear();
         if entry == DEFAULT_SORT_LABEL {
             self.reset_sort();
+            self.remember_sort();
             self.invalidate_rows();
             self.flash = format!("sort by {DEFAULT_SORT_LABEL}");
             self.flash_err = false;
@@ -252,6 +253,7 @@ impl App {
         self.sort_desc = self.sort_column == Some(idx) && !self.sort_desc;
         self.sort_column = Some(idx);
         self.invalidate_rows();
+        self.remember_sort();
         self.flash = format!(
             "sort by {entry} {}",
             if self.sort_desc {

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -427,6 +427,9 @@ impl App {
     pub(super) fn toggle_wide(&mut self) {
         self.wide = !self.wide;
         self.refresh_view_spec();
+        // A remembered sort on a wide-only column comes back the moment its
+        // column does.
+        self.apply_remembered_sort();
         self.flash = format!("wide columns: {}", if self.wide { "on" } else { "off" });
         self.flash_err = false;
     }
@@ -563,6 +566,51 @@ impl App {
         self.sort_desc = false;
     }
 
+    /// Record the active sort for the current kind (and persist it), so the
+    /// choice survives view switches and restarts. Called after every user
+    /// sort change; with no active sort (the picker's default entry) the
+    /// kind's entry is forgotten instead. View switches call `reset_sort`
+    /// directly and must NOT land here — a switch isn't a sort choice.
+    pub(super) fn remember_sort(&mut self) {
+        if self.kind_plural.is_empty() {
+            return;
+        }
+        let kind = self.kind_plural.clone();
+        match self
+            .sort_column
+            .and_then(|i| self.display_headers().get(i).cloned())
+        {
+            Some(h) => self.sort_memory.set(&kind, &h, self.sort_desc),
+            None if self.sort_memory.clear(&kind) => {}
+            None => return, // nothing was remembered; skip the disk write
+        }
+        if let Some(path) = self.sort_memory_path.clone()
+            && let Err(e) = self.sort_memory.save(&path)
+        {
+            self.flash_warn(&format!("failed to save sort state: {e}"));
+        }
+    }
+
+    /// Restore the remembered sort for the current kind, unless a sort is
+    /// already active (a bookmark's sort spec, or a header repinned across a
+    /// spec refresh, must win). A remembered header missing from the current
+    /// layout is left in memory untouched: CRD printer columns arrive after
+    /// the watch starts (see `Msg::PrinterColumns`, which retries this), and
+    /// a wide-only column simply stays dormant until `w`.
+    pub(super) fn apply_remembered_sort(&mut self) {
+        if self.sort_column.is_some() {
+            return;
+        }
+        let Some((header, desc)) = self.sort_memory.get(&self.kind_plural) else {
+            return;
+        };
+        if let Some(i) = self.display_headers().iter().position(|h| *h == header) {
+            self.sort_column = Some(i);
+            self.sort_desc = desc;
+            self.invalidate_rows();
+        }
+    }
+
     /// Toggle ascending/descending for the active sort column (k9s `I`).
     pub(super) fn toggle_sort_dir(&mut self) {
         let Some(i) = self.sort_column else {
@@ -571,6 +619,7 @@ impl App {
         };
         self.sort_desc = !self.sort_desc;
         self.invalidate_rows();
+        self.remember_sort();
         let label = self.display_headers().get(i).cloned().unwrap_or_default();
         self.flash = format!(
             "sort by {label} {}",

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2515,6 +2515,63 @@ async fn sort_picker_picks_toggles_and_clears() {
 }
 
 #[tokio::test]
+async fn sort_choice_is_remembered_per_kind_across_view_switches() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+
+    // Pick RESTARTS via the picker, then invert with `I`.
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    for c in "rst".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_key(press(KeyCode::Char('I'))).unwrap();
+    let restarts = app.display_headers().iter().position(|h| h == "RESTARTS");
+    assert_eq!(app.sort_column, restarts);
+    assert!(app.sort_desc);
+    assert_eq!(app.sort_memory.get("pods"), Some(("RESTARTS".into(), true)));
+
+    // A kind with no memory starts unsorted; the pods memory is untouched.
+    app.switch_kind("deployments");
+    assert_eq!(app.sort_column, None);
+    assert_eq!(app.sort_memory.get("pods"), Some(("RESTARTS".into(), true)));
+
+    // Coming back restores column and direction.
+    app.switch_kind("pods");
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "RESTARTS")
+    );
+    assert!(app.sort_desc);
+
+    // A header click is remembered too.
+    app.switch_kind("deployments");
+    let ready = app
+        .display_headers()
+        .iter()
+        .position(|h| h == "READY")
+        .unwrap();
+    app.sort_column = Some(ready);
+    app.sort_desc = false;
+    app.remember_sort();
+    assert_eq!(
+        app.sort_memory.get("deployments"),
+        Some(("READY".into(), false))
+    );
+
+    // Picking the pinned default forgets the kind's memory.
+    app.switch_kind("pods");
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    app.sort_picker_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.sort_column, None);
+    assert_eq!(app.sort_memory.get("pods"), None);
+    app.switch_kind("deployments");
+    app.switch_kind("pods");
+    assert_eq!(app.sort_column, None);
+}
+
+#[tokio::test]
 async fn sort_picker_esc_clears_filter_then_closes() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod logfilter;
 mod providers;
 mod rightsize;
 mod snapshot;
+mod sortmem;
 mod store;
 mod text;
 mod theme;
@@ -175,6 +176,11 @@ async fn main() -> Result<()> {
     let fleet_marks_path = fleet::FleetMarks::default_path();
     app.fleet_marks = fleet::FleetMarks::load(&fleet_marks_path);
     app.fleet_marks_path = Some(fleet_marks_path);
+    // Remembered sort columns (`S`/`I`/header clicks) persist the same way,
+    // restored per kind on every view start.
+    let sort_memory_path = sortmem::SortMemory::default_path();
+    app.sort_memory = sortmem::SortMemory::load(&sort_memory_path);
+    app.sort_memory_path = Some(sort_memory_path);
     // Kubeconfig contexts are stable for the session; cache them once so the
     // palette can complete `:ctx <name>` without re-reading the file per keystroke.
     match Cluster::list_contexts() {

--- a/src/sortmem.rs
+++ b/src/sortmem.rs
@@ -1,0 +1,123 @@
+//! Remembered sort choices, persisted across restarts.
+//!
+//! Picking a sort column (`S`, a header click) or flipping direction (`I`)
+//! records the choice per resource kind in `<state-dir>/sort.toml`, so the
+//! next visit to that kind — in this session or the next — comes back sorted
+//! the same way. Picking the pinned default ordering forgets the entry. Like
+//! fleet marks, this is deliberately a separate state file: sofka never
+//! rewrites the user's config, and a `[views] sort` there stays the
+//! hand-edited fallback these choices overlay.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Per-kind sort memory. Keys are the kind plural (or a synthetic view name
+/// like `helm`); values are `HEADER` or `HEADER:desc`, the same spec format
+/// bookmarks use, so the file stays hand-editable.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SortMemory {
+    pub kinds: BTreeMap<String, String>,
+}
+
+impl SortMemory {
+    /// Where remembered sorts live: `<state-dir>/sort.toml`.
+    pub fn default_path() -> PathBuf {
+        crate::diagnostics::state_dir().join("sort.toml")
+    }
+
+    /// Load persisted sorts. A missing or unparsable file is an empty set —
+    /// startup must not fail over hand-mangled state.
+    pub fn load(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        let text = toml::to_string(self).map_err(|e| e.to_string())?;
+        std::fs::write(path, text).map_err(|e| e.to_string())
+    }
+
+    /// Remember `header` (+ direction) for `kind`.
+    pub fn set(&mut self, kind: &str, header: &str, desc: bool) {
+        let spec = if desc {
+            format!("{header}:desc")
+        } else {
+            header.to_string()
+        };
+        self.kinds.insert(kind.to_string(), spec);
+    }
+
+    /// Forget `kind`'s entry. Returns whether one existed.
+    pub fn clear(&mut self, kind: &str) -> bool {
+        self.kinds.remove(kind).is_some()
+    }
+
+    /// The remembered `(HEADER, desc)` for `kind`, if any. Parses the same
+    /// `COLUMN[:asc|:desc]` spec bookmarks accept, uppercased to match
+    /// display headers.
+    pub fn get(&self, kind: &str) -> Option<(String, bool)> {
+        let spec = self.kinds.get(kind)?;
+        let (name, desc) = match spec.rsplit_once(':') {
+            Some((col, "desc")) => (col.trim(), true),
+            Some((col, "asc")) => (col.trim(), false),
+            _ => (spec.trim(), false),
+        };
+        Some((name.to_uppercase(), desc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_get_roundtrip_and_clear() {
+        let mut m = SortMemory::default();
+        m.set("pods", "RESTARTS", true);
+        m.set("deployments", "READY", false);
+        assert_eq!(m.get("pods"), Some(("RESTARTS".into(), true)));
+        assert_eq!(m.get("deployments"), Some(("READY".into(), false)));
+        assert_eq!(m.get("nodes"), None);
+        assert!(m.clear("pods"));
+        assert!(!m.clear("pods"));
+        assert_eq!(m.get("pods"), None);
+    }
+
+    #[test]
+    fn get_parses_hand_edited_specs() {
+        let mut m = SortMemory::default();
+        m.kinds.insert("pods".into(), "age:desc".into());
+        m.kinds.insert("nodes".into(), "cpu:asc".into());
+        m.kinds.insert("jobs".into(), "completions".into());
+        assert_eq!(m.get("pods"), Some(("AGE".into(), true)));
+        assert_eq!(m.get("nodes"), Some(("CPU".into(), false)));
+        assert_eq!(m.get("jobs"), Some(("COMPLETIONS".into(), false)));
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("sofka-sortmem-{}", std::process::id()));
+        let path = dir.join("sort.toml");
+        let mut m = SortMemory::default();
+        m.set("pods", "RESTARTS", true);
+        m.save(&path).unwrap();
+        assert_eq!(SortMemory::load(&path), m);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_missing_or_garbage_is_empty() {
+        assert_eq!(
+            SortMemory::load(Path::new("/nonexistent/sort.toml")),
+            SortMemory::default()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Sorting is no longer lost on every view switch: picking a column (`S`, header click) or flipping direction (`I`) is remembered **per resource kind** and restored automatically when you come back to that kind
- Memory persists across restarts in `<state-dir>/sort.toml` (new `SortMemory`, modeled on `FleetMarks` — sofka still never rewrites the user's config); values use the same `COLUMN[:asc|:desc]` spec bookmarks use, so the file is hand-editable
- Picking the pinned "default (ns/name)" entry forgets the kind's memory
- Precedence: an active sort (e.g. a bookmark's `sort`) wins over memory; memory wins over a view's configured initial `sort` (the memory *is* the user's last explicit choice); `[views] sort` still applies for kinds with no memory
- A remembered header that isn't in the current layout stays dormant instead of erroring: it resolves when CRD printer columns arrive or when `w` reveals its wide-only column

## Test plan
- [x] `cargo test sort` — new `sort_choice_is_remembered_per_kind_across_view_switches` + `sortmem` unit tests (roundtrip, hand-edited specs, missing/garbage file)
- [x] Manually: sort pods by RESTARTS desc, switch to deployments and back → sort restored; restart sofka → still sorted; pick "default (ns/name)" → forgotten