### PR TITLE
fix: clear describe progress flash and honest sync dot for static docs

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -923,8 +923,14 @@ impl App {
                     ..Default::default()
                 };
                 self.mode = Mode::Detail;
-                if let Some(w) = warn {
-                    self.flash_warn(&w);
+                match warn {
+                    Some(w) => self.flash_warn(&w),
+                    // The "describing X…" progress flash has served its
+                    // purpose once the document arrives.
+                    None => {
+                        self.flash.clear();
+                        self.flash_err = false;
+                    }
                 }
             }
             Msg::Events {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1511,6 +1511,30 @@ async fn restart_key_opens_confirm() {
 }
 
 #[tokio::test]
+async fn detail_arrival_clears_progress_flash() {
+    let (mut app, _rx) = test_app();
+    app.flash = "describing web…".into();
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        title: "web — describe".into(),
+        lines: vec!["Name: web".into()],
+        warn: None,
+    });
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.flash.is_empty(), "{}", app.flash);
+
+    // A fallback warning still replaces the progress flash.
+    app.flash = "describing web…".into();
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        title: "web — YAML".into(),
+        lines: vec!["kind: Pod".into()],
+        warn: Some("kubectl not found; showing YAML".into()),
+    });
+    assert!(app.flash.contains("kubectl not found"), "{}", app.flash);
+}
+
+#[tokio::test]
 async fn scale_prompt_targets_marked_rows() {
     let (mut app, _rx) = test_app();
     app.switch_kind("deployments");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -346,11 +346,7 @@ fn draw_compact_header(frame: &mut Frame, app: &App, area: Rect) {
         spans.push(Span::styled(app.flash.clone(), style));
     }
 
-    let (synced, sync_color) = if app.store.synced {
-        ("● live", theme::green())
-    } else {
-        ("○ syncing", theme::yellow())
-    };
+    let (synced, sync_color) = sync_indicator(app.mode, app.doc_filter_return, app.store.synced);
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Min(10), Constraint::Length(10)])
@@ -3357,17 +3353,33 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Paragraph::new(line), area);
 }
 
+/// Status-bar sync indicator. The table (and the views rebuilt from its
+/// store) is watch-backed, so it's honestly "live"/"syncing" — but a
+/// describe/YAML/diff document is a point-in-time snapshot that never
+/// updates, so label it "static" instead of claiming it's live.
+fn sync_indicator(mode: Mode, doc_filter_return: Mode, synced: bool) -> (&'static str, Color) {
+    let static_doc = match mode {
+        Mode::Detail | Mode::Diff => true,
+        // `/` search over one of those documents — same underlying snapshot.
+        Mode::DocFilter => matches!(doc_filter_return, Mode::Detail | Mode::Diff),
+        _ => false,
+    };
+    if static_doc {
+        ("○ static", theme::overlay1())
+    } else if synced {
+        ("● live", theme::green())
+    } else {
+        ("○ syncing", theme::yellow())
+    }
+}
+
 fn draw_status(frame: &mut Frame, app: &App, area: Rect) {
     let style = if app.flash_err {
         Style::default().fg(theme::red())
     } else {
         Style::default().fg(theme::subtext0())
     };
-    let synced = if app.store.synced {
-        "● live"
-    } else {
-        "○ syncing"
-    };
+    let (synced, sync_color) = sync_indicator(app.mode, app.doc_filter_return, app.store.synced);
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Min(10), Constraint::Length(12)])
@@ -3376,11 +3388,6 @@ fn draw_status(frame: &mut Frame, app: &App, area: Rect) {
         Paragraph::new(Line::from(Span::styled(format!(" {}", app.flash), style))),
         cols[0],
     );
-    let sync_color = if app.store.synced {
-        theme::green()
-    } else {
-        theme::yellow()
-    };
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
             synced,
@@ -3494,6 +3501,34 @@ fn centered_rect_with_min(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A describe/YAML/diff document is a snapshot — the status bar must not
+    /// claim it's live (#175 follow-up report from Discord).
+    #[test]
+    fn sync_indicator_labels_static_documents() {
+        assert_eq!(sync_indicator(Mode::Table, Mode::Detail, true).0, "● live");
+        assert_eq!(
+            sync_indicator(Mode::Table, Mode::Detail, false).0,
+            "○ syncing"
+        );
+        assert_eq!(
+            sync_indicator(Mode::Detail, Mode::Detail, true).0,
+            "○ static"
+        );
+        assert_eq!(sync_indicator(Mode::Diff, Mode::Detail, true).0, "○ static");
+        // `/` search inside a document keeps the static label…
+        assert_eq!(
+            sync_indicator(Mode::DocFilter, Mode::Detail, true).0,
+            "○ static"
+        );
+        // …but searching help (not resource data) doesn't.
+        assert_eq!(
+            sync_indicator(Mode::DocFilter, Mode::Help, true).0,
+            "● live"
+        );
+        // Events are watch-backed, genuinely live.
+        assert_eq!(sync_indicator(Mode::Events, Mode::Detail, true).0, "● live");
+    }
 
     /// Deficit: a Flex column whose content fits inside its weight-share takes
     /// only what it needs — the padding it would have hoarded under a pure


### PR DESCRIPTION
## Summary
- The "describing X…" progress flash never went away — flashes have no TTL and the `Msg::Detail` handler didn't clear it. It's now cleared when the document arrives (a fallback warning like "kubectl not found; showing YAML" still replaces it).
- The status bar showed the table watch's `● live` dot in describe/YAML/diff views, but those documents are point-in-time snapshots. Those modes (and `/` search within them) now show a dim `○ static`; events/logs/table stay `● live` since they're watch-backed.

Both reported on Discord by lucsoft.

## Test plan
- [x] `cargo test` — 481 passed, incl. new `detail_arrival_clears_progress_flash` and `sync_indicator_labels_static_documents`
- [x] `cargo clippy --all-targets` clean
- [ ] Manual: `d` on a pod — flash disappears once the describe renders, footer shows `○ static`; esc back to the table shows `● live`