### PR TITLE
feat: remember the last picked namespace per context

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,8 @@ Everything below is optional. An empty config behaves exactly like no config.
 ## Base options
 
 ```toml
-default_namespace = "kube-system"
+default_namespace = "kube-system"  # fallback only: the last namespace picked in a
+                                   # context is remembered across restarts
 default_resource  = "deployments"
 readonly          = false  # true disables every mutating action (delete, edit,
                            # scale, shell, plugins, …); --readonly/--write win

--- a/docs/features.md
+++ b/docs/features.md
@@ -47,7 +47,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `list`. An explicit search checks the full discovery catalog, because some
   delegated authorizers return incomplete rule reviews.
 - **Namespace switcher** (`n`) with pinned favourites (★) and per-context
-  session recents (·) above the rest, plus a context switcher (`:ctx`).
+  session recents (·) above the rest, plus a context switcher (`:ctx`). The
+  last namespace picked in each context is remembered across restarts
+  (`<state-dir>/namespaces.toml`); `-n`/`-A` override it for a session.
 - **Mouse support** - the wheel scrolls every view (one notch is three steps of
   that view's own up/down), clicking a row selects it, clicking a column header
   sorts by it (click again to flip). Document views (YAML/describe, diff,

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -177,6 +177,7 @@ impl App {
             // k9s: 0 = all namespaces.
             KeyCode::Char('0') => {
                 self.namespace.clear();
+                self.remember_namespace();
                 self.flash = "namespace: all namespaces".into();
                 self.flash_err = false;
                 self.table_state.select(Some(0));

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -17,6 +17,7 @@ impl App {
                 if let Some(ns) = ns {
                     self.namespace = normalize_ns(ns);
                     self.note_recent_namespace(ns);
+                    self.remember_namespace();
                 }
                 let title = kind.title();
                 self.set_root_view(kind);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1020,6 +1020,13 @@ pub struct App {
     /// Where remembered sorts persist (`<state-dir>/sort.toml`, set at
     /// startup); `None` (tests) keeps them in memory only.
     pub sort_memory_path: Option<std::path::PathBuf>,
+    /// Last namespace picked per context (`n`/`0`/`:ns`/`:<kind> <ns>`),
+    /// restored at launch and on `:ctx`. Persisted to `namespace_memory_path`
+    /// on every pick.
+    pub namespace_memory: crate::nsmem::NamespaceMemory,
+    /// Where remembered namespaces persist (`<state-dir>/namespaces.toml`,
+    /// set at startup); `None` (tests) keeps them in memory only.
+    pub namespace_memory_path: Option<std::path::PathBuf>,
     /// Global fuzzy-find (`:find`) results and picker cursor.
     pub find_items: Vec<crate::store::FindItem>,
     pub find_state: ListState,
@@ -1283,6 +1290,8 @@ impl App {
             fleet_marks_path: None,
             sort_memory: crate::sortmem::SortMemory::default(),
             sort_memory_path: None,
+            namespace_memory: crate::nsmem::NamespaceMemory::default(),
+            namespace_memory_path: None,
             find_items: Vec::new(),
             find_state: ListState::default(),
             find_query: String::new(),

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -263,6 +263,7 @@ impl App {
         }
         self.namespace = ns;
         self.note_recent_namespace(name);
+        self.remember_namespace();
         self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
         self.record_history();

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -140,6 +140,24 @@ impl App {
         }
     }
 
+    /// Persist the active namespace as the current context's last pick, so
+    /// the next launch (and the next `:ctx` back here) restores it. Called
+    /// after every explicit namespace choice — not after drill-downs,
+    /// history, or bookmarks, which scope a view rather than pick a home.
+    pub(super) fn remember_namespace(&mut self) {
+        if !self
+            .namespace_memory
+            .set(&self.cluster.context, &self.namespace)
+        {
+            return;
+        }
+        if let Some(path) = self.namespace_memory_path.clone()
+            && let Err(e) = self.namespace_memory.save(&path)
+        {
+            self.flash_warn(&format!("failed to save namespace state: {e}"));
+        }
+    }
+
     /// Open the sort-column picker (k9s cycles with `S`; sofka jumps straight
     /// to a column instead, which scales to wide mode and custom views). The
     /// cursor starts on the active sort so enter-without-typing re-selects it,
@@ -427,6 +445,7 @@ impl App {
     pub(super) fn set_namespace(&mut self, sel: String) {
         self.namespace = normalize_ns(&sel);
         self.note_recent_namespace(&sel);
+        self.remember_namespace();
         self.flash = format!("namespace: {}", self.namespace_label());
         self.flash_err = false;
         self.ns_filter.clear();
@@ -729,9 +748,11 @@ impl App {
         self.readonly = self.readonly_override.unwrap_or(resolved.config.readonly);
         cluster.add_aliases(&self.user_aliases);
         self.bump_generation();
-        self.namespace = resolved
-            .config
-            .default_namespace
+        // Where you last were in this context beats its config default.
+        self.namespace = self
+            .namespace_memory
+            .get(&cluster.context)
+            .or(resolved.config.default_namespace)
             .unwrap_or_else(|| cluster.default_namespace.clone());
         self.cluster = *cluster;
         self.stack.clear();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4966,6 +4966,42 @@ async fn namespace_switcher_pins_favorites_then_recents() {
 }
 
 #[tokio::test]
+async fn last_picked_namespace_is_remembered_per_context() {
+    let (mut app, _rx) = test_app();
+    let dir = std::env::temp_dir().join(format!("sofka-nsmem-app-{}", std::process::id()));
+    let path = dir.join("namespaces.toml");
+    app.namespace_memory_path = Some(path.clone());
+    app.switch_kind("pods");
+
+    // Every explicit pick lands in memory and on disk.
+    app.set_namespace("payments".into());
+    assert_eq!(app.namespace_memory.get("test"), Some("payments".into()));
+    assert_eq!(
+        crate::nsmem::NamespaceMemory::load(&path).get("test"),
+        Some("payments".into())
+    );
+    app.switch_kind_ns("deployments", Some("checkout"));
+    assert_eq!(app.namespace_memory.get("test"), Some("checkout".into()));
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    assert_eq!(app.namespace_memory.get("test"), Some(String::new()));
+    assert_eq!(
+        crate::nsmem::NamespaceMemory::load(&path).get("test"),
+        Some(String::new())
+    );
+
+    // Drill-downs and history don't count as picks.
+    app.set_namespace("payments".into());
+    app.push_frame();
+    app.namespace = "kube-system".into();
+    app.pop_frame();
+    assert_eq!(app.namespace_memory.get("test"), Some("payments".into()));
+
+    // Other contexts are untouched.
+    assert_eq!(app.namespace_memory.get("other"), None);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
 async fn recent_namespaces_dedupe_and_bound() {
     let (mut app, _rx) = test_app();
     for n in ["a", "b", "c", "a"] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod journal;
 mod k8s;
 mod keys;
 mod logfilter;
+mod nsmem;
 mod providers;
 mod rightsize;
 mod snapshot;
@@ -212,6 +213,11 @@ async fn run_main(args: Args) -> Result<()> {
     let sort_memory_path = sortmem::SortMemory::default_path();
     app.sort_memory = sortmem::SortMemory::load(&sort_memory_path);
     app.sort_memory_path = Some(sort_memory_path);
+    // The last namespace picked per context persists too, so a relaunch (or
+    // a `:ctx` switch back) lands where you left off.
+    let namespace_memory_path = nsmem::NamespaceMemory::default_path();
+    app.namespace_memory = nsmem::NamespaceMemory::load(&namespace_memory_path);
+    app.namespace_memory_path = Some(namespace_memory_path);
     // Kubeconfig contexts are stable for the session; cache them once so the
     // palette can complete `:ctx <name>` without re-reading the file per keystroke.
     match Cluster::list_contexts() {
@@ -290,9 +296,13 @@ async fn run_main(args: Args) -> Result<()> {
         _ => None,
     };
     app.readonly = app.readonly_override.unwrap_or(cfg.readonly);
+    // CLI flags win; then the namespace remembered for this context from the
+    // last session; then the config default; then the kubeconfig's.
     if args.all_namespaces {
         app.namespace = String::new();
     } else if let Some(ns) = args.namespace {
+        app.namespace = ns;
+    } else if let Some(ns) = app.namespace_memory.get(&app.cluster.context) {
         app.namespace = ns;
     } else if let Some(ns) = cfg.default_namespace.clone() {
         app.namespace = ns;

--- a/src/nsmem.rs
+++ b/src/nsmem.rs
@@ -1,0 +1,137 @@
+//! Remembered namespace per context, persisted across restarts.
+//!
+//! Picking a namespace (`n`, `0`, `:ns`, `:<kind> <ns>`) records the choice
+//! for the active context in `<state-dir>/namespaces.toml`, so the next
+//! launch — and the next `:ctx` switch back — lands where you left off. Like
+//! sort memory, this is a separate state file: sofka never rewrites the
+//! user's config, and `default_namespace` there stays the fallback for a
+//! context with no remembered pick. `-n`/`-A` on the CLI always win.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Spelling of "all namespaces" in the file, so it stays hand-editable
+/// (the in-app representation is the empty string).
+const ALL: &str = "all";
+
+/// Per-context namespace memory. Keys are kubeconfig context names; values
+/// are a namespace or `all`.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NamespaceMemory {
+    pub contexts: BTreeMap<String, String>,
+}
+
+impl NamespaceMemory {
+    /// Where remembered namespaces live: `<state-dir>/namespaces.toml`.
+    pub fn default_path() -> PathBuf {
+        crate::diagnostics::state_dir().join("namespaces.toml")
+    }
+
+    /// Load persisted namespaces. A missing or unparsable file is an empty
+    /// set — startup must not fail over hand-mangled state.
+    pub fn load(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        let text = toml::to_string(self).map_err(|e| e.to_string())?;
+        std::fs::write(path, text).map_err(|e| e.to_string())
+    }
+
+    /// Remember `namespace` (empty = all namespaces) for `context`. Returns
+    /// whether anything changed, so callers can skip the disk write. An
+    /// empty context name (no kubeconfig context) is never recorded.
+    pub fn set(&mut self, context: &str, namespace: &str) -> bool {
+        if context.is_empty() {
+            return false;
+        }
+        let value = if namespace.is_empty() {
+            ALL.to_string()
+        } else {
+            namespace.to_string()
+        };
+        if self.contexts.get(context) == Some(&value) {
+            return false;
+        }
+        self.contexts.insert(context.to_string(), value);
+        true
+    }
+
+    /// The remembered namespace for `context`, if any; the empty string means
+    /// all namespaces. Accepts the same `all`/`*` spellings the palette does.
+    pub fn get(&self, context: &str) -> Option<String> {
+        let v = self.contexts.get(context)?.trim();
+        Some(match v {
+            "" | "all" | "*" | "<all>" => String::new(),
+            ns => ns.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_get_roundtrip() {
+        let mut m = NamespaceMemory::default();
+        assert!(m.set("prod", "payments"));
+        assert!(m.set("staging", ""));
+        assert!(
+            !m.set("prod", "payments"),
+            "unchanged pick reports no change"
+        );
+        assert!(m.set("prod", "checkout"));
+        assert_eq!(m.get("prod"), Some("checkout".into()));
+        assert_eq!(m.get("staging"), Some(String::new()));
+        assert_eq!(m.get("dev"), None);
+        assert_eq!(m.contexts.get("staging").map(String::as_str), Some("all"));
+    }
+
+    #[test]
+    fn empty_context_is_not_recorded() {
+        let mut m = NamespaceMemory::default();
+        assert!(!m.set("", "payments"));
+        assert!(m.contexts.is_empty());
+    }
+
+    #[test]
+    fn get_parses_hand_edited_specs() {
+        let mut m = NamespaceMemory::default();
+        m.contexts.insert("a".into(), "*".into());
+        m.contexts.insert("b".into(), " <all> ".into());
+        m.contexts.insert("c".into(), " kube-system ".into());
+        assert_eq!(m.get("a"), Some(String::new()));
+        assert_eq!(m.get("b"), Some(String::new()));
+        assert_eq!(m.get("c"), Some("kube-system".into()));
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("sofka-nsmem-{}", std::process::id()));
+        let path = dir.join("namespaces.toml");
+        let mut m = NamespaceMemory::default();
+        m.set("prod", "payments");
+        m.set("staging", "");
+        m.save(&path).unwrap();
+        assert_eq!(NamespaceMemory::load(&path), m);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_missing_or_garbage_is_empty() {
+        assert_eq!(
+            NamespaceMemory::load(Path::new("/nonexistent/namespaces.toml")),
+            NamespaceMemory::default()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Persist the last picked namespace per context to `<state-dir>/namespaces.toml` (new `nsmem` module, same pattern as sort memory and fleet marks; `all` spells all-namespaces so the file stays hand-editable).
- Record a pick on every explicit namespace choice: the `n` switcher, `0`, `:ns <ns>` from the namespaces view, and `:<kind> <ns>`. Drill-downs, history, bookmarks and workspaces scope a view and are not recorded.
- Startup precedence is now `-A`/`-n` → remembered namespace for the context → config `default_namespace` → cluster default. `:ctx` restores the target context's remembered namespace the same way.
- Docs: note the behaviour in `features.md` and mark `default_namespace` as the fallback in `configuration.md`.

## Test plan
- [x] Unit tests for `NamespaceMemory` (set/get, `all`/`*`/`<all>` spellings, save/load roundtrip, missing/garbage file, empty context ignored)
- [x] App test: `n`, `:<kind> <ns>` and `0` update memory and the file; a frame pop does not
- [x] `cargo clippy --all-targets` clean, 488 tests pass
- [x] Manual: pick a namespace, quit, relaunch without `-n`, land in the same namespace; `:ctx` to another context and back restores each context's own pick
