### PR TITLE
fix: scale all marked rows, not just the cursor position

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1031,19 +1031,32 @@ impl App {
             self.flash_warn("scale applies to deployments/statefulsets/replicasets");
             return;
         }
-        let Some(obj) = self.selected_ref() else {
+        let objs = self.action_target_objects();
+        if objs.is_empty() {
             return;
+        }
+        self.prompt_label = if let [obj] = objs.as_slice() {
+            let name = obj.metadata.name.clone().unwrap_or_default();
+            let cur = obj
+                .data
+                .pointer("/spec/replicas")
+                .and_then(Value::as_i64)
+                .unwrap_or(0);
+            format!("Scale {name} to replicas (current {cur}):")
+        } else {
+            format!("Scale {} {} to replicas:", objs.len(), self.kind_plural)
         };
-        let name = obj.metadata.name.clone().unwrap_or_default();
-        let ns = obj.metadata.namespace.clone().unwrap_or_default();
-        let cur = obj
-            .data
-            .pointer("/spec/replicas")
-            .and_then(Value::as_i64)
-            .unwrap_or(0);
-        self.prompt_label = format!("Scale {name} to replicas (current {cur}):");
+        let targets = objs
+            .iter()
+            .map(|o| {
+                (
+                    o.metadata.name.clone().unwrap_or_default(),
+                    o.metadata.namespace.clone().unwrap_or_default(),
+                )
+            })
+            .collect();
         self.prompt_input.clear();
-        self.prompt_kind = Some(PromptKind::Scale { ns, name });
+        self.prompt_kind = Some(PromptKind::Scale { targets });
         self.mode = Mode::Prompt;
     }
 
@@ -1456,18 +1469,28 @@ impl App {
             .select(if len == 0 { None } else { Some(i.min(len - 1)) });
     }
 
-    pub(super) fn do_scale(&mut self, ns: String, name: String, replicas: i32) {
+    pub(super) fn do_scale(&mut self, targets: Vec<(String, String)>, replicas: i32) {
         let Some(kind) = self.kind.clone() else {
             return;
         };
-        self.note_action(format!("scale to {replicas}"), format!("{name} in {ns}"));
-        self.flash = format!("scaling {name} → {replicas}");
+        let label = self.action_label(&targets);
+        self.note_action(format!("scale to {replicas}"), label);
+        self.flash = if let [(name, _)] = targets.as_slice() {
+            format!("scaling {name} → {replicas}")
+        } else {
+            format!(
+                "scaling {} {} → {replicas}",
+                targets.len(),
+                self.kind_plural
+            )
+        };
         self.flash_err = false;
+        self.marked.clear();
         self.spawn_patch_action(
             kind,
-            vec![(name, ns)],
+            targets,
             Patch::Merge(scale_patch(replicas)),
-            |_, e| format!("scale failed: {e}"),
+            |name, e| format!("scale {name} failed: {e}"),
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -306,8 +306,7 @@ enum LogSource {
 
 enum PromptKind {
     Scale {
-        ns: String,
-        name: String,
+        targets: Vec<(String, String)>,
     },
     PortForward {
         ns: String,

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -247,8 +247,8 @@ impl App {
                     Mode::Table
                 };
                 match self.prompt_kind.take() {
-                    Some(PromptKind::Scale { ns, name }) => match input.parse::<i32>() {
-                        Ok(n) if n >= 0 => self.do_scale(ns, name, n),
+                    Some(PromptKind::Scale { targets }) => match input.parse::<i32>() {
+                        Ok(n) if n >= 0 => self.do_scale(targets, n),
                         _ => self.flash_warn("invalid replica count"),
                     },
                     Some(PromptKind::PortForward { ns, name }) => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1511,6 +1511,65 @@ async fn restart_key_opens_confirm() {
 }
 
 #[tokio::test]
+async fn scale_prompt_targets_marked_rows() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    for n in ["a", "b", "c"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "apps/v1", "kind": "Deployment",
+                   "metadata": {"name": n, "namespace": "default"},
+                   "spec": {"replicas": 2}}),
+        );
+    }
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
+    assert_eq!(app.marked.len(), 2);
+
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert!(
+        app.prompt_label.contains("Scale 2 deployments"),
+        "{}",
+        app.prompt_label
+    );
+    assert!(matches!(
+        app.prompt_kind,
+        Some(PromptKind::Scale { ref targets }) if targets.len() == 2
+    ));
+
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.marked.is_empty());
+    assert!(
+        app.flash.contains("scaling 2 deployments → 0"),
+        "{}",
+        app.flash
+    );
+}
+
+#[tokio::test]
+async fn scale_prompt_single_row_shows_current_replicas() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    apply(
+        &mut app,
+        json!({"apiVersion": "apps/v1", "kind": "Deployment",
+               "metadata": {"name": "web", "namespace": "default"},
+               "spec": {"replicas": 3}}),
+    );
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert!(
+        app.prompt_label
+            .contains("Scale web to replicas (current 3)"),
+        "{}",
+        app.prompt_label
+    );
+}
+
+#[tokio::test]
 async fn esc_clears_marks_before_popping() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");


### PR DESCRIPTION
## Summary
- `s` (scale) now targets the marked rows (SPACE-selected), falling back to the current selection when nothing is marked — same bulk semantics as suspend/reconcile/delete
- `PromptKind::Scale` carries the full target list; the prompt shows `Scale N deployments to replicas:` for multi-select and keeps the `(current N)` hint for a single row
- `do_scale` patches every target, clears marks afterwards, and reports failures per name

Fixes #176

## Test plan
- [x] `cargo test` — 479 passed, incl. new `scale_prompt_targets_marked_rows` and `scale_prompt_single_row_shows_current_replicas`
- [x] `cargo clippy --all-targets` clean
- [x] Manual: mark several deployments with SPACE, press `s`, enter a replica count — all marked deployments scale