### PR TITLE
perf: cheaper filters, Helm decode and caches; watch node pod counts

### DIFF
--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -207,10 +207,98 @@ fn log_viewport(c: &mut Criterion) {
     g.finish();
 }
 
+/// 3.2 — the same rebuild with a *structured* comparison filter. Unlike the
+/// fuzzy group above, every object pays `column_cell` (one column extracted
+/// per object) plus the comparison itself, so this is where per-object
+/// allocation in `eval_cmp` shows up.
+fn filter_cmp(c: &mut Criterion) {
+    let mut g = c.benchmark_group("filter_cmp");
+    let n = 2_000usize;
+    for (label, pat) in [
+        ("str_curated", "status=Running"),
+        ("str_ns", "namespace=ns-3"),
+        ("num", "restarts>=5"),
+    ] {
+        let (mut app, _rx) = bs::pods_app(n);
+        app.filter = pat.to_string();
+        black_box(app.row_count());
+        g.bench_with_input(BenchmarkId::new(label, n), &n, |b, &n| {
+            let mut i = 0usize;
+            b.iter(|| {
+                bs::touch_one(&mut app, i % n);
+                i += 1;
+                black_box(app.row_count())
+            });
+        });
+    }
+    g.finish();
+}
+
+/// 3.4 — the aggregated Helm release list. Every rebuild dedups the store
+/// down to the latest revision per release. `refilter` is the case a cache
+/// can help: the order is stale but the store has not changed, so the dedup
+/// result is still valid.
+fn helm_rows(c: &mut Criterion) {
+    let mut g = c.benchmark_group("helm_rows");
+    for n in [300usize, 1_200] {
+        let (app, _rx) = bs::helm_app(n);
+        black_box(app.row_count());
+        g.bench_with_input(BenchmarkId::new("refilter", n), &n, |b, _| {
+            b.iter(|| {
+                bs::invalidate(&app);
+                black_box(app.row_count())
+            });
+        });
+    }
+    g.finish();
+}
+
+/// 2.7 — the context switcher's fleet column: one membership test per listed
+/// context, on every frame the picker is open.
+fn fleet_marks(c: &mut Criterion) {
+    let mut g = c.benchmark_group("fleet_marks");
+    for n in [32usize, 128] {
+        let (app, _rx) = bs::contexts_app(n);
+        g.bench_with_input(BenchmarkId::new("draw", n), &n, |b, _| {
+            b.iter(|| black_box(bs::fleet_marks_for_all(&app)));
+        });
+    }
+    g.finish();
+}
+
+/// 4.3.2A — where a Helm release decode actually spends its time. Swapping in
+/// a SIMD JSON parser is only worth a dependency if the parse dominates.
+/// `full` is `helm::decode` end to end; `parse_only` is a DOM parse of the
+/// same bytes, which upper-bounds the parse share (the real code deserializes
+/// into a typed struct, which is cheaper than building a `Value`).
+fn helm_decode(c: &mut Criterion) {
+    let mut g = c.benchmark_group("helm_decode");
+    let secret = bs::helm_secret(1);
+    let json = bs::helm_release_json(1);
+    g.bench_function("full", |b| {
+        b.iter(|| black_box(sofka::helm::decode(black_box(&secret))));
+    });
+    g.bench_function("parse_only", |b| {
+        b.iter(|| {
+            let v: serde_json::Value =
+                serde_json::from_slice(black_box(&json)).expect("fixture json");
+            black_box(v)
+        });
+    });
+    g.bench_function("parse_typed", |b| {
+        b.iter(|| black_box(sofka::helm::parse_release_json(black_box(&json))));
+    });
+    g.finish();
+}
+
 criterion_group!(
     benches,
     rows_cache,
     filter,
+    filter_cmp,
+    helm_rows,
+    fleet_marks,
+    helm_decode,
     cells,
     metadata,
     log_filter,

--- a/src/app/find.rs
+++ b/src/app/find.rs
@@ -92,6 +92,9 @@ impl App {
                     Err(_) => failed += 1,
                 }
             }
+            // Stable on purpose: `FindItem::ns` is not in the tie-break, so
+            // two hits that differ only by namespace compare equal here and an
+            // unstable sort would order them arbitrarily between runs.
             scored.sort_by(|a, b| {
                 b.0.cmp(&a.0)
                     .then_with(|| a.1.name.cmp(&b.1.name))

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -31,8 +31,15 @@ impl App {
     }
 
     /// Whether `ctx` is currently part of the fleet (config + marks).
+    ///
+    /// Answers the membership question directly rather than materializing
+    /// [`Self::fleet_contexts`]: the context switcher asks this once per row
+    /// per frame, and building (and cloning into) a `Vec` per row made that
+    /// draw quadratic in allocations.
     pub fn is_fleet_context(&self, ctx: &str) -> bool {
-        self.fleet_contexts().iter().any(|c| c == ctx)
+        let listed = self.fleet_cfg.contexts.iter().any(|c| c == ctx)
+            && !self.fleet_marks.removed.iter().any(|c| c == ctx);
+        listed || self.fleet_marks.added.iter().any(|c| c == ctx)
     }
 
     /// Toggle a context in/out of the fleet (`space` in the context

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -525,7 +525,9 @@ where
             (seen.clone(), event_line(event, events_v1, &seen))
         })
         .collect();
