### PR TITLE
fix: clear stuck status-bar messages after actions complete

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2053,17 +2053,21 @@ impl App {
         self.flash_err = true;
     }
 
-    /// Auto-clear the flash 8s after it last changed. Called from the main
-    /// loop's 1s tick; detects a change by diffing against `flash_seen`
-    /// rather than requiring every `self.flash = …` call site to also touch
-    /// a timestamp.
+    /// Auto-clear a successful transient flash 8s after it last changed.
+    /// Errors and the initial welcome hint remain until another interaction
+    /// replaces them. Called from the main loop's 1s tick; detects a change by
+    /// diffing against `flash_seen` rather than requiring every
+    /// `self.flash = …` call site to also touch a timestamp.
     pub fn expire_flash(&mut self) {
         if self.flash != self.flash_seen {
             self.flash_seen = self.flash.clone();
             self.flash_since = std::time::Instant::now();
             return;
         }
-        if !self.flash.is_empty() && self.flash_since.elapsed() >= std::time::Duration::from_secs(8)
+        if !self.flash.is_empty()
+            && !self.flash_err
+            && self.flash != WELCOME_FLASH
+            && self.flash_since.elapsed() >= std::time::Duration::from_secs(8)
         {
             self.flash.clear();
             self.flash_err = false;

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -91,7 +91,7 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
-            let mut errors = 0u32;
+            let mut failed = false;
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = if kind.namespaced && !ns.is_empty() {
                     Api::namespaced_with(client.clone(), &ns, &kind.ar)
@@ -99,7 +99,7 @@ impl App {
                     Api::all_with(client.clone(), &kind.ar)
                 };
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
-                    errors += 1;
+                    failed = true;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -108,12 +108,12 @@ impl App {
                         .await;
                 }
             }
-            if errors == 0 {
+            if !failed {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
                         message: ok_message,
-                        ok: true,
+                        err: false,
                     })
                     .await;
             }
@@ -153,7 +153,7 @@ impl App {
             if force {
                 dp = dp.grace_period(0);
             }
-            let mut errors = 0u32;
+            let mut failed = false;
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = if kind.namespaced && !ns.is_empty() {
                     Api::namespaced_with(client.clone(), &ns, &kind.ar)
@@ -161,7 +161,7 @@ impl App {
                     Api::all_with(client.clone(), &kind.ar)
                 };
                 if let Err(e) = api.delete(&name, &dp).await {
-                    errors += 1;
+                    failed = true;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -170,12 +170,12 @@ impl App {
                         .await;
                 }
             }
-            if errors == 0 {
+            if !failed {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
                         message: done_label,
-                        ok: true,
+                        err: false,
                     })
                     .await;
             }
@@ -288,22 +288,25 @@ impl App {
             format!("draining {} nodes…", targets.len())
         };
         self.flash_err = false;
+        // Not "drained": the task is done once the API accepts the evictions,
+        // but the pods are still terminating at that point (real `kubectl
+        // drain` blocks until they're gone).
         let done_label = if targets.len() == 1 {
-            format!("drained {}", targets[0])
+            format!("drain requested: {}", targets[0])
         } else {
-            format!("drained {} nodes", targets.len())
+            format!("drain requested: {} nodes", targets.len())
         };
         tokio::spawn(async move {
             let nodes: Api<DynamicObject> = Api::all_with(client.clone(), &kind.ar);
             let node_patch = Patch::Merge(node_unschedulable_patch(true));
             let pods: Api<Pod> = Api::all(client.clone());
-            let mut errors = 0u32;
+            let mut failed = false;
             for node in targets {
                 if let Err(e) = nodes
                     .patch(&node, &PatchParams::default(), &node_patch)
                     .await
                 {
-                    errors += 1;
+                    failed = true;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -319,7 +322,7 @@ impl App {
                 let pod_list = match listed {
                     Ok(list) => list,
                     Err(e) => {
-                        errors += 1;
+                        failed = true;
                         let _ = tx
                             .send(Msg::Error {
                                 generation: genr,
@@ -346,7 +349,7 @@ impl App {
                             if let Err(delete_err) =
                                 pod_api.delete(name, &DeleteParams::default()).await
                             {
-                                errors += 1;
+                                failed = true;
                                 let _ = tx
                                     .send(Msg::Error {
                                         generation: genr,
@@ -358,7 +361,7 @@ impl App {
                             }
                         }
                         Err(e) => {
-                            errors += 1;
+                            failed = true;
                             let _ = tx
                                 .send(Msg::Error {
                                     generation: genr,
@@ -369,12 +372,12 @@ impl App {
                     }
                 }
             }
-            if errors == 0 {
+            if !failed {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
                         message: done_label,
-                        ok: true,
+                        err: false,
                     })
                     .await;
             }
@@ -763,7 +766,7 @@ impl App {
             format!("set-image {container}={image}"),
             format!("{name} in {ns}"),
         );
-        self.flash = format!("setting image: {container} → {image}");
+        self.flash = format!("setting image: {container} → {image}…");
         self.flash_err = false;
         let ok_message = format!("image set: {container} → {image}");
         self.spawn_patch_action(
@@ -1539,10 +1542,10 @@ impl App {
         let label = self.action_label(&targets);
         self.note_action(format!("scale to {replicas}"), label);
         self.flash = if let [(name, _)] = targets.as_slice() {
-            format!("scaling {name} → {replicas}")
+            format!("scaling {name} → {replicas}…")
         } else {
             format!(
-                "scaling {} {} → {replicas}",
+                "scaling {} {} → {replicas}…",
                 targets.len(),
                 self.kind_plural
             )
@@ -1843,6 +1846,13 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        // `request_flux_menu` checks this, but the menu stays open across
+        // watch updates: if the selected row is deleted while it's up, Enter
+        // would otherwise flash "suspended 0 …" for a patch loop that ran zero
+        // times.
+        if targets.is_empty() {
+            return;
+        }
         let label = self.action_label(&targets);
         self.note_action(if suspend { "suspend" } else { "resume" }, label);
         let verb = if suspend { "suspending" } else { "resuming" };
@@ -1875,6 +1885,9 @@ impl App {
         let Some(kind) = self.kind.clone() else {
             return;
         };
+        if targets.is_empty() {
+            return; // see `do_set_suspend`
+        }
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
         let label = self.action_label(&targets);
         self.note_action("reconcile", label);
@@ -1885,10 +1898,17 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
+        // Same overclaim as "drained": `reconcile_patch` only stamps
+        // `reconcile.fluxcd.io/requestedAt`, and the Flux controller acts on it
+        // later — unlike `flux reconcile`, which waits for the result.
         let ok_message = if targets.len() == 1 {
-            format!("reconciled {}", targets[0].0)
+            format!("reconcile requested: {}", targets[0].0)
         } else {
-            format!("reconciled {} {}", targets.len(), self.kind_plural)
+            format!(
+                "reconcile requested: {} {}",
+                targets.len(),
+                self.kind_plural
+            )
         };
         self.spawn_patch_action(
             kind,
@@ -1951,13 +1971,13 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
-            let mut errors = 0u32;
+            let mut failed = false;
             for (name, ns, job) in jobs {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &job_ar);
                 let job: DynamicObject = match serde_json::from_value(job) {
                     Ok(j) => j,
                     Err(e) => {
-                        errors += 1;
+                        failed = true;
                         let _ = tx
                             .send(Msg::Error {
                                 generation: genr,
@@ -1968,7 +1988,7 @@ impl App {
                     }
                 };
                 if let Err(e) = api.create(&PostParams::default(), &job).await {
-                    errors += 1;
+                    failed = true;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -1977,12 +1997,12 @@ impl App {
                         .await;
                 }
             }
-            if errors == 0 {
+            if !failed {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
                         message: done_label,
-                        ok: true,
+                        err: false,
                     })
                     .await;
             }
@@ -2025,10 +2045,12 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
+        // Likewise a request: the `force-sync` annotation is picked up by the
+        // operator on its next pass, so the secret isn't refreshed yet.
         let ok_message = if targets.len() == 1 {
-            format!("refreshed {}", targets[0].0)
+            format!("refresh requested: {}", targets[0].0)
         } else {
-            format!("refreshed {} {}", targets.len(), self.kind_plural)
+            format!("refresh requested: {} {}", targets.len(), self.kind_plural)
         };
         self.spawn_patch_action(
             kind,
@@ -2053,24 +2075,59 @@ impl App {
         self.flash_err = true;
     }
 
-    /// Auto-clear a successful transient flash 8s after it last changed.
-    /// Errors and the initial welcome hint remain until another interaction
-    /// replaces them. Called from the main loop's 1s tick; detects a change by
+    /// Set the status bar to a successful transient message and (re)start its
+    /// expiry timer. Assigning `self.flash` directly still works — the tick
+    /// notices by diffing — but only this path restarts the timer when the new
+    /// text equals the old, so repeating an action inside the window re-shows
+    /// its confirmation for the full [`FLASH_TTL`] instead of inheriting the
+    /// first one's remaining time.
+    pub(super) fn set_flash(&mut self, msg: impl Into<String>) {
+        self.flash = msg.into();
+        self.flash_err = false;
+        self.flash_sticky = false;
+        self.flash_seen.clone_from(&self.flash);
+        self.flash_since = std::time::Instant::now();
+    }
+
+    /// Drop an in-flight progress flash whose result can no longer reach us.
+    /// [`Msg::Flash`] is generation-gated, so bumping the generation orphans
+    /// the task that would have replaced "deleting 3 pods…" with its result —
+    /// and [`App::expire_flash`] deliberately never times a progress message
+    /// out. Without this, a refresh (`r`) during a bulk delete would strand
+    /// that message on the bar for good.
+    pub(super) fn clear_orphaned_progress_flash(&mut self) {
+        if self.flash.ends_with('…') {
+            self.flash.clear();
+            self.flash_err = false;
+        }
+    }
+
+    /// Auto-clear a *finished* transient flash [`FLASH_TTL`] after it last
+    /// changed. Called from the main loop's 1s tick; detects a change by
     /// diffing against `flash_seen` rather than requiring every
     /// `self.flash = …` call site to also touch a timestamp.
+    ///
+    /// Three kinds of message are exempt. Errors stay until the next action
+    /// replaces them — a failed delete that erases itself while you're away
+    /// from the terminal leaves no trace that anything broke. The welcome hint
+    /// is sticky. And an in-flight progress message must outlive its own
+    /// operation: a drain or a bulk delete easily runs past the window, and
+    /// blanking it mid-flight would read as "nothing is happening". Those all
+    /// end in `…` by convention, which is what marks them here.
     pub fn expire_flash(&mut self) {
         if self.flash != self.flash_seen {
-            self.flash_seen = self.flash.clone();
+            self.flash_seen.clone_from(&self.flash);
             self.flash_since = std::time::Instant::now();
+            self.flash_sticky = false;
             return;
         }
         if !self.flash.is_empty()
             && !self.flash_err
-            && self.flash != WELCOME_FLASH
-            && self.flash_since.elapsed() >= std::time::Duration::from_secs(8)
+            && !self.flash_sticky
+            && !self.flash.ends_with('…')
+            && self.flash_since.elapsed() >= FLASH_TTL
         {
             self.flash.clear();
-            self.flash_err = false;
             self.flash_seen.clear();
         }
     }
@@ -2158,7 +2215,7 @@ impl App {
                         .send(Msg::Flash {
                             generation: genr,
                             message: format!("rolled back {name} to revision {revision}"),
-                            ok: true,
+                            err: false,
                         })
                         .await;
                 }
@@ -2220,12 +2277,12 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
-            let mut errors = 0u32;
+            let mut failed = false;
             for (name, ns) in targets {
                 let mut argv = helm_base.clone();
                 argv.extend(["uninstall".to_string(), name.clone(), "-n".to_string(), ns]);
                 if let Err(e) = run_helm(&argv).await {
-                    errors += 1;
+                    failed = true;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -2234,12 +2291,12 @@ impl App {
                         .await;
                 }
             }
-            if errors == 0 {
+            if !failed {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
                         message: done_label,
-                        ok: true,
+                        err: false,
                     })
                     .await;
             }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -82,6 +82,7 @@ impl App {
         kind: Kind,
         targets: Vec<(String, String)>,
         patch: Patch<Value>,
+        ok_message: String,
         error_message: F,
     ) where
         F: Fn(&str, kube::Error) -> String + Send + 'static,
@@ -90,6 +91,7 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
+            let mut errors = 0u32;
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = if kind.namespaced && !ns.is_empty() {
                     Api::namespaced_with(client.clone(), &ns, &kind.ar)
@@ -97,6 +99,7 @@ impl App {
                     Api::all_with(client.clone(), &kind.ar)
                 };
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
+                    errors += 1;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -104,6 +107,15 @@ impl App {
                         })
                         .await;
                 }
+            }
+            if errors == 0 {
+                let _ = tx
+                    .send(Msg::Flash {
+                        generation: genr,
+                        message: ok_message,
+                        ok: true,
+                    })
+                    .await;
             }
         });
     }
@@ -128,6 +140,11 @@ impl App {
             format!("deleting {} {}…", targets.len(), self.kind_plural)
         };
         self.flash_err = false;
+        let done_label = if targets.len() == 1 {
+            format!("deleted {}", targets[0].0)
+        } else {
+            format!("deleted {} {}", targets.len(), self.kind_plural)
+        };
         tokio::spawn(async move {
             let mut dp = DeleteParams {
                 propagation_policy: Some(cascade.policy()),
@@ -136,6 +153,7 @@ impl App {
             if force {
                 dp = dp.grace_period(0);
             }
+            let mut errors = 0u32;
             for (name, ns) in targets {
                 let api: Api<DynamicObject> = if kind.namespaced && !ns.is_empty() {
                     Api::namespaced_with(client.clone(), &ns, &kind.ar)
@@ -143,6 +161,7 @@ impl App {
                     Api::all_with(client.clone(), &kind.ar)
                 };
                 if let Err(e) = api.delete(&name, &dp).await {
+                    errors += 1;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -150,6 +169,15 @@ impl App {
                         })
                         .await;
                 }
+            }
+            if errors == 0 {
+                let _ = tx
+                    .send(Msg::Flash {
+                        generation: genr,
+                        message: done_label,
+                        ok: true,
+                    })
+                    .await;
             }
         });
     }
@@ -188,6 +216,17 @@ impl App {
             format!("{verb} {} nodes…", targets.len())
         };
         self.flash_err = false;
+        let verb_done = if unschedulable {
+            "cordoned"
+        } else {
+            "uncordoned"
+        };
+        let targets_len = targets.len();
+        let ok_message = if targets_len == 1 {
+            format!("{verb_done} {}", targets[0])
+        } else {
+            format!("{verb_done} {targets_len} nodes")
+        };
         let targets = targets
             .into_iter()
             .map(|name| (name, String::new()))
@@ -196,6 +235,7 @@ impl App {
             kind,
             targets,
             Patch::Merge(node_unschedulable_patch(unschedulable)),
+            ok_message,
             move |name, e| format!("{verb} {name} failed: {e}"),
         );
     }
@@ -248,15 +288,22 @@ impl App {
             format!("draining {} nodes…", targets.len())
         };
         self.flash_err = false;
+        let done_label = if targets.len() == 1 {
+            format!("drained {}", targets[0])
+        } else {
+            format!("drained {} nodes", targets.len())
+        };
         tokio::spawn(async move {
             let nodes: Api<DynamicObject> = Api::all_with(client.clone(), &kind.ar);
             let node_patch = Patch::Merge(node_unschedulable_patch(true));
             let pods: Api<Pod> = Api::all(client.clone());
+            let mut errors = 0u32;
             for node in targets {
                 if let Err(e) = nodes
                     .patch(&node, &PatchParams::default(), &node_patch)
                     .await
                 {
+                    errors += 1;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -272,6 +319,7 @@ impl App {
                 let pod_list = match listed {
                     Ok(list) => list,
                     Err(e) => {
+                        errors += 1;
                         let _ = tx
                             .send(Msg::Error {
                                 generation: genr,
@@ -298,6 +346,7 @@ impl App {
                             if let Err(delete_err) =
                                 pod_api.delete(name, &DeleteParams::default()).await
                             {
+                                errors += 1;
                                 let _ = tx
                                     .send(Msg::Error {
                                         generation: genr,
@@ -309,6 +358,7 @@ impl App {
                             }
                         }
                         Err(e) => {
+                            errors += 1;
                             let _ = tx
                                 .send(Msg::Error {
                                     generation: genr,
@@ -318,6 +368,15 @@ impl App {
                         }
                     }
                 }
+            }
+            if errors == 0 {
+                let _ = tx
+                    .send(Msg::Flash {
+                        generation: genr,
+                        message: done_label,
+                        ok: true,
+                    })
+                    .await;
             }
         });
     }
@@ -591,10 +650,12 @@ impl App {
         self.note_action("restart", format!("{name} in {ns}"));
         self.flash = format!("restarting {name}…");
         self.flash_err = false;
+        let ok_message = format!("restarted {name}");
         self.spawn_patch_action(
             kind,
             vec![(name, ns)],
             Patch::Strategic(restart_patch(&now)),
+            ok_message,
             |_, e| format!("restart failed: {e}"),
         );
     }
@@ -704,10 +765,12 @@ impl App {
         );
         self.flash = format!("setting image: {container} → {image}");
         self.flash_err = false;
+        let ok_message = format!("image set: {container} → {image}");
         self.spawn_patch_action(
             kind,
             vec![(name, ns)],
             Patch::Strategic(set_image_patch(&plural, &container, &image)),
+            ok_message,
             |_, e| format!("set image failed: {e}"),
         );
     }
@@ -1486,10 +1549,16 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
+        let ok_message = if let [(name, _)] = targets.as_slice() {
+            format!("scaled {name} → {replicas}")
+        } else {
+            format!("scaled {} {} → {replicas}", targets.len(), self.kind_plural)
+        };
         self.spawn_patch_action(
             kind,
             targets,
             Patch::Merge(scale_patch(replicas)),
+            ok_message,
             |name, e| format!("scale {name} failed: {e}"),
         );
     }
@@ -1777,6 +1846,7 @@ impl App {
         let label = self.action_label(&targets);
         self.note_action(if suspend { "suspend" } else { "resume" }, label);
         let verb = if suspend { "suspending" } else { "resuming" };
+        let verb_done = if suspend { "suspended" } else { "resumed" };
         self.flash = if targets.len() == 1 {
             format!("{verb} {}…", targets[0].0)
         } else {
@@ -1784,10 +1854,16 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
+        let ok_message = if targets.len() == 1 {
+            format!("{verb_done} {}", targets[0].0)
+        } else {
+            format!("{verb_done} {} {}", targets.len(), self.kind_plural)
+        };
         self.spawn_patch_action(
             kind,
             targets,
             Patch::Merge(suspend_patch(suspend)),
+            ok_message,
             move |name, e| format!("{verb} {name} failed: {e}"),
         );
     }
@@ -1809,10 +1885,16 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
+        let ok_message = if targets.len() == 1 {
+            format!("reconciled {}", targets[0].0)
+        } else {
+            format!("reconciled {} {}", targets.len(), self.kind_plural)
+        };
         self.spawn_patch_action(
             kind,
             targets,
             Patch::Merge(reconcile_patch(&now)),
+            ok_message,
             |name, e| format!("reconcile {name} failed: {e}"),
         );
     }
@@ -1853,6 +1935,11 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
+        let done_label = if jobs.len() == 1 {
+            format!("triggered {}", jobs[0].0)
+        } else {
+            format!("triggered {} {}", jobs.len(), self.kind_plural)
+        };
         let job_ar = ApiResource {
             group: "batch".into(),
             version: "v1".into(),
@@ -1864,11 +1951,13 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
+            let mut errors = 0u32;
             for (name, ns, job) in jobs {
                 let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &job_ar);
                 let job: DynamicObject = match serde_json::from_value(job) {
                     Ok(j) => j,
                     Err(e) => {
+                        errors += 1;
                         let _ = tx
                             .send(Msg::Error {
                                 generation: genr,
@@ -1879,6 +1968,7 @@ impl App {
                     }
                 };
                 if let Err(e) = api.create(&PostParams::default(), &job).await {
+                    errors += 1;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -1886,6 +1976,15 @@ impl App {
                         })
                         .await;
                 }
+            }
+            if errors == 0 {
+                let _ = tx
+                    .send(Msg::Flash {
+                        generation: genr,
+                        message: done_label,
+                        ok: true,
+                    })
+                    .await;
             }
         });
     }
@@ -1926,10 +2025,16 @@ impl App {
         };
         self.flash_err = false;
         self.marked.clear();
+        let ok_message = if targets.len() == 1 {
+            format!("refreshed {}", targets[0].0)
+        } else {
+            format!("refreshed {} {}", targets.len(), self.kind_plural)
+        };
         self.spawn_patch_action(
             kind,
             targets,
             Patch::Merge(external_secret_refresh_patch(&now)),
+            ok_message,
             |name, e| format!("refresh {name} failed: {e}"),
         );
     }
@@ -1946,6 +2051,24 @@ impl App {
     pub(super) fn flash_warn(&mut self, msg: &str) {
         self.flash = msg.to_string();
         self.flash_err = true;
+    }
+
+    /// Auto-clear the flash 8s after it last changed. Called from the main
+    /// loop's 1s tick; detects a change by diffing against `flash_seen`
+    /// rather than requiring every `self.flash = …` call site to also touch
+    /// a timestamp.
+    pub fn expire_flash(&mut self) {
+        if self.flash != self.flash_seen {
+            self.flash_seen = self.flash.clone();
+            self.flash_since = std::time::Instant::now();
+            return;
+        }
+        if !self.flash.is_empty() && self.flash_since.elapsed() >= std::time::Duration::from_secs(8)
+        {
+            self.flash.clear();
+            self.flash_err = false;
+            self.flash_seen.clear();
+        }
     }
 
     /// Base argv for a `kubectl` shell-out, pinned to the active context so it
@@ -2025,13 +2148,24 @@ impl App {
         // No manual re-watch on success: the live `secrets` watch backing the
         // helm/helmhistory view picks up the new revision Secret on its own.
         tokio::spawn(async move {
-            if let Err(e) = run_helm(&argv).await {
-                let _ = tx
-                    .send(Msg::Error {
-                        generation: genr,
-                        error: format!("helm rollback {name} failed: {e}"),
-                    })
-                    .await;
+            match run_helm(&argv).await {
+                Ok(_) => {
+                    let _ = tx
+                        .send(Msg::Flash {
+                            generation: genr,
+                            message: format!("rolled back {name} to revision {revision}"),
+                            ok: true,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(Msg::Error {
+                            generation: genr,
+                            error: format!("helm rollback {name} failed: {e}"),
+                        })
+                        .await;
+                }
             }
         });
     }
@@ -2073,14 +2207,21 @@ impl App {
             format!("uninstalling {} Helm releases…", targets.len())
         };
         self.flash_err = false;
+        let done_label = if targets.len() == 1 {
+            format!("uninstalled {}", targets[0].0)
+        } else {
+            format!("uninstalled {} Helm releases", targets.len())
+        };
         let helm_base = self.helm_base();
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
+            let mut errors = 0u32;
             for (name, ns) in targets {
                 let mut argv = helm_base.clone();
                 argv.extend(["uninstall".to_string(), name.clone(), "-n".to_string(), ns]);
                 if let Err(e) = run_helm(&argv).await {
+                    errors += 1;
                     let _ = tx
                         .send(Msg::Error {
                             generation: genr,
@@ -2088,6 +2229,15 @@ impl App {
                         })
                         .await;
                 }
+            }
+            if errors == 0 {
+                let _ = tx
+                    .send(Msg::Flash {
+                        generation: genr,
+                        message: done_label,
+                        ok: true,
+                    })
+                    .await;
             }
         });
     }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -508,7 +508,10 @@ impl App {
             return;
         }
         let claim = self.claim_status("saving logs…");
-        let genr = self.log_gen;
+        // Saving is a one-shot file operation, not part of the live log
+        // stream. Leaving Logs bumps `log_gen`, but must not drop this result
+        // and strand its progress flash.
+        let genr = self.generation;
         let tx = self.tx.clone();
         let ts = k8s_openapi::jiff::Timestamp::now().as_second();
         let safe: String = self
@@ -2128,8 +2131,18 @@ impl App {
         let claim = StatusClaim(self.next_status_claim);
         let message = msg.into();
         self.set_flash(message.clone());
-        self.status_claim = Some((claim, message));
+        self.status_claim = Some(ActiveStatusClaim {
+            claim,
+            text: message,
+            pending: true,
+        });
         claim
+    }
+
+    fn owns_status(&self, claim: StatusClaim) -> bool {
+        self.status_claim
+            .as_ref()
+            .is_some_and(|owner| owner.claim == claim && self.flash == owner.text)
     }
 
     /// Replace the status owned by `claim`. A newer operation or any direct
@@ -2142,10 +2155,7 @@ impl App {
         err: bool,
     ) {
         let message = msg.into();
-        let owns = self
-            .status_claim
-            .as_ref()
-            .is_some_and(|(owner, text)| *owner == claim && self.flash == *text);
+        let owns = self.owns_status(claim);
         if err {
             // A failure is never silently dropped. Even when the bar has no
             // room for it, `:debug` can still answer "did anything break?".
@@ -2154,7 +2164,11 @@ impl App {
         if owns {
             self.set_flash(message.clone());
             self.flash_err = err;
-            self.status_claim = Some((claim, message));
+            self.status_claim = Some(ActiveStatusClaim {
+                claim,
+                text: message,
+                pending: false,
+            });
             return;
         }
         // A stale success is dropped — the operation the user started later
@@ -2163,23 +2177,56 @@ impl App {
         // misses; it never displaces the owner's finished result. Ownership
         // does not change hands, so the owner still reports when it lands.
         if err && self.flash.ends_with('…') {
-            let owner = self.status_claim.as_ref().map(|(owner, _)| *owner);
+            let owner = self.status_claim.take();
             self.set_flash(message.clone());
             self.flash_err = true;
             // `set_flash` drops the claim; hand it straight back against the
             // borrowed text so the owner still reports when it finishes.
-            self.status_claim = owner.map(|owner| (owner, message));
+            self.status_claim = owner.map(|mut owner| {
+                owner.text = message;
+                owner
+            });
         }
+    }
+
+    /// Temporarily show a process/watch-level message without stealing an
+    /// asynchronous operation's ownership. Its result can still replace the
+    /// borrowed text when it arrives.
+    pub(super) fn borrow_status(&mut self, msg: impl Into<String>, err: bool) {
+        let mut owner = self.status_claim.take();
+        let message = msg.into();
+        self.set_flash(message.clone());
+        self.flash_err = err;
+        if let Some(owner) = &mut owner {
+            owner.text = message;
+        }
+        self.status_claim = owner;
+    }
+
+    /// Update a recurring poll's status while retaining its claim for the next
+    /// result. A successful poll clears an earlier warning but leaves an empty,
+    /// pending claim so a later incomplete poll can surface its warning.
+    pub(super) fn set_recurring_status(&mut self, claim: StatusClaim, warn: Option<String>) {
+        if !self.owns_status(claim) {
+            return;
+        }
+        let (message, err) = match warn {
+            Some(message) => (message, true),
+            None => (String::new(), false),
+        };
+        self.set_flash(message.clone());
+        self.flash_err = err;
+        self.status_claim = Some(ActiveStatusClaim {
+            claim,
+            text: message,
+            pending: true,
+        });
     }
 
     /// Clear a completed operation's progress only while it still owns the
     /// bar. Its document/result may still be applied after ownership moves.
     pub(super) fn clear_claimed_status(&mut self, claim: StatusClaim) {
-        if self
-            .status_claim
-            .as_ref()
-            .is_some_and(|(owner, text)| *owner == claim && self.flash == *text)
-        {
+        if self.owns_status(claim) {
             self.flash.clear();
             self.flash_err = false;
             self.flash_seen.clear();
@@ -2226,9 +2273,19 @@ impl App {
             && !self.flash.ends_with('…')
             && self.flash_since.elapsed() >= FLASH_TTL
         {
+            let pending = self
+                .status_claim
+                .as_ref()
+                .is_some_and(|owner| owner.pending && self.flash == owner.text);
             self.flash.clear();
             self.flash_seen.clear();
-            self.status_claim = None;
+            if pending {
+                if let Some(owner) = &mut self.status_claim {
+                    owner.text.clear();
+                }
+            } else {
+                self.status_claim = None;
+            }
         }
     }
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2227,11 +2227,16 @@ impl App {
     /// bar. Its document/result may still be applied after ownership moves.
     pub(super) fn clear_claimed_status(&mut self, claim: StatusClaim) {
         if self.owns_status(claim) {
+            self.status_claim = None;
+            // A stale action failure may borrow this operation's progress
+            // flash. Completing a report must relinquish its claim without
+            // erasing that sticky failure from the bar.
+            if self.flash_err {
+                return;
+            }
             self.flash.clear();
-            self.flash_err = false;
             self.flash_seen.clear();
             self.flash_sticky = false;
-            self.status_claim = None;
         }
     }
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -507,6 +507,7 @@ impl App {
             self.flash_warn("no log lines to save");
             return;
         }
+        let claim = self.claim_status("saving logs…");
         let genr = self.log_gen;
         let tx = self.tx.clone();
         let ts = k8s_openapi::jiff::Timestamp::now().as_second();
@@ -526,6 +527,7 @@ impl App {
             let _ = tx
                 .send(Msg::LogsSaved {
                     generation: genr,
+                    claim,
                     result,
                 })
                 .await;
@@ -583,7 +585,8 @@ impl App {
         );
     }
 
-    pub(super) fn copy_to_clipboard_async(&self, text: String, success: String, failure: &str) {
+    pub(super) fn copy_to_clipboard_async(&mut self, text: String, success: String, failure: &str) {
+        let claim = self.claim_status("copying to clipboard…");
         let tx = self.tx.clone();
         let genr = self.generation;
         let failure = failure.to_string();
@@ -594,6 +597,7 @@ impl App {
             let _ = tx
                 .send(Msg::ClipboardCopied {
                     generation: genr,
+                    claim,
                     copied,
                     success,
                     failure,
@@ -1060,8 +1064,7 @@ impl App {
     /// the name prefix *and* `spec.nodeName` avoids touching unrelated pods.
     pub(super) fn do_cleanup_debuggers(&mut self) {
         let targets = std::mem::take(&mut self.launched_node_debuggers);
-        self.flash = format!("cleaning up {} node debugger(s)…", targets.len());
-        self.flash_err = false;
+        let claim = self.claim_status(format!("cleaning up {} node debugger(s)…", targets.len()));
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
@@ -1096,6 +1099,7 @@ impl App {
             let _ = tx
                 .send(Msg::DebuggersCleaned {
                     generation: genr,
+                    claim,
                     deleted,
                     failed,
                 })
@@ -1756,8 +1760,7 @@ impl App {
             if upload { "cp upload" } else { "cp download" },
             format!("{pod} in {ns}"),
         );
-        self.flash = format!("copying {from} → {to}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("copying {from} → {to}…"));
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
@@ -1799,6 +1802,7 @@ impl App {
             let _ = tx
                 .send(Msg::TransferDone {
                     generation: genr,
+                    claim,
                     result,
                 })
                 .await;
@@ -2129,24 +2133,43 @@ impl App {
     }
 
     /// Replace the status owned by `claim`. A newer operation or any direct
-    /// status assignment makes the old result a no-op.
+    /// status assignment makes an old *success* a no-op; a failure always
+    /// lands (see below).
     pub(super) fn set_claimed_status(
         &mut self,
         claim: StatusClaim,
         msg: impl Into<String>,
         err: bool,
     ) {
-        if !self
+        let message = msg.into();
+        let owns = self
             .status_claim
             .as_ref()
-            .is_some_and(|(owner, text)| *owner == claim && self.flash == *text)
-        {
+            .is_some_and(|(owner, text)| *owner == claim && self.flash == *text);
+        if err {
+            // A failure is never silently dropped. Even when the bar has no
+            // room for it, `:debug` can still answer "did anything break?".
+            self.last_action_error = Some(message.clone());
+        }
+        if owns {
+            self.set_flash(message.clone());
+            self.flash_err = err;
+            self.status_claim = Some((claim, message));
             return;
         }
-        let message = msg.into();
-        self.set_flash(message.clone());
-        self.flash_err = err;
-        self.status_claim = Some((claim, message));
+        // A stale success is dropped — the operation the user started later
+        // owns the bar. A stale *failure* may still borrow it while the owner
+        // has nothing to show yet, since an unresolved `…` is not news anyone
+        // misses; it never displaces the owner's finished result. Ownership
+        // does not change hands, so the owner still reports when it lands.
+        if err && self.flash.ends_with('…') {
+            let owner = self.status_claim.as_ref().map(|(owner, _)| *owner);
+            self.set_flash(message.clone());
+            self.flash_err = true;
+            // `set_flash` drops the claim; hand it straight back against the
+            // borrowed text so the owner still reports when it finishes.
+            self.status_claim = owner.map(|owner| (owner, message));
+        }
     }
 
     /// Clear a completed operation's progress only while it still owns the

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -82,6 +82,7 @@ impl App {
         kind: Kind,
         targets: Vec<(String, String)>,
         patch: Patch<Value>,
+        claim: StatusClaim,
         ok_message: String,
         error_message: F,
     ) where
@@ -101,9 +102,11 @@ impl App {
                 if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
                     failed = true;
                     let _ = tx
-                        .send(Msg::Error {
+                        .send(Msg::Flash {
                             generation: genr,
-                            error: error_message(&name, e),
+                            claim,
+                            message: error_message(&name, e),
+                            err: true,
                         })
                         .await;
                 }
@@ -112,6 +115,7 @@ impl App {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
+                        claim,
                         message: ok_message,
                         err: false,
                     })
@@ -134,12 +138,12 @@ impl App {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
-        self.flash = if targets.len() == 1 {
+        let progress = if targets.len() == 1 {
             format!("deleting {}…", targets[0].0)
         } else {
             format!("deleting {} {}…", targets.len(), self.kind_plural)
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         let done_label = if targets.len() == 1 {
             format!("deleted {}", targets[0].0)
         } else {
@@ -163,9 +167,11 @@ impl App {
                 if let Err(e) = api.delete(&name, &dp).await {
                     failed = true;
                     let _ = tx
-                        .send(Msg::Error {
+                        .send(Msg::Flash {
                             generation: genr,
-                            error: format!("delete {name} failed: {e}"),
+                            claim,
+                            message: format!("delete {name} failed: {e}"),
+                            err: true,
                         })
                         .await;
                 }
@@ -174,6 +180,7 @@ impl App {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
+                        claim,
                         message: done_label,
                         err: false,
                     })
@@ -210,12 +217,12 @@ impl App {
         } else {
             "uncordoning"
         };
-        self.flash = if targets.len() == 1 {
+        let progress = if targets.len() == 1 {
             format!("{verb} {}…", targets[0])
         } else {
             format!("{verb} {} nodes…", targets.len())
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         let verb_done = if unschedulable {
             "cordoned"
         } else {
@@ -235,6 +242,7 @@ impl App {
             kind,
             targets,
             Patch::Merge(node_unschedulable_patch(unschedulable)),
+            claim,
             ok_message,
             move |name, e| format!("{verb} {name} failed: {e}"),
         );
@@ -282,12 +290,12 @@ impl App {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
-        self.flash = if targets.len() == 1 {
+        let progress = if targets.len() == 1 {
             format!("draining {}…", targets[0])
         } else {
             format!("draining {} nodes…", targets.len())
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         // Not "drained": the task is done once the API accepts the evictions,
         // but the pods are still terminating at that point (real `kubectl
         // drain` blocks until they're gone).
@@ -308,9 +316,11 @@ impl App {
                 {
                     failed = true;
                     let _ = tx
-                        .send(Msg::Error {
+                        .send(Msg::Flash {
                             generation: genr,
-                            error: format!("drain {node}: cordon failed: {e}"),
+                            claim,
+                            message: format!("drain {node}: cordon failed: {e}"),
+                            err: true,
                         })
                         .await;
                     continue;
@@ -324,9 +334,11 @@ impl App {
                     Err(e) => {
                         failed = true;
                         let _ = tx
-                            .send(Msg::Error {
+                            .send(Msg::Flash {
                                 generation: genr,
-                                error: format!("drain {node}: list pods failed: {e}"),
+                                claim,
+                                message: format!("drain {node}: list pods failed: {e}"),
+                                err: true,
                             })
                             .await;
                         continue;
@@ -351,11 +363,13 @@ impl App {
                             {
                                 failed = true;
                                 let _ = tx
-                                    .send(Msg::Error {
+                                    .send(Msg::Flash {
                                         generation: genr,
-                                        error: format!(
+                                        claim,
+                                        message: format!(
                                             "drain {node}: delete {ns}/{name} failed after eviction fallback: {delete_err}"
                                         ),
+                                        err: true,
                                     })
                                     .await;
                             }
@@ -363,9 +377,11 @@ impl App {
                         Err(e) => {
                             failed = true;
                             let _ = tx
-                                .send(Msg::Error {
+                                .send(Msg::Flash {
                                     generation: genr,
-                                    error: format!("drain {node}: evict {ns}/{name} failed: {e}"),
+                                    claim,
+                                    message: format!("drain {node}: evict {ns}/{name} failed: {e}"),
+                                    err: true,
                                 })
                                 .await;
                         }
@@ -376,6 +392,7 @@ impl App {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
+                        claim,
                         message: done_label,
                         err: false,
                     })
@@ -651,13 +668,13 @@ impl App {
     pub(super) fn do_restart(&mut self, kind: Kind, name: String, ns: String) {
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
         self.note_action("restart", format!("{name} in {ns}"));
-        self.flash = format!("restarting {name}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("restarting {name}…"));
         let ok_message = format!("restarted {name}");
         self.spawn_patch_action(
             kind,
             vec![(name, ns)],
             Patch::Strategic(restart_patch(&now)),
+            claim,
             ok_message,
             |_, e| format!("restart failed: {e}"),
         );
@@ -766,13 +783,13 @@ impl App {
             format!("set-image {container}={image}"),
             format!("{name} in {ns}"),
         );
-        self.flash = format!("setting image: {container} → {image}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("setting image: {container} → {image}…"));
         let ok_message = format!("image set: {container} → {image}");
         self.spawn_patch_action(
             kind,
             vec![(name, ns)],
             Patch::Strategic(set_image_patch(&plural, &container, &image)),
+            claim,
             ok_message,
             |_, e| format!("set image failed: {e}"),
         );
@@ -1541,7 +1558,7 @@ impl App {
         };
         let label = self.action_label(&targets);
         self.note_action(format!("scale to {replicas}"), label);
-        self.flash = if let [(name, _)] = targets.as_slice() {
+        let progress = if let [(name, _)] = targets.as_slice() {
             format!("scaling {name} → {replicas}…")
         } else {
             format!(
@@ -1550,7 +1567,7 @@ impl App {
                 self.kind_plural
             )
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         self.marked.clear();
         let ok_message = if let [(name, _)] = targets.as_slice() {
             format!("scaled {name} → {replicas}")
@@ -1561,6 +1578,7 @@ impl App {
             kind,
             targets,
             Patch::Merge(scale_patch(replicas)),
+            claim,
             ok_message,
             |name, e| format!("scale {name} failed: {e}"),
         );
@@ -1857,12 +1875,12 @@ impl App {
         self.note_action(if suspend { "suspend" } else { "resume" }, label);
         let verb = if suspend { "suspending" } else { "resuming" };
         let verb_done = if suspend { "suspended" } else { "resumed" };
-        self.flash = if targets.len() == 1 {
+        let progress = if targets.len() == 1 {
             format!("{verb} {}…", targets[0].0)
         } else {
             format!("{verb} {} {}…", targets.len(), self.kind_plural)
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         self.marked.clear();
         let ok_message = if targets.len() == 1 {
             format!("{verb_done} {}", targets[0].0)
@@ -1873,6 +1891,7 @@ impl App {
             kind,
             targets,
             Patch::Merge(suspend_patch(suspend)),
+            claim,
             ok_message,
             move |name, e| format!("{verb} {name} failed: {e}"),
         );
@@ -1891,12 +1910,12 @@ impl App {
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
         let label = self.action_label(&targets);
         self.note_action("reconcile", label);
-        self.flash = if targets.len() == 1 {
+        let progress = if targets.len() == 1 {
             format!("reconciling {}…", targets[0].0)
         } else {
             format!("reconciling {} {}…", targets.len(), self.kind_plural)
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         self.marked.clear();
         // Same overclaim as "drained": `reconcile_patch` only stamps
         // `reconcile.fluxcd.io/requestedAt`, and the Flux controller acts on it
@@ -1914,6 +1933,7 @@ impl App {
             kind,
             targets,
             Patch::Merge(reconcile_patch(&now)),
+            claim,
             ok_message,
             |name, e| format!("reconcile {name} failed: {e}"),
         );
@@ -1948,12 +1968,12 @@ impl App {
             .collect();
         let label = self.action_label(&targets);
         self.note_action("trigger", label);
-        self.flash = if jobs.len() == 1 {
+        let progress = if jobs.len() == 1 {
             format!("triggering {}…", jobs[0].0)
         } else {
             format!("triggering {} {}…", jobs.len(), self.kind_plural)
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         self.marked.clear();
         let done_label = if jobs.len() == 1 {
             format!("triggered {}", jobs[0].0)
@@ -1979,9 +1999,11 @@ impl App {
                     Err(e) => {
                         failed = true;
                         let _ = tx
-                            .send(Msg::Error {
+                            .send(Msg::Flash {
                                 generation: genr,
-                                error: format!("trigger {name} failed: {e}"),
+                                claim,
+                                message: format!("trigger {name} failed: {e}"),
+                                err: true,
                             })
                             .await;
                         continue;
@@ -1990,9 +2012,11 @@ impl App {
                 if let Err(e) = api.create(&PostParams::default(), &job).await {
                     failed = true;
                     let _ = tx
-                        .send(Msg::Error {
+                        .send(Msg::Flash {
                             generation: genr,
-                            error: format!("trigger {name} failed: {e}"),
+                            claim,
+                            message: format!("trigger {name} failed: {e}"),
+                            err: true,
                         })
                         .await;
                 }
@@ -2001,6 +2025,7 @@ impl App {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
+                        claim,
                         message: done_label,
                         err: false,
                     })
@@ -2038,12 +2063,12 @@ impl App {
         let now = k8s_openapi::jiff::Timestamp::now().as_second().to_string();
         let label = self.action_label(&targets);
         self.note_action("refresh", label);
-        self.flash = if targets.len() == 1 {
+        let progress = if targets.len() == 1 {
             format!("refreshing {}…", targets[0].0)
         } else {
             format!("refreshing {} {}…", targets.len(), self.kind_plural)
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         self.marked.clear();
         // Likewise a request: the `force-sync` annotation is picked up by the
         // operator on its next pass, so the secret isn't refreshed yet.
@@ -2056,6 +2081,7 @@ impl App {
             kind,
             targets,
             Patch::Merge(external_secret_refresh_patch(&now)),
+            claim,
             ok_message,
             |name, e| format!("refresh {name} failed: {e}"),
         );
@@ -2073,6 +2099,7 @@ impl App {
     pub(super) fn flash_warn(&mut self, msg: &str) {
         self.flash = msg.to_string();
         self.flash_err = true;
+        self.status_claim = None;
     }
 
     /// Set the status bar to a successful transient message and (re)start its
@@ -2085,27 +2112,69 @@ impl App {
         self.flash = msg.into();
         self.flash_err = false;
         self.flash_sticky = false;
+        self.status_claim = None;
         self.flash_seen.clone_from(&self.flash);
         self.flash_since = std::time::Instant::now();
     }
 
-    /// Take an in-flight progress message off the bar — but only if that is
-    /// still what the bar is showing. The trailing `…` is the test, the same
-    /// convention [`App::expire_flash`] reads.
-    ///
-    /// Two callers, one rule. A generation bump orphans the task that would
-    /// have replaced "deleting 3 pods…" with its result, and `expire_flash`
-    /// deliberately never times a progress message out, so without this a
-    /// refresh (`r`) during a bulk delete strands that message for good. And a
-    /// document/report task finishing (`Msg::Detail`/`Explain`/`Gitops`) is
-    /// done with its own "describing web…", but a concurrent action may have
-    /// claimed the bar since — clearing unconditionally would wipe that
-    /// action's confirmation, or a sticky error, and leave nothing behind.
+    /// Put an asynchronous operation's progress on the shared status bar and
+    /// return the claim its eventual result must present.
+    pub(super) fn claim_status(&mut self, msg: impl Into<String>) -> StatusClaim {
+        self.next_status_claim = self.next_status_claim.wrapping_add(1);
+        let claim = StatusClaim(self.next_status_claim);
+        let message = msg.into();
+        self.set_flash(message.clone());
+        self.status_claim = Some((claim, message));
+        claim
+    }
+
+    /// Replace the status owned by `claim`. A newer operation or any direct
+    /// status assignment makes the old result a no-op.
+    pub(super) fn set_claimed_status(
+        &mut self,
+        claim: StatusClaim,
+        msg: impl Into<String>,
+        err: bool,
+    ) {
+        if !self
+            .status_claim
+            .as_ref()
+            .is_some_and(|(owner, text)| *owner == claim && self.flash == *text)
+        {
+            return;
+        }
+        let message = msg.into();
+        self.set_flash(message.clone());
+        self.flash_err = err;
+        self.status_claim = Some((claim, message));
+    }
+
+    /// Clear a completed operation's progress only while it still owns the
+    /// bar. Its document/result may still be applied after ownership moves.
+    pub(super) fn clear_claimed_status(&mut self, claim: StatusClaim) {
+        if self
+            .status_claim
+            .as_ref()
+            .is_some_and(|(owner, text)| *owner == claim && self.flash == *text)
+        {
+            self.flash.clear();
+            self.flash_err = false;
+            self.flash_seen.clear();
+            self.flash_sticky = false;
+            self.status_claim = None;
+        }
+    }
+
+    /// Take an in-flight progress message off the bar when its generation is
+    /// abandoned. The trailing `…` is the same progress convention
+    /// [`App::expire_flash`] reads. Normal completions use their operation
+    /// token through [`Self::clear_claimed_status`] instead.
     pub(super) fn clear_progress_flash(&mut self) {
         if self.flash.ends_with('…') {
             self.flash.clear();
             self.flash_err = false;
         }
+        self.status_claim = None;
     }
 
     /// Auto-clear a *finished* transient flash [`FLASH_TTL`] after it last
@@ -2122,6 +2191,7 @@ impl App {
     /// end in `…` by convention, which is what marks them here.
     pub fn expire_flash(&mut self) {
         if self.flash != self.flash_seen {
+            self.status_claim = None;
             self.flash_seen.clone_from(&self.flash);
             self.flash_since = std::time::Instant::now();
             self.flash_sticky = false;
@@ -2135,6 +2205,7 @@ impl App {
         {
             self.flash.clear();
             self.flash_seen.clear();
+            self.status_claim = None;
         }
     }
 
@@ -2208,8 +2279,7 @@ impl App {
             "-n".to_string(),
             ns,
         ]);
-        self.flash = format!("rolling back {name} to revision {revision}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("rolling back {name} to revision {revision}…"));
         let tx = self.tx.clone();
         let genr = self.generation;
         // No manual re-watch on success: the live `secrets` watch backing the
@@ -2220,6 +2290,7 @@ impl App {
                     let _ = tx
                         .send(Msg::Flash {
                             generation: genr,
+                            claim,
                             message: format!("rolled back {name} to revision {revision}"),
                             err: false,
                         })
@@ -2227,9 +2298,11 @@ impl App {
                 }
                 Err(e) => {
                     let _ = tx
-                        .send(Msg::Error {
+                        .send(Msg::Flash {
                             generation: genr,
-                            error: format!("helm rollback {name} failed: {e}"),
+                            claim,
+                            message: format!("helm rollback {name} failed: {e}"),
+                            err: true,
                         })
                         .await;
                 }
@@ -2268,12 +2341,12 @@ impl App {
             many => format!("{} Helm releases", many.len()),
         };
         self.note_action("helm uninstall", label);
-        self.flash = if targets.len() == 1 {
+        let progress = if targets.len() == 1 {
             format!("uninstalling {}…", targets[0].0)
         } else {
             format!("uninstalling {} Helm releases…", targets.len())
         };
-        self.flash_err = false;
+        let claim = self.claim_status(progress);
         let done_label = if targets.len() == 1 {
             format!("uninstalled {}", targets[0].0)
         } else {
@@ -2290,9 +2363,11 @@ impl App {
                 if let Err(e) = run_helm(&argv).await {
                     failed = true;
                     let _ = tx
-                        .send(Msg::Error {
+                        .send(Msg::Flash {
                             generation: genr,
-                            error: format!("helm uninstall {name} failed: {e}"),
+                            claim,
+                            message: format!("helm uninstall {name} failed: {e}"),
+                            err: true,
                         })
                         .await;
                 }
@@ -2301,6 +2376,7 @@ impl App {
                 let _ = tx
                     .send(Msg::Flash {
                         generation: genr,
+                        claim,
                         message: done_label,
                         err: false,
                     })

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2089,13 +2089,19 @@ impl App {
         self.flash_since = std::time::Instant::now();
     }
 
-    /// Drop an in-flight progress flash whose result can no longer reach us.
-    /// [`Msg::Flash`] is generation-gated, so bumping the generation orphans
-    /// the task that would have replaced "deleting 3 pods…" with its result —
-    /// and [`App::expire_flash`] deliberately never times a progress message
-    /// out. Without this, a refresh (`r`) during a bulk delete would strand
-    /// that message on the bar for good.
-    pub(super) fn clear_orphaned_progress_flash(&mut self) {
+    /// Take an in-flight progress message off the bar — but only if that is
+    /// still what the bar is showing. The trailing `…` is the test, the same
+    /// convention [`App::expire_flash`] reads.
+    ///
+    /// Two callers, one rule. A generation bump orphans the task that would
+    /// have replaced "deleting 3 pods…" with its result, and `expire_flash`
+    /// deliberately never times a progress message out, so without this a
+    /// refresh (`r`) during a bulk delete strands that message for good. And a
+    /// document/report task finishing (`Msg::Detail`/`Explain`/`Gitops`) is
+    /// done with its own "describing web…", but a concurrent action may have
+    /// claimed the bar since — clearing unconditionally would wipe that
+    /// action's confirmation, or a sticky error, and leave nothing behind.
+    pub(super) fn clear_progress_flash(&mut self) {
         if self.flash.ends_with('…') {
             self.flash.clear();
             self.flash_err = false;

--- a/src/app/authz.rs
+++ b/src/app/authz.rs
@@ -102,19 +102,19 @@ impl App {
                     if status.denied.unwrap_or(false) {
                         deny_msg(genr, &subject, reason)
                     } else if status.allowed {
-                        Msg::CanIResult {
+                        Msg::Flash {
                             generation: genr,
-                            text: format!("✓ yes — can {subject}"),
-                            ok: true,
+                            message: format!("✓ yes — can {subject}"),
+                            err: false,
                         }
                     } else {
                         deny_msg(genr, &subject, reason)
                     }
                 }
-                Err(e) => Msg::CanIResult {
+                Err(e) => Msg::Flash {
                     generation: genr,
-                    text: format!("can-i {subject}: review failed: {e}"),
-                    ok: false,
+                    message: format!("can-i {subject}: review failed: {e}"),
+                    err: true,
                 },
             };
             let _ = tx.send(msg).await;
@@ -124,10 +124,10 @@ impl App {
 
 fn deny_msg(generation: u64, subject: &str, reason: Option<String>) -> Msg {
     let tail = reason.map(|r| format!(" ({r})")).unwrap_or_default();
-    Msg::CanIResult {
+    Msg::Flash {
         generation,
-        text: format!("✗ no — cannot {subject}{tail}"),
-        ok: false,
+        message: format!("✗ no — cannot {subject}{tail}"),
+        err: true,
     }
 }
 

--- a/src/app/authz.rs
+++ b/src/app/authz.rs
@@ -20,8 +20,7 @@ impl App {
             self.namespace.clone()
         };
         let user = self.cluster.context.clone();
-        self.flash = format!("can-i: reviewing rules in {ns}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("can-i: reviewing rules in {ns}…"));
         tokio::spawn(async move {
             let review = SelfSubjectRulesReview {
                 spec: SelfSubjectRulesReviewSpec {
@@ -33,12 +32,14 @@ impl App {
             let msg = match api.create(&kube::api::PostParams::default(), &review).await {
                 Ok(resp) => Msg::Detail {
                     generation: genr,
+                    claim,
                     title: format!("can-i · {user} · namespace {ns}"),
                     lines: format_rules(resp.status, &ns),
                     warn: None,
                 },
                 Err(e) => Msg::Detail {
                     generation: genr,
+                    claim,
                     title: format!("can-i · namespace {ns}"),
                     lines: vec![format!("access review failed: {e}")],
                     warn: Some("could not review permissions".into()),
@@ -77,8 +78,7 @@ impl App {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
-        self.flash = format!("can-i {subject}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("can-i {subject}…"));
         tokio::spawn(async move {
             let review = SelfSubjectAccessReview {
                 spec: SelfSubjectAccessReviewSpec {
@@ -100,19 +100,21 @@ impl App {
                     let reason = status.reason.filter(|r| !r.is_empty());
                     // `denied` overrides `allowed` (an explicit deny wins).
                     if status.denied.unwrap_or(false) {
-                        deny_msg(genr, &subject, reason)
+                        deny_msg(genr, claim, &subject, reason)
                     } else if status.allowed {
                         Msg::Flash {
                             generation: genr,
+                            claim,
                             message: format!("✓ yes — can {subject}"),
                             err: false,
                         }
                     } else {
-                        deny_msg(genr, &subject, reason)
+                        deny_msg(genr, claim, &subject, reason)
                     }
                 }
                 Err(e) => Msg::Flash {
                     generation: genr,
+                    claim,
                     message: format!("can-i {subject}: review failed: {e}"),
                     err: true,
                 },
@@ -122,10 +124,11 @@ impl App {
     }
 }
 
-fn deny_msg(generation: u64, subject: &str, reason: Option<String>) -> Msg {
+fn deny_msg(generation: u64, claim: StatusClaim, subject: &str, reason: Option<String>) -> Msg {
     let tail = reason.map(|r| format!(" ({r})")).unwrap_or_default();
     Msg::Flash {
         generation,
+        claim,
         message: format!("✗ no — cannot {subject}{tail}"),
         err: true,
     }

--- a/src/app/bundle.rs
+++ b/src/app/bundle.rs
@@ -78,8 +78,7 @@ impl App {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
-        self.flash = format!("assembling bundle for {name}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("assembling bundle for {name}…"));
 
         tokio::spawn(async move {
             let ts = k8s_openapi::jiff::Timestamp::now();
@@ -270,6 +269,7 @@ impl App {
             let _ = tx
                 .send(Msg::Bundle {
                     generation: genr,
+                    claim,
                     title,
                     text,
                     filename,
@@ -285,6 +285,9 @@ impl App {
             return;
         };
         let path = std::env::temp_dir().join(filename);
+        // Claimed like every other async result, which needs a progress
+        // message to own — the write is quick, but the bar is shared.
+        let claim = self.claim_status("saving bundle…");
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
@@ -295,6 +298,7 @@ impl App {
             let _ = tx
                 .send(Msg::BundleSaved {
                     generation: genr,
+                    claim,
                     result,
                 })
                 .await;

--- a/src/app/dashboards.rs
+++ b/src/app/dashboards.rs
@@ -5,13 +5,12 @@ impl App {
     pub fn open_pulse(&mut self) {
         self.bump_generation();
         self.pulse = Pulse::default();
-        self.flash = "pulse — cluster health".into();
-        self.flash_err = false;
         self.mode = Mode::Pulse;
         self.spawn_pulse();
     }
 
     pub(super) fn spawn_pulse(&mut self) {
+        let claim = self.claim_status("pulse — cluster health…");
         let resolve = |n: &str| self.cluster.resolve(n).map(|k| (k.ar, k.namespaced));
         let nodes = resolve("nodes");
         let pods = resolve("pods");
@@ -96,6 +95,7 @@ impl App {
                 if tx
                     .send(Msg::PulseData {
                         generation: genr,
+                        claim,
                         data: p,
                     })
                     .await
@@ -132,13 +132,12 @@ impl App {
         self.bump_generation();
         self.xray_items.clear();
         self.xray_state.select(Some(0));
-        self.flash = format!("xray: {}", self.kind_plural);
-        self.flash_err = false;
         self.mode = Mode::Xray;
         self.spawn_xray();
     }
 
     pub(super) fn spawn_xray(&mut self) {
+        let claim = self.claim_status(format!("xray: {}…", self.kind_plural));
         let Some((root_ar, root_nsd)) = self.kind.as_ref().map(|k| (k.ar.clone(), k.namespaced))
         else {
             return;
@@ -194,6 +193,7 @@ impl App {
                 if tx
                     .send(Msg::XrayData {
                         generation: genr,
+                        claim,
                         items,
                         warn,
                     })

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -141,8 +141,7 @@ impl App {
             argv.push("-n".into());
             argv.push(ns.clone());
         }
-        self.flash = format!("describing {name}…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("describing {name}…"));
         tokio::spawn(async move {
             let msg = match tokio::process::Command::new(&argv[0])
                 .args(&argv[1..])
@@ -151,6 +150,7 @@ impl App {
             {
                 Ok(out) if out.status.success() => Msg::Detail {
                     generation: genr,
+                    claim,
                     title: format!("{name} — describe"),
                     lines: String::from_utf8_lossy(&out.stdout)
                         .lines()
@@ -162,6 +162,7 @@ impl App {
                     let err = String::from_utf8_lossy(&out.stderr);
                     Msg::Detail {
                         generation: genr,
+                        claim,
                         title: yaml_title,
                         lines: yaml,
                         warn: Some(format!(
@@ -172,6 +173,7 @@ impl App {
                 }
                 Err(_) => Msg::Detail {
                     generation: genr,
+                    claim,
                     title: yaml_title,
                     lines: yaml,
                     warn: Some("kubectl not found; showing YAML".into()),

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -60,6 +60,13 @@ impl App {
         }
 
         lines.push(String::new());
+        lines.push("Actions".into());
+        match &self.last_action_error {
+            Some(e) => lines.push(format!("  last failure: {e}")),
+            None => lines.push("  last failure: none".into()),
+        }
+
+        lines.push(String::new());
         lines.push("Config sources".into());
         match self.config.base_path() {
             Some(path) => {

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -65,11 +65,10 @@ impl App {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
-        self.flash = format!(
+        let claim = self.claim_status(format!(
             "explaining {}…",
             obj.metadata.name.clone().unwrap_or_default()
-        );
-        self.flash_err = false;
+        ));
 
         tokio::spawn(async move {
             let mut warn = None;
@@ -103,6 +102,7 @@ impl App {
             let _ = tx
                 .send(Msg::Explain {
                     generation: genr,
+                    claim,
                     title,
                     findings,
                 })

--- a/src/app/find.rs
+++ b/src/app/find.rs
@@ -42,8 +42,7 @@ impl App {
         self.find_items.clear();
         self.find_state.select(None);
         self.mode = Mode::Find;
-        self.flash = format!("finding '{query}'…");
-        self.flash_err = false;
+        let claim = self.claim_status(format!("finding '{query}'…"));
 
         let kinds: Vec<(String, ApiResource)> = FIND_KINDS
             .iter()
@@ -109,6 +108,7 @@ impl App {
             let _ = tx
                 .send(Msg::FindResults {
                     generation: genr,
+                    claim,
                     query,
                     items,
                     warn,

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -74,8 +74,7 @@ impl App {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
-        self.flash = format!("GitOps: {}…", subject);
-        self.flash_err = false;
+        let claim = self.claim_status(format!("GitOps: {}…", subject));
 
         tokio::spawn(async move {
             let mut warn = None;
@@ -129,6 +128,7 @@ impl App {
             let _ = tx
                 .send(Msg::Gitops {
                     generation: genr,
+                    claim,
                     title,
                     findings,
                 })

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -393,14 +393,12 @@ impl App {
                 // Mirror describe: stay put, swap to the doc view when output
                 // lands, so a view switch mid-run cleanly drops the result.
                 self.set_return_mode();
-                self.flash = plugin_flash(&name, n, "");
-                self.flash_err = false;
-                self.spawn_plugin(jobs, format!("{name} — output"), mode, timeout);
+                let claim = self.claim_status(plugin_flash(&name, n, ""));
+                self.spawn_plugin(jobs, format!("{name} — output"), mode, timeout, claim);
             }
             PluginMode::Background => {
-                self.flash = plugin_flash(&name, n, " (background)");
-                self.flash_err = false;
-                self.spawn_plugin(jobs, name, mode, timeout);
+                let claim = self.claim_status(plugin_flash(&name, n, " (background)"));
+                self.spawn_plugin(jobs, name, mode, timeout, claim);
             }
         }
     }
@@ -416,6 +414,7 @@ impl App {
         title: String,
         mode: PluginMode,
         timeout: u64,
+        claim: StatusClaim,
     ) {
         let tx = self.tx.clone();
         let genr = self.generation;
@@ -437,8 +436,8 @@ impl App {
                 .collect()
                 .await;
             let msg = match mode {
-                PluginMode::Popup => plugin_popup_msg(genr, title, timeout, results),
-                _ => plugin_bulk_msg(genr, title, timeout, results),
+                PluginMode::Popup => plugin_popup_msg(genr, claim, title, timeout, results),
+                _ => plugin_bulk_msg(genr, claim, title, timeout, results),
             };
             let _ = tx.send(msg).await;
         });
@@ -1330,6 +1329,7 @@ fn reduce_outcome(timeout: u64, outcome: SpawnOutcome) -> (bool, Vec<String>, St
 /// per job (with a `== label ==` header when there's more than one).
 fn plugin_popup_msg(
     generation: u64,
+    claim: StatusClaim,
     title: String,
     timeout: u64,
     results: Vec<(String, SpawnOutcome)>,
@@ -1354,6 +1354,7 @@ fn plugin_popup_msg(
     let warn = (failed > 0).then(|| format!("{failed} of {total} failed"));
     Msg::PluginOutput {
         generation,
+        claim,
         title,
         lines,
         warn,
@@ -1364,6 +1365,7 @@ fn plugin_popup_msg(
 /// successes and listing the failures (target label + reason).
 fn plugin_bulk_msg(
     generation: u64,
+    claim: StatusClaim,
     name: String,
     timeout: u64,
     results: Vec<(String, SpawnOutcome)>,
@@ -1380,6 +1382,7 @@ fn plugin_bulk_msg(
     }
     Msg::PluginBulkDone {
         generation,
+        claim,
         name,
         ok,
         failed,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -262,6 +262,7 @@ impl App {
         };
         self.applied_filter_labels = filter_labels;
         self.applied_filter_fields = filter_fields;
+        self.clear_orphaned_progress_flash();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -777,6 +778,7 @@ impl App {
 
     pub(super) fn bump_generation(&mut self) {
         self.stop_event_stream();
+        self.clear_orphaned_progress_flash();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -841,10 +843,13 @@ impl App {
             Msg::Flash {
                 generation,
                 message,
-                ok,
+                err,
             } if generation == self.generation => {
-                self.flash = message;
-                self.flash_err = !ok;
+                // Through the setter, so re-running an action inside the
+                // expiry window restarts the timer on an identical message
+                // instead of letting it vanish a moment later.
+                self.set_flash(message);
+                self.flash_err = err;
             }
             Msg::Panic(error) => {
                 self.last_error = Some(error.clone());
@@ -987,14 +992,10 @@ impl App {
                 self.explain_state
                     .select((!self.explain_items.is_empty()).then_some(first));
                 self.mode = Mode::Explain;
-            }
-            Msg::CanIResult {
-                generation,
-                text,
-                ok,
-            } if generation == self.generation => {
-                self.flash = text;
-                self.flash_err = !ok;
+                // As in the `Msg::Gitops` arm below: the "explaining X…"
+                // progress flash has done its job now the findings are up.
+                self.flash.clear();
+                self.flash_err = false;
             }
             Msg::Gitops {
                 generation,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -837,8 +837,7 @@ impl App {
             Msg::Error { generation, error } if generation == self.generation => {
                 self.watch_errors = self.watch_errors.saturating_add(1);
                 self.last_error = Some(error.clone());
-                self.flash = format!("error: {error}");
-                self.flash_err = true;
+                self.borrow_status(format!("error: {error}"), true);
             }
             Msg::Flash {
                 generation,
@@ -850,12 +849,10 @@ impl App {
             }
             Msg::Panic(error) => {
                 self.last_error = Some(error.clone());
-                self.flash = format!("internal error: {error}");
-                self.flash_err = true;
+                self.borrow_status(format!("internal error: {error}"), true);
             }
             Msg::Notify(text) => {
-                self.flash = format!("🔔 {text}");
-                self.flash_err = false;
+                self.borrow_status(format!("🔔 {text}"), false);
                 // Delivery happens once per frame in the run loop (see
                 // `take_notification`), so a batch of these coalesces.
                 self.pending_notify.push(text);
@@ -954,12 +951,12 @@ impl App {
                 claim,
                 data,
             } if generation == self.generation => {
-                match &data.warn {
-                    Some(w) => {
-                        self.set_claimed_status(claim, format!("pulse is incomplete — {w}"), true)
-                    }
-                    None => self.clear_claimed_status(claim),
-                }
+                self.set_recurring_status(
+                    claim,
+                    data.warn
+                        .as_ref()
+                        .map(|w| format!("pulse is incomplete — {w}")),
+                );
                 self.pulse = data;
             }
             Msg::Rbac {
@@ -975,12 +972,7 @@ impl App {
                 items,
                 warn,
             } if generation == self.generation => {
-                match warn {
-                    Some(w) => {
-                        self.set_claimed_status(claim, format!("xray is incomplete — {w}"), true)
-                    }
-                    None => self.clear_claimed_status(claim),
-                }
+                self.set_recurring_status(claim, warn.map(|w| format!("xray is incomplete — {w}")));
                 let keep = self.xray_state.selected().unwrap_or(0);
                 self.xray_items = items;
                 self.xray_state
@@ -1190,7 +1182,7 @@ impl App {
                 generation,
                 claim,
                 result,
-            } if generation == self.log_gen => match result {
+            } if generation == self.generation => match result {
                 Ok(path) => self.set_claimed_status(
                     claim,
                     format!("saved logs → {}", path.display()),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -838,6 +838,14 @@ impl App {
                 self.flash = format!("error: {error}");
                 self.flash_err = true;
             }
+            Msg::Flash {
+                generation,
+                message,
+                ok,
+            } if generation == self.generation => {
+                self.flash = message;
+                self.flash_err = !ok;
+            }
             Msg::Panic(error) => {
                 self.last_error = Some(error.clone());
                 self.flash = format!("internal error: {error}");
@@ -1003,6 +1011,8 @@ impl App {
                 self.gitops_state
                     .select((!self.gitops_items.is_empty()).then_some(first));
                 self.mode = Mode::Gitops;
+                self.flash.clear();
+                self.flash_err = false;
             }
             Msg::PluginOutput {
                 generation,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -842,23 +842,11 @@ impl App {
             }
             Msg::Flash {
                 generation,
+                claim,
                 message,
                 err,
             } if generation == self.generation => {
-                // Two actions started close together share a generation, so a
-                // slower one can land after a faster one already failed. An
-                // error on the bar is the newer, more important news and now
-                // never expires, so a late success must not be what erases it.
-                // Starting the next action clears `flash_err` through its own
-                // progress flash, so this only ever suppresses a result that
-                // raced an error — never the ordinary one-action flow.
-                if err || !self.flash_err {
-                    // Through the setter, so re-running an action inside the
-                    // expiry window restarts the timer on an identical message
-                    // instead of letting it vanish a moment later.
-                    self.set_flash(message);
-                    self.flash_err = err;
-                }
+                self.set_claimed_status(claim, message, err);
             }
             Msg::Panic(error) => {
                 self.last_error = Some(error.clone());
@@ -987,6 +975,7 @@ impl App {
             }
             Msg::Explain {
                 generation,
+                claim,
                 title,
                 findings,
             } if generation == self.generation => {
@@ -1003,10 +992,11 @@ impl App {
                 self.mode = Mode::Explain;
                 // As in the `Msg::Gitops` arm below: the "explaining X…"
                 // progress flash has done its job now the findings are up.
-                self.clear_progress_flash();
+                self.clear_claimed_status(claim);
             }
             Msg::Gitops {
                 generation,
+                claim,
                 title,
                 findings,
             } if generation == self.generation => {
@@ -1020,7 +1010,7 @@ impl App {
                 self.gitops_state
                     .select((!self.gitops_items.is_empty()).then_some(first));
                 self.mode = Mode::Gitops;
-                self.clear_progress_flash();
+                self.clear_claimed_status(claim);
             }
             Msg::PluginOutput {
                 generation,
@@ -1123,6 +1113,7 @@ impl App {
             }
             Msg::Detail {
                 generation,
+                claim,
                 title,
                 lines,
                 warn,
@@ -1134,10 +1125,10 @@ impl App {
                 };
                 self.mode = Mode::Detail;
                 match warn {
-                    Some(w) => self.flash_warn(&w),
+                    Some(w) => self.set_claimed_status(claim, w, true),
                     // The "describing X…" progress flash has served its
                     // purpose once the document arrives.
-                    None => self.clear_progress_flash(),
+                    None => self.clear_claimed_status(claim),
                 }
             }
             Msg::Events {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -262,7 +262,7 @@ impl App {
         };
         self.applied_filter_labels = filter_labels;
         self.applied_filter_fields = filter_fields;
-        self.clear_orphaned_progress_flash();
+        self.clear_progress_flash();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -778,7 +778,7 @@ impl App {
 
     pub(super) fn bump_generation(&mut self) {
         self.stop_event_stream();
-        self.clear_orphaned_progress_flash();
+        self.clear_progress_flash();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -845,11 +845,20 @@ impl App {
                 message,
                 err,
             } if generation == self.generation => {
-                // Through the setter, so re-running an action inside the
-                // expiry window restarts the timer on an identical message
-                // instead of letting it vanish a moment later.
-                self.set_flash(message);
-                self.flash_err = err;
+                // Two actions started close together share a generation, so a
+                // slower one can land after a faster one already failed. An
+                // error on the bar is the newer, more important news and now
+                // never expires, so a late success must not be what erases it.
+                // Starting the next action clears `flash_err` through its own
+                // progress flash, so this only ever suppresses a result that
+                // raced an error — never the ordinary one-action flow.
+                if err || !self.flash_err {
+                    // Through the setter, so re-running an action inside the
+                    // expiry window restarts the timer on an identical message
+                    // instead of letting it vanish a moment later.
+                    self.set_flash(message);
+                    self.flash_err = err;
+                }
             }
             Msg::Panic(error) => {
                 self.last_error = Some(error.clone());
@@ -994,8 +1003,7 @@ impl App {
                 self.mode = Mode::Explain;
                 // As in the `Msg::Gitops` arm below: the "explaining X…"
                 // progress flash has done its job now the findings are up.
-                self.flash.clear();
-                self.flash_err = false;
+                self.clear_progress_flash();
             }
             Msg::Gitops {
                 generation,
@@ -1012,8 +1020,7 @@ impl App {
                 self.gitops_state
                     .select((!self.gitops_items.is_empty()).then_some(first));
                 self.mode = Mode::Gitops;
-                self.flash.clear();
-                self.flash_err = false;
+                self.clear_progress_flash();
             }
             Msg::PluginOutput {
                 generation,
@@ -1130,10 +1137,7 @@ impl App {
                     Some(w) => self.flash_warn(&w),
                     // The "describing X…" progress flash has served its
                     // purpose once the document arrives.
-                    None => {
-                        self.flash.clear();
-                        self.flash_err = false;
-                    }
+                    None => self.clear_progress_flash(),
                 }
             }
             Msg::Events {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -929,26 +929,36 @@ impl App {
             }
             Msg::FindResults {
                 generation,
+                claim,
                 query,
                 items,
                 warn,
             } if generation == self.generation => {
-                if let Some(w) = warn {
-                    self.flash = format!("find is incomplete — {w}");
-                    self.flash_err = true;
-                } else {
-                    self.flash = format!("{} hit(s) for '{query}'", items.len());
-                    self.flash_err = false;
+                match warn {
+                    Some(w) => {
+                        self.set_claimed_status(claim, format!("find is incomplete — {w}"), true)
+                    }
+                    None => self.set_claimed_status(
+                        claim,
+                        format!("{} hit(s) for '{query}'", items.len()),
+                        false,
+                    ),
                 }
                 self.find_query = query;
                 self.find_items = items;
                 self.find_state
                     .select((!self.find_items.is_empty()).then_some(0));
             }
-            Msg::PulseData { generation, data } if generation == self.generation => {
-                if let Some(w) = &data.warn {
-                    self.flash = format!("pulse is incomplete — {w}");
-                    self.flash_err = true;
+            Msg::PulseData {
+                generation,
+                claim,
+                data,
+            } if generation == self.generation => {
+                match &data.warn {
+                    Some(w) => {
+                        self.set_claimed_status(claim, format!("pulse is incomplete — {w}"), true)
+                    }
+                    None => self.clear_claimed_status(claim),
                 }
                 self.pulse = data;
             }
@@ -961,12 +971,15 @@ impl App {
             }
             Msg::XrayData {
                 generation,
+                claim,
                 items,
                 warn,
             } if generation == self.generation => {
-                if let Some(w) = warn {
-                    self.flash = format!("xray is incomplete — {w}");
-                    self.flash_err = true;
+                match warn {
+                    Some(w) => {
+                        self.set_claimed_status(claim, format!("xray is incomplete — {w}"), true)
+                    }
+                    None => self.clear_claimed_status(claim),
                 }
                 let keep = self.xray_state.selected().unwrap_or(0);
                 self.xray_items = items;
@@ -1014,6 +1027,7 @@ impl App {
             }
             Msg::PluginOutput {
                 generation,
+                claim,
                 title,
                 lines,
                 warn,
@@ -1025,22 +1039,19 @@ impl App {
                 };
                 self.mode = Mode::Detail;
                 match warn {
-                    Some(w) => self.flash_warn(&w),
-                    None => {
-                        self.flash = "plugin done".into();
-                        self.flash_err = false;
-                    }
+                    Some(w) => self.set_claimed_status(claim, w, true),
+                    None => self.set_claimed_status(claim, "plugin done", false),
                 }
             }
             Msg::PluginBulkDone {
                 generation,
+                claim,
                 name,
                 ok,
                 failed,
             } if generation == self.generation => {
                 if failed.is_empty() {
-                    self.flash = format!("plugin {name}: {ok} ok");
-                    self.flash_err = false;
+                    self.set_claimed_status(claim, format!("plugin {name}: {ok} ok"), false);
                 } else {
                     let shown: Vec<&str> = failed.iter().take(3).map(String::as_str).collect();
                     let more = failed.len().saturating_sub(shown.len());
@@ -1049,32 +1060,45 @@ impl App {
                     } else {
                         String::new()
                     };
-                    self.flash_warn(&format!(
-                        "plugin {name}: {ok} ok, {} failed — {}{tail}",
-                        failed.len(),
-                        shown.join("; ")
-                    ));
+                    self.set_claimed_status(
+                        claim,
+                        format!(
+                            "plugin {name}: {ok} ok, {} failed — {}{tail}",
+                            failed.len(),
+                            shown.join("; ")
+                        ),
+                        true,
+                    );
                 }
             }
             Msg::DebuggersCleaned {
                 generation,
+                claim,
                 deleted,
                 failed,
             } if generation == self.generation => {
                 if failed.is_empty() {
-                    self.flash = format!("removed {deleted} node debugger pod(s)");
-                    self.flash_err = false;
+                    self.set_claimed_status(
+                        claim,
+                        format!("removed {deleted} node debugger pod(s)"),
+                        false,
+                    );
                 } else {
                     let shown: Vec<&str> = failed.iter().take(3).map(String::as_str).collect();
-                    self.flash_warn(&format!(
-                        "debug-clean: removed {deleted}, {} failed — {}",
-                        failed.len(),
-                        shown.join("; ")
-                    ));
+                    self.set_claimed_status(
+                        claim,
+                        format!(
+                            "debug-clean: removed {deleted}, {} failed — {}",
+                            failed.len(),
+                            shown.join("; ")
+                        ),
+                        true,
+                    );
                 }
             }
             Msg::Bundle {
                 generation,
+                claim,
                 title,
                 text,
                 filename,
@@ -1087,30 +1111,37 @@ impl App {
                 self.pending_bundle = Some((filename, text));
                 self.set_return_mode();
                 self.mode = Mode::Detail;
-                self.flash = "bundle ready — review, then :bundle-save".into();
-                self.flash_err = false;
+                self.set_claimed_status(claim, "bundle ready — review, then :bundle-save", false);
             }
-            Msg::BundleSaved { generation, result } if generation == self.generation => {
-                match result {
-                    Ok(path) => {
-                        self.flash = format!("saved bundle → {}", path.display());
-                        self.flash_err = false;
-                    }
-                    Err(e) => self.flash_warn(&format!("bundle save failed: {e}")),
-                }
-            }
+            Msg::BundleSaved {
+                generation,
+                claim,
+                result,
+            } if generation == self.generation => match result {
+                Ok(path) => self.set_claimed_status(
+                    claim,
+                    format!("saved bundle → {}", path.display()),
+                    false,
+                ),
+                Err(e) => self.set_claimed_status(claim, format!("bundle save failed: {e}"), true),
+            },
             Msg::FleetRow { generation, row } if generation == self.generation => {
                 self.apply_fleet_row(*row);
             }
-            Msg::SnapshotSaved { generation, result } if generation == self.generation => {
-                match result {
-                    Ok(path) => {
-                        self.flash = format!("saved snapshot → {}", path.display());
-                        self.flash_err = false;
-                    }
-                    Err(e) => self.flash_warn(&format!("snapshot save failed: {e}")),
+            Msg::SnapshotSaved {
+                generation,
+                claim,
+                result,
+            } if generation == self.generation => match result {
+                Ok(path) => self.set_claimed_status(
+                    claim,
+                    format!("saved snapshot → {}", path.display()),
+                    false,
+                ),
+                Err(e) => {
+                    self.set_claimed_status(claim, format!("snapshot save failed: {e}"), true)
                 }
-            }
+            },
             Msg::Detail {
                 generation,
                 claim,
@@ -1147,33 +1178,37 @@ impl App {
                     .scroll
                     .min(self.detail.lines.len().saturating_sub(1));
             }
-            Msg::TransferDone { generation, result } if generation == self.generation => {
-                match result {
-                    Ok(summary) => {
-                        self.flash = summary;
-                        self.flash_err = false;
-                    }
-                    Err(e) => self.flash_warn(&format!("cp failed: {e}")),
-                }
-            }
-            Msg::LogsSaved { generation, result } if generation == self.log_gen => match result {
-                Ok(path) => {
-                    self.flash = format!("saved logs → {}", path.display());
-                    self.flash_err = false;
-                }
-                Err(e) => self.flash_warn(&format!("save failed: {e}")),
+            Msg::TransferDone {
+                generation,
+                claim,
+                result,
+            } if generation == self.generation => match result {
+                Ok(summary) => self.set_claimed_status(claim, summary, false),
+                Err(e) => self.set_claimed_status(claim, format!("cp failed: {e}"), true),
+            },
+            Msg::LogsSaved {
+                generation,
+                claim,
+                result,
+            } if generation == self.log_gen => match result {
+                Ok(path) => self.set_claimed_status(
+                    claim,
+                    format!("saved logs → {}", path.display()),
+                    false,
+                ),
+                Err(e) => self.set_claimed_status(claim, format!("save failed: {e}"), true),
             },
             Msg::ClipboardCopied {
                 generation,
+                claim,
                 copied,
                 success,
                 failure,
             } if generation == self.generation => {
                 if copied {
-                    self.flash = success;
-                    self.flash_err = false;
+                    self.set_claimed_status(claim, success, false);
                 } else {
-                    self.flash_warn(&failure);
+                    self.set_claimed_status(claim, failure, true);
                 }
             }
             Msg::Namespaces { generation, list } if generation == self.generation => {
@@ -1196,6 +1231,7 @@ impl App {
             }
             Msg::ContextRenamed {
                 generation,
+                claim,
                 old,
                 new,
                 result,
@@ -1220,10 +1256,9 @@ impl App {
                             self.recent_namespaces.insert(new.clone(), recents);
                         }
                     }
-                    self.flash = format!("renamed context {old} → {new}");
-                    self.flash_err = false;
+                    self.set_claimed_status(claim, format!("renamed context {old} → {new}"), false);
                 }
-                Err(e) => self.flash_warn(&format!("rename failed: {e}")),
+                Err(e) => self.set_claimed_status(claim, format!("rename failed: {e}"), true),
             },
             Msg::ContextSwitched {
                 generation,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -32,7 +32,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
 use crate::k8s::{Cluster, Kind};
-use crate::store::{Msg, Pulse, RowKey, Store, StoreMutation, XrayItem, row_key};
+use crate::store::{Msg, Pulse, RowKey, StatusClaim, Store, StoreMutation, XrayItem, row_key};
 
 pub(crate) use guardrails::ConfirmLevel;
 
@@ -1220,6 +1220,12 @@ pub struct App {
     /// starts sticky; the first flash that replaces it clears the flag, so no
     /// call site has to.
     pub(super) flash_sticky: bool,
+    /// Monotonic source for asynchronous status-bar ownership claims.
+    pub(super) next_status_claim: u64,
+    /// Current claim and the exact text it owns. Comparing the text makes a
+    /// direct status assignment invalidate the claim even before the next
+    /// expiry tick observes that assignment.
+    pub(super) status_claim: Option<(StatusClaim, String)>,
 
     pub detail: Scrollable,
     /// Search query for the help view (`?`), which has no backing
@@ -1550,6 +1556,8 @@ impl App {
             flash_seen: WELCOME_FLASH.into(),
             flash_since: std::time::Instant::now(),
             flash_sticky: true,
+            next_status_claim: 0,
+            status_claim: None,
             detail: Scrollable::empty(),
             help_filter: String::new(),
             doc_filter_return: Mode::Detail,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1202,6 +1202,11 @@ pub struct App {
     pub cmd_sel: usize,
     pub flash: String,
     pub flash_err: bool,
+    /// Last flash text observed by [`App::expire_flash`], so a change can be
+    /// detected (and re-timestamped) without touching every call site that
+    /// sets `flash` directly.
+    pub(super) flash_seen: String,
+    pub(super) flash_since: std::time::Instant,
 
     pub detail: Scrollable,
     /// Search query for the help view (`?`), which has no backing
@@ -1528,6 +1533,8 @@ impl App {
             flash: "Welcome to sofka — ':' resource · enter drill · d describe · l logs · ? help"
                 .into(),
             flash_err: false,
+            flash_seen: String::new(),
+            flash_since: std::time::Instant::now(),
             detail: Scrollable::empty(),
             help_filter: String::new(),
             doc_filter_return: Mode::Detail,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -59,6 +59,11 @@ const MAX_LOG_LINES_PAUSED: usize = 100_000;
 const LOG_BATCH_LINES: usize = 64;
 const LOG_BATCH_MS: u64 = 50;
 
+/// Initial status-bar hint. Unlike transient action results, this stays visible
+/// until another interaction replaces it.
+const WELCOME_FLASH: &str =
+    "Welcome to sofka — ':' resource · enter drill · d describe · l logs · ? help";
+
 /// Flux CD resource kinds whose spec has a `suspend: bool` field — every kind
 /// with a corresponding `flux suspend/resume` subcommand: kustomize- and
 /// helm-controller reconcilers, source-controller fetchers, image-automation
@@ -1530,8 +1535,7 @@ impl App {
             command: String::new(),
             cmd_suggestions: Vec::new(),
             cmd_sel: 0,
-            flash: "Welcome to sofka — ':' resource · enter drill · d describe · l logs · ? help"
-                .into(),
+            flash: WELCOME_FLASH.into(),
             flash_err: false,
             flash_seen: String::new(),
             flash_since: std::time::Instant::now(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -103,6 +103,18 @@ pub const CRONJOB_MENU_ITEMS: &[&str] = &["Trigger now", "Suspend", "Resume", "C
 /// prompting for the source and destination paths.
 pub const TRANSFER_MENU_ITEMS: &[&str] = &["Download from pod", "Upload to pod", "Cancel"];
 
+/// An asynchronous operation's ownership of the shared status bar.
+#[derive(Debug)]
+pub(super) struct ActiveStatusClaim {
+    claim: StatusClaim,
+    /// Exact text currently displayed for this claim, including a background
+    /// message that is only borrowing the bar.
+    text: String,
+    /// The owner still has a result to deliver. If borrowed transient text
+    /// expires first, preserve the claim against an empty bar.
+    pending: bool,
+}
+
 /// External Secrets Operator kinds that honour the `force-sync` annotation to
 /// trigger an immediate secret refresh. Both are namespaced; the cluster-scoped
 /// `ClusterExternalSecret` is deliberately left out so the namespaced patch
@@ -1225,7 +1237,7 @@ pub struct App {
     /// Current claim and the exact text it owns. Comparing the text makes a
     /// direct status assignment invalidate the claim even before the next
     /// expiry tick observes that assignment.
-    pub(super) status_claim: Option<(StatusClaim, String)>,
+    pub(super) status_claim: Option<ActiveStatusClaim>,
     /// Last action failure, recorded even when a newer operation owned the
     /// status bar and the message could not be shown. Surfaced by `:debug`
     /// so a failure is never lost outright.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1226,6 +1226,10 @@ pub struct App {
     /// direct status assignment invalidate the claim even before the next
     /// expiry tick observes that assignment.
     pub(super) status_claim: Option<(StatusClaim, String)>,
+    /// Last action failure, recorded even when a newer operation owned the
+    /// status bar and the message could not be shown. Surfaced by `:debug`
+    /// so a failure is never lost outright.
+    pub last_action_error: Option<String>,
 
     pub detail: Scrollable,
     /// Search query for the help view (`?`), which has no backing
@@ -1558,6 +1562,7 @@ impl App {
             flash_sticky: true,
             next_status_claim: 0,
             status_claim: None,
+            last_action_error: None,
             detail: Scrollable::empty(),
             help_filter: String::new(),
             doc_filter_return: Mode::Detail,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -64,6 +64,10 @@ const LOG_BATCH_MS: u64 = 50;
 const WELCOME_FLASH: &str =
     "Welcome to sofka — ':' resource · enter drill · d describe · l logs · ? help";
 
+/// How long a finished, successful flash stays on screen before the 1s tick
+/// clears it (see [`App::expire_flash`]).
+const FLASH_TTL: std::time::Duration = std::time::Duration::from_secs(8);
+
 /// Flux CD resource kinds whose spec has a `suspend: bool` field — every kind
 /// with a corresponding `flux suspend/resume` subcommand: kustomize- and
 /// helm-controller reconcilers, source-controller fetchers, image-automation
@@ -1212,6 +1216,10 @@ pub struct App {
     /// sets `flash` directly.
     pub(super) flash_seen: String,
     pub(super) flash_since: std::time::Instant,
+    /// Keeps the current flash on screen indefinitely. Only the welcome hint
+    /// starts sticky; the first flash that replaces it clears the flag, so no
+    /// call site has to.
+    pub(super) flash_sticky: bool,
 
     pub detail: Scrollable,
     /// Search query for the help view (`?`), which has no backing
@@ -1537,8 +1545,11 @@ impl App {
             cmd_sel: 0,
             flash: WELCOME_FLASH.into(),
             flash_err: false,
-            flash_seen: String::new(),
+            // Pre-seeded so the first tick sees no change and leaves the
+            // welcome hint's sticky flag alone.
+            flash_seen: WELCOME_FLASH.into(),
             flash_since: std::time::Instant::now(),
+            flash_sticky: true,
             detail: Scrollable::empty(),
             help_filter: String::new(),
             doc_filter_return: Mode::Detail,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -264,8 +264,7 @@ impl App {
         self.namespace = ns;
         self.note_recent_namespace(name);
         self.remember_namespace();
-        self.flash = format!("namespace: {}", self.namespace_label());
-        self.flash_err = false;
+        self.set_flash(format!("namespace: {}", self.namespace_label()));
         self.record_history();
         self.start_watch();
     }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -446,8 +446,7 @@ impl App {
         self.namespace = normalize_ns(&sel);
         self.note_recent_namespace(&sel);
         self.remember_namespace();
-        self.flash = format!("namespace: {}", self.namespace_label());
-        self.flash_err = false;
+        self.set_flash(format!("namespace: {}", self.namespace_label()));
         self.ns_filter.clear();
         self.mode = Mode::Table;
         self.table_state.select(Some(0));
@@ -675,13 +674,14 @@ impl App {
         if name == self.cluster.context && self.cluster.connected {
             return;
         }
-        self.flash = format!("switching to {name}…");
-        self.flash_err = false;
         // Stop the current context's watches and clear stale rows while we
         // reconnect; the new watch starts when the connection lands. The rows
         // are stashed first — if the switch fails we stay on this context,
         // where they're still valid (a successful switch drops the cache).
+        // Bump first: this switch's own progress flash belongs to the new
+        // generation, and the bump clears any left over from the old one.
         self.bump_generation();
+        self.set_flash(format!("switching to {name}…"));
         self.stash_view_snapshot();
         self.store.clear();
         self.invalidate_rows();

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -642,6 +642,7 @@ impl App {
             self.flash_warn(&format!("context '{new}' already exists"));
             return;
         }
+        let claim = self.claim_status(format!("renaming {old} → {new}…"));
         let tx = self.tx.clone();
         let genr = self.generation;
         tokio::spawn(async move {
@@ -657,6 +658,7 @@ impl App {
             let _ = tx
                 .send(Msg::ContextRenamed {
                     generation: genr,
+                    claim,
                     old,
                     new,
                     result,

--- a/src/app/rightsize.rs
+++ b/src/app/rightsize.rs
@@ -50,8 +50,7 @@ impl App {
             .as_ref()
             .map(|k| k.ar.kind.clone())
             .unwrap_or_else(|| self.kind_plural.clone());
-        self.flash = format!("right-sizing {name} over {}…", provider.window);
-        self.flash_err = false;
+        let claim = self.claim_status(format!("right-sizing {name} over {}…", provider.window));
 
         tokio::spawn(async move {
             let title = format!("right-size — {kind_name}/{name}");
@@ -63,6 +62,7 @@ impl App {
                         let _ = tx
                             .send(Msg::Detail {
                                 generation: genr,
+                                claim,
                                 title,
                                 lines: vec![format!("no metrics backend: {e}")],
                                 warn: Some("right-size needs Prometheus/VictoriaMetrics".into()),
@@ -98,6 +98,7 @@ impl App {
             let _ = tx
                 .send(Msg::Detail {
                     generation: genr,
+                    claim,
                     title,
                     lines,
                     warn,

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -30,13 +30,13 @@ impl App {
         let path = snapshots_dir().join(snap.filename(format));
         let tx = self.tx.clone();
         let genr = self.generation;
-        self.flash = format!("saving snapshot ({} rows)…", snap.rows.len());
-        self.flash_err = false;
+        let claim = self.claim_status(format!("saving snapshot ({} rows)…", snap.rows.len()));
         tokio::spawn(async move {
             let result = write_snapshot(&path, &text).await;
             let _ = tx
                 .send(Msg::SnapshotSaved {
                     generation: genr,
+                    claim,
                     result,
                 })
                 .await;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2176,6 +2176,85 @@ async fn an_action_with_no_targets_claims_nothing() {
 }
 
 #[tokio::test]
+async fn a_finished_report_does_not_erase_a_concurrent_action_result() {
+    let (mut app, _rx) = test_app();
+
+    // A describe and a delete share a generation. The delete lands first and
+    // claims the bar; the report is done with its own progress message, but
+    // clearing unconditionally would wipe the confirmation and show nothing.
+    app.flash = "describing web…".into();
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        message: "deleted 3 pods".into(),
+        err: false,
+    });
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        title: "web — describe".into(),
+        lines: vec!["Name: web".into()],
+        warn: None,
+    });
+    assert_eq!(app.flash, "deleted 3 pods");
+
+    // Same for an error, which no longer expires on its own — losing it here
+    // would lose it for good.
+    app.flash = "explaining web…".into();
+    app.handle_msg(Msg::Error {
+        generation: app.generation,
+        error: "delete web failed: forbidden".into(),
+    });
+    app.handle_msg(Msg::Explain {
+        generation: app.generation,
+        title: "explain — web".into(),
+        findings: Vec::new(),
+    });
+    assert_eq!(app.mode, Mode::Explain);
+    assert!(app.flash_err);
+    assert!(app.flash.contains("forbidden"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_late_success_does_not_erase_an_error() {
+    let (mut app, _rx) = test_app();
+
+    // Two actions started close together share a generation, so a slower one
+    // can report success after a faster one has already failed.
+    app.flash = "deleting 3 pods…".into();
+    app.handle_msg(Msg::Error {
+        generation: app.generation,
+        error: "scale web failed: forbidden".into(),
+    });
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        message: "deleted 3 pods".into(),
+        err: false,
+    });
+    assert!(app.flash_err);
+    assert!(app.flash.contains("scale web failed"), "{}", app.flash);
+
+    // The next action clears the error through its own progress flash, so
+    // ordinary results are unaffected.
+    app.flash = "deleting 2 pods…".into();
+    app.flash_err = false;
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        message: "deleted 2 pods".into(),
+        err: false,
+    });
+    assert_eq!(app.flash, "deleted 2 pods");
+
+    // A `:can-i` verdict answers a question the user just asked, so it lands
+    // even over an error.
+    app.flash_err = true;
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        message: "✗ no — cannot delete pods".into(),
+        err: true,
+    });
+    assert_eq!(app.flash, "✗ no — cannot delete pods");
+}
+
+#[tokio::test]
 async fn can_i_verdict_arrives_as_a_flash() {
     let (mut app, _rx) = test_app();
     // `:can-i` shares `Msg::Flash` with the action results. A denial is an

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2006,6 +2006,46 @@ async fn detail_arrival_clears_progress_flash() {
 }
 
 #[tokio::test]
+async fn welcome_flash_does_not_expire() {
+    let (mut app, _rx) = test_app();
+    assert_eq!(app.flash, WELCOME_FLASH);
+
+    app.expire_flash();
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+
+    assert_eq!(app.flash, WELCOME_FLASH);
+    assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn error_flash_does_not_expire() {
+    let (mut app, _rx) = test_app();
+    app.flash = "delete failed: forbidden".into();
+    app.flash_err = true;
+
+    app.expire_flash();
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+
+    assert_eq!(app.flash, "delete failed: forbidden");
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn successful_transient_flash_expires() {
+    let (mut app, _rx) = test_app();
+    app.flash = "deleted web".into();
+
+    app.expire_flash();
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+
+    assert!(app.flash.is_empty(), "{}", app.flash);
+    assert!(!app.flash_err);
+}
+
+#[tokio::test]
 async fn scale_prompt_targets_marked_rows() {
     let (mut app, _rx) = test_app();
     app.switch_kind("deployments");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2356,7 +2356,8 @@ async fn an_action_failure_is_never_silently_dropped() {
         Some("delete web failed: forbidden")
     );
 
-    // Borrowing does not take ownership: the describe still reports normally.
+    // Borrowing does not take ownership: the describe still reports normally,
+    // but completing that report must not erase the sticky action failure.
     app.handle_msg(Msg::Detail {
         generation: app.generation,
         claim: describe,
@@ -2364,7 +2365,10 @@ async fn an_action_failure_is_never_silently_dropped() {
         lines: vec!["Name: api".into()],
         warn: None,
     });
-    assert!(app.flash.is_empty(), "{}", app.flash);
+    assert_eq!(app.mode, Mode::Detail);
+    assert_eq!(app.flash, "delete web failed: forbidden");
+    assert!(app.flash_err);
+    assert!(app.status_claim.is_none());
 
     // A failure that cannot even borrow the bar — a newer operation has
     // already put a finished result there — is still recorded for `:debug`.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1984,9 +1984,10 @@ async fn restart_key_opens_confirm() {
 #[tokio::test]
 async fn detail_arrival_clears_progress_flash() {
     let (mut app, _rx) = test_app();
-    app.flash = "describing web…".into();
+    let claim = app.claim_status("describing web…");
     app.handle_msg(Msg::Detail {
         generation: app.generation,
+        claim,
         title: "web — describe".into(),
         lines: vec!["Name: web".into()],
         warn: None,
@@ -1995,9 +1996,10 @@ async fn detail_arrival_clears_progress_flash() {
     assert!(app.flash.is_empty(), "{}", app.flash);
 
     // A fallback warning still replaces the progress flash.
-    app.flash = "describing web…".into();
+    let claim = app.claim_status("describing web…");
     app.handle_msg(Msg::Detail {
         generation: app.generation,
+        claim,
         title: "web — YAML".into(),
         lines: vec!["kind: Pod".into()],
         warn: Some("kubectl not found; showing YAML".into()),
@@ -2057,7 +2059,7 @@ async fn successful_transient_flash_expires() {
 #[tokio::test]
 async fn progress_flash_outlives_the_expiry_window() {
     let (mut app, _rx) = test_app();
-    app.flash = "draining 3 nodes…".into();
+    let claim = app.claim_status("draining 3 nodes…");
 
     // A drain or a bulk delete easily runs past 8s; blanking the bar
     // mid-flight would read as though nothing were happening.
@@ -2069,6 +2071,7 @@ async fn progress_flash_outlives_the_expiry_window() {
     // The result replaces it, and that one does expire on schedule.
     app.handle_msg(Msg::Flash {
         generation: app.generation,
+        claim,
         message: "drain requested: 3 nodes".into(),
         err: false,
     });
@@ -2083,7 +2086,7 @@ async fn progress_flash_outlives_the_expiry_window() {
 async fn refreshing_mid_action_drops_the_orphaned_progress_flash() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");
-    app.flash = "deleting 3 pods…".into();
+    let claim = app.claim_status("deleting 3 pods…");
     let stale = app.generation;
 
     // `r` restarts the watch, which bumps the generation, so the delete's
@@ -2097,6 +2100,7 @@ async fn refreshing_mid_action_drops_the_orphaned_progress_flash() {
     // The orphaned result is still dropped, not shown late.
     app.handle_msg(Msg::Flash {
         generation: stale,
+        claim,
         message: "deleted 3 pods".into(),
         err: false,
     });
@@ -2146,12 +2150,13 @@ async fn action_progress_flashes_keep_the_ellipsis_convention() {
 #[tokio::test]
 async fn explain_findings_clear_the_progress_flash() {
     let (mut app, _rx) = test_app();
-    app.flash = "explaining web…".into();
+    let claim = app.claim_status("explaining web…");
 
     // Nothing else replaces this one, and `expire_flash` won't time a `…` out,
     // so the handler has to clear it — as the `Msg::Gitops` arm does.
     app.handle_msg(Msg::Explain {
         generation: app.generation,
+        claim,
         title: "explain — web".into(),
         findings: Vec::new(),
     });
@@ -2176,35 +2181,43 @@ async fn an_action_with_no_targets_claims_nothing() {
 }
 
 #[tokio::test]
-async fn a_finished_report_does_not_erase_a_concurrent_action_result() {
+async fn a_finished_report_only_clears_its_own_status_claim() {
     let (mut app, _rx) = test_app();
 
-    // A describe and a delete share a generation. The delete lands first and
-    // claims the bar; the report is done with its own progress message, but
-    // clearing unconditionally would wipe the confirmation and show nothing.
-    app.flash = "describing web…".into();
-    app.handle_msg(Msg::Flash {
-        generation: app.generation,
-        message: "deleted 3 pods".into(),
-        err: false,
-    });
+    // A describe and a delete share a generation. The delete claims the bar
+    // after describe; the older report must not clear that in-flight progress.
+    let describe_claim = app.claim_status("describing web…");
+    let delete_claim = app.claim_status("deleting 3 pods…");
     app.handle_msg(Msg::Detail {
         generation: app.generation,
+        claim: describe_claim,
         title: "web — describe".into(),
         lines: vec!["Name: web".into()],
         warn: None,
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim: delete_claim,
+        message: "deleted 3 pods".into(),
+        err: false,
     });
     assert_eq!(app.flash, "deleted 3 pods");
 
     // Same for an error, which no longer expires on its own — losing it here
     // would lose it for good.
-    app.flash = "explaining web…".into();
-    app.handle_msg(Msg::Error {
+    let explain_claim = app.claim_status("explaining web…");
+    let delete_claim = app.claim_status("deleting web…");
+    app.handle_msg(Msg::Flash {
         generation: app.generation,
-        error: "delete web failed: forbidden".into(),
+        claim: delete_claim,
+        message: "delete web failed: forbidden".into(),
+        err: true,
     });
     app.handle_msg(Msg::Explain {
         generation: app.generation,
+        claim: explain_claim,
         title: "explain — web".into(),
         findings: Vec::new(),
     });
@@ -2214,44 +2227,63 @@ async fn a_finished_report_does_not_erase_a_concurrent_action_result() {
 }
 
 #[tokio::test]
-async fn a_late_success_does_not_erase_an_error() {
+async fn an_older_action_result_cannot_overwrite_a_newer_action() {
     let (mut app, _rx) = test_app();
 
-    // Two actions started close together share a generation, so a slower one
-    // can report success after a faster one has already failed.
-    app.flash = "deleting 3 pods…".into();
-    app.handle_msg(Msg::Error {
-        generation: app.generation,
-        error: "scale web failed: forbidden".into(),
-    });
+    let old = app.claim_status("deleting 3 pods…");
+    let new = app.claim_status("scaling web → 3…");
     app.handle_msg(Msg::Flash {
         generation: app.generation,
+        claim: old,
         message: "deleted 3 pods".into(),
         err: false,
+    });
+    assert_eq!(app.flash, "scaling web → 3…");
+
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim: new,
+        message: "scale web failed: forbidden".into(),
+        err: true,
     });
     assert!(app.flash_err);
     assert!(app.flash.contains("scale web failed"), "{}", app.flash);
 
-    // The next action clears the error through its own progress flash, so
-    // ordinary results are unaffected.
-    app.flash = "deleting 2 pods…".into();
-    app.flash_err = false;
+    // An older error also cannot erase a newer successful result.
+    let old = app.claim_status("deleting api…");
+    let new = app.claim_status("scaling worker → 2…");
     app.handle_msg(Msg::Flash {
         generation: app.generation,
-        message: "deleted 2 pods".into(),
+        claim: new,
+        message: "scaled worker → 2".into(),
         err: false,
     });
-    assert_eq!(app.flash, "deleted 2 pods");
-
-    // A `:can-i` verdict answers a question the user just asked, so it lands
-    // even over an error.
-    app.flash_err = true;
     app.handle_msg(Msg::Flash {
         generation: app.generation,
-        message: "✗ no — cannot delete pods".into(),
+        claim: old,
+        message: "delete api failed: forbidden".into(),
         err: true,
     });
-    assert_eq!(app.flash, "✗ no — cannot delete pods");
+    assert_eq!(app.flash, "scaled worker → 2");
+    assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn an_unclaimed_status_update_invalidates_the_current_claim() {
+    let (mut app, _rx) = test_app();
+    let claim = app.claim_status("deleting api…");
+
+    // Most existing synchronous status updates assign `flash` directly. The
+    // expected-text half of ownership makes those safe without migrating every
+    // call site in this fix.
+    app.flash = "namespace: prod".into();
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim,
+        message: "deleted api".into(),
+        err: false,
+    });
+    assert_eq!(app.flash, "namespace: prod");
 }
 
 #[tokio::test]
@@ -2260,8 +2292,10 @@ async fn can_i_verdict_arrives_as_a_flash() {
     // `:can-i` shares `Msg::Flash` with the action results. A denial is an
     // answer, not a failure, so it doesn't go through `Msg::Error` — but it
     // still reads as an error and sticks around like one.
+    let claim = app.claim_status("can-i delete pods…");
     app.handle_msg(Msg::Flash {
         generation: app.generation,
+        claim,
         message: "✗ no — cannot delete pods".into(),
         err: true,
     });

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -13,6 +13,15 @@ fn test_app() -> (App, Receiver<Msg>) {
     (App::new(Cluster::fake(), tx), rx)
 }
 
+/// The claim the operation that just started owns, for tests that hand-build
+/// the result message it is waiting for.
+fn current_claim(app: &App) -> crate::store::StatusClaim {
+    app.status_claim
+        .as_ref()
+        .expect("no operation has claimed the status bar")
+        .0
+}
+
 fn press(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)
 }
@@ -1029,16 +1038,20 @@ async fn pulse_and_xray_warns_surface_as_flash() {
         warn: Some("listing pods: 403".into()),
         ..Default::default()
     };
+    let claim = app.claim_status("pulse — cluster health…");
     app.handle_msg(Msg::PulseData {
         generation: app.generation,
+        claim,
         data,
     });
     assert!(app.flash_err);
     assert!(app.flash.contains("incomplete"), "{}", app.flash);
 
     app.flash_err = false;
+    let claim = app.claim_status("xray: pods…");
     app.handle_msg(Msg::XrayData {
         generation: app.generation,
+        claim,
         items: Vec::new(),
         warn: Some("listing replicasets: 403".into()),
     });
@@ -1557,6 +1570,7 @@ async fn find_opens_picker_and_enter_navigates_to_the_object() {
 
     app.handle_msg(Msg::FindResults {
         generation: app.generation,
+        claim: current_claim(&app),
         query: "web".into(),
         items: vec![
             crate::store::FindItem {
@@ -1581,8 +1595,11 @@ async fn find_opens_picker_and_enter_navigates_to_the_object() {
     assert_eq!(app.fields.as_deref(), Some("metadata.name=web-1"));
 
     // Incomplete sweeps say so instead of pretending the list is exhaustive.
+    // A fresh sweep, because navigating away retired the first one's claim.
+    assert!(app.run_palette_command("find web"));
     app.handle_msg(Msg::FindResults {
         generation: app.generation,
+        claim: current_claim(&app),
         query: "web".into(),
         items: Vec::new(),
         warn: Some("2 kind(s) could not be listed".into()),
@@ -2266,6 +2283,170 @@ async fn an_older_action_result_cannot_overwrite_a_newer_action() {
     });
     assert_eq!(app.flash, "scaled worker → 2");
     assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn an_action_failure_is_never_silently_dropped() {
+    let (mut app, _rx) = test_app();
+
+    // A delete fails after a describe has claimed the bar. The failure is not
+    // this operation's to show, but the bar only holds an unresolved `…`, so
+    // borrowing it costs nothing and losing the failure costs a lot.
+    let delete = app.claim_status("deleting web…");
+    let describe = app.claim_status("describing api…");
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim: delete,
+        message: "delete web failed: forbidden".into(),
+        err: true,
+    });
+    assert!(app.flash_err);
+    assert_eq!(app.flash, "delete web failed: forbidden");
+    assert_eq!(
+        app.last_action_error.as_deref(),
+        Some("delete web failed: forbidden")
+    );
+
+    // Borrowing does not take ownership: the describe still reports normally.
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        claim: describe,
+        title: "api — describe".into(),
+        lines: vec!["Name: api".into()],
+        warn: None,
+    });
+    assert!(app.flash.is_empty(), "{}", app.flash);
+
+    // A failure that cannot even borrow the bar — a newer operation has
+    // already put a finished result there — is still recorded for `:debug`.
+    let stale = app.claim_status("draining node-1…");
+    let newer = app.claim_status("scaling web → 3…");
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim: newer,
+        message: "scaled web → 3".into(),
+        err: false,
+    });
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim: stale,
+        message: "drain node-1 failed: forbidden".into(),
+        err: true,
+    });
+    assert_eq!(app.flash, "scaled web → 3");
+    assert!(!app.flash_err);
+    assert_eq!(
+        app.last_action_error.as_deref(),
+        Some("drain node-1 failed: forbidden")
+    );
+    app.open_info();
+    assert!(
+        app.detail.lines.iter().any(|l| l
+            .to_string()
+            .contains("last failure: drain node-1 failed: forbidden")),
+        "`:info` does not report the failure"
+    );
+}
+
+#[tokio::test]
+async fn every_async_result_is_scoped_to_its_own_operation() {
+    // The claim plumbing has to reach *every* operation that writes the bar,
+    // not just the action ones — an unclaimed handler overwrites whatever the
+    // user started later.
+    let (mut app, _rx) = test_app();
+
+    let find = app.claim_status("finding 'foo'…");
+    let delete = app.claim_status("deleting 3 pods…");
+    app.handle_msg(Msg::FindResults {
+        generation: app.generation,
+        claim: find,
+        query: "foo".into(),
+        items: Vec::new(),
+        warn: None,
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+    // The results still land, only the status is scoped.
+    assert_eq!(app.find_query, "foo");
+
+    app.handle_msg(Msg::TransferDone {
+        generation: app.generation,
+        claim: find,
+        result: Ok("copied a → b".into()),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::SnapshotSaved {
+        generation: app.generation,
+        claim: find,
+        result: Ok(std::path::PathBuf::from("/tmp/snap.json")),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::BundleSaved {
+        generation: app.generation,
+        claim: find,
+        result: Ok(std::path::PathBuf::from("/tmp/bundle.txt")),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::DebuggersCleaned {
+        generation: app.generation,
+        claim: find,
+        deleted: 2,
+        failed: Vec::new(),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::ClipboardCopied {
+        generation: app.generation,
+        claim: find,
+        copied: true,
+        success: "copied 12 log lines".into(),
+        failure: "no clipboard target".into(),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::LogsSaved {
+        generation: app.log_gen,
+        claim: find,
+        result: Ok(std::path::PathBuf::from("/tmp/sofka.log")),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::PluginBulkDone {
+        generation: app.generation,
+        claim: find,
+        name: "sync".into(),
+        ok: 3,
+        failed: Vec::new(),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::ContextRenamed {
+        generation: app.generation,
+        claim: find,
+        old: "test".into(),
+        new: "staging".into(),
+        result: Ok(()),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    app.handle_msg(Msg::XrayData {
+        generation: app.generation,
+        claim: find,
+        items: Vec::new(),
+        warn: None,
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+
+    // And the owner still reports when it lands.
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim: delete,
+        message: "deleted 3 pods".into(),
+        err: false,
+    });
+    assert_eq!(app.flash, "deleted 3 pods");
 }
 
 #[tokio::test]
@@ -3210,14 +3391,18 @@ async fn stale_log_save_result_is_dropped() {
     let stale = app.log_gen;
     app.log_gen += 1;
 
+    let claim = app.claim_status("saving logs…");
     app.handle_msg(Msg::LogsSaved {
         generation: stale,
+        claim,
         result: Err("old write failed".into()),
     });
     assert!(!app.flash.contains("old write failed"));
 
+    let claim = app.claim_status("saving logs…");
     app.handle_msg(Msg::LogsSaved {
         generation: app.log_gen,
+        claim,
         result: Ok(std::env::temp_dir().join("sofka-test.log")),
     });
     assert!(app.flash.contains("sofka-test.log"));
@@ -3230,16 +3415,20 @@ async fn stale_clipboard_result_is_dropped() {
     let stale = app.generation;
     app.bump_generation();
 
+    let claim = app.claim_status("copying to clipboard…");
     app.handle_msg(Msg::ClipboardCopied {
         generation: stale,
+        claim,
         copied: false,
         success: "copied stale".into(),
         failure: "stale failed".into(),
     });
     assert!(!app.flash.contains("stale failed"));
 
+    let claim = app.claim_status("copying to clipboard…");
     app.handle_msg(Msg::ClipboardCopied {
         generation: app.generation,
+        claim,
         copied: true,
         success: "copied current".into(),
         failure: "current failed".into(),
@@ -4511,8 +4700,10 @@ async fn context_renamed_updates_lists_and_current_context() {
     app.all_contexts = vec!["prod".into(), "test".into()];
     app.note_recent_namespace("shop");
 
+    let claim = app.claim_status("renaming test → staging…");
     app.handle_msg(Msg::ContextRenamed {
         generation: app.generation,
+        claim,
         old: "test".into(),
         new: "staging".into(),
         result: Ok(()),
@@ -4546,8 +4737,10 @@ async fn context_renamed_updates_lists_and_current_context() {
     );
 
     // A failed rename only flashes.
+    let claim = app.claim_status("renaming prod → live…");
     app.handle_msg(Msg::ContextRenamed {
         generation: app.generation,
+        claim,
         old: "prod".into(),
         new: "live".into(),
         result: Err("no context exists with the name".into()),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19,7 +19,7 @@ fn current_claim(app: &App) -> crate::store::StatusClaim {
     app.status_claim
         .as_ref()
         .expect("no operation has claimed the status bar")
-        .0
+        .claim
 }
 
 fn press(code: KeyCode) -> KeyEvent {
@@ -1057,6 +1057,55 @@ async fn pulse_and_xray_warns_surface_as_flash() {
     });
     assert!(app.flash_err);
     assert!(app.flash.contains("incomplete"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn recurring_dashboard_poll_can_warn_after_an_initial_success() {
+    let (mut app, _rx) = test_app();
+    let claim = app.claim_status("pulse — cluster health…");
+
+    app.handle_msg(Msg::PulseData {
+        generation: app.generation,
+        claim,
+        data: crate::store::Pulse::default(),
+    });
+    assert!(app.flash.is_empty(), "{}", app.flash);
+
+    app.handle_msg(Msg::PulseData {
+        generation: app.generation,
+        claim,
+        data: crate::store::Pulse {
+            warn: Some("listing pods: 403".into()),
+            ..Default::default()
+        },
+    });
+    assert!(app.flash_err);
+    assert!(app.flash.contains("pulse is incomplete"), "{}", app.flash);
+
+    // The next complete poll clears the warning while retaining the recurring
+    // claim for future polls.
+    app.handle_msg(Msg::PulseData {
+        generation: app.generation,
+        claim,
+        data: crate::store::Pulse::default(),
+    });
+    assert!(app.flash.is_empty(), "{}", app.flash);
+
+    let claim = app.claim_status("xray: pods…");
+    app.handle_msg(Msg::XrayData {
+        generation: app.generation,
+        claim,
+        items: Vec::new(),
+        warn: None,
+    });
+    app.handle_msg(Msg::XrayData {
+        generation: app.generation,
+        claim,
+        items: Vec::new(),
+        warn: Some("listing replicasets: 403".into()),
+    });
+    assert!(app.flash_err);
+    assert!(app.flash.contains("xray is incomplete"), "{}", app.flash);
 }
 
 #[tokio::test]
@@ -2407,7 +2456,7 @@ async fn every_async_result_is_scoped_to_its_own_operation() {
     assert_eq!(app.flash, "deleting 3 pods…");
 
     app.handle_msg(Msg::LogsSaved {
-        generation: app.log_gen,
+        generation: app.generation,
         claim: find,
         result: Ok(std::path::PathBuf::from("/tmp/sofka.log")),
     });
@@ -2465,6 +2514,53 @@ async fn an_unclaimed_status_update_invalidates_the_current_claim() {
         err: false,
     });
     assert_eq!(app.flash, "namespace: prod");
+}
+
+#[tokio::test]
+async fn background_status_borrows_the_bar_without_orphaning_an_action() {
+    let (mut app, _rx) = test_app();
+
+    let claim = app.claim_status("deleting api…");
+    app.handle_msg(Msg::Error {
+        generation: app.generation,
+        error: "watch disconnected".into(),
+    });
+    assert!(app.flash.contains("watch disconnected"), "{}", app.flash);
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim,
+        message: "deleted api".into(),
+        err: false,
+    });
+    assert_eq!(app.flash, "deleted api");
+
+    let claim = app.claim_status("scaling web → 3…");
+    app.handle_msg(Msg::Panic("worker panic".into()));
+    assert!(app.flash.contains("worker panic"), "{}", app.flash);
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim,
+        message: "scaled web → 3".into(),
+        err: false,
+    });
+    assert_eq!(app.flash, "scaled web → 3");
+
+    let claim = app.claim_status("draining node-1…");
+    app.handle_msg(Msg::Notify("pod/web: Ready True → False".into()));
+    assert!(app.flash.starts_with('🔔'), "{}", app.flash);
+
+    // A transient notification may expire before the action. The pending
+    // owner still retains its claim against the now-empty bar.
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+    assert!(app.flash.is_empty(), "{}", app.flash);
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        claim,
+        message: "drain requested: node-1".into(),
+        err: false,
+    });
+    assert_eq!(app.flash, "drain requested: node-1");
 }
 
 #[tokio::test]
@@ -3386,27 +3482,32 @@ async fn log_filter_supports_regex_inverse_and_clear() {
 }
 
 #[tokio::test]
-async fn stale_log_save_result_is_dropped() {
+async fn log_save_result_survives_leaving_logs() {
     let (mut app, _rx) = test_app();
-    let stale = app.log_gen;
-    app.log_gen += 1;
-
     let claim = app.claim_status("saving logs…");
+    // Leaving Logs invalidates its stream but not the independent file write.
+    app.log_gen += 1;
+    app.handle_msg(Msg::LogsSaved {
+        generation: app.generation,
+        claim,
+        result: Ok(std::env::temp_dir().join("sofka-test.log")),
+    });
+    assert!(app.flash.contains("sofka-test.log"));
+    assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn stale_log_save_result_is_dropped_after_a_view_generation_change() {
+    let (mut app, _rx) = test_app();
+    let stale = app.generation;
+    let claim = app.claim_status("saving logs…");
+    app.bump_generation();
     app.handle_msg(Msg::LogsSaved {
         generation: stale,
         claim,
         result: Err("old write failed".into()),
     });
     assert!(!app.flash.contains("old write failed"));
-
-    let claim = app.claim_status("saving logs…");
-    app.handle_msg(Msg::LogsSaved {
-        generation: app.log_gen,
-        claim,
-        result: Ok(std::env::temp_dir().join("sofka-test.log")),
-    });
-    assert!(app.flash.contains("sofka-test.log"));
-    assert!(!app.flash_err);
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2016,6 +2016,15 @@ async fn welcome_flash_does_not_expire() {
 
     assert_eq!(app.flash, WELCOME_FLASH);
     assert!(!app.flash_err);
+
+    // Stickiness rides on a flag rather than on matching the constant, and the
+    // first real flash to land clears it.
+    app.flash = "deleted web".into();
+    app.expire_flash();
+    assert!(!app.flash_sticky);
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+    assert!(app.flash.is_empty(), "{}", app.flash);
 }
 
 #[tokio::test]
@@ -2043,6 +2052,167 @@ async fn successful_transient_flash_expires() {
 
     assert!(app.flash.is_empty(), "{}", app.flash);
     assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn progress_flash_outlives_the_expiry_window() {
+    let (mut app, _rx) = test_app();
+    app.flash = "draining 3 nodes…".into();
+
+    // A drain or a bulk delete easily runs past 8s; blanking the bar
+    // mid-flight would read as though nothing were happening.
+    app.expire_flash();
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(30);
+    app.expire_flash();
+    assert_eq!(app.flash, "draining 3 nodes…");
+
+    // The result replaces it, and that one does expire on schedule.
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        message: "drain requested: 3 nodes".into(),
+        err: false,
+    });
+    assert_eq!(app.flash, "drain requested: 3 nodes");
+    assert!(!app.flash_err);
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+    assert!(app.flash.is_empty(), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn refreshing_mid_action_drops_the_orphaned_progress_flash() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.flash = "deleting 3 pods…".into();
+    let stale = app.generation;
+
+    // `r` restarts the watch, which bumps the generation, so the delete's
+    // `Msg::Flash` can no longer land. Nothing would replace the progress
+    // message and `expire_flash` won't time a `…` one out — hence the bump
+    // clears it itself.
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert_ne!(app.generation, stale);
+    assert!(app.flash.is_empty(), "{}", app.flash);
+
+    // The orphaned result is still dropped, not shown late.
+    app.handle_msg(Msg::Flash {
+        generation: stale,
+        message: "deleted 3 pods".into(),
+        err: false,
+    });
+    assert!(app.flash.is_empty(), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn action_progress_flashes_keep_the_ellipsis_convention() {
+    // `expire_flash` reads the trailing `…` as "still running". An action that
+    // forgets it gets its progress message blanked out mid-flight, which is
+    // exactly the failure the ellipsis guard exists to prevent.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    let targets = vec![("web".to_string(), "default".to_string())];
+
+    app.do_scale(targets.clone(), 3);
+    assert!(app.flash.ends_with('…'), "scale: {}", app.flash);
+
+    app.do_scale(
+        vec![
+            targets[0].clone(),
+            ("api".to_string(), "default".to_string()),
+        ],
+        3,
+    );
+    assert!(app.flash.ends_with('…'), "bulk scale: {}", app.flash);
+
+    app.do_set_image(
+        "default".into(),
+        "web".into(),
+        "deployments".into(),
+        "app".into(),
+        "nginx:1.27".into(),
+    );
+    assert!(app.flash.ends_with('…'), "set-image: {}", app.flash);
+
+    app.do_set_suspend(targets.clone(), true);
+    assert!(app.flash.ends_with('…'), "suspend: {}", app.flash);
+
+    app.do_reconcile(targets.clone());
+    assert!(app.flash.ends_with('…'), "reconcile: {}", app.flash);
+
+    app.do_refresh_es(targets);
+    assert!(app.flash.ends_with('…'), "refresh: {}", app.flash);
+}
+
+#[tokio::test]
+async fn explain_findings_clear_the_progress_flash() {
+    let (mut app, _rx) = test_app();
+    app.flash = "explaining web…".into();
+
+    // Nothing else replaces this one, and `expire_flash` won't time a `…` out,
+    // so the handler has to clear it — as the `Msg::Gitops` arm does.
+    app.handle_msg(Msg::Explain {
+        generation: app.generation,
+        title: "explain — web".into(),
+        findings: Vec::new(),
+    });
+
+    assert_eq!(app.mode, Mode::Explain);
+    assert!(app.flash.is_empty(), "{}", app.flash);
+    assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn an_action_with_no_targets_claims_nothing() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    app.flash.clear();
+
+    // `request_flux_menu` guards this, but the menu stays open across watch
+    // updates — the selected row can be gone by the time Enter lands.
+    app.do_set_suspend(Vec::new(), true);
+    assert!(app.flash.is_empty(), "{}", app.flash);
+    app.do_reconcile(Vec::new());
+    assert!(app.flash.is_empty(), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn can_i_verdict_arrives_as_a_flash() {
+    let (mut app, _rx) = test_app();
+    // `:can-i` shares `Msg::Flash` with the action results. A denial is an
+    // answer, not a failure, so it doesn't go through `Msg::Error` — but it
+    // still reads as an error and sticks around like one.
+    app.handle_msg(Msg::Flash {
+        generation: app.generation,
+        message: "✗ no — cannot delete pods".into(),
+        err: true,
+    });
+    assert!(app.flash_err);
+    assert_eq!(app.last_error, None);
+
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+    assert_eq!(app.flash, "✗ no — cannot delete pods");
+}
+
+#[tokio::test]
+async fn repeating_an_action_restarts_the_expiry_timer() {
+    let (mut app, _rx) = test_app();
+    app.set_flash("namespace: prod");
+
+    // 7s on, the same command runs again. The text is identical, so the
+    // `flash_seen` diff can't tell a repeat from a flash that has been sitting
+    // there all along — only going through the setter can.
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(7);
+    app.set_flash("namespace: prod");
+
+    // 14s since the first showing, 7s since the repeat: still up.
+    app.flash_since -= std::time::Duration::from_secs(7);
+    app.expire_flash();
+    assert_eq!(app.flash, "namespace: prod");
+
+    app.flash_since -= std::time::Duration::from_secs(2);
+    app.expire_flash();
+    assert!(app.flash.is_empty(), "{}", app.flash);
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -702,6 +702,7 @@ async fn run(
             }
             _ = tick.tick() => {
                 app.reap_port_forwards(); // age columns + drop dead forwards
+                app.expire_flash();
                 dirty = true;
             }
             // A held Esc was a real keypress after all, not the head of a

--- a/src/store.rs
+++ b/src/store.rs
@@ -72,12 +72,6 @@ pub enum Msg {
         title: String,
         findings: Vec<crate::explain::Finding>,
     },
-    /// Result of a `:can-i <verb> <resource>` access review, shown as a flash.
-    CanIResult {
-        generation: u64,
-        text: String,
-        ok: bool,
-    },
     /// Reconciliation-chain findings for the GitOps view, gathered off-thread.
     Gitops {
         generation: u64,
@@ -215,11 +209,17 @@ pub enum Msg {
         error: String,
     },
     /// A background action (delete, restart, scale, drain, helm op, …)
-    /// finished; replaces its "…ing" progress flash with a result.
+    /// finished; replaces its "…ing" progress flash with a result. Also
+    /// carries `:can-i` verdicts, which are the same thing: a one-line answer
+    /// from an off-thread task.
     Flash {
         generation: u64,
         message: String,
-        ok: bool,
+        /// Render in the error style. Action results never set this — a failed
+        /// action reports through [`Msg::Error`] instead — but a `:can-i`
+        /// denial is a legitimate answer rather than a failure, and still
+        /// wants to read as a "no".
+        err: bool,
     },
     /// A panic in a background task, reported by the process panic hook.
     /// Deliberately generation-free: it must surface no matter which view is

--- a/src/store.rs
+++ b/src/store.rs
@@ -55,10 +55,12 @@ pub enum Msg {
     },
     PulseData {
         generation: u64,
+        claim: StatusClaim,
         data: Pulse,
     },
     XrayData {
         generation: u64,
+        claim: StatusClaim,
         items: Vec<XrayItem>,
         /// A list that failed during the gather — the tree may be incomplete.
         warn: Option<String>,
@@ -87,6 +89,7 @@ pub enum Msg {
     /// Captured output of an `output = "popup"` plugin run.
     PluginOutput {
         generation: u64,
+        claim: StatusClaim,
         title: String,
         lines: Vec<String>,
         /// Set when the plugin failed or timed out (a nonzero exit, stderr).
@@ -96,6 +99,7 @@ pub enum Msg {
     /// bulk): how many jobs succeeded and the failures (label + reason).
     PluginBulkDone {
         generation: u64,
+        claim: StatusClaim,
         name: String,
         ok: usize,
         failed: Vec<String>,
@@ -119,16 +123,19 @@ pub enum Msg {
     /// "copied …" summary, or kubectl's error.
     TransferDone {
         generation: u64,
+        claim: StatusClaim,
         result: Result<String, String>,
     },
     /// Result of an off-thread log save.
     LogsSaved {
         generation: u64,
+        claim: StatusClaim,
         result: Result<std::path::PathBuf, String>,
     },
     /// Result of an off-thread clipboard copy.
     ClipboardCopied {
         generation: u64,
+        claim: StatusClaim,
         copied: bool,
         success: String,
         failure: String,
@@ -153,6 +160,7 @@ pub enum Msg {
     /// context switcher).
     ContextRenamed {
         generation: u64,
+        claim: StatusClaim,
         old: String,
         new: String,
         result: Result<(), String>,
@@ -176,12 +184,14 @@ pub enum Msg {
     /// deleted and any per-pod failures (`ns/name: reason`).
     DebuggersCleaned {
         generation: u64,
+        claim: StatusClaim,
         deleted: usize,
         failed: Vec<String>,
     },
     /// An assembled diagnostic bundle (`:bundle`), ready to preview and save.
     Bundle {
         generation: u64,
+        claim: StatusClaim,
         title: String,
         text: String,
         /// Suggested filename for `:bundle-save`.
@@ -190,11 +200,13 @@ pub enum Msg {
     /// Result of writing a bundle to disk (`:bundle-save`).
     BundleSaved {
         generation: u64,
+        claim: StatusClaim,
         result: Result<std::path::PathBuf, String>,
     },
     /// Result of writing a snapshot to disk (`:snapshot`).
     SnapshotSaved {
         generation: u64,
+        claim: StatusClaim,
         result: Result<std::path::PathBuf, String>,
     },
     /// One context's summary for the fleet dashboard (`:fleet`), arriving
@@ -206,6 +218,7 @@ pub enum Msg {
     /// Results of a `:find <text>` sweep across kinds.
     FindResults {
         generation: u64,
+        claim: StatusClaim,
         query: String,
         items: Vec<FindItem>,
         /// Kinds that failed to list — the results may be incomplete.

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,6 +6,10 @@ use std::sync::Arc;
 
 use kube::core::DynamicObject;
 
+/// Identity of an asynchronous operation's claim on the shared status bar.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StatusClaim(pub(crate) u64);
+
 /// Messages flowing from watch tasks to the UI loop. Tagged with a
 /// `generation` so messages from a superseded watch can be discarded.
 pub enum Msg {
@@ -69,12 +73,14 @@ pub enum Msg {
     /// Findings for the explain-unhealthy view, gathered off-thread.
     Explain {
         generation: u64,
+        claim: StatusClaim,
         title: String,
         findings: Vec<crate::explain::Finding>,
     },
     /// Reconciliation-chain findings for the GitOps view, gathered off-thread.
     Gitops {
         generation: u64,
+        claim: StatusClaim,
         title: String,
         findings: Vec<crate::explain::Finding>,
     },
@@ -97,6 +103,7 @@ pub enum Msg {
     /// Result of an off-thread `kubectl describe` (or its YAML fallback).
     Detail {
         generation: u64,
+        claim: StatusClaim,
         title: String,
         lines: Vec<String>,
         /// Set when describe failed and we fell back to YAML.
@@ -214,11 +221,11 @@ pub enum Msg {
     /// from an off-thread task.
     Flash {
         generation: u64,
+        claim: StatusClaim,
         message: String,
-        /// Render in the error style. Action results never set this — a failed
-        /// action reports through [`Msg::Error`] instead — but a `:can-i`
-        /// denial is a legitimate answer rather than a failure, and still
-        /// wants to read as a "no".
+        /// Render in the error style. This covers both action failures and a
+        /// `:can-i` denial, which is an answer rather than a watch error but
+        /// still wants to read as a "no".
         err: bool,
     },
     /// A panic in a background task, reported by the process panic hook.

--- a/src/store.rs
+++ b/src/store.rs
@@ -214,6 +214,13 @@ pub enum Msg {
         generation: u64,
         error: String,
     },
+    /// A background action (delete, restart, scale, drain, helm op, …)
+    /// finished; replaces its "…ing" progress flash with a result.
+    Flash {
+        generation: u64,
+        message: String,
+        ok: bool,
+    },
     /// A panic in a background task, reported by the process panic hook.
     /// Deliberately generation-free: it must surface no matter which view is
     /// current.


### PR DESCRIPTION
Progress flashes like "deleting …" in bottom status bar never resolved on success and stayed stuck. They now report completion and auto-expire after 8s.