### PR TITLE
feat: decode secrets in-view with x; auto-bump homebrew tap on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,6 +110,23 @@ jobs:
       - name: Upload release assets
         run: gh release upload "$RELEASE_TAG" dist/*.tar.gz --clobber
 
+  # Kick the tap's bump workflow so `brew install nklmilojevic/sofka/sofka`
+  # picks up the new version immediately instead of waiting for the tap's
+  # 6-hourly cron (which stays as the fallback). Needs TAP_GITHUB_TOKEN, a
+  # fine-grained PAT scoped to homebrew-sofka with Actions read/write.
+  homebrew-bump:
+    needs: upload-assets
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Dispatch tap bump
+        run: |
+          gh workflow run bump.yaml \
+            -R nklmilojevic/homebrew-sofka \
+            -f tag="$RELEASE_TAG"
+
   crates-publish:
     needs: upload-assets
     runs-on: ubuntu-latest

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -63,6 +63,13 @@ impl App {
     /// search and `c` copy work like every other single-document view.
     pub(super) fn open_decoded_secret(&mut self) {
         self.set_return_mode();
+        self.show_decoded_secret();
+    }
+
+    /// The decoded-secret view itself, without touching the return mode — the
+    /// in-document `x` binding lands here, so esc still returns to wherever
+    /// the describe/YAML view was opened from.
+    pub(super) fn show_decoded_secret(&mut self) {
         let Some(obj) = self.selected_ref() else {
             return;
         };

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -966,6 +966,11 @@ impl App {
             KeyCode::Char('c') if detail => {
                 self.copy_doc();
             }
+            // `x` decodes the secret's data from inside its describe/YAML
+            // view too — no need to back out to the table first.
+            KeyCode::Char('x') if self.mode == Mode::Detail && self.kind_plural == "secrets" => {
+                self.show_decoded_secret();
+            }
             KeyCode::Char('j') | KeyCode::Down => target.scroll_by(1),
             KeyCode::Char('k') | KeyCode::Up => target.scroll_by(-1),
             KeyCode::Char('h') | KeyCode::Left => target.scroll_h(-5),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5309,6 +5309,38 @@ async fn x_decodes_secret_data_into_detail_view() {
 }
 
 #[tokio::test]
+async fn x_decodes_secret_from_inside_the_detail_view() {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+
+    let (mut app, _rx) = test_app();
+    app.switch_kind("secrets");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Secret",
+        "metadata": {"name": "creds", "namespace": "default"},
+        "type": "Opaque",
+        "data": {"password": BASE64.encode("hunter2")}}),
+    );
+    app.table_state.select(Some(0));
+
+    // Open the YAML view (stands in for describe — same Mode::Detail), then
+    // decode from inside it without backing out to the table.
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.title.contains("YAML"), "{}", app.detail.title);
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.title.contains("decoded"), "{}", app.detail.title);
+    let lines: Vec<&str> = app.detail.lines.iter().map(String::as_str).collect();
+    assert!(lines.contains(&"password: hunter2"), "{lines:?}");
+
+    // Esc still returns to where the original view was opened from.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
 async fn x_on_secret_without_data_warns() {
     let (mut app, _rx) = test_app();
     app.switch_kind("secrets");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1966,7 +1966,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "/ · n/N",
             "search within YAML/describe/diff/events (highlight in place, n/N to jump); filters help",
         ),
-        bind("x", "secrets: show data base64-decoded"),
+        bind(
+            "x",
+            "secrets: show data base64-decoded (also inside YAML/describe)",
+        ),
         bind(
             "shift-x · :explain",
             "explain why the selection is unhealthy (evidence-backed)",
@@ -3299,7 +3302,12 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Detail | Mode::Events | Mode::Diff => {
-            let hint = "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  esc:back";
+            // The `x` decode binding only applies to a secret's document view.
+            let hint = if app.mode == Mode::Detail && app.kind_plural == "secrets" {
+                "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  x:decode  esc:back"
+            } else {
+                "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  esc:back"
+            };
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),


### PR DESCRIPTION
## Summary
- `x` now decodes a secret's data from inside its YAML/describe view (`Mode::Detail`), instead of only from the table — esc still returns to wherever the view was opened from (table or xray)
- footer hint shows `x:decode` on a secret's document view; help text updated
- release workflow gains a `homebrew-bump` job that dispatches the tap's `bump.yaml` with the release tag after assets upload, so the formula updates immediately instead of waiting for the tap's 6-hourly cron (uses the new `TAP_GITHUB_TOKEN` secret; cron stays as fallback)

## Test plan
- [x] `cargo test` — 477 passed, including new `x_decodes_secret_from_inside_the_detail_view`
- [x] `cargo clippy --all-targets` clean
- [x] on next release: verify the tap bump workflow is dispatched and the formula lands the new version