### PR TITLE
feat: add --context and --kubeconfig CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ notarization are on the [roadmap](docs/roadmap.md).
 ## Usage
 
 ```
-sofka [RESOURCE] [-n NAMESPACE] [-A] [--readonly | --write]
+sofka [RESOURCE] [-n NAMESPACE] [-A] [--context NAME] [--kubeconfig PATH] [--readonly | --write]
 
   RESOURCE          resource to open (alias/plural/kind), default: pods
   -n, --namespace   namespace to start in
   -A, --all-namespaces
+  --context         kubeconfig context to start in (default: current context)
+  --kubeconfig      kubeconfig file to use (sets $KUBECONFIG for the session)
   --readonly        disable every mutating action for the session
   --write           force write mode, overriding any config `readonly`
 ```

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -127,11 +127,14 @@ impl Cluster {
     /// instead of exiting). Identity fields come straight from the kubeconfig
     /// so the header still names the broken context; the client points at the
     /// configured server but nothing uses it until a real context connects.
-    pub fn disconnected() -> Self {
+    /// `requested` is the `--context` flag when the failed connect targeted a
+    /// named context, so the header names what the user asked for instead of
+    /// the kubeconfig current-context.
+    pub fn disconnected(requested: Option<&str>) -> Self {
         let kubeconfig = Kubeconfig::read().ok();
-        let context = kubeconfig
-            .as_ref()
-            .and_then(|k| k.current_context.clone())
+        let context = requested
+            .map(str::to_owned)
+            .or_else(|| kubeconfig.as_ref().and_then(|k| k.current_context.clone()))
             .unwrap_or_default();
         let cluster_name = kubeconfig
             .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,10 @@ mod timeline;
 mod ui;
 mod views;
 
+use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use clap::Parser;
 use crossterm::event::{Event, KeyEventKind};
 use futures_util::StreamExt;
@@ -57,6 +58,15 @@ struct Args {
     /// Start across all namespaces.
     #[arg(short = 'A', long)]
     all_namespaces: bool,
+
+    /// Kubeconfig context to start in (defaults to the current context).
+    #[arg(long)]
+    context: Option<String>,
+
+    /// Path to the kubeconfig file (sets $KUBECONFIG for the whole session,
+    /// including kubectl shell-outs).
+    #[arg(long, value_name = "PATH")]
+    kubeconfig: Option<PathBuf>,
 
     /// Disable every action that could modify the cluster (delete, edit,
     /// scale, shell, plugins, …). Overrides the config `readonly` option,
@@ -86,9 +96,23 @@ struct Args {
     info: bool,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let args = Args::parse();
+    // `--kubeconfig`: export for the whole process so every kubeconfig read
+    // (kube-rs config inference, context listing/switching, `--info`) and
+    // every kubectl shell-out sees the same file.
+    // SAFETY: single-threaded here — the tokio runtime only spawns below.
+    if let Some(path) = &args.kubeconfig {
+        unsafe { std::env::set_var("KUBECONFIG", path) };
+    }
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("starting tokio runtime")?
+        .block_on(run_main(args))
+}
+
+async fn run_main(args: Args) -> Result<()> {
     let (loader, mut config_warnings) = config::ConfigLoader::load();
 
     // `--info`: print static diagnostics (no cluster connection) and exit.
@@ -102,7 +126,11 @@ async fn main() -> Result<()> {
     // in the context picker instead (k9s behavior). Headless modes still exit
     // with the error, since there is no picker to fall back to.
     eprintln!("Connecting to cluster…");
-    let (mut cluster, connect_error) = match Cluster::connect().await {
+    let connect = match args.context.as_deref() {
+        Some(name) => Cluster::connect_context(name).await,
+        None => Cluster::connect().await,
+    };
+    let (mut cluster, connect_error) = match connect {
         Ok(c) => (c, None),
         Err(e) if args.check || args.snapshot => {
             eprintln!("\x1b[31merror:\x1b[0m {e:#}");
@@ -110,7 +138,10 @@ async fn main() -> Result<()> {
         }
         Err(e) => {
             eprintln!("\x1b[33mwarning:\x1b[0m {e:#}");
-            (Cluster::disconnected(), Some(format!("{e:#}")))
+            (
+                Cluster::disconnected(args.context.as_deref()),
+                Some(format!("{e:#}")),
+            )
         }
     };
     // Per-cluster/per-context override files merge over the base config.


### PR DESCRIPTION
## Summary
- Add `--context NAME` to start sofka in a named kubeconfig context instead of the current one, reusing the `:ctx` switcher's `Cluster::connect_context` path so kubectl shell-outs stay pinned to the same context.
- Add `--kubeconfig PATH`, exported as `KUBECONFIG` for the whole process before the tokio runtime starts — one point covers kube-rs config inference, every `Kubeconfig::read()` (context picker, `--info`, disconnected fallback), and inherited env for kubectl shell-outs.
- When a `--context` connect fails, the disconnected placeholder (context picker fallback) now names the requested context in the header instead of the kubeconfig current-context.
- Document both flags in the README usage block.

## Test plan
- [x] `just check` — fmt, clippy `-D warnings`, 482 tests pass
- [x] `sofka --check --context <name>` connects to the named context while the kubeconfig current-context differs
- [x] `sofka --check --context does-not-exist` exits 1 with a clear error
- [x] `sofka --info --kubeconfig /missing/path` reports no current context (env override respected)