-    rows.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    // Unstable: the comparator orders on both tuple fields, i.e. the whole
+    // element, so a tie means the two rows are indistinguishable.
+    rows.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
 
     let mut lines = vec![format!(
         "{:<20} {:<8} {:<24} {:>5} {}",

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1411,6 +1411,9 @@ fn plugin_flash(name: &str, n: usize, suffix: &str) -> String {
 /// lists (empty query: everything ties at one score) skip the length
 /// tie-break so they stay alphabetical.
 fn rank_completions<T>(scored: &mut [(i64, T)], label: fn(&T) -> &str, by_len: bool) {
+    // Stable on purpose: `T` is `Suggestion` at one call site, whose `kind` is
+    // not part of the ordering, so two suggestions sharing a label compare
+    // equal and an unstable sort could swap which one the list offers first.
     scored.sort_by(|a, b| {
         b.0.cmp(&a.0)
             .then_with(|| {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -569,6 +569,11 @@ impl App {
     /// node resources — mirroring `kubectl describe node`. Replaces a full
     /// cluster-wide pod re-list every 10s with one watch, kept incrementally
     /// up to date and coalesced to at most one `Msg::NodePods` per second.
+    ///
+    /// RBAC granting `list` but not `watch` still works: `watcher` serves the
+    /// initial list itself, so counts publish from that, and a refused watch
+    /// just sends it round again for a fresh list. Backoff is what keeps that
+    /// loop from becoming a hot retry against the API server.
     pub(super) fn spawn_node_pods_poll(&mut self) {
         let Some(pkind) = self.cluster.resolve("pods") else {
             return;
@@ -584,7 +589,12 @@ impl App {
             let cfg = watcher::Config::default()
                 .any_semantic()
                 .fields("status.phase!=Succeeded,status.phase!=Failed");
-            let mut stream = watcher(api, cfg).boxed();
+            // `watcher` re-lists as fast as the stream is polled, so an error
+            // that does not clear itself (a refused watch) would hammer the API
+            // server — measured at ~9,800 requests a second against a test
+            // server. `DefaultBackoff` is client-go's: 800ms doubling to 30s,
+            // jittered, reset after 2 minutes of quiet.
+            let mut stream = watcher(api, cfg).default_backoff().boxed();
             // Node per pod, kept incrementally so per-node counts never need
             // a full rescan of the cluster's pods.
             let mut pod_nodes: HashMap<String, String> = HashMap::new();
@@ -649,6 +659,8 @@ impl App {
                                 synced = true;
                                 dirty = true;
                             }
+                            // The stream self-heals, and the backoff above
+                            // paces the retries.
                             Err(_) => {}
                         }
                     }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -590,6 +590,11 @@ impl App {
             let mut pod_nodes: HashMap<String, String> = HashMap::new();
             let mut counts: HashMap<String, usize> = HashMap::new();
             let mut dirty = false;
+            // The initial list arrives as a stream of `InitApply`s, so the
+            // counts are incomplete until `InitDone`. Publishing mid-init
+            // would walk the PODS column up from zero on every (re)sync —
+            // the old full-list poll only ever emitted complete counts.
+            let mut synced = false;
             let mut ticker = tokio::time::interval(Duration::from_secs(1));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
@@ -638,9 +643,12 @@ impl App {
                             Ok(watcher::Event::Init) => {
                                 pod_nodes.clear();
                                 counts.clear();
+                                synced = false;
+                            }
+                            Ok(watcher::Event::InitDone) => {
+                                synced = true;
                                 dirty = true;
                             }
-                            Ok(watcher::Event::InitDone) => dirty = true,
                             Err(_) => {}
                         }
                     }
@@ -648,7 +656,7 @@ impl App {
                         if flag.load(Ordering::SeqCst) != genr {
                             break;
                         }
-                        if dirty {
+                        if dirty && synced {
                             if tx
                                 .send(Msg::NodePods {
                                     generation: genr,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -564,10 +564,11 @@ impl App {
         self.tasks.push(handle);
     }
 
-    /// Poll the pods API for the nodes view: pod count per node (the PODS
+    /// Watch the pods API for the nodes view: pod count per node (the PODS
     /// column). Counts non-terminated pods — Succeeded/Failed pods hold no
-    /// node resources — mirroring `kubectl describe node`. List failures
-    /// (e.g. no cluster-wide pod list permission) leave the column at "-".
+    /// node resources — mirroring `kubectl describe node`. Replaces a full
+    /// cluster-wide pod re-list every 10s with one watch, kept incrementally
+    /// up to date and coalesced to at most one `Msg::NodePods` per second.
     pub(super) fn spawn_node_pods_poll(&mut self) {
         let Some(pkind) = self.cluster.resolve("pods") else {
             return;
@@ -579,36 +580,89 @@ impl App {
         let ar = pkind.ar.clone();
 
         let handle = tokio::spawn(async move {
-            let params =
-                ListParams::default().fields("status.phase!=Succeeded,status.phase!=Failed");
+            let api: Api<DynamicObject> = Api::all_with(client, &ar);
+            let cfg = watcher::Config::default()
+                .any_semantic()
+                .fields("status.phase!=Succeeded,status.phase!=Failed");
+            let mut stream = watcher(api, cfg).boxed();
+            // Node per pod, kept incrementally so per-node counts never need
+            // a full rescan of the cluster's pods.
+            let mut pod_nodes: HashMap<String, String> = HashMap::new();
+            let mut counts: HashMap<String, usize> = HashMap::new();
+            let mut dirty = false;
+            let mut ticker = tokio::time::interval(Duration::from_secs(1));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
-                if flag.load(Ordering::SeqCst) != genr {
-                    break;
-                }
-                let api: Api<DynamicObject> = Api::all_with(client.clone(), &ar);
-                if let Ok(list) = api.list(&params).await {
-                    let mut counts: HashMap<String, usize> = HashMap::new();
-                    for item in list {
-                        if let Some(node) = item
-                            .data
-                            .pointer("/spec/nodeName")
-                            .and_then(serde_json::Value::as_str)
-                        {
-                            *counts.entry(node.to_string()).or_insert(0) += 1;
+                tokio::select! {
+                    maybe_event = stream.next() => {
+                        let Some(event) = maybe_event else { break };
+                        if flag.load(Ordering::SeqCst) != genr {
+                            break;
+                        }
+                        let retire = |node: &str, counts: &mut HashMap<String, usize>| {
+                            if let Some(c) = counts.get_mut(node) {
+                                *c = c.saturating_sub(1);
+                                if *c == 0 {
+                                    counts.remove(node);
+                                }
+                            }
+                        };
+                        match event {
+                            Ok(watcher::Event::Apply(obj)) | Ok(watcher::Event::InitApply(obj)) => {
+                                let key = row_key(&obj);
+                                let new_node = obj
+                                    .data
+                                    .pointer("/spec/nodeName")
+                                    .and_then(serde_json::Value::as_str)
+                                    .map(str::to_string);
+                                let old_node = match &new_node {
+                                    Some(n) => pod_nodes.insert(key, n.clone()),
+                                    None => pod_nodes.remove(&key),
+                                };
+                                if old_node != new_node {
+                                    if let Some(old) = &old_node {
+                                        retire(old, &mut counts);
+                                    }
+                                    if let Some(new) = &new_node {
+                                        *counts.entry(new.clone()).or_insert(0) += 1;
+                                    }
+                                    dirty = true;
+                                }
+                            }
+                            Ok(watcher::Event::Delete(obj)) => {
+                                if let Some(old) = pod_nodes.remove(&row_key(&obj)) {
+                                    retire(&old, &mut counts);
+                                    dirty = true;
+                                }
+                            }
+                            Ok(watcher::Event::Init) => {
+                                pod_nodes.clear();
+                                counts.clear();
+                                dirty = true;
+                            }
+                            Ok(watcher::Event::InitDone) => dirty = true,
+                            Err(_) => {}
                         }
                     }
-                    if tx
-                        .send(Msg::NodePods {
-                            generation: genr,
-                            counts,
-                        })
-                        .await
-                        .is_err()
-                    {
-                        break;
+                    _ = ticker.tick() => {
+                        if flag.load(Ordering::SeqCst) != genr {
+                            break;
+                        }
+                        if dirty {
+                            if tx
+                                .send(Msg::NodePods {
+                                    generation: genr,
+                                    counts: counts.clone(),
+                                })
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                            dirty = false;
+                        }
                     }
                 }
-                tokio::time::sleep(Duration::from_secs(10)).await;
             }
         });
         self.tasks.push(handle);

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+fn node_pods_watch_forbidden(error: &watcher::Error) -> bool {
+    match error {
+        watcher::Error::InitialListFailed(kube::Error::Api(status))
+        | watcher::Error::WatchStartFailed(kube::Error::Api(status))
+        | watcher::Error::WatchFailed(kube::Error::Api(status)) => status.is_forbidden(),
+        watcher::Error::WatchError(status) => status.is_forbidden(),
+        _ => false,
+    }
+}
+
 impl App {
     // ----- navigation ----------------------------------------------------
 
@@ -570,10 +580,9 @@ impl App {
     /// cluster-wide pod re-list every 10s with one watch, kept incrementally
     /// up to date and coalesced to at most one `Msg::NodePods` per second.
     ///
-    /// RBAC granting `list` but not `watch` still works: `watcher` serves the
-    /// initial list itself, so counts publish from that, and a refused watch
-    /// just sends it round again for a fresh list. Backoff is what keeps that
-    /// loop from becoming a hot retry against the API server.
+    /// RBAC granting `list` but not `watch` still works: a refused watch falls
+    /// back to the old 10-second list poll. Other transient watcher failures
+    /// use client-go's backoff while the stream heals itself.
     pub(super) fn spawn_node_pods_poll(&mut self) {
         let Some(pkind) = self.cluster.resolve("pods") else {
             return;
@@ -594,7 +603,7 @@ impl App {
             // server — measured at ~9,800 requests a second against a test
             // server. `DefaultBackoff` is client-go's: 800ms doubling to 30s,
             // jittered, reset after 2 minutes of quiet.
-            let mut stream = watcher(api, cfg).default_backoff().boxed();
+            let mut stream = watcher(api.clone(), cfg).default_backoff().boxed();
             // Node per pod, kept incrementally so per-node counts never need
             // a full rescan of the cluster's pods.
             let mut pod_nodes: HashMap<String, String> = HashMap::new();
@@ -607,6 +616,7 @@ impl App {
             let mut synced = false;
             let mut ticker = tokio::time::interval(Duration::from_secs(1));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut poll_fallback = false;
             loop {
                 tokio::select! {
                     maybe_event = stream.next() => {
@@ -659,8 +669,19 @@ impl App {
                                 synced = true;
                                 dirty = true;
                             }
+                            // A list-only RBAC grant cannot maintain counts via
+                            // this watcher: after a refused watch, kube retries
+                            // that watch from the same resourceVersion rather
+                            // than re-listing. Restore the periodic list path in
+                            // that case. This also paces a refused initial list,
+                            // whose preceding `Init` event would otherwise keep
+                            // resetting `DefaultBackoff` to its minimum delay.
+                            Err(error) if node_pods_watch_forbidden(&error) => {
+                                poll_fallback = true;
+                                break;
+                            }
                             // The stream self-heals, and the backoff above
-                            // paces the retries.
+                            // paces other transient failures.
                             Err(_) => {}
                         }
                     }
@@ -683,6 +704,41 @@ impl App {
                         }
                     }
                 }
+            }
+
+            if !poll_fallback {
+                return;
+            }
+
+            let params =
+                ListParams::default().fields("status.phase!=Succeeded,status.phase!=Failed");
+            loop {
+                if flag.load(Ordering::SeqCst) != genr {
+                    break;
+                }
+                if let Ok(list) = api.list(&params).await {
+                    let mut counts: HashMap<String, usize> = HashMap::new();
+                    for item in list {
+                        if let Some(node) = item
+                            .data
+                            .pointer("/spec/nodeName")
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            *counts.entry(node.to_string()).or_insert(0) += 1;
+                        }
+                    }
+                    if tx
+                        .send(Msg::NodePods {
+                            generation: genr,
+                            counts,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(10)).await;
             }
         });
         self.tasks.push(handle);

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Fallback delay if the watcher backoff ever runs out of steps. `DefaultBackoff`
+/// is unbounded in attempts, so this is belt and braces rather than a real path.
+const NODE_PODS_BACKOFF_CEILING: Duration = Duration::from_secs(30);
+
 fn node_pods_watch_forbidden(error: &watcher::Error) -> bool {
     match error {
         watcher::Error::InitialListFailed(kube::Error::Api(status))
@@ -599,11 +603,20 @@ impl App {
                 .any_semantic()
                 .fields("status.phase!=Succeeded,status.phase!=Failed");
             // `watcher` re-lists as fast as the stream is polled, so an error
-            // that does not clear itself (a refused watch) would hammer the API
-            // server — measured at ~9,800 requests a second against a test
-            // server. `DefaultBackoff` is client-go's: 800ms doubling to 30s,
-            // jittered, reset after 2 minutes of quiet.
-            let mut stream = watcher(api.clone(), cfg).default_backoff().boxed();
+            // that does not clear itself would hammer the API server —
+            // measured at ~9,800 requests a second against a test server.
+            //
+            // The pacing is driven here rather than through `.default_backoff()`
+            // because that wrapper resets on *any* `Ok` item, and `watcher`
+            // emits `Ok(Event::Init)` before every list attempt. A failing
+            // initial list therefore cycles `Init -> error -> minimum delay`
+            // forever and never escalates, which is worse than the 10s list
+            // poll it replaced. The strategy is still client-go's — 800ms
+            // doubling to 30s, jittered, self-resetting after 2 minutes of
+            // quiet — but it is reset only once the stream has actually got
+            // somewhere: see `established` below.
+            let mut stream = watcher(api.clone(), cfg).boxed();
+            let mut backoff = watcher::DefaultBackoff::default();
             // Node per pod, kept incrementally so per-node counts never need
             // a full rescan of the cluster's pods.
             let mut pod_nodes: HashMap<String, String> = HashMap::new();
@@ -632,6 +645,19 @@ impl App {
                                 }
                             }
                         };
+                        // Progress, as opposed to another doomed list attempt.
+                        // `Init` and the `InitApply`s behind it are replayed on
+                        // every attempt, so resetting on those is exactly the
+                        // mistake `.default_backoff()` makes.
+                        let established = matches!(
+                            event,
+                            Ok(watcher::Event::Apply(_)
+                                | watcher::Event::Delete(_)
+                                | watcher::Event::InitDone)
+                        );
+                        if established {
+                            backoff.reset();
+                        }
                         match event {
                             Ok(watcher::Event::Apply(obj)) | Ok(watcher::Event::InitApply(obj)) => {
                                 let key = row_key(&obj);
@@ -673,16 +699,21 @@ impl App {
                             // this watcher: after a refused watch, kube retries
                             // that watch from the same resourceVersion rather
                             // than re-listing. Restore the periodic list path in
-                            // that case. This also paces a refused initial list,
-                            // whose preceding `Init` event would otherwise keep
-                            // resetting `DefaultBackoff` to its minimum delay.
+                            // that case.
                             Err(error) if node_pods_watch_forbidden(&error) => {
                                 poll_fallback = true;
                                 break;
                             }
-                            // The stream self-heals, and the backoff above
-                            // paces other transient failures.
-                            Err(_) => {}
+                            // Everything else is transient and the stream heals
+                            // itself, so pace the next attempt and stay on the
+                            // watch. Sleeping here also stops publishing while
+                            // the counts are going nowhere; `dirty` survives, so
+                            // the next tick after recovery still emits.
+                            Err(_) => {
+                                let delay =
+                                    backoff.next().unwrap_or(NODE_PODS_BACKOFF_CEILING);
+                                tokio::time::sleep(delay).await;
+                            }
                         }
                     }
                     _ = ticker.tick() => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,7 @@
 //! drills into a child (workload -> pods, pod -> containers, namespace ->
 //! re-scope the previous view), and `esc` pops back.
 
+use std::borrow::Cow;
 use std::cell::{Ref, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
@@ -34,6 +35,17 @@ use crate::k8s::{Cluster, Kind};
 use crate::store::{Msg, Pulse, RowKey, Store, StoreMutation, XrayItem, row_key};
 
 pub(crate) use guardrails::ConfirmLevel;
+
+impl App {
+    /// Mark the row ordering stale without touching the store — the shape of a
+    /// filter keystroke or a sort toggle. `invalidate_rows` is `pub(super)`;
+    /// this exposes it to `benchsupport` under the bench feature only, rather
+    /// than widening it for the shipped binary.
+    #[cfg(feature = "bench")]
+    pub fn bench_invalidate_rows(&self) {
+        self.invalidate_rows();
+    }
+}
 
 /// Larger cap used while autoscroll is paused: we stop trimming so the line
 /// indices don't shift under the frozen view (which would make it appear to
@@ -1025,6 +1037,10 @@ struct RowsCache {
     /// Computed primary sort keys, valid per (sort header, resourceVersion) —
     /// a rebuild touches every object, but only changed rows re-extract.
     sort_keys: HashMap<RowKey, SortKeyEntry>,
+    /// Helm view only: the latest-revision dedup, paired with the store
+    /// version it was computed from. A rebuild staled by a filter keystroke or
+    /// a sort toggle leaves the store untouched, so the dedup still holds.
+    helm_latest: Option<(u64, HashSet<RowKey>)>,
 }
 
 struct CellCacheEntry {
@@ -1635,6 +1651,7 @@ impl App {
                 keys: Vec::new(),
                 cells: HashMap::new(),
                 sort_keys: HashMap::new(),
+                helm_latest: None,
             }),
             log_provider: None,
             metrics_provider: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,7 +25,7 @@ use kube::api::{
 };
 use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;
-use kube::runtime::{WatchStreamExt, watcher};
+use kube::runtime::{utils::Backoff, watcher};
 use ratatui::widgets::{ListState, TableState};
 use serde_json::{Value, json};
 use tokio::sync::mpsc::Sender;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,7 +25,7 @@ use kube::api::{
 };
 use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;
-use kube::runtime::watcher;
+use kube::runtime::{WatchStreamExt, watcher};
 use ratatui::widgets::{ListState, TableState};
 use serde_json::{Value, json};
 use tokio::sync::mpsc::Sender;

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -193,14 +193,15 @@ impl App {
                     .eval(crate::columns::parse_leading_num(&cell).total_cmp(want)),
                 None => false,
             },
-            // `want` is already case-folded by the parser and the cell is
-            // folded lazily through the iterator, so a text comparison
-            // allocates nothing per object. UTF-8 orders by code point, so
-            // comparing `char`s matches what comparing the folded `str`s did.
+            // `want` was folded once at parse time and the cell is folded
+            // lazily through the iterator, so a text comparison allocates
+            // nothing per object. UTF-8 orders by code point, so comparing
+            // `char`s matches what comparing the folded `str`s did. Both sides
+            // go through `fold_lower` — see there for why that matters.
             CmpValue::Str(want) => match self.column_cell(o, &cmp.key) {
                 Some(cell) => cmp
                     .op
-                    .eval(cell.chars().flat_map(char::to_lowercase).cmp(want.chars())),
+                    .eval(crate::filter::fold_lower(&cell).cmp(want.chars())),
                 None => false,
             },
         }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -376,13 +376,33 @@ impl App {
         // leaves far more cells than keys. Bounding against `keys` there
         // evicted the whole cache on every rebuild and re-rendered every
         // row's cells on the next one.
-        if cache.cells.len() > self.store.len().saturating_mul(2).max(64) {
+        //
+        // The two maps are filled by different paths — cells by the filter,
+        // sort keys by the sort — so they are checked independently rather
+        // than one standing in for the other.
+        let bound = self.store.len().saturating_mul(2).max(64);
+        if cache.cells.len() > bound {
             cache
                 .cells
                 .retain(|k, _| self.store.get(k.as_ref()).is_some());
+        }
+        if cache.sort_keys.len() > bound {
             cache
                 .sort_keys
                 .retain(|k, _| self.store.get(k.as_ref()).is_some());
+        }
+        // Emptying a map does not hand its table back, and `invalidate_row`
+        // already drops a deleted row's entries one at a time — so after a
+        // 20k-pod namespace is left for one holding 50, length says nothing
+        // and only capacity still shows the 20k-slot allocation. Shrink only
+        // when the table dwarfs the view (4x), and shrink to `bound` rather
+        // than to fit, so the next rebuild does not trip the same check and
+        // rehash again.
+        if cache.cells.capacity() > bound.saturating_mul(4) {
+            cache.cells.shrink_to(bound);
+        }
+        if cache.sort_keys.capacity() > bound.saturating_mul(4) {
+            cache.sort_keys.shrink_to(bound);
         }
     }
 

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -12,6 +12,7 @@ impl App {
         cache.keys.clear();
         cache.cells.clear();
         cache.sort_keys.clear();
+        cache.helm_latest = None;
     }
 
     pub(super) fn invalidate_row(&self, key: &str) {
@@ -192,8 +193,14 @@ impl App {
                     .eval(crate::columns::parse_leading_num(&cell).total_cmp(want)),
                 None => false,
             },
+            // `want` is already case-folded by the parser and the cell is
+            // folded lazily through the iterator, so a text comparison
+            // allocates nothing per object. UTF-8 orders by code point, so
+            // comparing `char`s matches what comparing the folded `str`s did.
             CmpValue::Str(want) => match self.column_cell(o, &cmp.key) {
-                Some(cell) => cmp.op.eval(cell.to_lowercase().cmp(&want.to_lowercase())),
+                Some(cell) => cmp
+                    .op
+                    .eval(cell.chars().flat_map(char::to_lowercase).cmp(want.chars())),
                 None => false,
             },
         }
@@ -203,16 +210,18 @@ impl App {
     /// header), plus NAMESPACE and a `/status/phase` fallback for kinds
     /// without a STATUS column. Extracts only the named column — this runs
     /// per object per rebuild when a structured filter is active.
-    fn column_cell(&self, o: &DynamicObject, key: &str) -> Option<String> {
+    fn column_cell<'o>(&self, o: &'o DynamicObject, key: &str) -> Option<Cow<'o, str>> {
         if key.eq_ignore_ascii_case("namespace") || key.eq_ignore_ascii_case("ns") {
-            return Some(o.metadata.namespace.clone().unwrap_or_default());
+            // Borrowed: the namespace is already a `String` on the object, and
+            // this runs per object per rebuild.
+            return Some(o.metadata.namespace.as_deref().unwrap_or("").into());
         }
         if let Some(i) = self.spec.header_index(key) {
-            return self.spec.cell_at(o, i);
+            return self.spec.cell_at(o, i).map(Cow::Owned);
         }
         if key.eq_ignore_ascii_case("status") {
             let phase = phase(o);
-            return (!phase.is_empty()).then_some(phase);
+            return (!phase.is_empty()).then_some(Cow::Owned(phase));
         }
         None
     }
@@ -267,22 +276,39 @@ impl App {
         // The aggregated Helm release list (`helm list` semantics) shows only
         // the latest revision per release; `helmhistory` (one release's full
         // history) shows every revision, so it skips this.
-        let helm_latest = (self.kind_plural == "helm").then(|| self.helm_latest_revision_keys());
+        // Recomputed only when the store actually moved: a rebuild staled by a
+        // filter keystroke or a sort toggle reuses the previous dedup.
+        if self.kind_plural == "helm" {
+            let version = self.store.version();
+            if cache
+                .helm_latest
+                .as_ref()
+                .is_none_or(|(v, _)| *v != version)
+            {
+                cache.helm_latest = Some((version, self.helm_latest_revision_keys()));
+            }
+        } else if cache.helm_latest.is_some() {
+            cache.helm_latest = None;
+        }
         // Parsed once, not once per object: the filter check used to re-borrow
         // the filter cache and re-compare the raw filter string for every row.
         let parsed = self.parsed_filter();
         // Disjoint field borrows so the filter can warm the cell cache while
         // the sort-key cache is also held.
         let RowsCache {
-            cells, sort_keys, ..
+            cells,
+            sort_keys,
+            helm_latest,
+            ..
         } = &mut *cache;
+        let helm_latest = helm_latest.as_ref().map(|(_, keys)| keys);
 
         // (primary sort key, (ns, name) tiebreak, store key)
         let empty_sort: Rc<str> = Rc::from("");
         let mut entries: Vec<(SortKey, (&str, &str), &RowKey)> =
             Vec::with_capacity(self.store.len());
         for (k, o) in self.store.iter() {
-            if let Some(keep) = &helm_latest
+            if let Some(keep) = helm_latest
                 && !keep.contains(k)
             {
                 continue;
@@ -344,11 +370,19 @@ impl App {
         // `clear_rows_cache` on a view change — bound their growth once they
         // have drifted well past what the current view needs (stale entries
         // for rows removed one-by-one mid-view, rather than by a view
-        // switch). A no-op when the cache already tracks the store 1:1.
-        if cache.cells.len() > cache.keys.len().saturating_mul(2).max(64) {
-            let live: HashSet<RowKey> = cache.keys.iter().cloned().collect();
-            cache.cells.retain(|k, _| live.contains(k));
-            cache.sort_keys.retain(|k, _| live.contains(k));
+        // switch). The bound is the *store* size, not the visible row count:
+        // the filter path warms a cell entry for every object it tests,
+        // including the ones it rejects, so a narrow filter legitimately
+        // leaves far more cells than keys. Bounding against `keys` there
+        // evicted the whole cache on every rebuild and re-rendered every
+        // row's cells on the next one.
+        if cache.cells.len() > self.store.len().saturating_mul(2).max(64) {
+            cache
+                .cells
+                .retain(|k, _| self.store.get(k.as_ref()).is_some());
+            cache
+                .sort_keys
+                .retain(|k, _| self.store.get(k.as_ref()).is_some());
         }
     }
 
@@ -646,7 +680,7 @@ impl App {
             // timestamp, never the rendered string. Negated epoch seconds so
             // ascending = most recent first, matching AGE; unknowns last.
             "UPDATED" => SortKey::Num(
-                crate::helm::decode(o)
+                crate::helm::decode_summary(o)
                     .and_then(|r| r.last_deployed_secs)
                     .map(|s| -(s as f64))
                     .unwrap_or(f64::INFINITY),

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -193,15 +193,11 @@ impl App {
                     .eval(crate::columns::parse_leading_num(&cell).total_cmp(want)),
                 None => false,
             },
-            // `want` was folded once at parse time and the cell is folded
-            // lazily through the iterator, so a text comparison allocates
-            // nothing per object. UTF-8 orders by code point, so comparing
-            // `char`s matches what comparing the folded `str`s did. Both sides
-            // go through `fold_lower` — see there for why that matters.
+            // `want` was folded once at parse time. ASCII cells compare through
+            // an allocation-free byte iterator; non-ASCII cells use
+            // whole-string lowercasing for context-sensitive Unicode mappings.
             CmpValue::Str(want) => match self.column_cell(o, &cmp.key) {
-                Some(cell) => cmp
-                    .op
-                    .eval(crate::filter::fold_lower(&cell).cmp(want.chars())),
+                Some(cell) => cmp.op.eval(crate::filter::cmp_folded_lower(&cell, want)),
                 None => false,
             },
         }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -339,6 +339,17 @@ impl App {
         });
         cache.keys = entries.into_iter().map(|(_, _, k)| k.clone()).collect();
         cache.dirty = false;
+
+        // `cells`/`sort_keys` are otherwise only ever cleared wholesale by
+        // `clear_rows_cache` on a view change — bound their growth once they
+        // have drifted well past what the current view needs (stale entries
+        // for rows removed one-by-one mid-view, rather than by a view
+        // switch). A no-op when the cache already tracks the store 1:1.
+        if cache.cells.len() > cache.keys.len().saturating_mul(2).max(64) {
+            let live: HashSet<RowKey> = cache.keys.iter().cloned().collect();
+            cache.cells.retain(|k, _| live.contains(k));
+            cache.sort_keys.retain(|k, _| live.contains(k));
+        }
     }
 
     /// Store keys of the highest-revision secret per (namespace, release) —

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -30,11 +30,17 @@ fn alt(code: KeyCode) -> KeyEvent {
 async fn mock_pods_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-    const POD_LIST: &str = concat!(
+    const POD_LIST_INITIAL: &str = concat!(
         r#"{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"7"},"items":["#,
         r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","resourceVersion":"1"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
         r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"b","namespace":"default","resourceVersion":"2"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
         r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"c","namespace":"default","resourceVersion":"3"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}}"#,
+        r#"]}"#
+    );
+    const POD_LIST_UPDATED: &str = concat!(
+        r#"{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"8"},"items":["#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"c","namespace":"default","resourceVersion":"4"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}},"#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"d","namespace":"default","resourceVersion":"5"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}}"#,
         r#"]}"#
     );
     const FORBIDDEN: &str = r#"{"kind":"Status","apiVersion":"v1","status":"Failure","message":"pods is forbidden: cannot watch at the cluster scope","reason":"Forbidden","code":403}"#;
@@ -69,12 +75,21 @@ async fn mock_pods_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
                     .nth(1)
                     .unwrap_or("")
                     .to_string();
+                let list_number = {
+                    let mut requests = seen.lock().unwrap();
+                    requests.push(path.clone());
+                    requests
+                        .iter()
+                        .filter(|p| !p.contains("watch=true"))
+                        .count()
+                };
                 let (status, body) = if path.contains("watch=true") {
                     ("403 Forbidden", FORBIDDEN)
+                } else if list_number == 1 {
+                    ("200 OK", POD_LIST_INITIAL)
                 } else {
-                    ("200 OK", POD_LIST)
+                    ("200 OK", POD_LIST_UPDATED)
                 };
-                seen.lock().unwrap().push(path);
                 let response = format!(
                     "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
                     body.len()
@@ -98,9 +113,10 @@ fn mock_cluster(url: &str) -> Cluster {
     cluster
 }
 
-/// RBAC granting `list` but not `watch`. `watcher` serves the initial list
-/// itself, so the counts still arrive; the risk is the refused watch spinning
-/// the list-watch cycle as fast as the API server can answer it.
+/// RBAC granting `list` but not `watch`. The first list seeds counts, then the
+/// refused watch must switch to periodic lists: kube's watcher retries only
+/// the watch from the same resourceVersion, so it cannot provide that fallback
+/// itself. The mock changes its list response to prove counts remain fresh.
 #[tokio::test]
 async fn node_pods_survives_a_forbidden_watch_without_hammering_the_api() {
     let (url, seen) = mock_pods_api().await;
@@ -109,34 +125,29 @@ async fn node_pods_survives_a_forbidden_watch_without_hammering_the_api() {
 
     app.spawn_node_pods_poll();
 
-    let counts = loop {
-        let msg = tokio::time::timeout(std::time::Duration::from_secs(60), rx.recv())
-            .await
-            .expect("no NodePods message before the timeout")
-            .expect("channel closed");
-        if let Msg::NodePods { counts, .. } = msg {
-            break counts;
+    let counts = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let msg = rx.recv().await.expect("channel closed");
+            if let Msg::NodePods { counts, .. } = msg
+                && !counts.contains_key("node-a")
+                && counts.get("node-b") == Some(&2)
+            {
+                break counts;
+            }
         }
-    };
-    assert_eq!(counts.get("node-a"), Some(&2), "counts: {counts:?}");
-    assert_eq!(counts.get("node-b"), Some(&1), "counts: {counts:?}");
+    })
+    .await
+    .expect("periodic-list fallback did not publish refreshed counts");
+    assert_eq!(counts.len(), 1, "counts: {counts:?}");
 
-    // Now let the refused watch keep failing for a while. Unbackoffed, the
-    // cycle re-lists as fast as the server answers.
+    // Now let the fallback hold for a while. It must neither retry the refused
+    // watch nor start polling faster than its 10-second interval.
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    let watch_attempts = seen
-        .lock()
-        .unwrap()
-        .iter()
-        .filter(|p| p.contains("watch=true"))
-        .count();
-    // Backoff holds this to a couple of attempts; without it the same second
-    // measured ~9,800 — a hot retry loop against the API server for as long as
-    // the nodes view stays open.
-    assert!(
-        watch_attempts <= 10,
-        "the refused watch must be paced by backoff, saw {watch_attempts} attempts in ~1s"
-    );
+    let requests = seen.lock().unwrap();
+    let watch_attempts = requests.iter().filter(|p| p.contains("watch=true")).count();
+    let list_attempts = requests.len() - watch_attempts;
+    assert_eq!(watch_attempts, 1, "fallback must stop retrying the watch");
+    assert_eq!(list_attempts, 2, "fallback should wait 10s between lists");
 }
 
 /// The row cache's cleanup pass runs at the end of a rebuild; it must both

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24,6 +24,185 @@ fn alt(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::ALT)
 }
 
+/// A stand-in API server for the nodes view's pod counter: the *watch* is
+/// refused, the plain *list* succeeds. That is the RBAC shape — `list` granted,
+/// `watch` not — the poll fallback exists for. Records every request path.
+async fn mock_pods_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    const POD_LIST: &str = concat!(
+        r#"{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"7"},"items":["#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","resourceVersion":"1"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"b","namespace":"default","resourceVersion":"2"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"c","namespace":"default","resourceVersion":"3"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}}"#,
+        r#"]}"#
+    );
+    const FORBIDDEN: &str = r#"{"kind":"Status","apiVersion":"v1","status":"Failure","message":"pods is forbidden: cannot watch at the cluster scope","reason":"Forbidden","code":403}"#;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock pods api");
+    let addr = listener.local_addr().expect("local addr");
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = Arc::clone(&requests);
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let seen = Arc::clone(&seen);
+            tokio::spawn(async move {
+                let (r, mut w) = sock.split();
+                let mut reader = BufReader::new(r);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).await.unwrap_or(0) == 0 {
+                    return;
+                }
+                loop {
+                    let mut header = String::new();
+                    if reader.read_line(&mut header).await.unwrap_or(0) == 0 || header == "\r\n" {
+                        break;
+                    }
+                }
+                let path = request_line
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap_or("")
+                    .to_string();
+                let (status, body) = if path.contains("watch=true") {
+                    ("403 Forbidden", FORBIDDEN)
+                } else {
+                    ("200 OK", POD_LIST)
+                };
+                seen.lock().unwrap().push(path);
+                let response = format!(
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = w.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    (format!("http://{addr}"), requests)
+}
+
+/// A `Cluster` whose client talks to `url` instead of a real API server.
+fn mock_cluster(url: &str) -> Cluster {
+    let mut config = kube::Config::new(url.parse().expect("mock url"));
+    // The client's own retry policy would turn each 403 into a long stall;
+    // this test is about the app's fallback, not the client's retries.
+    config.default_retry = false;
+    let mut cluster = Cluster::fake();
+    cluster.client = Client::try_from(config).expect("mock client");
+    cluster.cluster_url = url.into();
+    cluster
+}
+
+/// RBAC granting `list` but not `watch`. `watcher` serves the initial list
+/// itself, so the counts still arrive; the risk is the refused watch spinning
+/// the list-watch cycle as fast as the API server can answer it.
+#[tokio::test]
+async fn node_pods_survives_a_forbidden_watch_without_hammering_the_api() {
+    let (url, seen) = mock_pods_api().await;
+    let (tx, mut rx) = mpsc::channel(1024);
+    let mut app = App::new(mock_cluster(&url), tx);
+
+    app.spawn_node_pods_poll();
+
+    let counts = loop {
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(60), rx.recv())
+            .await
+            .expect("no NodePods message before the timeout")
+            .expect("channel closed");
+        if let Msg::NodePods { counts, .. } = msg {
+            break counts;
+        }
+    };
+    assert_eq!(counts.get("node-a"), Some(&2), "counts: {counts:?}");
+    assert_eq!(counts.get("node-b"), Some(&1), "counts: {counts:?}");
+
+    // Now let the refused watch keep failing for a while. Unbackoffed, the
+    // cycle re-lists as fast as the server answers.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let watch_attempts = seen
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|p| p.contains("watch=true"))
+        .count();
+    // Backoff holds this to a couple of attempts; without it the same second
+    // measured ~9,800 — a hot retry loop against the API server for as long as
+    // the nodes view stays open.
+    assert!(
+        watch_attempts <= 10,
+        "the refused watch must be paced by backoff, saw {watch_attempts} attempts in ~1s"
+    );
+}
+
+/// The row cache's cleanup pass runs at the end of a rebuild; it must both
+/// drop stale entries and hand the memory back. `retain` on its own keeps the
+/// peak allocation, which is the whole point of the bound.
+#[tokio::test]
+async fn row_cache_releases_capacity_after_a_large_view_contracts() {
+    let (mut app, _rx) = test_app();
+    // A filter is what fills `cells`: every object it tests gets an entry,
+    // including the ones it rejects.
+    app.filter = "zzz-matches-nothing".into();
+    for i in 0..2_000 {
+        apply(
+            &mut app,
+            serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": format!("pod-{i:05}"),
+                    "namespace": "default",
+                    "resourceVersion": format!("{i}"),
+                },
+                "status": {"phase": "Running"},
+            }),
+        );
+    }
+    assert_eq!(app.row_count(), 0, "filter matches nothing");
+    let peak = app.rows_cache.borrow().cells.capacity();
+    assert!(peak >= 2_000, "cells cached an entry per tested object");
+
+    for i in 0..1_990 {
+        app.handle_msg(Msg::Deleted {
+            generation: app.generation,
+            key: format!("default/pod-{i:05}"),
+        });
+    }
+    app.row_count();
+
+    let cache = app.rows_cache.borrow();
+    assert!(
+        cache.cells.len() <= 10,
+        "stale entries dropped, got {}",
+        cache.cells.len()
+    );
+    assert!(
+        cache.cells.capacity() < peak / 2,
+        "capacity must be handed back, not just emptied: {} -> {}",
+        peak,
+        cache.cells.capacity()
+    );
+    let settled = cache.cells.capacity();
+    drop(cache);
+
+    // ...and then hold still. Shrinking to a capacity that immediately trips
+    // the same check again would rehash the table on every single rebuild.
+    for _ in 0..3 {
+        app.invalidate_rows();
+        app.row_count();
+    }
+    assert_eq!(
+        app.rows_cache.borrow().cells.capacity(),
+        settled,
+        "the shrink must settle, not re-fire on every rebuild"
+    );
+}
+
 /// Inject a watched object as the current generation would.
 fn apply(app: &mut App, v: serde_json::Value) {
     let o = obj(v);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4168,6 +4168,35 @@ async fn helm_list_shows_only_latest_revision_per_release() {
     assert_eq!(cells[3], "mychart-1.0.0");
 }
 
+/// The latest-revision dedup is cached against the store's mutation counter,
+/// so a rebuild staled by a filter or sort reuses it. A new revision arriving
+/// *after* the rows were read must still invalidate it.
+#[tokio::test]
+async fn helm_list_dedup_refreshes_when_a_new_revision_arrives() {
+    let (mut app, _rx) = test_app();
+    app.open_helm_releases();
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 1, "deployed"),
+    );
+    // Read once so the dedup is cached, then supersede it.
+    assert_eq!(app.rows().len(), 1);
+    assert_eq!(crate::helm::revision(app.rows()[0]), Some(1));
+
+    apply(
+        &mut app,
+        helm_release_secret("myapp", "default", 2, "deployed"),
+    );
+
+    let rows = app.rows();
+    assert_eq!(rows.len(), 1, "still one row per release");
+    assert_eq!(
+        crate::helm::revision(rows[0]),
+        Some(2),
+        "a cached dedup must not pin the superseded revision"
+    );
+}
+
 #[tokio::test]
 async fn helm_filter_matches_release_name_not_secret_name() {
     let (mut app, _rx) = test_app();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::store::row_key;
 use serde_json::json;
+use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver};
 
 fn obj(v: serde_json::Value) -> DynamicObject {
@@ -101,6 +102,167 @@ async fn mock_pods_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
     (format!("http://{addr}"), requests)
 }
 
+/// A stand-in API server that serves a real list *and* a real watch stream, so
+/// the incremental counting path can be driven event by event. `lists` supplies
+/// one body per list attempt (the last repeats), which is what lets a resync
+/// return a different pod set. The returned sender pushes raw watch frames;
+/// dropping it ends the stream.
+async fn mock_pods_stream_api(
+    lists: Vec<&'static str>,
+) -> (
+    String,
+    mpsc::Sender<String>,
+    Arc<std::sync::Mutex<Vec<String>>>,
+) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock pods api");
+    let addr = listener.local_addr().expect("local addr");
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = Arc::clone(&requests);
+    let (frame_tx, frame_rx) = mpsc::channel::<String>(64);
+    let frames = Arc::new(tokio::sync::Mutex::new(Some(frame_rx)));
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let seen = Arc::clone(&seen);
+            let frames = Arc::clone(&frames);
+            let lists = lists.clone();
+            tokio::spawn(async move {
+                let (r, mut w) = sock.split();
+                let mut reader = BufReader::new(r);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).await.unwrap_or(0) == 0 {
+                    return;
+                }
+                loop {
+                    let mut header = String::new();
+                    if reader.read_line(&mut header).await.unwrap_or(0) == 0 || header == "\r\n" {
+                        break;
+                    }
+                }
+                let path = request_line
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap_or("")
+                    .to_string();
+                let list_number = {
+                    let mut requests = seen.lock().unwrap();
+                    requests.push(path.clone());
+                    requests
+                        .iter()
+                        .filter(|p| !p.contains("watch=true"))
+                        .count()
+                };
+
+                if path.contains("watch=true") {
+                    // Chunked, so the connection stays open and `watcher` reads
+                    // newline-delimited frames off it as they are pushed.
+                    let _ = w
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ntransfer-encoding: chunked\r\n\r\n",
+                        )
+                        .await;
+                    // Only the first watch is scripted. A re-watch after the
+                    // scripted stream ends just parks, so the test observes the
+                    // resync rather than a reconnect loop.
+                    let scripted = frames.lock().await.take();
+                    match scripted {
+                        Some(mut rx) => {
+                            while let Some(frame) = rx.recv().await {
+                                let body = format!("{frame}\n");
+                                let chunk = format!("{:x}\r\n{body}\r\n", body.len());
+                                if w.write_all(chunk.as_bytes()).await.is_err() {
+                                    return;
+                                }
+                            }
+                            let _ = w.write_all(b"0\r\n\r\n").await;
+                        }
+                        None => std::future::pending::<()>().await,
+                    }
+                    return;
+                }
+
+                let body = lists[(list_number - 1).min(lists.len() - 1)];
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = w.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    (format!("http://{addr}"), frame_tx, requests)
+}
+
+/// A stand-in API server whose pod list always fails with a 500, recording when
+/// each attempt arrived so the retry pacing can be measured.
+async fn mock_pods_failing_api() -> (String, Arc<std::sync::Mutex<Vec<Instant>>>) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    const SERVER_ERROR: &str = r#"{"kind":"Status","apiVersion":"v1","status":"Failure","message":"internal","reason":"InternalError","code":500}"#;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock pods api");
+    let addr = listener.local_addr().expect("local addr");
+    let attempts = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = Arc::clone(&attempts);
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let seen = Arc::clone(&seen);
+            tokio::spawn(async move {
+                let (r, mut w) = sock.split();
+                let mut reader = BufReader::new(r);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).await.unwrap_or(0) == 0 {
+                    return;
+                }
+                loop {
+                    let mut header = String::new();
+                    if reader.read_line(&mut header).await.unwrap_or(0) == 0 || header == "\r\n" {
+                        break;
+                    }
+                }
+                seen.lock().unwrap().push(Instant::now());
+                let response = format!(
+                    "HTTP/1.1 500 Internal Server Error\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{SERVER_ERROR}",
+                    SERVER_ERROR.len()
+                );
+                let _ = w.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    (format!("http://{addr}"), attempts)
+}
+
+/// Wait for a `Msg::NodePods` carrying exactly `want`. Publications are
+/// coalesced to one a second, so intermediate states can be skipped — the test
+/// drives one change at a time and waits for each to land.
+async fn await_counts(rx: &mut Receiver<Msg>, want: &[(&str, usize)]) {
+    let want: std::collections::HashMap<String, usize> =
+        want.iter().map(|(n, c)| ((*n).to_string(), *c)).collect();
+    let seen = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            if let Msg::NodePods { counts, .. } = rx.recv().await.expect("channel closed")
+                && counts == want
+            {
+                return;
+            }
+        }
+    })
+    .await;
+    assert!(seen.is_ok(), "never saw counts {want:?}");
+}
+
 /// A `Cluster` whose client talks to `url` instead of a real API server.
 fn mock_cluster(url: &str) -> Cluster {
     let mut config = kube::Config::new(url.parse().expect("mock url"));
@@ -148,6 +310,125 @@ async fn node_pods_survives_a_forbidden_watch_without_hammering_the_api() {
     let list_attempts = requests.len() - watch_attempts;
     assert_eq!(watch_attempts, 1, "fallback must stop retrying the watch");
     assert_eq!(list_attempts, 2, "fallback should wait 10s between lists");
+}
+
+/// The incremental path end to end: initial sync, a new pod, a pod moving to a
+/// different node, and a delete. Each step is awaited before the next is
+/// pushed, because publications are coalesced to one a second.
+#[tokio::test]
+async fn node_pods_counts_follow_the_watch_incrementally() {
+    const INITIAL: &str = concat!(
+        r#"{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"7"},"items":["#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","resourceVersion":"1"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"b","namespace":"default","resourceVersion":"2"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"c","namespace":"default","resourceVersion":"3"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}}"#,
+        r#"]}"#
+    );
+
+    let (url, frames, _seen) = mock_pods_stream_api(vec![INITIAL]).await;
+    let (tx, mut rx) = mpsc::channel(1024);
+    let mut app = App::new(mock_cluster(&url), tx);
+    app.spawn_node_pods_poll();
+
+    // Nothing is published until `InitDone`: a partial initial list would walk
+    // the PODS column up from zero on every resync.
+    await_counts(&mut rx, &[("node-a", 2), ("node-b", 1)]).await;
+
+    frames
+        .send(r#"{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"d","namespace":"default","resourceVersion":"10"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}}}"#.into())
+        .await
+        .expect("push add");
+    await_counts(&mut rx, &[("node-a", 2), ("node-b", 2)]).await;
+
+    // Reassignment: the same pod key reported on a different node has to
+    // decrement the old one as well as increment the new one.
+    frames
+        .send(r#"{"type":"MODIFIED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","resourceVersion":"11"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}}}"#.into())
+        .await
+        .expect("push move");
+    await_counts(&mut rx, &[("node-a", 1), ("node-b", 3)]).await;
+
+    // A node's last pod leaving drops the node from the map rather than
+    // leaving a zero behind.
+    frames
+        .send(r#"{"type":"DELETED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"name":"b","namespace":"default","resourceVersion":"12"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}}}"#.into())
+        .await
+        .expect("push delete");
+    await_counts(&mut rx, &[("node-b", 3)]).await;
+}
+
+/// A 410 desyncs the watch, so `watcher` re-lists and replays `Init` ->
+/// `InitApply` -> `InitDone`. The counts must be rebuilt from that list alone:
+/// merging into the old ones would strand nodes that no longer have pods.
+#[tokio::test]
+async fn node_pods_rebuilds_counts_after_a_desync_resync() {
+    const INITIAL: &str = concat!(
+        r#"{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"7"},"items":["#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","resourceVersion":"1"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"b","namespace":"default","resourceVersion":"2"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}}"#,
+        r#"]}"#
+    );
+    const AFTER_RESYNC: &str = concat!(
+        r#"{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"99"},"items":["#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"e","namespace":"default","resourceVersion":"20"},"spec":{"nodeName":"node-c"},"status":{"phase":"Running"}}"#,
+        r#"]}"#
+    );
+
+    let (url, frames, _seen) = mock_pods_stream_api(vec![INITIAL, AFTER_RESYNC]).await;
+    let (tx, mut rx) = mpsc::channel(1024);
+    let mut app = App::new(mock_cluster(&url), tx);
+    app.spawn_node_pods_poll();
+
+    await_counts(&mut rx, &[("node-a", 2)]).await;
+
+    frames
+        .send(r#"{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","status":"Failure","message":"too old resource version","reason":"Expired","code":410}}"#.into())
+        .await
+        .expect("push desync");
+    drop(frames);
+
+    // node-a is gone entirely, not left at its old count.
+    await_counts(&mut rx, &[("node-c", 1)]).await;
+}
+
+/// A persistently failing initial list must back off. `watcher` emits
+/// `Ok(Event::Init)` before *every* list attempt and `StreamBackoff` resets on
+/// any `Ok`, so leaving the pacing to `.default_backoff()` pins the retry at
+/// the 800ms minimum forever — worse than the 10s poll this replaced.
+#[tokio::test]
+async fn node_pods_backs_off_when_the_initial_list_keeps_failing() {
+    let (url, attempts) = mock_pods_failing_api().await;
+    let (tx, _rx) = mpsc::channel(1024);
+    let mut app = App::new(mock_cluster(&url), tx);
+    app.spawn_node_pods_poll();
+
+    // Three attempts is enough to see the interval grow: the delays are
+    // 800ms and 1.6s before jitter, which only ever adds.
+    let gaps = tokio::time::timeout(std::time::Duration::from_secs(20), async {
+        loop {
+            {
+                let seen = attempts.lock().unwrap();
+                if seen.len() >= 3 {
+                    break vec![
+                        seen[1].duration_since(seen[0]),
+                        seen[2].duration_since(seen[1]),
+                    ];
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("did not see three list attempts");
+
+    assert!(
+        gaps[0] >= std::time::Duration::from_millis(700),
+        "first retry did not back off at all: {gaps:?}"
+    );
+    assert!(
+        gaps[1] > gaps[0],
+        "retry interval did not grow, backoff is being reset: {gaps:?}"
+    );
 }
 
 /// The row cache's cleanup pass runs at the end of a rebuild; it must both

--- a/src/benchsupport.rs
+++ b/src/benchsupport.rs
@@ -143,6 +143,28 @@ pub fn helm_secret(i: usize) -> DynamicObject {
     .expect("bench helm fixture is valid")
 }
 
+/// The decompressed release JSON inside a fixture secret — exactly the bytes
+/// `helm::decode` hands to serde. Lets a bench separate the JSON parse from
+/// the base64 + gunzip in front of it.
+pub fn helm_release_json(i: usize) -> Vec<u8> {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use std::io::Read as _;
+
+    let secret = helm_secret(i);
+    let wire = secret
+        .data
+        .pointer("/data/release")
+        .and_then(serde_json::Value::as_str)
+        .expect("fixture carries a release payload");
+    let helm_encoded = BASE64.decode(wire).expect("outer base64");
+    let gzipped = BASE64.decode(helm_encoded).expect("inner base64");
+    let mut gz = flate2::read::GzDecoder::new(&gzipped[..]);
+    let mut json = Vec::new();
+    gz.read_to_end(&mut json).expect("gunzip");
+    json
+}
+
 /// Criterion runs benchmarks on a bare thread, but building a kube `Client`
 /// spawns a tower buffer worker and panics without a reactor. One process-wide
 /// runtime, kept alive for the whole run, is enough: the offline client never
@@ -214,6 +236,34 @@ pub fn helm_app(n: usize) -> (App, Receiver<Msg>) {
     a.kind_plural = "helm".to_string();
     seed(&mut a, (0..n).map(helm_secret));
     (a, rx)
+}
+
+/// The context switcher's per-row fleet marker, exactly as `draw_contexts`
+/// computes it: one membership test per visible context, per frame.
+pub fn fleet_marks_for_all(app: &App) -> usize {
+    app.filtered_contexts()
+        .iter()
+        .filter(|c| app.is_fleet_context(c))
+        .count()
+}
+
+/// An app whose context switcher lists `n` contexts, half of them in the
+/// fleet — the shape the switcher draws.
+pub fn contexts_app(n: usize) -> (App, Receiver<Msg>) {
+    let (mut a, rx) = app();
+    a.ctx_list = (0..n).map(|i| format!("cluster-{i:03}")).collect();
+    a.fleet_cfg.contexts = (0..n)
+        .step_by(2)
+        .map(|i| format!("cluster-{i:03}"))
+        .collect();
+    (a, rx)
+}
+
+/// Mark the row ordering stale *without* a store write — a filter keystroke
+/// or sort toggle. The distinction matters for anything cached against store
+/// contents: a store write has to recompute it, this does not.
+pub fn invalidate(app: &App) {
+    app.bench_invalidate_rows();
 }
 
 /// Mark the row ordering stale the way one watch event does, so a bench

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -38,7 +38,7 @@ struct CellContext<'a> {
     name: &'a str,
     age: OnceCell<String>,
     pod: OnceCell<(String, String, String)>,
-    helm: OnceCell<Option<crate::helm::Release>>,
+    helm: OnceCell<Option<crate::helm::Summary>>,
 }
 
 impl<'a> CellContext<'a> {
@@ -64,9 +64,9 @@ impl<'a> CellContext<'a> {
     }
 
     /// The decoded Helm release backing this row's Secret, decoded once.
-    fn helm(&self) -> Option<&crate::helm::Release> {
+    fn helm(&self) -> Option<&crate::helm::Summary> {
         self.helm
-            .get_or_init(|| crate::helm::decode(self.obj))
+            .get_or_init(|| crate::helm::decode_summary(self.obj))
             .as_ref()
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -94,7 +94,9 @@ pub enum CmpValue {
     Mem(i64),
     /// Duration in seconds (`age<2h`).
     Duration(i64),
-    /// Anything else: case-insensitive text comparison.
+    /// Anything else: case-insensitive text comparison. Stored pre-folded to
+    /// lowercase — the comparison runs per object per rebuild, so folding the
+    /// needle once at parse time keeps it out of that loop.
     Str(String),
 }
 
@@ -277,7 +279,7 @@ fn typed_value(key: &str, raw: &str) -> Result<CmpValue, String> {
         _ => Ok(raw
             .parse::<f64>()
             .map(CmpValue::Num)
-            .unwrap_or_else(|_| CmpValue::Str(raw.to_string()))),
+            .unwrap_or_else(|_| CmpValue::Str(raw.to_lowercase()))),
     }
 }
 
@@ -412,6 +414,9 @@ mod tests {
         assert!(s.terms.is_empty());
     }
 
+    /// `CmpValue::Str` is stored pre-folded: the comparison is
+    /// case-insensitive, so the needle is lowercased once here rather than
+    /// once per object per rebuild.
     #[test]
     fn status_equality_and_inequality() {
         let s = structured("status=CrashLoopBackOff");
@@ -420,7 +425,7 @@ mod tests {
             vec![Term::Cmp(Cmp {
                 key: "status".into(),
                 op: Op::Eq,
-                value: CmpValue::Str("CrashLoopBackOff".into()),
+                value: CmpValue::Str("crashloopbackoff".into()),
             })]
         );
 
@@ -430,7 +435,7 @@ mod tests {
             vec![Term::Cmp(Cmp {
                 key: "status".into(),
                 op: Op::Ne,
-                value: CmpValue::Str("Running".into()),
+                value: CmpValue::Str("running".into()),
             })]
         );
     }
@@ -549,7 +554,7 @@ mod tests {
                 Term::Cmp(Cmp {
                     key: "status".into(),
                     op: Op::Eq,
-                    value: CmpValue::Str("Running".into()),
+                    value: CmpValue::Str("running".into()),
                 }),
             ]
         );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -263,15 +263,32 @@ fn split_cmp(tok: &str) -> Option<(&str, Op, &str)> {
     Some((key, op, value))
 }
 
-/// Case-fold one string for a filter comparison, per `char`.
+/// Fold a comparison needle once at parse time.
 ///
-/// Deliberately not `str::to_lowercase`: the two disagree on Greek final sigma
-/// (`Σ` folds to `ς` at the end of a word through `str`, always to `σ` through
-/// `char`). The needle is folded once at parse time and each cell is folded
-/// lazily on every rebuild, so they must fold *identically* or a comparison
-/// silently misses — hence one function, used by both sides.
-pub fn fold_lower(s: &str) -> impl Iterator<Item = char> + '_ {
-    s.chars().flat_map(char::to_lowercase)
+/// Whole-string lowercasing is required for non-ASCII text because it applies
+/// context-sensitive mappings such as Greek final sigma. ASCII uses its
+/// cheaper equivalent; the resulting `String` is retained in `CmpValue`.
+fn fold_lower(s: &str) -> String {
+    if s.is_ascii() {
+        s.to_ascii_lowercase()
+    } else {
+        s.to_lowercase()
+    }
+}
+
+/// Compare a cell with a needle already returned by [`fold_lower`].
+///
+/// The common ASCII path performs no per-cell allocation. If either operand is
+/// non-ASCII, use whole-string lowercasing to preserve the case-insensitive
+/// behavior that structured filters had before the ASCII optimization.
+pub fn cmp_folded_lower(cell: &str, want: &str) -> std::cmp::Ordering {
+    if cell.is_ascii() && want.is_ascii() {
+        cell.bytes()
+            .map(|byte| byte.to_ascii_lowercase())
+            .cmp(want.bytes())
+    } else {
+        cell.to_lowercase().as_str().cmp(want)
+    }
 }
 
 /// Type a comparison value from its key: quantities for `cpu`/`mem`/`memory`,
@@ -290,7 +307,7 @@ fn typed_value(key: &str, raw: &str) -> Result<CmpValue, String> {
         _ => Ok(raw
             .parse::<f64>()
             .map(CmpValue::Num)
-            .unwrap_or_else(|_| CmpValue::Str(fold_lower(raw).collect()))),
+            .unwrap_or_else(|_| CmpValue::Str(fold_lower(raw)))),
     }
 }
 
@@ -603,23 +620,29 @@ mod tests {
         assert_eq!(parse("-l app=api").fuzzy_needle(), None);
     }
 
-    /// The needle is folded once at parse time and each cell is folded on every
-    /// rebuild. `str::to_lowercase` applies the Greek final-sigma rule and
-    /// `char::to_lowercase` does not, so folding the two sides with different
-    /// functions makes a comparison silently miss. Both go through
-    /// `fold_lower`; this pins that down at the one place they could drift.
     #[test]
-    fn both_sides_of_a_comparison_fold_the_same_way() {
-        let cell = "ΟΔΟΣ";
-        // The divergence is real, not theoretical.
-        assert_eq!(cell.to_lowercase(), "οδος");
-        assert_eq!(fold_lower(cell).collect::<String>(), "οδοσ");
+    fn unicode_comparisons_fold_mixed_case_in_both_directions() {
+        for (cell, raw_needle) in [("ΟΔΟΣ", "οδος"), ("οδος", "ΟΔΟΣ")] {
+            let CmpValue::Str(needle) = typed_value("name", raw_needle).expect("typed") else {
+                panic!("expected a text comparison");
+            };
+            assert_eq!(
+                cmp_folded_lower(cell, &needle),
+                std::cmp::Ordering::Equal,
+                "cell={cell:?}, needle={raw_needle:?}"
+            );
+        }
+    }
 
-        // What matters is that the stored needle and the folded cell agree.
-        let CmpValue::Str(needle) = typed_value("name", cell).expect("typed") else {
+    #[test]
+    fn ascii_comparisons_remain_case_insensitive() {
+        let CmpValue::Str(needle) = typed_value("status", "rUnNiNg").expect("typed") else {
             panic!("expected a text comparison");
         };
-        assert!(fold_lower(cell).eq(needle.chars()));
+        assert_eq!(
+            cmp_folded_lower("RUNNING", &needle),
+            std::cmp::Ordering::Equal
+        );
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -263,6 +263,17 @@ fn split_cmp(tok: &str) -> Option<(&str, Op, &str)> {
     Some((key, op, value))
 }
 
+/// Case-fold one string for a filter comparison, per `char`.
+///
+/// Deliberately not `str::to_lowercase`: the two disagree on Greek final sigma
+/// (`Σ` folds to `ς` at the end of a word through `str`, always to `σ` through
+/// `char`). The needle is folded once at parse time and each cell is folded
+/// lazily on every rebuild, so they must fold *identically* or a comparison
+/// silently misses — hence one function, used by both sides.
+pub fn fold_lower(s: &str) -> impl Iterator<Item = char> + '_ {
+    s.chars().flat_map(char::to_lowercase)
+}
+
 /// Type a comparison value from its key: quantities for `cpu`/`mem`/`memory`,
 /// durations for `age`, and number-or-text for everything else.
 fn typed_value(key: &str, raw: &str) -> Result<CmpValue, String> {
@@ -279,7 +290,7 @@ fn typed_value(key: &str, raw: &str) -> Result<CmpValue, String> {
         _ => Ok(raw
             .parse::<f64>()
             .map(CmpValue::Num)
-            .unwrap_or_else(|_| CmpValue::Str(raw.to_lowercase()))),
+            .unwrap_or_else(|_| CmpValue::Str(fold_lower(raw).collect()))),
     }
 }
 
@@ -590,6 +601,25 @@ mod tests {
         assert_eq!(parse("").fuzzy_needle(), None);
         assert_eq!(parse("!x khc status=Running").fuzzy_needle(), Some("khc"));
         assert_eq!(parse("-l app=api").fuzzy_needle(), None);
+    }
+
+    /// The needle is folded once at parse time and each cell is folded on every
+    /// rebuild. `str::to_lowercase` applies the Greek final-sigma rule and
+    /// `char::to_lowercase` does not, so folding the two sides with different
+    /// functions makes a comparison silently miss. Both go through
+    /// `fold_lower`; this pins that down at the one place they could drift.
+    #[test]
+    fn both_sides_of_a_comparison_fold_the_same_way() {
+        let cell = "ΟΔΟΣ";
+        // The divergence is real, not theoretical.
+        assert_eq!(cell.to_lowercase(), "οδος");
+        assert_eq!(fold_lower(cell).collect::<String>(), "οδοσ");
+
+        // What matters is that the stored needle and the folded cell agree.
+        let CmpValue::Str(needle) = typed_value("name", cell).expect("typed") else {
+            panic!("expected a text comparison");
+        };
+        assert!(fold_lower(cell).eq(needle.chars()));
     }
 
     #[test]

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -129,10 +129,6 @@ pub fn parse_release_json(json: &[u8]) -> bool {
     serde_json::from_slice::<RawRelease>(json).is_ok()
 }
 
-/// Decode a release Secret into its `Release`. `None` if the secret doesn't
-/// carry a `data.release` payload or it can't be decoded (corrupt, unknown
-/// format, or not a Helm release secret at all) — callers treat that as
-/// "unrenderable", not a crash.
 /// The release payload as JSON: `data.release` is base64 twice over, then
 /// gzipped. Shared by [`decode`] and [`decode_summary`].
 fn release_json(secret: &DynamicObject) -> Option<Vec<u8>> {
@@ -167,6 +163,10 @@ pub fn decode_summary(secret: &DynamicObject) -> Option<Summary> {
     })
 }
 
+/// Decode a release Secret into its `Release`. `None` if the secret doesn't
+/// carry a `data.release` payload or it can't be decoded (corrupt, unknown
+/// format, or not a Helm release secret at all) — callers treat that as
+/// "unrenderable", not a crash.
 pub fn decode(secret: &DynamicObject) -> Option<Release> {
     let json = release_json(secret)?;
     let raw: RawRelease = serde_json::from_slice(&json).ok()?;

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -43,6 +43,20 @@ pub struct Release {
     pub manifest: String,
 }
 
+/// The fields the release *list* renders. Deliberately excludes `manifest`
+/// and `config`: those are the bulk of a release payload (a rendered manifest
+/// runs to hundreds of KB) and no column reads them, so the list's parse walks
+/// past them instead of allocating a `String` and a `Value` DOM per row.
+pub struct Summary {
+    pub status: String,
+    pub chart_name: String,
+    pub chart_version: String,
+    pub app_version: String,
+    pub description: String,
+    /// `info.last_deployed` as a unix timestamp, when parseable.
+    pub last_deployed_secs: Option<i64>,
+}
+
 #[derive(Deserialize, Default)]
 struct RawRelease {
     #[serde(default)]
@@ -87,25 +101,76 @@ struct RawMetadata {
     app_version: String,
 }
 
+/// [`RawRelease`] minus the two heavy payloads, and minus `info.notes`.
+#[derive(Deserialize, Default)]
+struct RawSummary {
+    #[serde(default)]
+    info: RawInfoSummary,
+    #[serde(default)]
+    chart: RawChart,
+}
+
+#[derive(Deserialize, Default)]
+struct RawInfoSummary {
+    #[serde(default)]
+    last_deployed: Option<String>,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    status: String,
+}
+
+/// The serde step of [`decode`] in isolation, so a benchmark can price the
+/// JSON parse against the base64 + gunzip in front of it. Deserializes into
+/// the same typed struct the real path uses — a `Value` DOM parse would
+/// overstate the parse share.
+#[cfg(feature = "bench")]
+pub fn parse_release_json(json: &[u8]) -> bool {
+    serde_json::from_slice::<RawRelease>(json).is_ok()
+}
+
 /// Decode a release Secret into its `Release`. `None` if the secret doesn't
 /// carry a `data.release` payload or it can't be decoded (corrupt, unknown
 /// format, or not a Helm release secret at all) — callers treat that as
 /// "unrenderable", not a crash.
-pub fn decode(secret: &DynamicObject) -> Option<Release> {
+/// The release payload as JSON: `data.release` is base64 twice over, then
+/// gzipped. Shared by [`decode`] and [`decode_summary`].
+fn release_json(secret: &DynamicObject) -> Option<Vec<u8>> {
     let wire = secret.data.pointer("/data/release")?.as_str()?;
     let helm_encoded = BASE64.decode(wire).ok()?;
     let gzipped = BASE64.decode(helm_encoded).ok()?;
     let mut gz = flate2::read::GzDecoder::new(&gzipped[..]);
     let mut json = Vec::new();
     gz.read_to_end(&mut json).ok()?;
-    let raw: RawRelease = serde_json::from_slice(&json).ok()?;
+    Some(json)
+}
 
-    let last_deployed_secs = raw
-        .info
-        .last_deployed
-        .as_deref()
-        .and_then(|s| s.parse::<Timestamp>().ok())
-        .map(|ts| ts.as_second());
+fn last_deployed_secs(raw: Option<&str>) -> Option<i64> {
+    raw.and_then(|s| s.parse::<Timestamp>().ok())
+        .map(|ts| ts.as_second())
+}
+
+/// Like [`decode`], but only the columns the release list shows. Half of a
+/// decode is the JSON parse, and most of that is the `manifest` string and the
+/// `config` DOM — neither of which the list reads. Use [`decode`] wherever
+/// they are.
+pub fn decode_summary(secret: &DynamicObject) -> Option<Summary> {
+    let json = release_json(secret)?;
+    let raw: RawSummary = serde_json::from_slice(&json).ok()?;
+    Some(Summary {
+        status: raw.info.status,
+        chart_name: raw.chart.metadata.name,
+        chart_version: raw.chart.metadata.version,
+        app_version: raw.chart.metadata.app_version,
+        description: raw.info.description,
+        last_deployed_secs: last_deployed_secs(raw.info.last_deployed.as_deref()),
+    })
+}
+
+pub fn decode(secret: &DynamicObject) -> Option<Release> {
+    let json = release_json(secret)?;
+    let raw: RawRelease = serde_json::from_slice(&json).ok()?;
+    let last_deployed_secs = last_deployed_secs(raw.info.last_deployed.as_deref());
 
     Some(Release {
         name: raw.name,
@@ -241,6 +306,51 @@ mod tests {
 
         assert_eq!(release_name(&secret), Some("myrelease"));
         assert_eq!(revision(&secret), Some(2));
+    }
+
+    /// `decode_summary` skips `manifest`/`config`/`notes` for speed, so the
+    /// fields it does return must still agree with the full decode — a
+    /// divergence here would show up as wrong cells in the release list.
+    #[test]
+    fn summary_decode_agrees_with_the_full_decode() {
+        let secret = fixture_secret(
+            r#"{
+                "name": "myrelease",
+                "version": 2,
+                "info": {
+                    "status": "deployed",
+                    "description": "Upgrade complete",
+                    "last_deployed": "2024-01-15T10:30:00Z",
+                    "notes": "Thanks for installing!"
+                },
+                "chart": {
+                    "metadata": { "name": "mychart", "version": "1.2.3", "appVersion": "4.5.6" }
+                },
+                "config": { "replicaCount": 3 },
+                "manifest": "apiVersion: v1\nkind: ConfigMap\n"
+            }"#,
+        );
+
+        let full = decode(&secret).expect("should decode");
+        let brief = decode_summary(&secret).expect("should decode");
+        assert_eq!(brief.status, full.status);
+        assert_eq!(brief.chart_name, full.chart_name);
+        assert_eq!(brief.chart_version, full.chart_version);
+        assert_eq!(brief.app_version, full.app_version);
+        assert_eq!(brief.description, full.description);
+        assert_eq!(brief.last_deployed_secs, full.last_deployed_secs);
+    }
+
+    #[test]
+    fn summary_decode_returns_none_for_non_release_secret() {
+        let data: Value = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": { "name": "not-a-release", "namespace": "default" },
+            "data": {},
+        });
+        let secret: DynamicObject = serde_json::from_value(data).unwrap();
+        assert!(decode_summary(&secret).is_none());
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -301,6 +301,10 @@ pub enum StoreMutation {
 #[derive(Default)]
 pub struct Store {
     items: Items,
+    /// Bumped by every mutation. Lets a derived view (the Helm latest-revision
+    /// dedup) cache its result and reuse it across rebuilds that were staled
+    /// by a filter or sort change rather than by the store moving.
+    version: u64,
     /// Fresh rows accumulating during a (re)list while `items` still shows the
     /// previous set — a cached view snapshot or the pre-relist state. Swapped
     /// in wholesale on `Synced`, so stale rows are replaced atomically instead
@@ -311,6 +315,7 @@ pub struct Store {
 
 impl Store {
     pub fn clear(&mut self) {
+        self.version += 1;
         self.items.clear();
         self.pending = None;
         self.synced = false;
@@ -319,6 +324,7 @@ impl Store {
     /// Replace the contents with a cached snapshot from a previous visit to
     /// this view — shown (unsynced) until the new watch's initial list lands.
     pub fn seed(&mut self, items: Items) {
+        self.version += 1;
         self.items = items;
         self.pending = None;
         self.synced = false;
@@ -327,6 +333,7 @@ impl Store {
     /// Move the items out (for stashing in the view cache), leaving the store
     /// empty.
     pub fn take_items(&mut self) -> Items {
+        self.version += 1;
         self.pending = None;
         self.synced = false;
         std::mem::take(&mut self.items)
@@ -338,6 +345,7 @@ impl Store {
     /// store keeps the old behavior of applying rows as they stream in.
     /// Returns whether the visible items were cleared.
     pub fn begin_reset(&mut self) -> bool {
+        self.version += 1;
         self.synced = false;
         if self.items.is_empty() {
             self.pending = None;
@@ -351,6 +359,7 @@ impl Store {
     /// Mark the initial list complete, swapping in the buffered rows if a
     /// reset was in progress. Returns whether a swap replaced the visible set.
     pub fn finish_sync(&mut self) -> bool {
+        self.version += 1;
         self.synced = true;
         match self.pending.take() {
             Some(fresh) => {
@@ -362,6 +371,7 @@ impl Store {
     }
 
     pub fn apply(&mut self, key: String, obj: DynamicObject) -> StoreMutation {
+        self.version += 1;
         let key: RowKey = key.into();
         let obj = Arc::new(obj);
         match &mut self.pending {
@@ -377,6 +387,7 @@ impl Store {
     }
 
     pub fn remove(&mut self, key: &str) -> StoreMutation {
+        self.version += 1;
         match &mut self.pending {
             Some(pending) => {
                 pending.remove(key);
@@ -398,6 +409,11 @@ impl Store {
             .as_ref()
             .and_then(|p| p.get(key))
             .or_else(|| self.items.get(key))
+    }
+
+    /// Monotonic mutation counter — see [`Self::version`]'s field docs.
+    pub fn version(&self) -> u64 {
+        self.version
     }
 
     pub fn len(&self) -> usize {

--- a/src/store.rs
+++ b/src/store.rs
@@ -436,3 +436,70 @@ impl Store {
         self.items.iter().map(|(k, v)| (k, v.as_ref()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pod(name: &str) -> DynamicObject {
+        serde_json::from_value(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": { "name": name, "namespace": "default" },
+        }))
+        .expect("pod fixture")
+    }
+
+    /// Every mutating path must advance the counter, because the Helm
+    /// latest-revision dedup is cached against it: a path that changed `items`
+    /// without bumping would leave that cache selecting rows for a store it no
+    /// longer describes. `items` is private and hands out no `&mut`, so these
+    /// seven methods are the complete set of ways it can change.
+    #[test]
+    fn every_mutation_advances_the_version() {
+        fn advanced(store: &Store, last: &mut u64, what: &str) {
+            assert!(
+                store.version() > *last,
+                "{what} must advance the store version ({} -> {})",
+                *last,
+                store.version()
+            );
+            *last = store.version();
+        }
+
+        let mut store = Store::default();
+        let mut last = store.version();
+
+        store.apply("default/a".into(), pod("a"));
+        advanced(&store, &mut last, "apply");
+
+        store.remove("default/a");
+        advanced(&store, &mut last, "remove");
+
+        // Conservative: a remove that matched nothing still bumps. Over-
+        // bumping only costs a recompute; under-bumping serves stale rows.
+        store.remove("default/gone");
+        advanced(&store, &mut last, "remove (no such key)");
+
+        let mut seeded = Items::new();
+        seeded.insert(Rc::from("default/b"), Arc::new(pod("b")));
+        store.seed(seeded);
+        advanced(&store, &mut last, "seed");
+
+        // Non-empty store, so this buffers rather than clearing.
+        assert!(!store.begin_reset(), "seeded store buffers the relist");
+        advanced(&store, &mut last, "begin_reset");
+
+        store.apply("default/c".into(), pod("c"));
+        advanced(&store, &mut last, "apply (buffered during relist)");
+
+        assert!(store.finish_sync(), "the buffered set is swapped in");
+        advanced(&store, &mut last, "finish_sync");
+
+        store.take_items();
+        advanced(&store, &mut last, "take_items");
+
+        store.clear();
+        advanced(&store, &mut last, "clear");
+    }
+}

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -17,8 +17,11 @@ use k8s_openapi::jiff::Timestamp;
 use kube::core::DynamicObject;
 use serde_json::Value;
 
-/// How many entries to keep per object before dropping the oldest.
-const MAX_PER_OBJECT: usize = 200;
+/// How many entries to keep per object before dropping the oldest. The
+/// detail view only ever shows one object's history at a time and far fewer
+/// than 200 transitions are useful there — kept modest to bound
+/// `MAX_PER_OBJECT * MAX_OBJECTS` worst-case memory.
+const MAX_PER_OBJECT: usize = 50;
 /// How many distinct objects to keep history for before evicting the
 /// least-recently-touched one.
 const MAX_OBJECTS: usize = 2000;


### PR DESCRIPTION
Follows #185 with the next tier of hot-path work. Measured with
`benches/hot_paths.rs` on 2,000 synthetic pods / 300 Helm releases / 128
contexts, Apple Silicon, bench profile. Every figure in the table below is
against `main`. Four bench groups are new (`filter_cmp`, `helm_rows`,
`fleet_marks`, `helm_decode`) — the structured filter and Helm dedup paths
had no coverage at all.

## Results

| Benchmark | Before | After | |
| --- | ---: | ---: | ---: |
| context switcher fleet marks (128 contexts) | 202 µs | **26 µs** | −87% |
| Helm list rebuild, filter keystroke | 35.7 µs | **11.0 µs** | −70% |
| filter `namespace=…` | 157 µs | **64 µs** | −60% |
| filter `status=…` | 767 µs | **671 µs** | −17% |
| filter, no match | 225 µs | **207 µs** | −14% |
| cells, helm (16 rows) | 387 µs | **336 µs** | −13% |
| filter, broad | 489 µs | **467 µs** | −7% |
| filter, name hit | 609 µs | **582 µs** | −7% |
| row update + redraw query | 9.3 µs | **8.8 µs** | −5% |
| cells, pods (256 rows) | 298 µs | **282 µs** | −4% |

## What changed

- **Nodes view watches pods instead of re-listing every 10s.** Counts are kept
  incrementally and coalesced to at most one message per second. Publishing is
  gated on `InitDone` — the initial list arrives as a stream, so emitting
  mid-init would walk the PODS column up from zero on every resync.
- **Backoff and RBAC fallback on that watch.** The first version retried a
  refused watch as fast as the API server could answer (~9,800 requests/s in
  the mock test). Other transient failures now use client-go's exponential
  backoff, while a forbidden list/watch switches to the old 10-second list
  poll. This keeps counts fresh for list-only RBAC without retrying a denied
  watch.
- **Structured filter comparisons allocate nothing per object.** `eval_cmp`
  lowercased both the cell and the needle for every object on every rebuild;
  the needle is now folded once at parse time and the cell folded lazily
  through an iterator. `column_cell` returns `Cow<str>` so a `namespace=…`
  comparison borrows instead of cloning.
- **The Helm release list decodes only what it renders.** `RawRelease`
  materialized `manifest: String` and `config: Value` — the bulk of a release
  payload, and neither is read by any column. `decode_summary` walks past
  them; the detail views still use the full `decode`.
- **Helm latest-revision dedup cached against a store mutation counter.** It
  rescanned the whole store on every rebuild, including rebuilds staled by a
  filter keystroke or a sort toggle, which cannot change the dedup.
- **`is_fleet_context` answers membership directly** instead of building and
  cloning a `Vec` of every fleet context per row, per frame.
- **Row cache retention is bounded against the store, and hands capacity
  back.** The bound has to be store size, not visible row count: the filter
  warms a cell entry for every object it tests, including the ones it rejects,
  so a narrow filter legitimately leaves far more cells than keys. `retain`
  alone also keeps the peak allocation, and since `invalidate_row` already
  drops deleted rows one at a time, length never signalled the oversized table
  a large view leaves behind — the shrink is gated on capacity, with 4×
  hysteresis so it settles instead of rehashing every rebuild.
- **Timeline history bounded** at 50 entries per object rather than 200.
- `sort_unstable_by` where the comparator is a total order over the element.
  The two sites where it is not — `FindItem::ns` and `Suggestion::kind` sit
  outside their tie-breaks, so an unstable sort would reorder equal-comparing
  items between runs — stay stable and say why.

## Measured and not kept

**SIMD JSON.** The typed parse is 12.1 µs of a 24.1 µs Helm decode, so the
parse genuinely dominates. But the reason is that the parse was materializing
payloads no column reads; skipping those got −13% with no new dependency and
no `unsafe`. A SIMD parser on top would optimize work that no longer happens.

**`panic = "abort"`.** Safe here — no `catch_unwind` anywhere, and the panic
hook that restores the terminal still runs — but cargo reports `` `panic`
setting is ignored for `bench` profile ``, so no speedup could be demonstrated
with this harness. Skipped rather than taken on faith. `codegen-units = 1`
remains rejected from #185.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features` (clean)
- `cargo test --all-features` — 524 passed, 1 existing ignored
- New tests: every `Store` mutation advancing the version the dedup cache is
  keyed on (mutation-checked — removing any one of the seven bumps fails it),
  the dedup refreshing when a new revision arrives, the row cache both
  releasing capacity and then settling, `decode_summary` agreeing with the
  full decode, and a mock API server that changes its list after refusing `watch`,
  asserting the 10-second fallback publishes refreshed counts and stops
  retrying the denied watch.

The version counter is a plain `u64` by design: `RowKey` is `Rc<str>`, so
`Store` is not `Send` and the compiler rejects it crossing a thread boundary.
The counters that do cross one — `gen_flag`, `log_flag`, `streaming_lists`,
the theme epoch — are atomics.

Note: `theme::tests::helm_release_statuses_are_colored` is flaky on `main`
independently of this branch (~1 in 6 runs) — `theme.rs:358` keeps the palette
in a process-global that `ui.rs:3614` mutates from another test. Worth a
separate issue.
