### PR TITLE
perf: cut per-frame work in the render, filter and log paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1063,15 +1063,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
 ]
 
 [[package]]
@@ -1833,6 +1824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,7 +2483,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2539,7 +2540,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2893,9 +2894,9 @@ dependencies = [
  "crossterm",
  "dhat",
  "flate2",
+ "foldhash",
  "form_urlencoded",
  "futures-util",
- "fuzzy-matcher",
  "http",
  "http-body-util",
  "hyper",
@@ -2904,6 +2905,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "memchr",
+ "nucleo-matcher",
  "ratatui",
  "regex",
  "serde",
@@ -3141,15 +3143,6 @@ name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
-
-[[package]]
-name = "thread_local"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "time"
@@ -3671,7 +3664,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 dhat = { version = "0.3.3", optional = true }
 flate2 = "1.1.5"
+foldhash = "0.2"
 form_urlencoded = "1.2.2"
 futures-util = "0.3.32"
-fuzzy-matcher = "0.3.7"
 http = "1.4.2"
 http-body-util = "0.1.3"
 hyper = { version = "1.10.1", features = ["client", "http1"] }
@@ -25,6 +25,7 @@ hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"
 k8s-openapi = { version = "0.28", features = ["latest"] }
 kube = { version = "4.2.0", features = ["runtime", "client", "derive", "ws", "http-proxy", "gzip"] }
 memchr = "2.8.3"
+nucleo-matcher = "0.3"
 ratatui = "0.30.1"
 regex = "1"
 serde = "1.0.228"

--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -75,10 +75,11 @@ fn cells(c: &mut Criterion) {
 
     let pods: Vec<_> = (0..256).map(bs::pod).collect();
     let pod_spec = columns::build_spec("pods", None, None, false);
+    let now = columns::now_secs();
     g.bench_function("pods_256", |b| {
         b.iter(|| {
             for o in &pods {
-                black_box(pod_spec.cells(o));
+                black_box(pod_spec.cells(o, now));
             }
         });
     });
@@ -89,7 +90,7 @@ fn cells(c: &mut Criterion) {
     g.bench_function("helm_16", |b| {
         b.iter(|| {
             for o in &helm {
-                black_box(helm_spec.cells(o));
+                black_box(helm_spec.cells(o, now));
             }
         });
     });
@@ -286,6 +287,27 @@ fn helm_decode(c: &mut Criterion) {
             black_box(v)
         });
     });
+    // The double base64 decode Helm's payload needs, SIMD against scalar.
+    {
+        let wire = secret
+            .data
+            .pointer("/data/release")
+            .and_then(serde_json::Value::as_str)
+            .expect("fixture payload")
+            .to_string();
+        let scalar = base64::engine::general_purpose::STANDARD;
+        let simd = base64::engine::Simd::standard(Default::default());
+        fn twice<E: base64::Engine>(e: &E, wire: &str) -> Vec<u8> {
+            let inner = e.decode(wire).expect("outer base64");
+            e.decode(inner).expect("inner base64")
+        }
+        g.bench_function("base64_scalar", |b| {
+            b.iter(|| black_box(twice(&scalar, black_box(&wire))));
+        });
+        g.bench_function("base64_simd", |b| {
+            b.iter(|| black_box(twice(&simd, black_box(&wire))));
+        });
+    }
     g.bench_function("parse_typed", |b| {
         b.iter(|| black_box(sofka::helm::parse_release_json(black_box(&json))));
     });
@@ -303,14 +325,47 @@ fn cell_extract(c: &mut Criterion) {
     g.bench_function("borrowed_ip_2000", |b| {
         b.iter(|| {
             for pod in &pods {
-                black_box(spec.cell_at(black_box(pod), 4).unwrap());
+                black_box(
+                    spec.cell_at(black_box(pod), 4, columns::now_secs())
+                        .unwrap(),
+                );
             }
         });
     });
     g.bench_function("owned_ip_baseline_2000", |b| {
         b.iter(|| {
             for pod in &pods {
-                black_box(spec.cell_at(black_box(pod), 4).unwrap().into_owned());
+                black_box(
+                    spec.cell_at(black_box(pod), 4, columns::now_secs())
+                        .unwrap()
+                        .into_owned(),
+                );
+            }
+        });
+    });
+    g.finish();
+}
+
+/// The per-frame clock. `now` measures the shipped path — one reading threaded
+/// through the row — against the previous one, where each elapsed cell read the
+/// clock for itself.
+fn frame_clock(c: &mut Criterion) {
+    let mut g = c.benchmark_group("frame_clock");
+    let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
+    let spec = columns::build_spec("pods", None, None, false);
+
+    g.bench_function("one_reading_per_frame_2000", |b| {
+        b.iter(|| {
+            let now = columns::now_secs();
+            for pod in &pods {
+                black_box(spec.volatile(pod, "pods", 0, now));
+            }
+        });
+    });
+    g.bench_function("one_reading_per_cell_2000", |b| {
+        b.iter(|| {
+            for pod in &pods {
+                black_box(spec.volatile(pod, "pods", 0, columns::now_secs()));
             }
         });
     });
@@ -339,6 +394,208 @@ fn provider_selection(c: &mut Criterion) {
     g.finish();
 }
 
+/// The extract-then-render path the borrowed one replaced: an owned `Value`
+/// for the whole subtree, then the same formatting. The shipped `render_cell`
+/// produces exactly this text without the clone.
+fn render_owned(obj: &kube::core::DynamicObject, pointer: &str) -> String {
+    use serde_json::Value;
+    let Some(v) = sofka::views::extract(obj, pointer) else {
+        return "<none>".into();
+    };
+    match v {
+        Value::Null => "<none>".into(),
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        ref other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Custom-column extraction: the shipped borrowed result against the owned
+/// `Value` it replaced, over the shapes a printer column actually points at.
+fn custom_columns(c: &mut Criterion) {
+    let mut g = c.benchmark_group("custom_columns");
+    let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
+    let col = |pointer: &str| sofka::views::UserColumn {
+        header: "COL".into(),
+        pointer: pointer.into(),
+        kind: sofka::views::ColumnKind::Text,
+        wide: false,
+        width: None,
+        align: None,
+        condition_field: None,
+    };
+    let now = columns::now_secs();
+
+    for (name, pointer) in [
+        ("scalar", "/status/phase"),
+        ("label", "/metadata/labels/app.kubernetes.io~1name"),
+        ("array", "/spec/containers"),
+        ("nested", "/spec/containers/0/resources"),
+    ] {
+        let column = col(pointer);
+        g.bench_with_input(BenchmarkId::new("render_2000", name), &column, |b, col| {
+            b.iter(|| {
+                for pod in &pods {
+                    black_box(sofka::views::render_cell(pod, col, now));
+                }
+            });
+        });
+        g.bench_with_input(
+            BenchmarkId::new("owned_baseline_2000", name),
+            &column,
+            |b, col| {
+                b.iter(|| {
+                    for pod in &pods {
+                        black_box(render_owned(pod, &col.pointer));
+                    }
+                });
+            },
+        );
+    }
+    g.finish();
+}
+
+/// Provider log records: the shipped selective visitor against the
+/// `serde_json::Value` DOM it replaced, over records carrying the extra fields
+/// an ingestion pipeline attaches.
+fn provider_records(c: &mut Criterion) {
+    let mut g = c.benchmark_group("provider_records");
+
+    for extra in [0usize, 12] {
+        let fields: String = (0..extra)
+            .map(|i| format!(r#","field_{i}":"value {i}""#))
+            .collect();
+        let lines: Vec<String> = (0..10_000)
+            .map(|i| {
+                format!(
+                    r#"{{"_time":"2026-09-05T12:00:00Z","_msg":"request {i} served","kubernetes.pod_name":"api-{i}","kubernetes.container_name":"app"{fields}}}"#
+                )
+            })
+            .collect();
+
+        g.bench_with_input(
+            BenchmarkId::new("visitor_10000", extra),
+            &lines,
+            |b, lines| {
+                b.iter(|| {
+                    for l in lines {
+                        black_box(sofka::providers::bench_parse_entry(l));
+                    }
+                });
+            },
+        );
+        g.bench_with_input(
+            BenchmarkId::new("dom_baseline_10000", extra),
+            &lines,
+            |b, lines| {
+                b.iter(|| {
+                    for l in lines {
+                        let v: serde_json::Value = serde_json::from_str(l).unwrap();
+                        black_box((
+                            v.get("_msg").and_then(|v| v.as_str()).map(str::to_string),
+                            v.get("_time").and_then(|v| v.as_str()).map(str::to_string),
+                            v.get("kubernetes.pod_name")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                            v.get("kubernetes.container_name")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                        ));
+                    }
+                });
+            },
+        );
+    }
+    g.finish();
+}
+
+/// The fuzzy matcher, over the two shapes it runs in: one needle against every
+/// row of a store, and the highlight positions the renderer asks for.
+fn fuzzy(c: &mut Criterion) {
+    let mut g = c.benchmark_group("fuzzy");
+    let names: Vec<String> = (0..20_000)
+        .map(|i| format!("kube-httpcache-{i:05}"))
+        .collect();
+    let f = sofka::fuzzy::Fuzzy::new();
+
+    g.bench_function("score_20000", |b| {
+        b.iter(|| {
+            for n in &names {
+                black_box(f.score(n, "khc"));
+            }
+        });
+    });
+    g.bench_function("indices_visible_50", |b| {
+        b.iter(|| {
+            for n in names.iter().take(50) {
+                black_box(f.indices(n, "khc"));
+            }
+        });
+    });
+    g.finish();
+}
+
+/// The memoized per-frame models: headers and the picker lists. Each pair is
+/// the memo against the rebuild it replaced.
+fn frame_models(c: &mut Criterion) {
+    let mut g = c.benchmark_group("frame_models");
+    let (app, _rx) = bs::pods_app(2_000);
+
+    g.bench_function("display_headers", |b| {
+        b.iter(|| black_box(app.display_headers()));
+    });
+
+    let (ctx_app, _ctx_rx) = bs::contexts_app(2_000);
+    g.bench_function("filtered_contexts_2000", |b| {
+        b.iter(|| black_box(ctx_app.filtered_contexts()));
+    });
+    g.bench_function("filtered_sort_entries", |b| {
+        b.iter(|| black_box(app.filtered_sort_entries()));
+    });
+    g.finish();
+}
+
+/// The dependency swaps whose baseline is in `std`, each against the
+/// implementation it replaced. The fuzzy matcher is measured in `fuzzy` above;
+/// its predecessor is not carried as a dependency just to benchmark it.
+fn dependencies(c: &mut Criterion) {
+    let mut g = c.benchmark_group("dependencies");
+
+    // --- hasher: foldhash against SipHash, over real row keys ---------------
+    // The shape that matters is a filter keystroke, which looks up every key
+    // in the store once. Keys are `namespace/name`, as the store holds them.
+    for n in [2_000usize, 20_000] {
+        let keys: Vec<std::rc::Rc<str>> = (0..n)
+            .map(|i| std::rc::Rc::from(format!("namespace-{}/pod-{i:05}", i % 40).as_str()))
+            .collect();
+
+        let mut fold: sofka::store::FastMap<std::rc::Rc<str>, u32> = Default::default();
+        let mut sip: std::collections::HashMap<std::rc::Rc<str>, u32> = Default::default();
+        for (i, k) in keys.iter().enumerate() {
+            fold.insert(k.clone(), i as u32);
+            sip.insert(k.clone(), i as u32);
+        }
+
+        g.bench_with_input(BenchmarkId::new("lookup_foldhash", n), &n, |b, _| {
+            b.iter(|| {
+                for k in &keys {
+                    black_box(fold.get(k.as_ref()));
+                }
+            });
+        });
+        g.bench_with_input(BenchmarkId::new("lookup_siphash", n), &n, |b, _| {
+            b.iter(|| {
+                for k in &keys {
+                    black_box(sip.get(k.as_ref()));
+                }
+            });
+        });
+    }
+
+    g.finish();
+}
+
 criterion_group!(
     benches,
     rows_cache,
@@ -353,6 +610,12 @@ criterion_group!(
     log_wrap,
     log_viewport,
     cell_extract,
-    provider_selection
+    provider_selection,
+    frame_clock,
+    custom_columns,
+    provider_records,
+    fuzzy,
+    frame_models,
+    dependencies
 );
 criterion_main!(benches);

--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -353,19 +353,30 @@ fn frame_clock(c: &mut Criterion) {
     let mut g = c.benchmark_group("frame_clock");
     let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
     let spec = columns::build_spec("pods", None, None, false);
+    // AGE is the elapsed cell this measures, and it is not column 0 — that is
+    // NAME, which is not volatile, so both sides would have returned `None`
+    // and timed the clock call against an empty result.
+    let age = spec
+        .header_index("AGE")
+        .expect("pods view must have an AGE column");
+    assert!(
+        spec.volatile(&pods[0], "pods", age, columns::now_secs())
+            .is_some(),
+        "AGE must render an elapsed value, or this measures nothing"
+    );
 
     g.bench_function("one_reading_per_frame_2000", |b| {
         b.iter(|| {
             let now = columns::now_secs();
             for pod in &pods {
-                black_box(spec.volatile(pod, "pods", 0, now));
+                black_box(spec.volatile(pod, "pods", age, now));
             }
         });
     });
     g.bench_function("one_reading_per_cell_2000", |b| {
         b.iter(|| {
             for pod in &pods {
-                black_box(spec.volatile(pod, "pods", 0, columns::now_secs()));
+                black_box(spec.volatile(pod, "pods", age, columns::now_secs()));
             }
         });
     });

--- a/src/app/find.rs
+++ b/src/app/find.rs
@@ -68,7 +68,7 @@ impl App {
 
             // Score after gathering: the matcher isn't Send, so it must not
             // live across the await above.
-            let matcher = SkimMatcherV2::default();
+            let matcher = crate::fuzzy::Fuzzy::new();
             let mut failed = 0usize;
             let mut scored: Vec<(i64, crate::store::FindItem)> = Vec::new();
             for (plural, res) in lists {
@@ -76,7 +76,7 @@ impl App {
                     Ok(list) => {
                         for o in list.items {
                             let name = o.metadata.name.unwrap_or_default();
-                            if let Some(score) = matcher.fuzzy_match(&name, &query) {
+                            if let Some(score) = matcher.score(&name, &query) {
                                 scored.push((
                                     score,
                                     crate::store::FindItem {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -636,7 +636,7 @@ impl App {
                 let best = c
                     .names
                     .iter()
-                    .filter_map(|n| self.matcher.fuzzy_match(n, q))
+                    .filter_map(|n| self.matcher.score(n, q))
                     .max();
                 if let Some(score) = best {
                     scored.push((
@@ -663,7 +663,7 @@ impl App {
                 {
                     continue;
                 }
-                if let Some(score) = self.matcher.fuzzy_match(name, q) {
+                if let Some(score) = self.matcher.score(name, q) {
                     scored.push((
                         score,
                         Suggestion {
@@ -682,7 +682,7 @@ impl App {
             let score = if q.is_empty() {
                 Some(i64::MAX)
             } else {
-                self.matcher.fuzzy_match(&b.name, q).map(|s| s + 1_000)
+                self.matcher.score(&b.name, q).map(|s| s + 1_000)
             };
             if let Some(score) = score {
                 scored.push((
@@ -700,7 +700,7 @@ impl App {
             let score = if q.is_empty() {
                 Some(i64::MAX)
             } else {
-                self.matcher.fuzzy_match(&w.name, q).map(|s| s + 1_000)
+                self.matcher.score(&w.name, q).map(|s| s + 1_000)
             };
             if let Some(score) = score {
                 scored.push((
@@ -737,7 +737,7 @@ impl App {
                 continue;
             }
             if let Some(group) = group {
-                let bare_matches = q.is_empty() || self.matcher.fuzzy_match(plural, q).is_some();
+                let bare_matches = q.is_empty() || self.matcher.score(plural, q).is_some();
                 let same_kind = self
                     .cluster
                     .resolve(plural)
@@ -753,7 +753,7 @@ impl App {
             {
                 Some(i64::MAX)
             } else {
-                self.matcher.fuzzy_match(c, q)
+                self.matcher.score(c, q)
             };
             if let Some(score) = score {
                 scored.push((
@@ -788,7 +788,7 @@ impl App {
         for n in names {
             let score = if arg.is_empty() {
                 0
-            } else if let Some(s) = self.matcher.fuzzy_match(&n, arg) {
+            } else if let Some(s) = self.matcher.score(&n, arg) {
                 s
             } else {
                 continue;
@@ -814,7 +814,7 @@ impl App {
         for c in &self.all_contexts {
             let score = if arg.is_empty() {
                 0
-            } else if let Some(s) = self.matcher.fuzzy_match(c, arg) {
+            } else if let Some(s) = self.matcher.score(c, arg) {
                 s
             } else {
                 continue;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,8 +15,6 @@ use std::time::Duration;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use futures_util::StreamExt;
-use fuzzy_matcher::FuzzyMatcher;
-use fuzzy_matcher::skim::SkimMatcherV2;
 use k8s_openapi::api::core::v1::Pod;
 use kube::Client;
 use kube::api::{
@@ -1229,7 +1227,7 @@ const PREV_REVISIONS_MAX: usize = 256;
 /// drilling away and back keeps the baseline.
 #[derive(Default)]
 pub(super) struct PrevRevisions {
-    map: HashMap<(String, String), Arc<DynamicObject>>,
+    map: crate::store::FastMap<(String, String), Arc<DynamicObject>>,
     order: VecDeque<(String, String)>,
 }
 
@@ -1260,6 +1258,93 @@ struct FilterCache {
     parsed: crate::filter::ParsedFilter,
 }
 
+/// Highlight positions per row name for the active fuzzy needle.
+///
+/// The filter pass already ran the matcher over every row; without this the
+/// renderer ran it again for every *visible* row on every redraw, which is
+/// the same fuzzy scoring work repeated at frame rate for a result that only
+/// changes when the needle or the name does.
+#[derive(Default)]
+struct HighlightCache {
+    /// The needle these entries were matched against. Anything else empties
+    /// the map — a new needle invalidates every entry at once.
+    needle: String,
+    /// Match positions per name. `None` — the name did not match — is a real
+    /// answer and is cached too, so a filter that excludes most rows does not
+    /// re-run the matcher over them every frame.
+    rows: crate::store::FastMap<Box<str>, Option<Rc<[usize]>>>,
+}
+
+/// The display header list, valid for the view spec and column toggles it was
+/// built from.
+///
+/// `display_headers` is asked for the header list from a dozen places — the
+/// renderer, sorting, mouse hit-testing, the copy picker, bookmarks — several
+/// times per frame, and each call used to build a fresh `Vec<String>` of owned
+/// headers only to read one entry out of it.
+struct HeaderCache {
+    /// `(namespace column, node capacity columns, metrics columns)` — the
+    /// toggles that add columns around the spec's own.
+    shape: (bool, bool, bool),
+    /// Bumped whenever the view spec is rebuilt.
+    spec_rev: u64,
+    headers: Rc<[String]>,
+}
+
+/// Memoized picker lists.
+///
+/// Every one of these is fuzzy-scored and sorted from scratch on each draw,
+/// and again on each keystroke by the input handlers that ask it for a length,
+/// a selection or a lookup — several full rebuilds per frame while a picker is
+/// open.
+///
+/// Each memo is keyed on the inputs themselves rather than on a revision
+/// counter someone has to remember to bump: comparing them is a handful of
+/// string compares against no allocation, and a new writer to `ns_list` or the
+/// favourites cannot leave a stale list on screen.
+#[derive(Default)]
+struct PickerMemos {
+    namespaces: Option<NamespaceMemo>,
+    contexts: Option<ContextMemo>,
+    sort_entries: Option<SortEntryMemo>,
+    copy_entries: Option<CopyEntryMemo>,
+}
+
+struct NamespaceMemo {
+    filter: String,
+    context: String,
+    ns_list: Vec<String>,
+    favorites: Vec<String>,
+    recents: Vec<String>,
+    value: Rc<Vec<String>>,
+}
+
+struct ContextMemo {
+    filter: String,
+    ctx_list: Vec<String>,
+    value: Rc<Vec<String>>,
+}
+
+struct SortEntryMemo {
+    filter: String,
+    /// The header list this was built from. Held as the same handle
+    /// `display_headers` returns, so a hit is a pointer comparison.
+    headers: Rc<[String]>,
+    value: Rc<Vec<String>>,
+}
+
+struct CopyEntryMemo {
+    filter: String,
+    fields: Vec<(String, String)>,
+    value: Rc<Vec<(String, String)>>,
+}
+
+/// Names are only inserted when they are drawn, so this holds a screenful in
+/// practice. The bound is here for the pathological case — a session left on
+/// one filter while rows churn through it — and clearing costs one redraw's
+/// worth of rematching.
+const HIGHLIGHT_CACHE_LIMIT: usize = 4096;
+
 /// Lazily-rebuilt cache of the display-ordered, filtered row keys. Recomputing
 /// the sort + fuzzy filter on every `rows()` call (per frame, per keystroke) is
 /// wasteful on large clusters; we rebuild only when the store or filter changes.
@@ -1267,14 +1352,14 @@ struct FilterCache {
 struct RowsCache {
     dirty: bool,
     keys: Vec<RowKey>,
-    cells: HashMap<RowKey, CellCacheEntry>,
+    cells: crate::store::FastMap<RowKey, CellCacheEntry>,
     /// Computed primary sort keys, valid per (sort header, resourceVersion) —
     /// a rebuild touches every object, but only changed rows re-extract.
-    sort_keys: HashMap<RowKey, SortKeyEntry>,
+    sort_keys: crate::store::FastMap<RowKey, SortKeyEntry>,
     /// Helm view only: the latest-revision dedup, paired with the store
     /// version it was computed from. A rebuild staled by a filter keystroke or
     /// a sort toggle leaves the store untouched, so the dedup still holds.
-    helm_latest: Option<(u64, HashSet<RowKey>)>,
+    helm_latest: Option<(u64, crate::store::FastSet<RowKey>)>,
 }
 
 struct CellCacheEntry {
@@ -1461,6 +1546,17 @@ pub struct App {
     /// Parsed form of `filter`, refreshed lazily when the string changes so
     /// neither row matching nor rendering reparses it per frame.
     filter_cache: RefCell<FilterCache>,
+    /// Fuzzy highlight positions per visible row name, valid for the needle
+    /// they were matched against.
+    highlight_cache: RefCell<HighlightCache>,
+    /// Memoized `display_headers()`, rebuilt when the spec or the column
+    /// toggles change.
+    header_cache: RefCell<Option<HeaderCache>>,
+    /// Memoized picker lists, each valid for the inputs it was built from.
+    picker_memos: RefCell<PickerMemos>,
+    /// Bumped on every view-spec rebuild, so caches derived from the spec can
+    /// tell that it moved.
+    spec_rev: u64,
     /// Server-side selectors (`-l`/`-f` filter terms) the running watch was
     /// started with. Compared against the parsed filter to know when a
     /// restart is needed and to mark the filter as server-side in the UI.
@@ -1756,7 +1852,7 @@ pub struct App {
     /// return so the cursor lands back on the same object.
     return_selection: Option<String>,
     pub should_quit: bool,
-    matcher: SkimMatcherV2,
+    matcher: crate::fuzzy::Fuzzy,
     rows_cache: RefCell<RowsCache>,
     /// Scratch buffer for the fuzzy filter's "namespace name" haystack, reused
     /// across rows so the filter pass doesn't allocate a `String` per object.
@@ -1822,6 +1918,10 @@ impl App {
                 raw: String::new(),
                 parsed: crate::filter::parse(""),
             }),
+            highlight_cache: RefCell::new(HighlightCache::default()),
+            header_cache: RefCell::new(None),
+            picker_memos: RefCell::new(PickerMemos::default()),
+            spec_rev: 0,
             applied_filter_labels: None,
             applied_filter_fields: None,
             command: String::new(),
@@ -1959,13 +2059,13 @@ impl App {
             return_mode: Mode::Table,
             return_selection: None,
             should_quit: false,
-            matcher: SkimMatcherV2::default(),
+            matcher: crate::fuzzy::Fuzzy::new(),
             hay_buf: RefCell::new(String::new()),
             rows_cache: RefCell::new(RowsCache {
                 dirty: true,
                 keys: Vec::new(),
-                cells: HashMap::new(),
-                sort_keys: HashMap::new(),
+                cells: crate::store::FastMap::default(),
+                sort_keys: crate::store::FastMap::default(),
                 helm_latest: None,
             }),
             log_provider: None,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -67,16 +67,29 @@ impl App {
     /// then the remaining namespaces alphabetically. With a filter active,
     /// everything is fuzzy-matched (favourites/recents lose their pinning so
     /// the best textual match wins).
-    pub fn filtered_namespaces(&self) -> Vec<String> {
+    pub fn filtered_namespaces(&self) -> Rc<Vec<String>> {
+        if let Some(m) = self.picker_memos.borrow().namespaces.as_ref()
+            && m.filter == self.ns_filter
+            && m.context == self.cluster.context
+            && m.ns_list == self.ns_list
+            && m.favorites == self.namespace_favorites
+            && m.recents
+                .iter()
+                .map(String::as_str)
+                .eq(self.recent_namespaces_for_context())
+        {
+            return Rc::clone(&m.value);
+        }
+
         let mut out = vec!["<all>".to_string()];
         let rest = self.ns_list.iter().filter(|n| n.as_str() != "<all>");
         if !self.ns_filter.is_empty() {
             let mut scored: Vec<(i64, &String)> = rest
-                .filter_map(|n| self.matcher.fuzzy_match(n, &self.ns_filter).map(|s| (s, n)))
+                .filter_map(|n| self.matcher.score(n, &self.ns_filter).map(|s| (s, n)))
                 .collect();
             scored.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(b.1)));
             out.extend(scored.into_iter().map(|(_, n)| n.clone()));
-            return out;
+            return self.remember_namespaces(out);
         }
 
         let available: std::collections::HashSet<&str> = rest.map(String::as_str).collect();
@@ -90,8 +103,8 @@ impl App {
         }
         // Then session recents that still exist and aren't already favourites.
         for r in self.recent_namespaces_for_context() {
-            if available.contains(r.as_str()) && seen.insert(r.clone()) {
-                out.push(r);
+            if available.contains(r) && seen.insert(r.to_string()) {
+                out.push(r.to_string());
             }
         }
         // Then everything else (ns_list is already sorted).
@@ -100,15 +113,32 @@ impl App {
                 out.push(n.clone());
             }
         }
-        out
+        self.remember_namespaces(out)
     }
 
-    /// The recent namespaces for the current context, newest first.
-    fn recent_namespaces_for_context(&self) -> Vec<String> {
+    fn remember_namespaces(&self, out: Vec<String>) -> Rc<Vec<String>> {
+        let value = Rc::new(out);
+        self.picker_memos.borrow_mut().namespaces = Some(NamespaceMemo {
+            filter: self.ns_filter.clone(),
+            context: self.cluster.context.clone(),
+            ns_list: self.ns_list.clone(),
+            favorites: self.namespace_favorites.clone(),
+            recents: self
+                .recent_namespaces_for_context()
+                .map(str::to_string)
+                .collect(),
+            value: Rc::clone(&value),
+        });
+        value
+    }
+
+    /// The recent namespaces for the current context, newest first. Borrowed:
+    /// every caller only reads them.
+    fn recent_namespaces_for_context(&self) -> impl Iterator<Item = &str> + Clone {
         self.recent_namespaces
             .get(&self.cluster.context)
-            .map(|dq| dq.iter().cloned().collect())
-            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|dq| dq.iter().map(String::as_str))
     }
 
     /// Whether `n` is a configured favourite namespace.
@@ -182,24 +212,41 @@ impl App {
     /// Entries for the sort picker: the default ordering is always pinned
     /// first; column headers are fuzzy-matched against the type-to-filter
     /// buffer (see `filtered_namespaces` for the same pattern).
-    pub fn filtered_sort_entries(&self) -> Vec<String> {
-        let mut out = vec![DEFAULT_SORT_LABEL.to_string()];
+    pub fn filtered_sort_entries(&self) -> Rc<Vec<String>> {
         let headers = self.display_headers();
+        if let Some(m) = self.picker_memos.borrow().sort_entries.as_ref()
+            && m.filter == self.sort_picker_filter
+            && Rc::ptr_eq(&m.headers, &headers)
+        {
+            return Rc::clone(&m.value);
+        }
+
+        let mut out = vec![DEFAULT_SORT_LABEL.to_string()];
         if self.sort_picker_filter.is_empty() {
-            out.extend(headers);
-            return out;
+            out.extend(headers.iter().cloned());
+            return self.remember_sort_entries(headers, out);
         }
         let mut scored: Vec<(i64, String)> = headers
-            .into_iter()
+            .iter()
             .filter_map(|h| {
                 self.matcher
-                    .fuzzy_match(&h, &self.sort_picker_filter)
-                    .map(|s| (s, h))
+                    .score(h, &self.sort_picker_filter)
+                    .map(|s| (s, h.clone()))
             })
             .collect();
         scored.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
         out.extend(scored.into_iter().map(|(_, h)| h));
-        out
+        self.remember_sort_entries(headers, out)
+    }
+
+    fn remember_sort_entries(&self, headers: Rc<[String]>, out: Vec<String>) -> Rc<Vec<String>> {
+        let value = Rc::new(out);
+        self.picker_memos.borrow_mut().sort_entries = Some(SortEntryMemo {
+            filter: self.sort_picker_filter.clone(),
+            headers,
+            value: Rc::clone(&value),
+        });
+        value
     }
 
     pub(super) fn key_sort_picker(&mut self, key: KeyEvent) {
@@ -306,21 +353,37 @@ impl App {
     /// Entries for the copy picker: the captured `(header, value)` pairs,
     /// fuzzy-matched against both the header and the value (so typing part
     /// of an IP finds it as readily as typing the column name).
-    pub fn filtered_copy_entries(&self) -> Vec<(String, String)> {
+    pub fn filtered_copy_entries(&self) -> Rc<Vec<(String, String)>> {
+        if let Some(m) = self.picker_memos.borrow().copy_entries.as_ref()
+            && m.filter == self.copy_picker_filter
+            && m.fields == self.copy_picker_fields
+        {
+            return Rc::clone(&m.value);
+        }
         if self.copy_picker_filter.is_empty() {
-            return self.copy_picker_fields.clone();
+            return self.remember_copy_entries(self.copy_picker_fields.clone());
         }
         let mut scored: Vec<(i64, (String, String))> = self
             .copy_picker_fields
             .iter()
             .filter_map(|(h, v)| {
                 self.matcher
-                    .fuzzy_match(&format!("{h} {v}"), &self.copy_picker_filter)
+                    .score(&format!("{h} {v}"), &self.copy_picker_filter)
                     .map(|s| (s, (h.clone(), v.clone())))
             })
             .collect();
         scored.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.0.cmp(&b.1.0)));
-        scored.into_iter().map(|(_, e)| e).collect()
+        self.remember_copy_entries(scored.into_iter().map(|(_, e)| e).collect())
+    }
+
+    fn remember_copy_entries(&self, out: Vec<(String, String)>) -> Rc<Vec<(String, String)>> {
+        let value = Rc::new(out);
+        self.picker_memos.borrow_mut().copy_entries = Some(CopyEntryMemo {
+            filter: self.copy_picker_filter.clone(),
+            fields: self.copy_picker_fields.clone(),
+            value: Rc::clone(&value),
+        });
+        value
     }
 
     pub(super) fn key_copy_picker(&mut self, key: KeyEvent) {
@@ -507,21 +570,33 @@ impl App {
 
     /// Contexts for the switcher, fuzzy-matched against the type-to-filter
     /// buffer (see `filtered_namespaces` for the same pattern).
-    pub fn filtered_contexts(&self) -> Vec<String> {
+    pub fn filtered_contexts(&self) -> Rc<Vec<String>> {
+        if let Some(m) = self.picker_memos.borrow().contexts.as_ref()
+            && m.filter == self.ctx_filter
+            && m.ctx_list == self.ctx_list
+        {
+            return Rc::clone(&m.value);
+        }
         if self.ctx_filter.is_empty() {
-            return self.ctx_list.clone();
+            return self.remember_contexts(self.ctx_list.clone());
         }
         let mut scored: Vec<(i64, &String)> = self
             .ctx_list
             .iter()
-            .filter_map(|c| {
-                self.matcher
-                    .fuzzy_match(c, &self.ctx_filter)
-                    .map(|s| (s, c))
-            })
+            .filter_map(|c| self.matcher.score(c, &self.ctx_filter).map(|s| (s, c)))
             .collect();
         scored.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(b.1)));
-        scored.into_iter().map(|(_, c)| c.clone()).collect()
+        self.remember_contexts(scored.into_iter().map(|(_, c)| c.clone()).collect())
+    }
+
+    fn remember_contexts(&self, out: Vec<String>) -> Rc<Vec<String>> {
+        let value = Rc::new(out);
+        self.picker_memos.borrow_mut().contexts = Some(ContextMemo {
+            filter: self.ctx_filter.clone(),
+            ctx_list: self.ctx_list.clone(),
+            value: Rc::clone(&value),
+        });
+        value
     }
 
     /// Contexts type-to-filter like the namespace picker. Existing action keys

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -62,12 +62,13 @@ impl App {
         o: &DynamicObject,
         key: &RowKey,
         parsed: &crate::filter::ParsedFilter,
-        cells: &mut HashMap<RowKey, CellCacheEntry>,
+        cells: &mut crate::store::FastMap<RowKey, CellCacheEntry>,
+        now: i64,
     ) -> bool {
         if self.filter.is_empty() {
             return true;
         }
-        self.eval_filter(o, key, parsed, cells)
+        self.eval_filter(o, key, parsed, cells, now)
     }
 
     fn eval_filter(
@@ -75,15 +76,18 @@ impl App {
         o: &DynamicObject,
         key: &RowKey,
         parsed: &crate::filter::ParsedFilter,
-        cells: &mut HashMap<RowKey, CellCacheEntry>,
+        cells: &mut crate::store::FastMap<RowKey, CellCacheEntry>,
+        now: i64,
     ) -> bool {
         use crate::filter::{ParsedFilter, Term};
         match parsed {
-            ParsedFilter::Fuzzy(pat) => pat.is_empty() || self.fuzzy_match_row(o, pat, key, cells),
+            ParsedFilter::Fuzzy(pat) => {
+                pat.is_empty() || self.fuzzy_match_row(o, pat, key, cells, now)
+            }
             ParsedFilter::Structured(s) => s.terms.iter().all(|t| match t {
-                Term::Fuzzy(pat) => self.fuzzy_match_row(o, pat, key, cells),
-                Term::NotFuzzy(pat) => !self.fuzzy_match_row(o, pat, key, cells),
-                Term::Cmp(cmp) => self.eval_cmp(o, cmp),
+                Term::Fuzzy(pat) => self.fuzzy_match_row(o, pat, key, cells, now),
+                Term::NotFuzzy(pat) => !self.fuzzy_match_row(o, pat, key, cells, now),
+                Term::Cmp(cmp) => self.eval_cmp(o, cmp, now),
             }),
         }
     }
@@ -106,7 +110,8 @@ impl App {
         o: &DynamicObject,
         pat: &str,
         key: &RowKey,
-        cells: &mut HashMap<RowKey, CellCacheEntry>,
+        cells: &mut crate::store::FastMap<RowKey, CellCacheEntry>,
+        now: i64,
     ) -> bool {
         let pat_mask = subseq_mask(pat);
         {
@@ -114,13 +119,11 @@ impl App {
             // `String` for every object on every keystroke.
             let mut hay = self.hay_buf.borrow_mut();
             self.write_fuzzy_hay(o, &mut hay);
-            if subseq_mask(&hay) & pat_mask == pat_mask
-                && self.matcher.fuzzy_match(&hay, pat).is_some()
-            {
+            if subseq_mask(&hay) & pat_mask == pat_mask && self.matcher.score(&hay, pat).is_some() {
                 return true;
             }
         }
-        let entry = self.cell_entry(key, o, cells);
+        let entry = self.cell_entry(key, o, cells, now);
         // No cell can contain every pattern character, so none can match.
         if entry.row_mask & pat_mask != pat_mask {
             return false;
@@ -129,7 +132,7 @@ impl App {
             .cells
             .iter()
             .zip(&entry.cell_masks)
-            .any(|(c, &m)| m & pat_mask == pat_mask && self.matcher.fuzzy_match(c, pat).is_some())
+            .any(|(c, &m)| m & pat_mask == pat_mask && self.matcher.score(c, pat).is_some())
     }
 
     /// The cached cells for `key`, rendering them if absent or stale.
@@ -137,14 +140,15 @@ impl App {
         &self,
         key: &RowKey,
         o: &DynamicObject,
-        cells: &'c mut HashMap<RowKey, CellCacheEntry>,
+        cells: &'c mut crate::store::FastMap<RowKey, CellCacheEntry>,
+        now: i64,
     ) -> &'c CellCacheEntry {
         let resource_version = o.metadata.resource_version.clone();
         let stale = cells
             .get(key)
             .is_none_or(|e| e.plural != self.kind_plural || e.resource_version != resource_version);
         if stale {
-            let (rendered, status_idx) = self.spec.cells(o);
+            let (rendered, status_idx) = self.spec.cells(o, now);
             let cell_masks: Vec<u64> = rendered.iter().map(|c| subseq_mask(c)).collect();
             let row_mask = cell_masks.iter().fold(0u64, |a, m| a | m);
             cells.insert(
@@ -182,16 +186,16 @@ impl App {
     /// read the live metrics snapshot, `age` the creation timestamp; any
     /// other key names a displayed column (numeric values compare by the
     /// cell's leading number, text case-insensitively).
-    fn eval_cmp(&self, o: &DynamicObject, cmp: &crate::filter::Cmp) -> bool {
+    fn eval_cmp(&self, o: &DynamicObject, cmp: &crate::filter::Cmp, now: i64) -> bool {
         use crate::filter::CmpValue;
         match &cmp.value {
             CmpValue::Cpu(want) => cmp.op.eval(self.metrics_for(o).0.cmp(want)),
             CmpValue::Mem(want) => cmp.op.eval(self.metrics_for(o).1.cmp(want)),
-            CmpValue::Duration(want) => match crate::columns::age_secs(o) {
+            CmpValue::Duration(want) => match crate::columns::age_secs(o, now) {
                 Some(age) => cmp.op.eval(age.cmp(want)),
                 None => false,
             },
-            CmpValue::Num(want) => match self.column_cell(o, &cmp.key) {
+            CmpValue::Num(want) => match self.column_cell(o, &cmp.key, now) {
                 Some(cell) => cmp
                     .op
                     .eval(crate::columns::parse_leading_num(&cell).total_cmp(want)),
@@ -200,7 +204,7 @@ impl App {
             // `want` was folded once at parse time. ASCII cells compare through
             // an allocation-free byte iterator; non-ASCII cells use
             // whole-string lowercasing for context-sensitive Unicode mappings.
-            CmpValue::Str(want) => match self.column_cell(o, &cmp.key) {
+            CmpValue::Str(want) => match self.column_cell(o, &cmp.key, now) {
                 Some(cell) => cmp.op.eval(crate::filter::cmp_folded_lower(&cell, want)),
                 None => false,
             },
@@ -211,14 +215,14 @@ impl App {
     /// header), plus NAMESPACE and a `/status/phase` fallback for kinds
     /// without a STATUS column. Extracts only the named column — this runs
     /// per object per rebuild when a structured filter is active.
-    fn column_cell<'o>(&self, o: &'o DynamicObject, key: &str) -> Option<Cow<'o, str>> {
+    fn column_cell<'o>(&self, o: &'o DynamicObject, key: &str, now: i64) -> Option<Cow<'o, str>> {
         if key.eq_ignore_ascii_case("namespace") || key.eq_ignore_ascii_case("ns") {
             // Borrowed: the namespace is already a `String` on the object, and
             // this runs per object per rebuild.
             return Some(o.metadata.namespace.as_deref().unwrap_or("").into());
         }
         if let Some(i) = self.spec.header_index(key) {
-            return self.spec.cell_at(o, i);
+            return self.spec.cell_at(o, i, now);
         }
         if key.eq_ignore_ascii_case("status") {
             let phase = phase(o);
@@ -251,13 +255,36 @@ impl App {
     /// active filter or no fuzzy term (every visible row already passed
     /// the filter pass, so this is purely a rendering aid, not a second
     /// filter decision).
-    pub fn filter_match_indices(&self, name: &str) -> Option<Vec<usize>> {
+    ///
+    /// Memoized per name for the current needle: the renderer asks this for
+    /// every visible row on every redraw, and re-running the fuzzy matcher to
+    /// get an answer that cannot have changed is the single most expensive
+    /// thing a filtered frame used to do.
+    pub fn filter_match_indices(&self, name: &str) -> Option<Rc<[usize]>> {
         if self.filter.is_empty() {
             return None;
         }
         let parsed = self.parsed_filter();
         let needle = parsed.fuzzy_needle()?;
-        self.matcher.fuzzy_indices(name, needle).map(|(_, idx)| idx)
+
+        let mut cache = self.highlight_cache.borrow_mut();
+        if cache.needle != needle {
+            cache.needle.clear();
+            cache.needle.push_str(needle);
+            cache.rows.clear();
+        }
+        if let Some(hit) = cache.rows.get(name) {
+            return hit.clone();
+        }
+        if cache.rows.len() >= HIGHLIGHT_CACHE_LIMIT {
+            cache.rows.clear();
+        }
+        let idx = self
+            .matcher
+            .indices(name, needle)
+            .map(|idx| Rc::from(idx.as_slice()));
+        cache.rows.insert(Box::from(name), idx.clone());
+        idx
     }
 
     pub(super) fn ensure_rows_cache(&self) {
@@ -294,6 +321,11 @@ impl App {
         // Parsed once, not once per object: the filter check used to re-borrow
         // the filter cache and re-compare the raw filter string for every row.
         let parsed = self.parsed_filter();
+        // One clock reading for the whole rebuild. Every AGE cell, DURATION
+        // cell and `age >` comparison in this pass is measured against the
+        // same instant, so a rebuild that crosses a second boundary cannot
+        // sort two rows against two different "now"s.
+        let now = crate::columns::now_secs();
         // Disjoint field borrows so the filter can warm the cell cache while
         // the sort-key cache is also held.
         let RowsCache {
@@ -319,7 +351,7 @@ impl App {
             {
                 continue;
             }
-            if !self.matches_filter_cached(o, k, &parsed, cells) {
+            if !self.matches_filter_cached(o, k, &parsed, cells, now) {
                 continue;
             }
             // One watch event marks the whole ordering dirty, so the
@@ -329,7 +361,7 @@ impl App {
             // their cells.
             let primary = match sort_header {
                 None => SortKey::Text(empty_sort.clone()),
-                Some(h) if volatile_sort => self.column_sort_key(o, h),
+                Some(h) if volatile_sort => self.column_sort_key(o, h, now),
                 Some(h) => {
                     let rv = o.metadata.resource_version.as_deref();
                     match sort_keys.get(k) {
@@ -337,7 +369,7 @@ impl App {
                             e.key.clone()
                         }
                         _ => {
-                            let key = self.column_sort_key(o, h);
+                            let key = self.column_sort_key(o, h, now);
                             sort_keys.insert(
                                 k.clone(),
                                 SortKeyEntry {
@@ -415,8 +447,9 @@ impl App {
     /// Store keys of the highest-revision secret per (namespace, release) —
     /// label-based (no gunzip/decode needed), used to dedup the aggregated
     /// Helm release list down to one row per release, like `helm list`.
-    fn helm_latest_revision_keys(&self) -> HashSet<RowKey> {
-        let mut latest: HashMap<(String, String), (i64, RowKey)> = HashMap::new();
+    fn helm_latest_revision_keys(&self) -> crate::store::FastSet<RowKey> {
+        let mut latest: crate::store::FastMap<(String, String), (i64, RowKey)> =
+            crate::store::FastMap::default();
         for (k, o) in self.store.iter() {
             let Some(name) = crate::helm::release_name(o) else {
                 continue;
@@ -469,6 +502,7 @@ impl App {
 
     pub(crate) fn ensure_table_cell_cache(&self, rows: &[&DynamicObject]) {
         let mut cache = self.rows_cache.borrow_mut();
+        let now = crate::columns::now_secs();
         for obj in rows {
             // Shares `cell_entry` with the filter pass, so a row rendered for
             // filtering is already warm for the renderer (and vice versa) and
@@ -479,7 +513,7 @@ impl App {
                 .key(&key)
                 .cloned()
                 .unwrap_or_else(|| Rc::from(key));
-            self.cell_entry(&key, obj, &mut cache.cells);
+            self.cell_entry(&key, obj, &mut cache.cells, now);
         }
     }
 
@@ -493,23 +527,46 @@ impl App {
     /// NAMESPACE prepended when listing across namespaces and CPU/MEM appended
     /// for pods/nodes. Kept in one place so sorting and rendering agree on the
     /// column layout.
-    pub fn display_headers(&self) -> Vec<String> {
+    /// Memoized against the view spec and the column toggles: this is asked
+    /// for from a dozen places, several times per frame, and each answer used
+    /// to be a freshly built list of owned header strings.
+    pub fn display_headers(&self) -> Rc<[String]> {
+        let shape = (
+            self.show_namespace_column(),
+            self.node_capacity_columns(),
+            self.metrics_columns(),
+        );
+        if let Some(c) = self.header_cache.borrow().as_ref()
+            && c.shape == shape
+            && c.spec_rev == self.spec_rev
+        {
+            return Rc::clone(&c.headers);
+        }
+
+        let (ns, caps, metrics) = shape;
         let mut h = self.spec.headers();
-        if self.show_namespace_column() {
+        if ns {
             h.insert(0, "NAMESPACE".into());
         }
-        if self.node_capacity_columns() {
+        if caps {
             h.push("PODS".into());
         }
-        if self.metrics_columns() {
+        if metrics {
             h.push("CPU".into());
             h.push("MEM".into());
         }
-        if self.node_capacity_columns() {
+        if caps {
             h.push("%CPU".into());
             h.push("%MEM".into());
         }
-        h
+
+        let headers: Rc<[String]> = Rc::from(h);
+        *self.header_cache.borrow_mut() = Some(HeaderCache {
+            shape,
+            spec_rev: self.spec_rev,
+            headers: Rc::clone(&headers),
+        });
+        headers
     }
 
     /// Nodes get usage as a percentage of `status.allocatable` next to the
@@ -552,6 +609,7 @@ impl App {
             self.wide,
         );
         self.spec = spec;
+        self.spec_rev = self.spec_rev.wrapping_add(1);
         if let Some(h) = sort_header {
             self.sort_column = self.display_headers().iter().position(|x| *x == h);
             if self.sort_column.is_none() {
@@ -659,12 +717,12 @@ impl App {
     }
 
     /// Comparable value of `header`'s cell for object `o`.
-    pub(super) fn column_sort_key(&self, o: &DynamicObject, header: &str) -> SortKey {
+    pub(super) fn column_sort_key(&self, o: &DynamicObject, header: &str, now: i64) -> SortKey {
         // User/printer columns sort by their declared type (quantity, number,
         // time…), and win over the curated special cases so an overlay that
         // redefines a header sorts by its own values.
         if self.spec.is_user_column(header)
-            && let Some(v) = self.spec.sort_value(o, header)
+            && let Some(v) = self.spec.sort_value(o, header, now)
         {
             return SortKey::from(v);
         }
@@ -678,7 +736,7 @@ impl App {
                     .into(),
             ),
             // Unknown timestamps sort last (oldest-unknown) in ascending order.
-            "AGE" => SortKey::Num(crate::columns::age_secs(o).unwrap_or(i64::MAX) as f64),
+            "AGE" => SortKey::Num(crate::columns::age_secs(o, now).unwrap_or(i64::MAX) as f64),
             "CPU" => SortKey::Num(self.metrics_for(o).0 as f64),
             "MEM" => SortKey::Num(self.metrics_for(o).1 as f64),
             // Unknown counts (poll hasn't landed) sort below every real count.
@@ -717,14 +775,14 @@ impl App {
                     .unwrap_or(f64::INFINITY),
             ),
             "DURATION" if self.kind_plural == "jobs" => {
-                SortKey::Num(crate::columns::job_duration_secs(o).unwrap_or(i64::MAX) as f64)
+                SortKey::Num(crate::columns::job_duration_secs(o, now).unwrap_or(i64::MAX) as f64)
             }
             // Helm revisions are plain integers; flux REVISION cells (shas,
             // `main@sha1:…`) stay text.
             "REVISION" if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") => {
                 SortKey::Num(crate::helm::revision(o).unwrap_or(0) as f64)
             }
-            _ => match self.spec.sort_value(o, header) {
+            _ => match self.spec.sort_value(o, header, now) {
                 Some(v) => SortKey::from(v),
                 None => SortKey::Text(Rc::from("")),
             },
@@ -830,11 +888,12 @@ impl App {
         if self.show_namespace_column() {
             values.push(obj.metadata.namespace.clone().unwrap_or_default());
         }
-        let (cells, _) = self.spec.cells(obj);
+        let now = crate::columns::now_secs();
+        let (cells, _) = self.spec.cells(obj, now);
         for (i, cell) in cells.into_iter().enumerate() {
             values.push(
                 self.spec
-                    .volatile(obj, &self.kind_plural, i)
+                    .volatile(obj, &self.kind_plural, i, now)
                     .unwrap_or(cell),
             );
         }
@@ -856,7 +915,8 @@ impl App {
             }
         }
         self.display_headers()
-            .into_iter()
+            .iter()
+            .cloned()
             .zip(values)
             .filter(|(_, v)| !v.is_empty())
             .collect()

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -47,7 +47,7 @@ impl App {
     /// the table renders (NAMESPACE prepended across namespaces, CPU/MEM
     /// appended for pods/nodes, volatile cells resolved), minus the coloring.
     pub(super) fn snapshot_table(&self) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers = self.display_headers();
+        let headers: Vec<String> = self.display_headers().to_vec();
         let show_ns = self.show_namespace_column();
         let metrics_cols = self.metrics_columns();
         let pods_view = self.kind_plural == "pods";
@@ -56,6 +56,9 @@ impl App {
         self.ensure_table_cell_cache(&objs);
         let cache = self.table_cell_cache();
         let spec = self.view_spec();
+        // One clock reading for the whole snapshot, so every row's elapsed
+        // cell is measured against the same instant.
+        let now = crate::columns::now_secs();
 
         let rows = objs
             .iter()
@@ -67,9 +70,9 @@ impl App {
                 }
                 if let Some((base_cells, _)) = cache.get(&rk) {
                     for (i, cell) in base_cells.iter().enumerate() {
-                        match spec.volatile(obj, &self.kind_plural, i) {
+                        match spec.volatile(obj, &self.kind_plural, i, now) {
                             Some(v) => cells.push(v),
-                            None => cells.push(cell.clone()),
+                            None => cells.push(cell.to_string()),
                         }
                     }
                 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1041,7 +1041,7 @@ async fn namespace_filter_selects_best_match_not_all() {
     }
     // "kube-system" is the only real match — it should be under the
     // cursor, not the pinned "<all>" at index 0.
-    let filtered = app.filtered_namespaces();
+    let filtered = app.filtered_namespaces().to_vec();
     let selected = app.ns_state.selected().and_then(|i| filtered.get(i));
     assert_eq!(selected.map(String::as_str), Some("kube-system"));
 
@@ -1688,6 +1688,7 @@ async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
     // Click the RESTARTS header → sort by it; again → flip direction.
     let ridx = app
         .display_headers()
+        .to_vec()
         .iter()
         .position(|h| h == "RESTARTS")
         .unwrap();
@@ -1736,7 +1737,7 @@ async fn horizontal_column_scroll_anchors_name_and_clamps() {
     );
     app.table_state.select(Some(0));
 
-    let headers = app.display_headers();
+    let headers = app.display_headers().to_vec();
     assert_eq!(headers[0], "NAME");
     let scrollable = headers.len() - 1;
 
@@ -4940,7 +4941,7 @@ async fn sort_by_numeric_column_and_invert() {
 
     // RESTARTS is the 4th pod column; sort by it numerically (not "1,5,9"
     // as strings, which happens to agree here, but parsing is what matters).
-    assert_eq!(app.display_headers()[3], "RESTARTS");
+    assert_eq!(app.display_headers().to_vec()[3], "RESTARTS");
     app.sort_column = Some(3);
     app.invalidate_rows();
     let names: Vec<String> = app
@@ -5039,7 +5040,7 @@ async fn sorted_order_updates_when_an_object_changes() {
     apply(&mut app, pod("a", "1", 5));
     apply(&mut app, pod("b", "1", 1));
     apply(&mut app, pod("c", "1", 9));
-    assert_eq!(app.display_headers()[3], "RESTARTS");
+    assert_eq!(app.display_headers().to_vec()[3], "RESTARTS");
     app.sort_column = Some(3);
     app.invalidate_rows();
     let names = |app: &App| -> Vec<String> {
@@ -5054,7 +5055,7 @@ async fn sorted_order_updates_when_an_object_changes() {
     assert_eq!(names(&app), ["a", "c", "b"]); // 5, 9, 20
 
     // Changing the sort column must not reuse keys computed for the old one.
-    assert_eq!(app.display_headers()[0], "NAME");
+    assert_eq!(app.display_headers().to_vec()[0], "NAME");
     app.sort_column = Some(0);
     app.invalidate_rows();
     assert_eq!(names(&app), ["a", "b", "c"]);
@@ -5068,7 +5069,7 @@ async fn sort_picker_picks_toggles_and_clears() {
     // `S` opens the picker: default entry pinned first and selected (no sort).
     app.handle_key(press(KeyCode::Char('S'))).unwrap();
     assert_eq!(app.mode, Mode::SortPicker);
-    assert_eq!(app.filtered_sort_entries()[0], DEFAULT_SORT_LABEL);
+    assert_eq!(app.filtered_sort_entries().to_vec()[0], DEFAULT_SORT_LABEL);
     assert_eq!(app.sort_picker_state.selected(), Some(0));
 
     // Type-to-filter fuzzy-matches columns; the cursor lands on the best
@@ -5076,11 +5077,15 @@ async fn sort_picker_picks_toggles_and_clears() {
     for c in "rst".chars() {
         app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
-    assert_eq!(app.filtered_sort_entries()[1], "RESTARTS");
+    assert_eq!(app.filtered_sort_entries().to_vec()[1], "RESTARTS");
     assert_eq!(app.sort_picker_state.selected(), Some(1));
     app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Table);
-    let restarts = app.display_headers().iter().position(|h| h == "RESTARTS");
+    let restarts = app
+        .display_headers()
+        .to_vec()
+        .iter()
+        .position(|h| h == "RESTARTS");
     assert!(restarts.is_some());
     assert_eq!(app.sort_column, restarts);
     assert!(!app.sort_desc);
@@ -5120,7 +5125,11 @@ async fn sort_choice_is_remembered_per_kind_across_view_switches() {
     }
     app.handle_key(press(KeyCode::Enter)).unwrap();
     app.handle_key(press(KeyCode::Char('I'))).unwrap();
-    let restarts = app.display_headers().iter().position(|h| h == "RESTARTS");
+    let restarts = app
+        .display_headers()
+        .to_vec()
+        .iter()
+        .position(|h| h == "RESTARTS");
     assert_eq!(app.sort_column, restarts);
     assert!(app.sort_desc);
     assert_eq!(app.sort_memory.get("pods"), Some(("RESTARTS".into(), true)));
@@ -5134,7 +5143,10 @@ async fn sort_choice_is_remembered_per_kind_across_view_switches() {
     app.switch_kind("pods");
     assert_eq!(
         app.sort_column,
-        app.display_headers().iter().position(|h| h == "RESTARTS")
+        app.display_headers()
+            .to_vec()
+            .iter()
+            .position(|h| h == "RESTARTS")
     );
     assert!(app.sort_desc);
 
@@ -5142,6 +5154,7 @@ async fn sort_choice_is_remembered_per_kind_across_view_switches() {
     app.switch_kind("deployments");
     let ready = app
         .display_headers()
+        .to_vec()
         .iter()
         .position(|h| h == "READY")
         .unwrap();
@@ -5215,7 +5228,7 @@ async fn copy_picker_lists_full_row_fields_and_filters_on_values() {
     for c in "96.13".chars() {
         app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
-    let entries = app.filtered_copy_entries();
+    let entries = app.filtered_copy_entries().to_vec();
     assert_eq!(entries[0], ("CLUSTER-IP".into(), "10.96.13.5".into()));
     assert_eq!(app.copy_picker_state.selected(), Some(0));
 
@@ -5251,6 +5264,7 @@ async fn metrics_update_invalidates_metric_sorted_rows() {
 
     let cpu_idx = app
         .display_headers()
+        .to_vec()
         .iter()
         .position(|h| *h == "CPU")
         .unwrap();
@@ -5285,7 +5299,7 @@ async fn node_capacity_percent_columns_render_and_sort() {
     let (mut app, _rx) = test_app();
     // Pods must not grow the node columns.
     app.switch_kind("pods");
-    assert!(!app.display_headers().contains(&"%CPU".to_string()));
+    assert!(!app.display_headers().to_vec().contains(&"%CPU".to_string()));
 
     app.switch_kind("nodes");
     let node = |name: &str, cpu: &str| {
@@ -5296,7 +5310,7 @@ async fn node_capacity_percent_columns_render_and_sort() {
     apply(&mut app, node("big", "4"));
     apply(&mut app, node("small", "2"));
 
-    let headers = app.display_headers();
+    let headers = app.display_headers().to_vec();
     assert!(headers.contains(&"%CPU".to_string()), "{headers:?}");
     assert!(headers.contains(&"%MEM".to_string()), "{headers:?}");
 
@@ -5312,6 +5326,7 @@ async fn node_capacity_percent_columns_render_and_sort() {
     });
     let pct_idx = app
         .display_headers()
+        .to_vec()
         .iter()
         .position(|h| *h == "%CPU")
         .unwrap();
@@ -5331,10 +5346,10 @@ async fn nodes_view_pods_column_counts_and_sorts() {
     let (mut app, _rx) = test_app();
     // Pods must not grow a PODS column.
     app.switch_kind("pods");
-    assert!(!app.display_headers().contains(&"PODS".to_string()));
+    assert!(!app.display_headers().to_vec().contains(&"PODS".to_string()));
 
     app.switch_kind("nodes");
-    let headers = app.display_headers();
+    let headers = app.display_headers().to_vec();
     let pods_idx = headers.iter().position(|h| *h == "PODS").unwrap();
     // PODS sits right before the CPU/MEM usage columns, k9s-style.
     assert_eq!(headers[pods_idx + 1], "CPU", "{headers:?}");
@@ -5393,6 +5408,7 @@ async fn node_pods_update_invalidates_pods_sorted_rows() {
     }
     let pods_idx = app
         .display_headers()
+        .to_vec()
         .iter()
         .position(|h| *h == "PODS")
         .unwrap();
@@ -5743,12 +5759,12 @@ async fn namespace_switcher_pins_all_and_fuzzy_filters() {
         "prod".into(),
     ];
     // No filter: <all> first, then the rest.
-    assert_eq!(app.filtered_namespaces()[0], "<all>");
-    assert_eq!(app.filtered_namespaces().len(), 4);
+    assert_eq!(app.filtered_namespaces().to_vec()[0], "<all>");
+    assert_eq!(app.filtered_namespaces().to_vec().len(), 4);
 
     // Fuzzy filter (subsequence) keeps <all> pinned on top.
     app.ns_filter = "sys".into();
-    let f = app.filtered_namespaces();
+    let f = app.filtered_namespaces().to_vec();
     assert_eq!(f[0], "<all>");
     assert!(f.contains(&"kube-system".to_string()));
     assert!(!f.contains(&"default".to_string()));
@@ -6118,22 +6134,86 @@ async fn context_picker_typing_filters_and_backspace_widens() {
     app.handle_key(press(KeyCode::Char('p'))).unwrap();
     assert!(app.ctx_filtering);
     assert_eq!(app.ctx_filter, "p");
-    assert_eq!(app.filtered_contexts(), vec!["prod".to_string()]);
+    assert_eq!(app.filtered_contexts().to_vec(), vec!["prod".to_string()]);
     assert_eq!(app.ctx_state.selected(), Some(0));
 
     app.handle_key(press(KeyCode::Backspace)).unwrap();
     assert!(app.ctx_filter.is_empty());
     assert_eq!(
-        app.filtered_contexts(),
+        app.filtered_contexts().to_vec(),
         vec!["dev".to_string(), "prod".to_string(), "test".to_string()]
     );
     assert_eq!(app.ctx_state.selected(), Some(0));
 
     app.handle_key(press(KeyCode::Char('z'))).unwrap();
-    assert!(app.filtered_contexts().is_empty());
+    assert!(app.filtered_contexts().to_vec().is_empty());
     assert_eq!(app.ctx_state.selected(), None);
     app.handle_key(press(KeyCode::Backspace)).unwrap();
     assert_eq!(app.ctx_state.selected(), Some(0));
+}
+
+/// The namespace list is memoized against its inputs, so each of them has to
+/// move it: the type-to-filter buffer, the list itself arriving from the API,
+/// and the configured favourites.
+#[tokio::test]
+async fn namespace_switcher_follows_its_inputs() {
+    let (mut app, _rx) = test_app();
+    app.handle_msg(Msg::Namespaces {
+        generation: app.generation,
+        list: vec!["dev".into(), "prod".into(), "test".into()],
+    });
+
+    let browsing = app.filtered_namespaces().to_vec();
+    assert_eq!(browsing, ["<all>", "dev", "prod", "test"]);
+    // A second read comes from the memo and must not differ.
+    assert_eq!(app.filtered_namespaces().to_vec(), browsing);
+
+    // Typing narrows it.
+    app.ns_filter = "pr".into();
+    assert_eq!(app.filtered_namespaces().to_vec(), ["<all>", "prod"]);
+    // Clearing restores it.
+    app.ns_filter.clear();
+    assert_eq!(app.filtered_namespaces().to_vec(), browsing);
+
+    // A later list from the API replaces it, with no filter keystroke to
+    // prompt a rebuild.
+    app.handle_msg(Msg::Namespaces {
+        generation: app.generation,
+        list: vec!["dev".into(), "staging".into()],
+    });
+    assert_eq!(
+        app.filtered_namespaces().to_vec(),
+        ["<all>", "dev", "staging"]
+    );
+
+    // Favourites re-order it without touching the list.
+    app.namespace_favorites = vec!["staging".into()];
+    assert_eq!(
+        app.filtered_namespaces().to_vec(),
+        ["<all>", "staging", "dev"]
+    );
+}
+
+/// The sort picker is memoized against the header list, so a view change has
+/// to move it even though the filter buffer never changed.
+#[tokio::test]
+async fn sort_picker_entries_follow_the_headers() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let pods = app.filtered_sort_entries().to_vec();
+    assert_eq!(app.filtered_sort_entries().to_vec(), pods);
+    assert!(pods.len() > 1);
+
+    app.wide = true;
+    app.refresh_view_spec();
+    let wide = app.filtered_sort_entries().to_vec();
+    assert_ne!(wide, pods, "a wider header list means more sort entries");
+
+    // And the filter still narrows whatever the current headers are.
+    app.sort_picker_filter = "age".into();
+    let filtered = app.filtered_sort_entries().to_vec();
+    assert!(filtered.len() < wide.len());
+    assert!(filtered.iter().any(|e| e == "AGE"), "{filtered:?}");
 }
 
 #[tokio::test]
@@ -6147,7 +6227,7 @@ async fn context_picker_enter_switches_to_filtered_selection() {
 
     app.handle_key(press(KeyCode::Char('p'))).unwrap();
     assert_eq!(
-        app.filtered_contexts(),
+        app.filtered_contexts().to_vec(),
         vec!["prod-east".to_string(), "prod-west".to_string()]
     );
     app.handle_key(press(KeyCode::Down)).unwrap();
@@ -6673,7 +6753,7 @@ async fn helm_list_shows_only_latest_revision_per_release() {
         .expect("myapp row present");
     assert_eq!(crate::helm::revision(myapp_row), Some(2));
 
-    let (cells, _) = crate::columns::cells(myapp_row, "helm");
+    let (cells, _) = crate::columns::cells(myapp_row, "helm", crate::columns::now_secs());
     assert_eq!(
         cells[0], "myapp",
         "NAME cell shows the release, not the secret"
@@ -6902,7 +6982,7 @@ async fn helm_sorts_updated_and_revision_by_value_not_text() {
     apply(&mut app, rel("alpha", 4, "2024-03-01T00:00:00Z"));
     apply(&mut app, rel("beta", 61, "2024-01-01T00:00:00Z"));
     apply(&mut app, rel("gamma", 11951, "2024-02-01T00:00:00Z"));
-    let headers = app.display_headers();
+    let headers = app.display_headers().to_vec();
 
     // UPDATED sorts by the deploy timestamp (ascending = most recent first,
     // like AGE), never the humanized "5d23h" cell text.
@@ -7498,7 +7578,7 @@ async fn namespace_switcher_pins_favorites_then_recents() {
 
     // Browsing: <all>, favourite, recents (newest first), then the rest.
     assert_eq!(
-        app.filtered_namespaces(),
+        app.filtered_namespaces().to_vec(),
         vec!["<all>", "monitoring", "alpha", "checkout", "beta"]
     );
     assert!(app.is_favorite_namespace("monitoring"));
@@ -7506,7 +7586,7 @@ async fn namespace_switcher_pins_favorites_then_recents() {
 
     // A filter falls back to pure fuzzy ranking (no pinning).
     app.ns_filter = "beta".into();
-    assert_eq!(app.filtered_namespaces(), vec!["<all>", "beta"]);
+    assert_eq!(app.filtered_namespaces().to_vec(), vec!["<all>", "beta"]);
 }
 
 #[tokio::test]
@@ -8082,7 +8162,10 @@ async fn user_view_overlays_columns_and_applies_initial_sort() {
     app.switch_kind("certificates");
 
     // Overlay: custom columns slot in before the trailing AGE.
-    assert_eq!(app.display_headers(), ["NAME", "READY", "EXPIRES", "AGE"]);
+    assert_eq!(
+        app.display_headers().to_vec(),
+        ["NAME", "READY", "EXPIRES", "AGE"]
+    );
     // The configured initial sort is active (EXPIRES, descending).
     assert_eq!(app.sort_column, Some(2));
     assert!(app.sort_desc);
@@ -8139,7 +8222,7 @@ async fn user_view_adds_provider_label_columns_to_curated_nodes() {
     app.switch_kind("nodes");
 
     assert_eq!(
-        app.display_headers(),
+        app.display_headers().to_vec(),
         [
             "NAME", "STATUS", "ROLES", "TAINTS", "VERSION", "NODEPOOL", "ZONE", "INSTANCE", "TYPE",
             "AGE", "PODS", "CPU", "MEM", "%CPU", "%MEM"
@@ -8195,7 +8278,7 @@ async fn user_view_replace_swaps_out_curated_columns() {
         "#,
     );
     app.switch_kind("certificates");
-    assert_eq!(app.display_headers(), ["NAME", "CPU"]);
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "CPU"]);
 
     // Quantities sort by value: 500m < 2 despite "2" < "500m" lexically.
     apply(&mut app, certificate("big", "True", "", "2"));
@@ -8211,7 +8294,7 @@ async fn user_view_replace_swaps_out_curated_columns() {
 async fn printer_columns_msg_upgrades_name_age_fallback() {
     let (mut app, _rx) = test_app();
     app.switch_kind("certificates");
-    assert_eq!(app.display_headers(), ["NAME", "AGE"]);
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "AGE"]);
 
     let crd = json!({
         "spec": {
@@ -8232,9 +8315,12 @@ async fn printer_columns_msg_upgrades_name_age_fallback() {
         view: Box::new(view),
     });
     // Narrow mode hides the priority>0 column; wide shows it.
-    assert_eq!(app.display_headers(), ["NAME", "READY", "AGE"]);
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "READY", "AGE"]);
     app.handle_key(press(KeyCode::Char('w'))).unwrap();
-    assert_eq!(app.display_headers(), ["NAME", "READY", "DETAIL", "AGE"]);
+    assert_eq!(
+        app.display_headers().to_vec(),
+        ["NAME", "READY", "DETAIL", "AGE"]
+    );
 
     // A stale-generation message must be dropped.
     app.switch_kind("pods");
@@ -8274,7 +8360,7 @@ async fn user_view_wins_over_printer_columns() {
             ..Default::default()
         })),
     });
-    assert_eq!(app.display_headers(), ["NAME", "MINE", "AGE"]);
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "MINE", "AGE"]);
 }
 
 #[tokio::test]
@@ -8282,7 +8368,7 @@ async fn wide_toggle_reveals_pod_columns_and_keeps_sort() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");
     assert_eq!(
-        app.display_headers(),
+        app.display_headers().to_vec(),
         ["NAME", "READY", "STATUS", "RESTARTS", "AGE", "CPU", "MEM"]
     );
 
@@ -8290,7 +8376,7 @@ async fn wide_toggle_reveals_pod_columns_and_keeps_sort() {
     app.sort_column = Some(4);
     app.handle_key(press(KeyCode::Char('w'))).unwrap();
     assert_eq!(
-        app.display_headers(),
+        app.display_headers().to_vec(),
         [
             "NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE", "CPU", "MEM"
         ]
@@ -8513,7 +8599,59 @@ async fn crd_drill_seeds_printer_columns_from_the_crd() {
     }));
     app.drill_into_crd(&crd);
     assert_eq!(app.kind_plural, "widgets");
-    assert_eq!(app.display_headers(), ["NAMESPACE", "NAME", "PHASE", "AGE"]);
+    assert_eq!(
+        app.display_headers().to_vec(),
+        ["NAMESPACE", "NAME", "PHASE", "AGE"]
+    );
+}
+
+/// The header list is memoized, so both of the things it derives from have to
+/// invalidate it: the view spec, and the toggles that add columns around it.
+#[tokio::test]
+async fn header_list_follows_the_spec_and_the_column_toggles() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let crd = obj(json!({
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {"name": "widgets.example.com"},
+        "spec": {
+            "group": "example.com",
+            "names": {"plural": "widgets", "kind": "Widget"},
+            "scope": "Namespaced",
+            "versions": [{
+                "name": "v1", "served": true, "storage": true,
+                "additionalPrinterColumns": [
+                    {"name": "Phase", "type": "string", "jsonPath": ".status.phase"}
+                ]
+            }]
+        }
+    }));
+    app.drill_into_crd(&crd);
+
+    let all_ns = app.display_headers().to_vec();
+    assert_eq!(all_ns, ["NAMESPACE", "NAME", "PHASE", "AGE"]);
+    // A second read comes from the memo and must not differ.
+    assert_eq!(app.display_headers().to_vec(), all_ns);
+
+    // A column toggle with no spec rebuild: scoping to one namespace drops
+    // the NAMESPACE column, and the memo has to notice.
+    app.namespace = "default".into();
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "PHASE", "AGE"]);
+
+    // …and back, so the memo is not one-way.
+    app.namespace.clear();
+    assert_eq!(app.display_headers().to_vec(), all_ns);
+
+    // A spec rebuild with no toggle change: wide mode widens the list.
+    app.wide = true;
+    app.refresh_view_spec();
+    let wide = app.display_headers().to_vec();
+    assert_eq!(app.display_headers().to_vec(), wide);
+
+    app.wide = false;
+    app.refresh_view_spec();
+    assert_eq!(app.display_headers().to_vec(), all_ns);
 }
 
 #[tokio::test]
@@ -8858,6 +8996,65 @@ async fn malformed_filter_enter_warns_and_stays_local() {
     assert_eq!(app.generation, before, "broken selector must not rewatch");
     assert!(!app.filter_server_side());
     assert!(app.filter_error().is_some());
+}
+
+/// Replace the filter through the same keys a user would press: `/` reopens
+/// the prompt with the current text, so the old text is backspaced away.
+fn retype_filter(app: &mut App, text: &str) {
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for _ in 0..app.filter.chars().count() {
+        app.handle_key(press(KeyCode::Backspace)).unwrap();
+    }
+    for c in text.chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+}
+
+/// Highlight positions are memoized per needle, so retyping the filter has to
+/// invalidate them — a stale entry would underline the wrong characters.
+#[tokio::test]
+async fn retyping_the_filter_recomputes_the_highlights() {
+    let (mut app, _rx) = test_app();
+
+    retype_filter(&mut app, "khc");
+    let first = app.filter_match_indices("kube-httpcache-0").unwrap();
+    assert_eq!(first.len(), 3);
+    // Asking again reads the memo and must answer identically.
+    assert_eq!(
+        app.filter_match_indices("kube-httpcache-0").unwrap(),
+        first,
+        "a second lookup must not change the answer"
+    );
+
+    // A different needle over the same name: different positions.
+    retype_filter(&mut app, "cache");
+    let second = app.filter_match_indices("kube-httpcache-0").unwrap();
+    assert_eq!(second.len(), 5);
+    assert_ne!(second, first, "the new needle must not reuse the old memo");
+
+    // A needle that matches nothing is remembered as "no match", not as the
+    // previous needle's positions.
+    retype_filter(&mut app, "zzz");
+    assert_eq!(app.filter_match_indices("kube-httpcache-0"), None);
+    assert_eq!(app.filter_match_indices("kube-httpcache-0"), None);
+
+    // Clearing the filter goes back to no highlighting at all.
+    retype_filter(&mut app, "");
+    assert_eq!(app.filter_match_indices("kube-httpcache-0"), None);
+}
+
+/// Two names under one needle must not share an entry.
+#[tokio::test]
+async fn highlights_are_memoized_per_name_not_per_needle() {
+    let (mut app, _rx) = test_app();
+    retype_filter(&mut app, "ap");
+
+    let a = app.filter_match_indices("api-server").unwrap();
+    let b = app.filter_match_indices("xxapp").unwrap();
+    assert_eq!(app.filter_match_indices("api-server").unwrap(), a);
+    assert_eq!(app.filter_match_indices("xxapp").unwrap(), b);
+    assert_ne!(a, b, "each name keeps its own positions");
 }
 
 #[tokio::test]
@@ -10054,7 +10251,7 @@ async fn filtering_matches_a_naive_fuzzy_pass() {
         });
 
         // Naive expectation: name haystack, else any rendered cell.
-        let matcher = fuzzy_matcher::skim::SkimMatcherV2::default();
+        let matcher = crate::fuzzy::Fuzzy::new();
         let spec = crate::columns::build_spec("pods", None, None, false);
         let mut want: Vec<String> = Vec::new();
         for (k, o) in app.store.iter() {
@@ -10063,9 +10260,9 @@ async fn filtering_matches_a_naive_fuzzy_pass() {
                 o.metadata.namespace.as_deref().unwrap_or(""),
                 o.metadata.name.as_deref().unwrap_or("")
             );
-            let hit = matcher.fuzzy_match(&hay, pat).is_some() || {
-                let (cells, _) = spec.cells(o);
-                cells.iter().any(|c| matcher.fuzzy_match(c, pat).is_some())
+            let hit = matcher.score(&hay, pat).is_some() || {
+                let (cells, _) = spec.cells(o, crate::columns::now_secs());
+                cells.iter().any(|c| matcher.score(c, pat).is_some())
             };
             if hit {
                 want.push(k.to_string());

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6216,6 +6216,44 @@ async fn sort_picker_entries_follow_the_headers() {
     assert!(filtered.iter().any(|e| e == "AGE"), "{filtered:?}");
 }
 
+/// A context name carrying a combining accent has to match itself. An atom's
+/// needle is built from grapheme clusters, but the haystack came from a
+/// constructor that, once collapsing left pure ASCII, handed back the original
+/// bytes — so the accent's continuation bytes stayed in the haystack, the
+/// needle no longer had them, and the name filtered itself out of its own list.
+#[tokio::test]
+async fn context_picker_matches_a_name_with_a_combining_accent() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Contexts;
+    // `pre` + U+0301 COMBINING ACUTE ACCENT + `prod`.
+    let accented = "pre\u{0301}prod";
+    app.handle_msg(Msg::Contexts {
+        generation: app.generation,
+        list: vec![accented.into(), "staging".into()],
+    });
+
+    for c in accented.chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    assert_eq!(app.ctx_filter, accented);
+    assert_eq!(
+        app.filtered_contexts().to_vec(),
+        vec![accented.to_string()],
+        "a context name must match itself"
+    );
+
+    // The prefix ending at the accent matches it too.
+    for _ in 0..4 {
+        app.handle_key(press(KeyCode::Backspace)).unwrap();
+    }
+    assert_eq!(app.ctx_filter, "pre\u{0301}");
+    assert_eq!(
+        app.filtered_contexts().to_vec(),
+        vec![accented.to_string()],
+        "a prefix ending at the accent must still match"
+    );
+}
+
 #[tokio::test]
 async fn context_picker_enter_switches_to_filtered_selection() {
     let (mut app, _rx) = test_app();

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -40,17 +40,22 @@ struct CellContext<'a> {
     obj: &'a DynamicObject,
     data: &'a Value,
     name: &'a str,
+    /// Wall clock for the frame this row belongs to, epoch seconds. Read by
+    /// every elapsed-time cell so one row cannot straddle a second boundary
+    /// mid-render and show AGE `59s` above DURATION measured a tick later.
+    now: i64,
     age: OnceCell<String>,
     pod: OnceCell<(String, String, String)>,
     helm: OnceCell<Option<crate::helm::Summary>>,
 }
 
 impl<'a> CellContext<'a> {
-    fn new(obj: &'a DynamicObject) -> Self {
+    fn new(obj: &'a DynamicObject, now: i64) -> Self {
         CellContext {
             obj,
             data: &obj.data,
             name: obj.metadata.name.as_deref().unwrap_or_default(),
+            now,
             age: OnceCell::new(),
             pod: OnceCell::new(),
             helm: OnceCell::new(),
@@ -58,7 +63,7 @@ impl<'a> CellContext<'a> {
     }
 
     fn age(&self) -> &str {
-        self.age.get_or_init(|| age(self.obj))
+        self.age.get_or_init(|| age(self.obj, self.now))
     }
 
     /// `(READY, STATUS, RESTARTS)` — one walk of `containerStatuses` for all
@@ -359,8 +364,8 @@ pub fn headers(plural: &str) -> Vec<&'static str> {
 /// Cells for one object, aligned with [`headers`]. The 2nd return value is the
 /// index of the column that should be colorized as a status (or None).
 #[cfg(test)]
-pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) {
-    let ctx = CellContext::new(obj);
+pub fn cells(obj: &DynamicObject, plural: &str, now: i64) -> (Vec<String>, Option<usize>) {
+    let ctx = CellContext::new(obj, now);
     let columns = columns_for(plural);
     let values = columns
         .iter()
@@ -474,14 +479,14 @@ impl ViewSpec {
 
     /// Cells for one object, aligned with [`Self::headers`], plus the index
     /// of the status column (if any).
-    pub fn cells(&self, obj: &DynamicObject) -> (Vec<String>, Option<usize>) {
-        let ctx = CellContext::new(obj);
+    pub fn cells(&self, obj: &DynamicObject, now: i64) -> (Vec<String>, Option<usize>) {
+        let ctx = CellContext::new(obj, now);
         let values = self
             .columns
             .iter()
             .map(|c| match &c.source {
                 SpecSource::Curated(extract) => extract(&ctx).into_owned(),
-                SpecSource::User(uc) => crate::views::render_cell(obj, uc),
+                SpecSource::User(uc) => crate::views::render_cell(obj, uc, now),
             })
             .collect();
         (values, self.status_idx)
@@ -489,14 +494,20 @@ impl ViewSpec {
 
     /// See [`volatile_cell`]. User `time` columns re-render every frame too:
     /// their humanized elapsed value drifts with wall time.
-    pub fn volatile(&self, obj: &DynamicObject, plural: &str, idx: usize) -> Option<String> {
+    pub fn volatile(
+        &self,
+        obj: &DynamicObject,
+        plural: &str,
+        idx: usize,
+        now: i64,
+    ) -> Option<String> {
         let col = self.columns.get(idx)?;
         match &col.source {
             SpecSource::User(uc) if uc.kind == crate::views::ColumnKind::Time => {
-                Some(crate::views::render_cell(obj, uc))
+                Some(crate::views::render_cell(obj, uc, now))
             }
             SpecSource::User(_) => None,
-            SpecSource::Curated(_) => volatile_cell(obj, plural, &col.header),
+            SpecSource::Curated(_) => volatile_cell(obj, plural, &col.header, now),
         }
     }
 
@@ -512,12 +523,17 @@ impl ViewSpec {
     /// column of every object — extracting the full row per object per
     /// rebuild is what this avoids. Curated JSON/name cells borrow from
     /// `obj`; user columns and computed curated cells remain owned.
-    pub fn cell_at<'a>(&self, obj: &'a DynamicObject, idx: usize) -> Option<Cow<'a, str>> {
+    pub fn cell_at<'a>(
+        &self,
+        obj: &'a DynamicObject,
+        idx: usize,
+        now: i64,
+    ) -> Option<Cow<'a, str>> {
         let col = self.columns.get(idx)?;
         Some(match &col.source {
-            SpecSource::User(uc) => Cow::Owned(crate::views::render_cell(obj, uc)),
+            SpecSource::User(uc) => Cow::Owned(crate::views::render_cell(obj, uc, now)),
             SpecSource::Curated(extract) => {
-                let ctx = CellContext::new(obj);
+                let ctx = CellContext::new(obj, now);
                 extract(&ctx)
             }
         })
@@ -533,17 +549,22 @@ impl ViewSpec {
 
     /// Comparable value of `header`'s cell for `obj`, or `None` when the
     /// header isn't in this spec.
-    pub fn sort_value(&self, obj: &DynamicObject, header: &str) -> Option<crate::views::SortValue> {
+    pub fn sort_value(
+        &self,
+        obj: &DynamicObject,
+        header: &str,
+        now: i64,
+    ) -> Option<crate::views::SortValue> {
         let col = self.columns.iter().find(|c| c.header == header)?;
         Some(match &col.source {
-            SpecSource::User(uc) => crate::views::sort_value(obj, uc),
+            SpecSource::User(uc) => crate::views::sort_value(obj, uc, now),
             SpecSource::Curated(extract) => {
-                let ctx = CellContext::new(obj);
+                let ctx = CellContext::new(obj, now);
                 let v = extract(&ctx);
                 if is_numeric_header(&self.plural, header) {
                     crate::views::SortValue::Num(parse_leading_num(&v))
                 } else {
-                    crate::views::SortValue::Text(v.to_lowercase())
+                    crate::views::SortValue::Text(v.to_lowercase().to_string())
                 }
             }
         })
@@ -602,14 +623,14 @@ pub(crate) fn parse_leading_num(s: &str) -> f64 {
 /// Cells whose display value changes with wall time even when the Kubernetes
 /// resourceVersion is unchanged. Table rendering can override cached values
 /// with these without recomputing every curated column.
-pub fn volatile_cell(obj: &DynamicObject, plural: &str, header: &str) -> Option<String> {
+pub fn volatile_cell(obj: &DynamicObject, plural: &str, header: &str, now: i64) -> Option<String> {
     match (plural, header) {
-        (_, "AGE") => Some(age(obj)),
+        (_, "AGE") => Some(age(obj, now)),
         ("jobs", "DURATION") if sget(&obj.data, &["status", "completionTime"]).is_none() => {
-            Some(job_duration(&obj.data))
+            Some(job_duration(&obj.data, now))
         }
         ("cronjobs", "LAST-SCHEDULE") => {
-            Some(time_since(&obj.data, &["status", "lastScheduleTime"]))
+            Some(time_since(&obj.data, &["status", "lastScheduleTime"], now))
         }
         _ => None,
     }
@@ -905,7 +926,7 @@ fn col_job_completions<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 }
 
 fn col_job_duration<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
-    Cow::Owned(job_duration(ctx.data))
+    Cow::Owned(job_duration(ctx.data, ctx.now))
 }
 
 fn col_cronjob_schedule<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
@@ -921,7 +942,11 @@ fn col_cronjob_active<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 }
 
 fn col_cronjob_last_schedule<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
-    Cow::Owned(time_since(ctx.data, &["status", "lastScheduleTime"]))
+    Cow::Owned(time_since(
+        ctx.data,
+        &["status", "lastScheduleTime"],
+        ctx.now,
+    ))
 }
 
 fn col_event_type<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
@@ -1256,8 +1281,8 @@ fn count_arr(v: &Value, path: &[&str]) -> usize {
 }
 
 /// Compact human age, e.g. `3d4h`, `12m`, `45s`.
-pub fn age(obj: &DynamicObject) -> String {
-    match age_secs(obj) {
+pub fn age(obj: &DynamicObject, now: i64) -> String {
+    match age_secs(obj, now) {
         Some(secs) => humanize(secs),
         None => "<unknown>".into(),
     }
@@ -1265,9 +1290,17 @@ pub fn age(obj: &DynamicObject) -> String {
 
 /// Age in seconds since creation, or `None` if the object has no timestamp.
 /// Used both for the AGE column and for sorting by age.
-pub fn age_secs(obj: &DynamicObject) -> Option<i64> {
+pub fn age_secs(obj: &DynamicObject, now: i64) -> Option<i64> {
     let ts = obj.metadata.creation_timestamp.as_ref()?;
-    Some((Timestamp::now().as_second() - ts.0.as_second()).max(0))
+    Some((now - ts.0.as_second()).max(0))
+}
+
+/// One reading of the wall clock, in epoch seconds, for a whole frame or
+/// rebuild. Every elapsed-time cell and sort key derives from a single call so
+/// a frame is internally consistent — and so a 2,000-row table takes one
+/// syscall instead of one per visible time cell.
+pub fn now_secs() -> i64 {
+    Timestamp::now().as_second()
 }
 
 fn timestamp_secs(d: &Value, path: &[&str]) -> Option<i64> {
@@ -1284,25 +1317,23 @@ pub fn last_schedule_secs(obj: &DynamicObject) -> Option<i64> {
 
 /// Elapsed seconds behind a Job's humanized DURATION cell (running jobs
 /// measure against now).
-pub fn job_duration_secs(obj: &DynamicObject) -> Option<i64> {
+pub fn job_duration_secs(obj: &DynamicObject, now: i64) -> Option<i64> {
     let start = timestamp_secs(&obj.data, &["status", "startTime"])?;
-    let end = timestamp_secs(&obj.data, &["status", "completionTime"])
-        .unwrap_or_else(|| Timestamp::now().as_second());
+    let end = timestamp_secs(&obj.data, &["status", "completionTime"]).unwrap_or(now);
     Some((end - start).max(0))
 }
 
-fn time_since(d: &Value, path: &[&str]) -> String {
+fn time_since(d: &Value, path: &[&str], now: i64) -> String {
     timestamp_secs(d, path)
-        .map(|secs| humanize((Timestamp::now().as_second() - secs).max(0)))
+        .map(|secs| humanize((now - secs).max(0)))
         .unwrap_or_else(|| "<none>".into())
 }
 
-fn job_duration(d: &Value) -> String {
+fn job_duration(d: &Value, now: i64) -> String {
     let Some(start) = timestamp_secs(d, &["status", "startTime"]) else {
         return "<none>".into();
     };
-    let end = timestamp_secs(d, &["status", "completionTime"])
-        .unwrap_or_else(|| Timestamp::now().as_second());
+    let end = timestamp_secs(d, &["status", "completionTime"]).unwrap_or(now);
     humanize((end - start).max(0))
 }
 
@@ -1812,6 +1843,84 @@ mod tests {
         serde_json::from_value(v).unwrap()
     }
 
+    /// Every elapsed-time cell reads the frame's clock, never its own. Fixing
+    /// `now` makes the rendered value exact instead of racing the wall clock.
+    #[test]
+    fn elapsed_cells_measure_against_the_frame_clock() {
+        let created = "2026-09-05T12:00:00Z";
+        let now = created.parse::<Timestamp>().unwrap().as_second() + 3600 + 120;
+
+        let p = obj(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web", "creationTimestamp": created},
+            "status": {"phase": "Running"}
+        }));
+
+        assert_eq!(age(&p, now), "1h2m");
+        assert_eq!(age_secs(&p, now), Some(3720));
+        assert_eq!(
+            volatile_cell(&p, "pods", "AGE", now).as_deref(),
+            Some("1h2m")
+        );
+    }
+
+    /// A running Job's DURATION also ends at the frame clock, so the whole row
+    /// is measured against one instant.
+    #[test]
+    fn a_running_job_measures_its_duration_against_the_frame_clock() {
+        let start = "2026-09-05T12:00:00Z";
+        let now = start.parse::<Timestamp>().unwrap().as_second() + 45;
+        let j = obj(json!({
+            "apiVersion": "batch/v1", "kind": "Job",
+            "metadata": {"name": "backup"},
+            "status": {"startTime": start}
+        }));
+
+        assert_eq!(job_duration_secs(&j, now), Some(45));
+        assert_eq!(
+            volatile_cell(&j, "jobs", "DURATION", now).as_deref(),
+            Some("45s")
+        );
+
+        // A finished Job measures start-to-completion and ignores the clock.
+        let done = obj(json!({
+            "apiVersion": "batch/v1", "kind": "Job",
+            "metadata": {"name": "backup"},
+            "status": {"startTime": start, "completionTime": "2026-09-05T12:00:30Z"}
+        }));
+        assert_eq!(job_duration_secs(&done, now), Some(30));
+        assert_eq!(job_duration_secs(&done, now + 10_000), Some(30));
+    }
+
+    /// The point of one reading per frame: two rows created a hair apart can
+    /// never be measured against two different "now"s, whatever the clock does
+    /// between them.
+    #[test]
+    fn one_frame_clock_keeps_rows_consistent() {
+        let base = "2026-09-05T12:00:00Z"
+            .parse::<Timestamp>()
+            .unwrap()
+            .as_second();
+        let row = |created: i64| {
+            obj(json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {
+                    "name": "web",
+                    "creationTimestamp": Timestamp::from_second(created)
+                        .unwrap()
+                        .to_string(),
+                },
+                "status": {"phase": "Running"}
+            }))
+        };
+        // Both created 59s before the frame's instant.
+        let now = base + 59;
+        assert_eq!(age(&row(base), now), age(&row(base), now));
+        assert_eq!(age(&row(base), now), "59s");
+        // One second later both roll over together, never one at a time.
+        assert_eq!(age(&row(base), now + 1), "1m");
+    }
+
     #[test]
     fn pod_cells_summarize_status_and_restarts() {
         let p = obj(json!({
@@ -1828,7 +1937,7 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&p, "pods");
+        let (cells, status_idx) = cells(&p, "pods", now_secs());
         assert_eq!(cells[0], "web");
         assert_eq!(cells[1], "1/2"); // ready
         assert_eq!(cells[2], "CrashLoopBackOff"); // waiting reason overrides phase
@@ -1854,7 +1963,7 @@ mod tests {
             3,
             json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 3}),
         );
-        let (c, status_idx) = cells(&d, "deployments");
+        let (c, status_idx) = cells(&d, "deployments", now_secs());
         assert_eq!(c[1], "3/3");
         assert_eq!(c[2], "Ready");
         assert_eq!(status_idx, Some(2));
@@ -1864,14 +1973,14 @@ mod tests {
             3,
             json!({"replicas": 3, "readyReplicas": 0, "updatedReplicas": 3}),
         );
-        assert_eq!(cells(&d, "deployments").0[2], "Unavailable");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Unavailable");
 
         // Rollout replacing pods (updated < desired) → progressing.
         let d = deploy(
             3,
             json!({"replicas": 4, "readyReplicas": 2, "updatedReplicas": 1}),
         );
-        assert_eq!(cells(&d, "deployments").0[2], "Progressing");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Progressing");
 
         // Fully rolled out but pods unready (crash loops, failed probes) →
         // degraded, not "progressing" — nothing is coming to fix it.
@@ -1879,14 +1988,14 @@ mod tests {
             3,
             json!({"replicas": 3, "readyReplicas": 2, "updatedReplicas": 3}),
         );
-        assert_eq!(cells(&d, "deployments").0[2], "Degraded");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Degraded");
 
         // Scaled to zero reads faded, not broken.
         let d = deploy(0, json!({}));
-        assert_eq!(cells(&d, "deployments").0[2], "ScaledDown");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "ScaledDown");
         // ... and still tearing down reads transitional.
         let d = deploy(0, json!({"replicas": 2, "readyReplicas": 2}));
-        assert_eq!(cells(&d, "deployments").0[2], "Progressing");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Progressing");
     }
 
     #[test]
@@ -1900,7 +2009,7 @@ mod tests {
                                 "reason": "ProgressDeadlineExceeded"}]
             }),
         );
-        assert_eq!(cells(&d, "deployments").0[2], "Stalled");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Stalled");
 
         // Available=False overrides a numerically-satisfied ready count.
         let d = deploy(
@@ -1910,7 +2019,7 @@ mod tests {
                 "conditions": [{"type": "Available", "status": "False"}]
             }),
         );
-        assert_eq!(cells(&d, "deployments").0[2], "Unavailable");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Unavailable");
     }
 
     #[test]
@@ -1922,7 +2031,7 @@ mod tests {
             "status": {"replicas": 3, "readyReplicas": 2, "updatedReplicas": 2}
         }));
         // Rolling update in flight (updated < desired) → progressing.
-        assert_eq!(cells(&sts, "statefulsets").0[2], "Progressing");
+        assert_eq!(cells(&sts, "statefulsets", now_secs()).0[2], "Progressing");
 
         let ds = obj(json!({
             "apiVersion": "apps/v1", "kind": "DaemonSet",
@@ -1931,7 +2040,7 @@ mod tests {
                        "numberReady": 3, "updatedNumberScheduled": 5}
         }));
         // Fully rolled out, nodes unready → degraded. STATUS follows AVAILABLE.
-        assert_eq!(cells(&ds, "daemonsets").0[5], "Degraded");
+        assert_eq!(cells(&ds, "daemonsets", now_secs()).0[5], "Degraded");
 
         // An old, scaled-down ReplicaSet must read faded, not broken.
         let rs = obj(json!({
@@ -1940,7 +2049,7 @@ mod tests {
             "spec": {"replicas": 0},
             "status": {"replicas": 0}
         }));
-        assert_eq!(cells(&rs, "replicasets").0[4], "ScaledDown");
+        assert_eq!(cells(&rs, "replicasets", now_secs()).0[4], "ScaledDown");
 
         // spec.replicas unset defaults to 1 — a bare RS with one ready pod
         // is healthy, not degraded.
@@ -1949,7 +2058,7 @@ mod tests {
             "metadata": {"name": "web-abc", "namespace": "default"},
             "status": {"replicas": 1, "readyReplicas": 1}
         }));
-        assert_eq!(cells(&rs, "replicasets").0[4], "Ready");
+        assert_eq!(cells(&rs, "replicasets", now_secs()).0[4], "Ready");
     }
 
     #[test]
@@ -1961,7 +2070,7 @@ mod tests {
             "spec": {"replicas": 3},
             "status": {"replicas": 3, "readyReplicas": 3, "updatedReplicas": 3}
         }));
-        assert_eq!(cells(&d, "deployments").0[2], "Terminating");
+        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Terminating");
     }
 
     #[test]
@@ -1977,7 +2086,7 @@ mod tests {
             "status": {"conditions": [{"type": "Ready", "status": "True"}],
                        "nodeInfo": {"kubeletVersion": "v1.31.0"}}
         }));
-        let (node_cells, status_idx) = cells(&n, "nodes");
+        let (node_cells, status_idx) = cells(&n, "nodes", now_secs());
         assert_eq!(node_cells[0], "cp-1");
         assert_eq!(node_cells[1], "Ready");
         assert_eq!(node_cells[2], "control-plane");
@@ -1986,7 +2095,7 @@ mod tests {
         assert_eq!(status_idx, Some(1));
 
         let bare = obj(json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "w-1"}}));
-        let (bare_cells, _) = cells(&bare, "nodes");
+        let (bare_cells, _) = cells(&bare, "nodes", now_secs());
         assert_eq!(bare_cells[3], "0");
     }
 
@@ -1999,7 +2108,7 @@ mod tests {
                      "ports": [{"port": 80, "protocol": "TCP"}]},
             "status": {"loadBalancer": {}}
         }));
-        let (cells, _) = cells(&s, "services");
+        let (cells, _) = cells(&s, "services", now_secs());
         assert_eq!(cells[1], "LoadBalancer");
         assert_eq!(cells[3], "<pending>");
         assert_eq!(cells[4], "80/TCP");
@@ -2025,7 +2134,7 @@ mod tests {
             headers("customresourcedefinitions"),
             vec!["NAME", "GROUP", "KIND", "VERSIONS", "SCOPE", "AGE"]
         );
-        let (cells, _) = cells(&crd, "customresourcedefinitions");
+        let (cells, _) = cells(&crd, "customresourcedefinitions", now_secs());
         assert_eq!(cells[0], "widgets.example.com");
         assert_eq!(cells[1], "example.com");
         assert_eq!(cells[2], "Widget");
@@ -2049,7 +2158,7 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&ks, "kustomizations");
+        let (cells, status_idx) = cells(&ks, "kustomizations", now_secs());
         assert_eq!(cells[0], "apps");
         assert_eq!(cells[1], "True");
         assert_eq!(cells[2], "Applied revision: main@sha1:abc123");
@@ -2073,7 +2182,7 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&hr, "helmreleases");
+        let (cells, status_idx) = cells(&hr, "helmreleases", now_secs());
         assert_eq!(cells[1], "False");
         assert_eq!(cells[2], "install retries exhausted");
         assert_eq!(cells[3], "6.5.4");
@@ -2095,7 +2204,7 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&git, "gitrepositories");
+        let (cells, status_idx) = cells(&git, "gitrepositories", now_secs());
         assert_eq!(
             headers("gitrepositories"),
             vec![
@@ -2129,7 +2238,7 @@ mod tests {
                 "conditions": [{"type": "Ready", "status": "False", "message": "denied"}]
             }
         }));
-        let (cells, status_idx) = cells(&bucket, "buckets");
+        let (cells, status_idx) = cells(&bucket, "buckets", now_secs());
         assert_eq!(cells[1], "False");
         assert_eq!(cells[2], "denied");
         assert_eq!(cells[3], "sha256:abc123");
@@ -2151,7 +2260,7 @@ mod tests {
                 "completionTime": "2024-01-01T01:05:00Z"
             }
         }));
-        let (cells, _) = cells(&job, "jobs");
+        let (cells, _) = cells(&job, "jobs", now_secs());
         assert_eq!(
             headers("jobs"),
             vec!["NAME", "COMPLETIONS", "DURATION", "AGE"]
@@ -2169,7 +2278,7 @@ mod tests {
             "spec": {"schedule": "*/15 * * * *", "suspend": false},
             "status": {"active": [{"name": "backup-1"}]}
         }));
-        let (cells, _) = cells(&cron, "cronjobs");
+        let (cells, _) = cells(&cron, "cronjobs", now_secs());
         assert_eq!(
             headers("cronjobs"),
             vec![
@@ -2199,7 +2308,7 @@ mod tests {
             "note": "Back-off restarting\nfailed container",
             "series": {"count": 7}
         }));
-        let (cells, status_idx) = cells(&event, "events");
+        let (cells, status_idx) = cells(&event, "events", now_secs());
         assert_eq!(
             headers("events"),
             vec![
@@ -2243,7 +2352,7 @@ mod tests {
                 }]
             }
         }));
-        let (cells, _) = cells(&hpa, "horizontalpodautoscalers");
+        let (cells, _) = cells(&hpa, "horizontalpodautoscalers", now_secs());
         assert_eq!(
             headers("horizontalpodautoscalers"),
             vec![
@@ -2270,7 +2379,7 @@ mod tests {
             "kind": "Kustomization",
             "metadata": {"name": "new"}
         }));
-        let (cells, _) = cells(&ks, "kustomizations");
+        let (cells, _) = cells(&ks, "kustomizations", now_secs());
         assert_eq!(cells[1], "Unknown");
         assert_eq!(cells[2], "");
         assert_eq!(cells[3], "");
@@ -2288,7 +2397,7 @@ mod tests {
             },
             "status": {"loadBalancer": {"ingress": [{"ip": "203.0.113.10"}]}}
         }));
-        let (cells, _) = cells(&ing, "ingresses");
+        let (cells, _) = cells(&ing, "ingresses", now_secs());
         assert_eq!(
             headers("ingresses"),
             ["NAME", "CLASS", "HOSTS", "ADDRESS", "AGE"]
@@ -2305,13 +2414,16 @@ mod tests {
             "metadata": {"name": "lb"},
             "status": {"loadBalancer": {"ingress": [{"hostname": "abc.elb.amazonaws.com"}]}}
         }));
-        assert_eq!(cells(&hostname, "ingresses").0[3], "abc.elb.amazonaws.com");
+        assert_eq!(
+            cells(&hostname, "ingresses", now_secs()).0[3],
+            "abc.elb.amazonaws.com"
+        );
 
         let pending = obj(json!({
             "apiVersion": "networking.k8s.io/v1", "kind": "Ingress",
             "metadata": {"name": "pending"}
         }));
-        assert_eq!(cells(&pending, "ingresses").0[3], "<none>");
+        assert_eq!(cells(&pending, "ingresses", now_secs()).0[3], "<none>");
     }
 
     #[test]
@@ -2322,7 +2434,7 @@ mod tests {
             "metadata": {"name": "web"},
             "spec": {"hostnames": ["app.example.com", "www.example.com"]}
         }));
-        let (row, idx) = cells(&route, "httproutes");
+        let (row, idx) = cells(&route, "httproutes", now_secs());
         assert_eq!(headers("httproutes"), ["NAME", "HOSTNAMES", "AGE"]);
         assert_eq!(row[1], "app.example.com,www.example.com");
         assert_eq!(idx, None);
@@ -2331,7 +2443,7 @@ mod tests {
             "apiVersion": "gateway.networking.k8s.io/v1", "kind": "HTTPRoute",
             "metadata": {"name": "any"}
         }));
-        assert_eq!(cells(&wildcard, "httproutes").0[1], "*");
+        assert_eq!(cells(&wildcard, "httproutes", now_secs()).0[1], "*");
     }
 
     #[test]
@@ -2340,7 +2452,7 @@ mod tests {
             "apiVersion": "example.com/v1", "kind": "Widget",
             "metadata": {"name": "thingy"}
         }));
-        let (cells, idx) = cells(&o, "widgets");
+        let (cells, idx) = cells(&o, "widgets", now_secs());
         assert_eq!(cells[0], "thingy");
         assert_eq!(cells.len(), 2);
         assert_eq!(idx, None);
@@ -2385,7 +2497,7 @@ mod tests {
 
         for kind in kinds {
             let headers = headers(kind);
-            let (cells, status_idx) = cells(&o, kind);
+            let (cells, status_idx) = cells(&o, kind, now_secs());
             assert_eq!(headers.len(), cells.len(), "{kind} column count");
             if let Some(idx) = status_idx {
                 assert!(idx < cells.len(), "{kind} status index");
@@ -2441,7 +2553,7 @@ mod tests {
             "metadata": {"name": "web"},
             "status": {"phase": "Running", "hostIP": "10.0.0.9"}
         }));
-        let (cells, status_idx) = spec.cells(&o);
+        let (cells, status_idx) = spec.cells(&o, now_secs());
         assert_eq!(cells[2], "Running");
         assert_eq!(cells[4], "10.0.0.9");
         assert_eq!(status_idx, Some(2));
@@ -2522,11 +2634,11 @@ mod tests {
         }));
         assert!(spec.is_user_column("CPU"));
         assert!(!spec.is_user_column("NAME"));
-        match spec.sort_value(&o, "CPU").unwrap() {
+        match spec.sort_value(&o, "CPU", now_secs()).unwrap() {
             SortValue::Num(n) => assert_eq!(n, 0.5),
             SortValue::Text(t) => panic!("expected numeric sort, got '{t}'"),
         }
-        assert!(spec.sort_value(&o, "MISSING").is_none());
+        assert!(spec.sort_value(&o, "MISSING", now_secs()).is_none());
     }
 
     #[test]
@@ -2542,14 +2654,17 @@ mod tests {
         let spec = build_spec("pods", None, None, true);
 
         assert!(matches!(
-            spec.cell_at(&pod, 0),
+            spec.cell_at(&pod, 0, now_secs()),
             Some(Cow::Borrowed("pod-a"))
         ));
         assert!(matches!(
-            spec.cell_at(&pod, 4),
+            spec.cell_at(&pod, 4, now_secs()),
             Some(Cow::Borrowed("10.0.0.7"))
         ));
-        assert!(matches!(spec.cell_at(&pod, 1), Some(Cow::Owned(_))));
+        assert!(matches!(
+            spec.cell_at(&pod, 1, now_secs()),
+            Some(Cow::Owned(_))
+        ));
     }
 
     #[test]
@@ -2564,10 +2679,11 @@ mod tests {
             }))
         };
         let spec = build_spec("kustomizations", None, None, false);
-        let ready = |status: &str| match spec.sort_value(&flux(status), "READY").unwrap() {
-            SortValue::Text(t) => t,
-            SortValue::Num(n) => panic!("flux READY must sort as text, got {n}"),
-        };
+        let ready =
+            |status: &str| match spec.sort_value(&flux(status), "READY", now_secs()).unwrap() {
+                SortValue::Text(t) => t,
+                SortValue::Num(n) => panic!("flux READY must sort as text, got {n}"),
+            };
         assert!(ready("False") < ready("True"));
         assert!(ready("True") < ready("Unknown"));
 
@@ -2580,7 +2696,7 @@ mod tests {
             ]}
         }));
         let spec = build_spec("pods", None, None, false);
-        match spec.sort_value(&pod, "READY").unwrap() {
+        match spec.sort_value(&pod, "READY", now_secs()).unwrap() {
             SortValue::Num(n) => assert_eq!(n, 1.0),
             SortValue::Text(t) => panic!("pod READY must sort numerically, got '{t}'"),
         }

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -59,6 +59,26 @@ fn atom(needle: &str) -> Atom {
     )
 }
 
+/// The haystack in the form the matcher compares against.
+///
+/// Deliberately not `Utf32Str::new`. An atom's needle is always built from
+/// grapheme clusters, one `char` per cluster, so `pre\u{0301}prod` becomes the
+/// seven chars `preprod`. `Utf32Str::new` collapses the haystack the same way,
+/// but when the result is pure ASCII it then returns the *original* bytes
+/// instead of the collapsed chars — leaving the two continuation bytes of the
+/// combining accent in the haystack as if they were characters. The needle no
+/// longer has them, so a name like that stops matching even itself. Collapsing
+/// here keeps both sides on one sequence; the ASCII fast path is unaffected,
+/// because a string with no accent to collapse takes the branch above.
+fn utf32<'a>(text: &'a str, buf: &'a mut Vec<char>) -> Utf32Str<'a> {
+    if text.is_ascii() {
+        return Utf32Str::Ascii(text.as_bytes());
+    }
+    buf.clear();
+    buf.extend(nucleo_matcher::chars::graphemes(text));
+    Utf32Str::Unicode(&*buf)
+}
+
 impl Fuzzy {
     pub fn new() -> Self {
         Fuzzy {
@@ -84,8 +104,7 @@ impl Fuzzy {
             haystack: buf,
             ..
         } = &mut *inner;
-        atom.score(Utf32Str::new(haystack, buf), matcher)
-            .map(i64::from)
+        atom.score(utf32(haystack, buf), matcher).map(i64::from)
     }
 
     /// The char positions in `haystack` that `needle` matched, ascending, or
@@ -101,7 +120,7 @@ impl Fuzzy {
             ..
         } = &mut *inner;
         indices.clear();
-        atom.indices(Utf32Str::new(haystack, buf), matcher, indices)?;
+        atom.indices(utf32(haystack, buf), matcher, indices)?;
         // Reported in match order, which is not necessarily ascending, and can
         // repeat a position; callers highlight by walking them in order.
         indices.sort_unstable();

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,0 +1,188 @@
+//! The fuzzy matcher behind row filtering, the pickers and `find`.
+//!
+//! One matcher instance is shared by everything that scores a needle against a
+//! haystack, so the scratch buffers below are allocated once for the process
+//! rather than once per row. The matcher needs `&mut self`, and the call sites
+//! hold `&App`, hence the interior mutability.
+
+use std::cell::RefCell;
+
+use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Normalization};
+use nucleo_matcher::{Config, Matcher, Utf32Str};
+
+/// A shared fuzzy matcher.
+///
+/// Case handling is *smart*: an all-lowercase needle matches case-insensitively
+/// and a needle with any uppercase character matches exactly, which is what the
+/// previous matcher did by default and what the filter's documented behaviour
+/// describes.
+///
+/// The whole needle is one fuzzy atom. The matcher's own pattern syntax —
+/// space-separated atoms, `^`/`$`/`'`/`!` prefixes — is deliberately not
+/// enabled: sofka parses `!`, `-l` and `key=value` terms itself before
+/// anything reaches here, and letting a second syntax through would change
+/// what a filter means.
+pub struct Fuzzy {
+    inner: RefCell<Inner>,
+}
+
+struct Inner {
+    matcher: Matcher,
+    /// The needle `atom` was built from. Building an atom case-folds and
+    /// normalizes it, and a filter pass scores one needle against every row in
+    /// the store, so it is built once per needle rather than once per row.
+    needle: String,
+    atom: Atom,
+    /// Scratch for the UTF-32 haystack and the match positions.
+    haystack: Vec<char>,
+    indices: Vec<u32>,
+}
+
+impl Inner {
+    fn sync(&mut self, needle: &str) {
+        if self.needle != needle {
+            self.needle.clear();
+            self.needle.push_str(needle);
+            self.atom = atom(needle);
+        }
+    }
+}
+
+fn atom(needle: &str) -> Atom {
+    Atom::new(
+        needle,
+        CaseMatching::Smart,
+        Normalization::Smart,
+        AtomKind::Fuzzy,
+        // `\ ` escaping belongs to the pattern syntax this deliberately avoids.
+        false,
+    )
+}
+
+impl Fuzzy {
+    pub fn new() -> Self {
+        Fuzzy {
+            inner: RefCell::new(Inner {
+                matcher: Matcher::new(Config::DEFAULT),
+                needle: String::new(),
+                atom: atom(""),
+                haystack: Vec::new(),
+                indices: Vec::new(),
+            }),
+        }
+    }
+
+    /// The match score, or `None` when `needle` does not match. Higher is a
+    /// better match; the absolute values are only ever compared with each
+    /// other.
+    pub fn score(&self, haystack: &str, needle: &str) -> Option<i64> {
+        let mut inner = self.inner.borrow_mut();
+        inner.sync(needle);
+        let Inner {
+            matcher,
+            atom,
+            haystack: buf,
+            ..
+        } = &mut *inner;
+        atom.score(Utf32Str::new(haystack, buf), matcher)
+            .map(i64::from)
+    }
+
+    /// The char positions in `haystack` that `needle` matched, ascending, or
+    /// `None` when it does not match.
+    pub fn indices(&self, haystack: &str, needle: &str) -> Option<Vec<usize>> {
+        let mut inner = self.inner.borrow_mut();
+        inner.sync(needle);
+        let Inner {
+            matcher,
+            atom,
+            haystack: buf,
+            indices,
+            ..
+        } = &mut *inner;
+        indices.clear();
+        atom.indices(Utf32Str::new(haystack, buf), matcher, indices)?;
+        // Reported in match order, which is not necessarily ascending, and can
+        // repeat a position; callers highlight by walking them in order.
+        indices.sort_unstable();
+        indices.dedup();
+        Some(indices.iter().map(|&i| i as usize).collect())
+    }
+}
+
+impl Default for Fuzzy {
+    fn default() -> Self {
+        Fuzzy::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_subsequences_and_reports_their_positions() {
+        let f = Fuzzy::new();
+        assert!(f.score("kube-httpcache-0", "khc").is_some());
+        assert!(f.score("kube-httpcache-0", "zzz").is_none());
+
+        let idx = f.indices("kube-httpcache-0", "khc").unwrap();
+        assert_eq!(idx.len(), 3);
+        assert!(idx.is_sorted());
+        // Every reported position is inside the name and names its character.
+        let chars: Vec<char> = "kube-httpcache-0".chars().collect();
+        for (pos, want) in idx.iter().zip("khc".chars()) {
+            assert_eq!(chars[*pos].to_ascii_lowercase(), want);
+        }
+    }
+
+    /// Smart case: a lowercase needle ignores case, an uppercase one does not.
+    #[test]
+    fn case_is_smart() {
+        let f = Fuzzy::new();
+        assert!(f.score("Kube-System", "kube").is_some());
+        assert!(f.score("Kube-System", "Kube").is_some());
+        assert!(f.score("kube-system", "Kube").is_none());
+    }
+
+    #[test]
+    fn an_empty_needle_matches_everything() {
+        let f = Fuzzy::new();
+        assert!(f.score("anything", "").is_some());
+        assert_eq!(f.indices("anything", "").unwrap(), Vec::<usize>::new());
+    }
+
+    /// Positions are char indices, not byte offsets, so a multibyte name
+    /// highlights the character the user sees.
+    #[test]
+    fn positions_are_char_indices() {
+        let f = Fuzzy::new();
+        let idx = f.indices("héllo-world", "hw").unwrap();
+        let chars: Vec<char> = "héllo-world".chars().collect();
+        assert_eq!(chars[idx[0]], 'h');
+        assert_eq!(chars[idx[1]], 'w');
+    }
+
+    /// Switching needles must rebuild the cached atom, not reuse the old one.
+    #[test]
+    fn a_new_needle_replaces_the_cached_atom() {
+        let f = Fuzzy::new();
+        assert!(f.score("alpha", "alp").is_some());
+        assert!(f.score("alpha", "zzz").is_none());
+        assert!(f.score("alpha", "pha").is_some());
+    }
+
+    /// The matcher's own pattern syntax stays off: these are literal
+    /// characters to match, not operators.
+    #[test]
+    fn pattern_syntax_is_not_interpreted() {
+        let f = Fuzzy::new();
+        // `^`, `$` and `!` would be anchors/negation in the pattern language.
+        assert!(f.score("web-1", "^web").is_none());
+        assert!(f.score("^web-1", "^web").is_some());
+        assert!(f.score("web-1", "!web").is_none());
+        // A space is a literal, not an atom separator.
+        assert!(f.score("default web-1", "t w").is_some());
+        assert!(f.score("web-1", "web 1").is_none());
+    }
+}

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -15,11 +15,25 @@
 use std::io::Read;
 
 use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
 use k8s_openapi::jiff::Timestamp;
 use kube::core::DynamicObject;
 use serde::Deserialize;
 use serde_json::Value;
+
+/// The base64 engine for release payloads.
+///
+/// Helm double-encodes the payload, so one decode runs base64 twice over the
+/// whole body — the only place base64 is on a hot path here rather than reading
+/// a short annotation. The SIMD engine detects the instruction set once, on
+/// first use, and produces byte-identical output to the scalar one for the same
+/// alphabet; it exists only for the architectures sofka ships binaries for, so
+/// everything else keeps the scalar engine.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+static BASE64: std::sync::LazyLock<base64::engine::Simd> =
+    std::sync::LazyLock::new(|| base64::engine::Simd::standard(Default::default()));
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+static BASE64: std::sync::LazyLock<base64::engine::general_purpose::GeneralPurpose> =
+    std::sync::LazyLock::new(|| base64::engine::general_purpose::STANDARD);
 
 /// A decoded Helm release revision. The k8s namespace is deliberately not
 /// carried here — callers already have the storage Secret's own namespace,
@@ -136,9 +150,31 @@ fn release_json(secret: &DynamicObject) -> Option<Vec<u8>> {
     let helm_encoded = BASE64.decode(wire).ok()?;
     let gzipped = BASE64.decode(helm_encoded).ok()?;
     let mut gz = flate2::read::GzDecoder::new(&gzipped[..]);
-    let mut json = Vec::new();
+    let mut json = Vec::with_capacity(inflated_hint(&gzipped));
     gz.read_to_end(&mut json).ok()?;
     Some(json)
+}
+
+/// Capacity to give the gunzip buffer, from gzip's ISIZE trailer — the
+/// uncompressed length mod 2^32 in the last four bytes. A release manifest
+/// inflates several times over, so growing from empty re-allocates and copies
+/// the whole payload repeatedly.
+///
+/// ISIZE comes off the cluster and is not trusted: it is a hint a corrupt or
+/// hostile Secret could set to 4 GiB. Clamped to what this input could
+/// plausibly inflate to, so a wrong value costs a resize, never a reservation
+/// the payload cannot fill. Deflate's ceiling is about 1032:1; the absolute cap
+/// is well above any real release and keeps the product in range.
+fn inflated_hint(gzipped: &[u8]) -> usize {
+    /// Refuse to reserve more than this up front, however large ISIZE claims.
+    const MAX_HINT: usize = 64 << 20;
+
+    let Some(trailer) = gzipped.last_chunk::<4>() else {
+        return 0;
+    };
+    let isize_field = u32::from_le_bytes(*trailer) as usize;
+    let plausible = gzipped.len().saturating_mul(1032);
+    isize_field.min(plausible).min(MAX_HINT)
 }
 
 fn last_deployed_secs(raw: Option<&str>) -> Option<i64> {
@@ -264,6 +300,118 @@ mod tests {
         .unwrap();
 
         serde_json::from_value(data).unwrap()
+    }
+
+    /// The SIMD engine must decode byte-for-byte what the scalar one did,
+    /// including the padding and rejection behaviour of a malformed payload.
+    #[test]
+    fn simd_and_scalar_base64_agree() {
+        let scalar = base64::engine::general_purpose::STANDARD;
+        for len in [0usize, 1, 2, 3, 15, 16, 17, 63, 64, 65, 588, 4096] {
+            let raw: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+            let encoded = scalar.encode(&raw);
+            assert_eq!(BASE64.encode(&raw), encoded, "encode len {len}");
+            assert_eq!(BASE64.decode(&encoded).unwrap(), raw, "decode len {len}");
+        }
+        // Both reject the same malformed input.
+        for bad in ["!!!!", "aGVsbG8", "a", "====", "aGVs bG8="] {
+            assert_eq!(
+                BASE64.decode(bad).is_err(),
+                scalar.decode(bad).is_err(),
+                "malformed {bad:?}"
+            );
+        }
+    }
+
+    /// Escapes and multibyte text have to survive the decode intact.
+    #[test]
+    fn escaped_and_multibyte_payloads_decode_intact() {
+        let secret = fixture_secret(
+            r#"{
+                "name": "myrelease",
+                "version": 1,
+                "info": {
+                    "status": "deployed",
+                    "description": "quote \" backslash \\ tab \t",
+                    "notes": "caf\u00e9 \u2014 done\nsecond line"
+                },
+                "chart": {"metadata": {"name": "c", "version": "1.0.0"}}
+            }"#,
+        );
+        let release = decode(&secret).unwrap();
+        assert_eq!(release.description, "quote \" backslash \\ tab \t");
+        assert_eq!(release.notes, "café — done\nsecond line");
+    }
+
+    /// A payload that is not JSON at all is unrenderable, not a panic.
+    #[test]
+    fn a_corrupt_payload_decodes_to_none() {
+        let secret = fixture_secret("{not json at all");
+        assert!(decode(&secret).is_none());
+        assert!(decode_summary(&secret).is_none());
+    }
+
+    /// `decode` and `decode_summary` read the same payload and must agree.
+    #[test]
+    fn decode_and_summary_agree_on_the_same_secret() {
+        let secret = fixture_secret(
+            r#"{
+                "name": "myrelease",
+                "version": 2,
+                "info": {"status": "deployed", "description": "Upgrade complete",
+                         "last_deployed": "2026-07-01T10:00:00Z"},
+                "chart": {"metadata": {"name": "nginx", "version": "1.2.3",
+                                       "appVersion": "1.25"}}
+            }"#,
+        );
+        let full = decode(&secret).unwrap();
+        let summary = decode_summary(&secret).unwrap();
+        assert_eq!(full.status, summary.status);
+        assert_eq!(full.chart_name, summary.chart_name);
+        assert_eq!(full.chart_version, summary.chart_version);
+        assert_eq!(full.app_version, summary.app_version);
+        assert_eq!(full.description, summary.description);
+        assert_eq!(full.last_deployed_secs, summary.last_deployed_secs);
+        // Re-decoding the same secret is stable.
+        assert_eq!(decode(&secret).unwrap().notes, full.notes);
+    }
+
+    #[test]
+    fn inflated_hint_reads_the_gzip_isize_trailer() {
+        let payload = "x".repeat(5000);
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        gz.write_all(payload.as_bytes()).unwrap();
+        let gzipped = gz.finish().unwrap();
+
+        assert_eq!(inflated_hint(&gzipped), payload.len());
+    }
+
+    #[test]
+    fn inflated_hint_clamps_a_lying_trailer_to_what_deflate_could_produce() {
+        // A hostile Secret claiming 4 GiB - 1 from a handful of bytes.
+        let mut gzipped = vec![0u8; 16];
+        gzipped.extend_from_slice(&u32::MAX.to_le_bytes());
+
+        assert_eq!(inflated_hint(&gzipped), gzipped.len() * 1032);
+    }
+
+    #[test]
+    fn inflated_hint_survives_a_truncated_stream() {
+        assert_eq!(inflated_hint(&[]), 0);
+        assert_eq!(inflated_hint(&[0x1f, 0x8b]), 0);
+    }
+
+    #[test]
+    fn a_release_that_inflates_past_the_hint_still_decodes() {
+        // Highly compressible: the true inflated size far exceeds any hint
+        // derived from the compressed bytes, so `read_to_end` must still grow.
+        let notes = "n".repeat(400_000);
+        let secret = fixture_secret(&format!(
+            r#"{{"name":"big","version":1,"info":{{"status":"deployed","notes":"{notes}"}}}}"#
+        ));
+
+        let release = decode(&secret).unwrap();
+        assert_eq!(release.notes.len(), notes.len());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod diagnostics;
 pub mod explain;
 pub mod filter;
 pub mod fleet;
+pub mod fuzzy;
 pub mod gitops;
 pub mod helm;
 pub mod journal;

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -874,30 +874,228 @@ fn drain_lines(buf: &mut Vec<u8>) -> Vec<String> {
         .collect()
 }
 
+/// The record fields a [`LogEntry`] keeps that are not configurable — every
+/// backend this speaks to names them this way.
+const MSG_FIELD: &str = "_msg";
+const TIME_FIELD: &str = "_time";
+
+/// One record through the production parse, with the default field mapping —
+/// the benches compare this against the `Value` DOM it replaced.
+#[cfg(feature = "bench")]
+pub fn bench_parse_entry(line: &str) -> Option<LogEntry> {
+    parse_entry(line, &Fields::default())
+}
+
 /// Parse one JSON-line record into a [`LogEntry`] using the configured field
 /// names. Records without a `_msg` (e.g. keep-alives) are dropped.
 fn parse_entry(line: &str, fields: &Fields) -> Option<LogEntry> {
-    let v: Value = serde_json::from_str(line).ok()?;
-    let msg = v.get("_msg")?.as_str()?.trim_end_matches('\n').to_string();
-    let time = v
-        .get("_time")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let nanos = time.parse::<Timestamp>().ok().map(|t| t.as_nanosecond());
-    let field = |name: &str| {
-        v.get(name)
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string()
-    };
-    Some(LogEntry {
-        nanos,
-        msg,
-        pod: field(&fields.pod),
-        container: field(&fields.container),
-        time,
-    })
+    use serde::de::DeserializeSeed;
+
+    let mut de = serde_json::Deserializer::from_str(line);
+    let entry = EntrySeed(fields).deserialize(&mut de).ok()??;
+    // A record with trailing content is malformed; `from_str` rejected it too.
+    de.end().ok()?;
+    Some(entry)
+}
+
+/// Deserializes a record straight into a [`LogEntry`], keeping only the four
+/// fields the entry retains and skipping every other one without building it.
+///
+/// The `serde_json::Value` DOM this replaces allocated a map entry, a key
+/// `String` and a `Value` for every field the backend sent — ingestion
+/// pipelines routinely send dozens — and then copied out the four that
+/// survive. Two of the four names come from the runtime [`Fields`] config, so
+/// this is a `DeserializeSeed` carrying them rather than a derived
+/// `Deserialize` with fixed names.
+struct EntrySeed<'a>(&'a Fields);
+
+impl<'de> serde::de::DeserializeSeed<'de> for EntrySeed<'_> {
+    /// `None` for a well-formed record that carries no `_msg`. A record that
+    /// is not a JSON object fails to deserialize and is dropped by the caller.
+    type Value = Option<LogEntry>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(EntryVisitor(self.0))
+    }
+}
+
+struct EntryVisitor<'a>(&'a Fields);
+
+impl<'de> serde::de::Visitor<'de> for EntryVisitor<'_> {
+    type Value = Option<LogEntry>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a log record object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let (mut msg, mut time, mut pod, mut container) = (None, None, None, None);
+
+        while let Some(key) = map.next_key::<RecordKey<'_>>()? {
+            let key = key.0.as_ref();
+            // Tested independently rather than as an `else if` chain: a config
+            // that points two fields at one record field must fill both, which
+            // is what indexing the DOM once per field used to do. Last
+            // occurrence of a repeated key wins, as it did in the DOM.
+            let (is_msg, is_time) = (key == MSG_FIELD, key == TIME_FIELD);
+            let (is_pod, is_container) = (key == self.0.pod, key == self.0.container);
+            if !(is_msg || is_time || is_pod || is_container) {
+                map.next_value::<serde::de::IgnoredAny>()?;
+                continue;
+            }
+            let value = map.next_value::<StringValue<'_>>()?.0;
+            if is_msg {
+                msg = value.clone();
+            }
+            if is_time {
+                time = value.clone();
+            }
+            if is_pod {
+                pod = value.clone();
+            }
+            if is_container {
+                container = value;
+            }
+        }
+
+        // No `_msg`, or a `_msg` that wasn't a string: not a log line.
+        let Some(msg) = msg else {
+            return Ok(None);
+        };
+        let time = time.map(std::borrow::Cow::into_owned).unwrap_or_default();
+        let nanos = time.parse::<Timestamp>().ok().map(|t| t.as_nanosecond());
+        Ok(Some(LogEntry {
+            nanos,
+            msg: msg.trim_end_matches('\n').to_string(),
+            pod: pod.map(std::borrow::Cow::into_owned).unwrap_or_default(),
+            container: container
+                .map(std::borrow::Cow::into_owned)
+                .unwrap_or_default(),
+            time,
+        }))
+    }
+}
+
+/// A record field name, borrowed from the input when it carries no escapes.
+struct RecordKey<'a>(std::borrow::Cow<'a, str>);
+
+impl<'de> serde::Deserialize<'de> for RecordKey<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(RecordKeyVisitor)
+    }
+}
+
+struct RecordKeyVisitor;
+
+impl<'de> serde::de::Visitor<'de> for RecordKeyVisitor {
+    type Value = RecordKey<'de>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a field name")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E> {
+        Ok(RecordKey(std::borrow::Cow::Borrowed(v)))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(RecordKey(std::borrow::Cow::Owned(v.to_string())))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
+        Ok(RecordKey(std::borrow::Cow::Owned(v)))
+    }
+}
+
+/// A field value, kept only when it is a JSON string and borrowed from the
+/// input when it carries no escapes. Every other JSON type reads as absent —
+/// the same conclusion `Value::as_str()` reached, without building the value
+/// to reach it.
+struct StringValue<'a>(Option<std::borrow::Cow<'a, str>>);
+
+impl<'de> serde::Deserialize<'de> for StringValue<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StringValueVisitor)
+    }
+}
+
+struct StringValueVisitor;
+
+impl<'de> serde::de::Visitor<'de> for StringValueVisitor {
+    type Value = StringValue<'de>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("any JSON value")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E> {
+        Ok(StringValue(Some(std::borrow::Cow::Borrowed(v))))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(StringValue(Some(std::borrow::Cow::Owned(v.to_string()))))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E> {
+        Ok(StringValue(Some(std::borrow::Cow::Owned(v))))
+    }
+
+    fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
+        Ok(StringValue(None))
+    }
+
+    fn visit_i64<E>(self, _: i64) -> Result<Self::Value, E> {
+        Ok(StringValue(None))
+    }
+
+    fn visit_u64<E>(self, _: u64) -> Result<Self::Value, E> {
+        Ok(StringValue(None))
+    }
+
+    fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
+        Ok(StringValue(None))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(StringValue(None))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(StringValue(None))
+    }
+
+    // Nested containers still have to be walked to reach the next key, but
+    // nothing inside them is built.
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+        Ok(StringValue(None))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        while map
+            .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+            .is_some()
+        {}
+        Ok(StringValue(None))
+    }
 }
 
 // ===== metrics provider (right-sizing) =====================================
@@ -1514,6 +1712,131 @@ mod tests {
         // Records without _msg (keep-alives) and garbage are dropped.
         assert!(parse_entry(r#"{"_time":"x"}"#, &fields()).is_none());
         assert!(parse_entry("not json", &fields()).is_none());
+    }
+
+    /// The `serde_json::Value` implementation the selective visitor replaced,
+    /// kept as the reference the visitor is checked against.
+    fn parse_entry_via_dom(line: &str, fields: &Fields) -> Option<LogEntry> {
+        let v: Value = serde_json::from_str(line).ok()?;
+        let msg = v.get("_msg")?.as_str()?.trim_end_matches('\n').to_string();
+        let time = v
+            .get("_time")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let nanos = time.parse::<Timestamp>().ok().map(|t| t.as_nanosecond());
+        let field = |name: &str| {
+            v.get(name)
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        Some(LogEntry {
+            nanos,
+            msg,
+            pod: field(&fields.pod),
+            container: field(&fields.container),
+            time,
+        })
+    }
+
+    /// The visitor must reach the same answer as the DOM for every record
+    /// shape a backend can emit — that equivalence is the whole licence for
+    /// skipping the DOM.
+    #[test]
+    fn selective_visitor_matches_the_dom_it_replaced() {
+        let cases = [
+            // Ordinary record.
+            r#"{"_time":"2026-07-13T06:41:47Z","_msg":"hello","kubernetes.pod_name":"api-1","kubernetes.container_name":"app"}"#,
+            // Unknown extra fields, including nested containers, are skipped.
+            r#"{"_msg":"hi","_stream_id":"0000","extra":{"a":[1,2,{"b":null}]},"n":3,"kubernetes.pod_name":"p"}"#,
+            // Fields the entry keeps, arriving after a large ignored one.
+            r#"{"junk":[1,2,3,4,5],"_msg":"after","_time":"2026-07-13T06:41:47Z"}"#,
+            // Missing _msg (keep-alive) and a non-string _msg are both dropped.
+            r#"{"_time":"2026-07-13T06:41:47Z"}"#,
+            r#"{"_msg":42}"#,
+            r#"{"_msg":null}"#,
+            r#"{"_msg":["a"]}"#,
+            r#"{"_msg":{"nested":"x"}}"#,
+            // Non-string optional fields fall back to empty, they do not drop.
+            r#"{"_msg":"m","_time":7,"kubernetes.pod_name":null,"kubernetes.container_name":{"x":1}}"#,
+            // An unparseable _time keeps the raw text and no nanos.
+            r#"{"_msg":"m","_time":"not-a-timestamp"}"#,
+            // Trailing newlines are trimmed off the message, all of them.
+            r#"{"_msg":"line\n"}"#,
+            r#"{"_msg":"line\n\n\n"}"#,
+            r#"{"_msg":"keep\nthe middle\n"}"#,
+            // Escapes force owned keys and values.
+            r#"{"_ms\u0067":"escaped key","kubernetes.pod_name":"p\u00e9"}"#,
+            // A repeated key: the last occurrence wins.
+            r#"{"_msg":"first","_msg":"second"}"#,
+            r#"{"_msg":"first","_msg":9}"#,
+            // Empty and non-object documents.
+            r#"{}"#,
+            r#"[]"#,
+            r#""bare string""#,
+            r#"null"#,
+            "not json",
+            "",
+            // Trailing content after a complete object is malformed.
+            r#"{"_msg":"m"} trailing"#,
+        ];
+
+        for line in cases {
+            let want = parse_entry_via_dom(line, &fields());
+            let got = parse_entry(line, &fields());
+            let shape = |e: &Option<LogEntry>| {
+                e.as_ref().map(|e| {
+                    (
+                        e.msg.clone(),
+                        e.pod.clone(),
+                        e.container.clone(),
+                        e.time.clone(),
+                        e.nanos,
+                    )
+                })
+            };
+            assert_eq!(shape(&got), shape(&want), "record {line}");
+        }
+    }
+
+    /// Field names come from config, so the visitor must read the configured
+    /// names and not the defaults it was written against.
+    #[test]
+    fn selective_visitor_honours_configured_field_names() {
+        let custom = Fields {
+            namespace: "ns".into(),
+            pod: "workload".into(),
+            container: "ctr".into(),
+        };
+        let line = r#"{"_msg":"m","workload":"api-1","ctr":"app","kubernetes.pod_name":"ignored"}"#;
+        let e = parse_entry(line, &custom).unwrap();
+        assert_eq!(e.pod, "api-1");
+        assert_eq!(e.container, "app");
+        assert_eq!(
+            parse_entry(line, &custom),
+            parse_entry_via_dom(line, &custom)
+        );
+
+        // A config that points two entry fields at one record field fills both.
+        let doubled = Fields {
+            namespace: "ns".into(),
+            pod: "who".into(),
+            container: "who".into(),
+        };
+        let line = r#"{"_msg":"m","who":"same"}"#;
+        let e = parse_entry(line, &doubled).unwrap();
+        assert_eq!((e.pod.as_str(), e.container.as_str()), ("same", "same"));
+
+        // A config that aims a field at `_msg` reads it, as the DOM did.
+        let overlap = Fields {
+            namespace: "ns".into(),
+            pod: "_msg".into(),
+            container: "ctr".into(),
+        };
+        let line = r#"{"_msg":"shared"}"#;
+        let e = parse_entry(line, &overlap).unwrap();
+        assert_eq!((e.msg.as_str(), e.pod.as_str()), ("shared", "shared"));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -322,7 +322,25 @@ pub fn row_key(obj: &DynamicObject) -> String {
 /// contributor to RSS and to per-event cost. Nothing mutates an object once
 /// stored (`apply` replaces wholesale), so sharing is safe.
 pub type RowKey = Rc<str>;
-pub type Items = HashMap<RowKey, Arc<DynamicObject>>;
+pub type Items = FastMap<RowKey, Arc<DynamicObject>>;
+
+/// The hasher for maps keyed by cluster data — row keys, cell caches, sort
+/// keys. The default `SipHash` is chosen to make hash flooding infeasible for
+/// keys an attacker supplies; a filter keystroke rehashes every row key in the
+/// store, so that costs real frame time here.
+///
+/// `foldhash`'s randomized state keeps a per-process seed, so a collision set
+/// cannot be precomputed against the binary. What it drops is the guarantee
+/// against an adversary who can both observe timing and choose keys — and here
+/// the keys are `namespace/name` of objects the API server already accepted,
+/// read by a user who is authenticated to that cluster and is watching those
+/// objects deliberately. Anything that could flood these maps could already
+/// exhaust them by simply creating objects.
+///
+/// Config, theme and registry maps keep the standard hasher: they are built
+/// once from local files and never sit in a hot path.
+pub type FastMap<K, V> = HashMap<K, V, foldhash::fast::RandomState>;
+pub type FastSet<T> = std::collections::HashSet<T, foldhash::fast::RandomState>;
 
 /// How a store operation affected the rows currently visible to the UI.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -387,7 +405,7 @@ impl Store {
             self.pending = None;
             true
         } else {
-            self.pending = Some(HashMap::new());
+            self.pending = Some(Items::default());
             false
         }
     }
@@ -521,7 +539,7 @@ mod tests {
         store.remove("default/gone");
         advanced(&store, &mut last, "remove (no such key)");
 
-        let mut seeded = Items::new();
+        let mut seeded = Items::default();
         seeded.insert(Rc::from("default/b"), Arc::new(pod("b")));
         store.seed(seeded);
         advanced(&store, &mut last, "seed");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -541,7 +541,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
 fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let show_ns = app.show_namespace_column();
     let metrics_cols = app.metrics_columns();
-    let headers: Vec<String> = app.display_headers();
+    let headers = app.display_headers();
     let pods_view = app.kind_plural == "pods";
     let sort_col = app.sort_column;
     let sort_arrow = if app.sort_desc { " ↓" } else { " ↑" };
@@ -639,6 +639,10 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let cell_cache = app.table_cell_cache();
     let spec = app.view_spec();
     let thresholds = app.resolved_thresholds();
+    // One clock reading for the whole frame. Every visible AGE/DURATION cell
+    // used to call `Timestamp::now()` for itself, so a full table took one
+    // reading per volatile cell and could show two rows a second apart.
+    let now = crate::columns::now_secs();
 
     // Widest visible value per display column (headers count too, plus the
     // sort arrow on the active sort column). Drives the content-aware widths
@@ -669,10 +673,10 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 style_idx = status_idx.map(|i| i + 1);
             }
             for (i, cell) in base_cells.iter().enumerate() {
-                if let Some(value) = spec.volatile(obj, &app.kind_plural, i) {
+                if let Some(value) = spec.volatile(obj, &app.kind_plural, i, now) {
                     cells.push(TableCellText::Owned(value));
                 } else {
-                    cells.push(TableCellText::Borrowed(cell));
+                    cells.push(TableCellText::Borrowed(cell.as_str()));
                 }
             }
             if app.node_capacity_columns() {
@@ -1071,7 +1075,7 @@ fn render_name_cell(app: &App, name: &str, base: Color) -> Cell<'static> {
     let Some(matched) = app.filter_match_indices(name).filter(|idx| !idx.is_empty()) else {
         return Cell::from(name.to_string()).style(Style::default().fg(base));
     };
-    let matched: std::collections::HashSet<usize> = matched.into_iter().collect();
+    let matched: std::collections::HashSet<usize> = matched.iter().copied().collect();
     let plain = Style::default().fg(base);
     let hl = Style::default()
         .fg(theme::yellow())

--- a/src/views.rs
+++ b/src/views.rs
@@ -410,6 +410,75 @@ pub fn lookup<'a>(views: &'a HashMap<String, View>, ar: &ApiResource) -> Option<
 /// `/metadata/…` and `/apiVersion`/`/kind` come from the typed fields, the
 /// rest from the body (`DynamicObject::data` holds spec/status/…).
 pub fn extract(obj: &DynamicObject, pointer: &str) -> Option<Value> {
+    extract_ref(obj, pointer).map(Extracted::into_value)
+}
+
+/// A custom column's extracted value, borrowed wherever the object already
+/// holds it in the shape the renderer needs: `DynamicObject::data` is already
+/// a `Value` tree, and `ObjectMeta`'s scalars and label/annotation values are
+/// already `String`s. A column pointing at a 100-element array or a nested
+/// object therefore formats it where it lies instead of deep-cloning the whole
+/// subtree first, and only the finished cell allocates.
+///
+/// `Owned` covers the metadata shapes that have to be serialized to answer the
+/// pointer at all (`ownerReferences`, whole `metadata`, timestamps).
+pub(crate) enum Extracted<'a> {
+    /// A node of the object body.
+    Json(&'a Value),
+    /// A string the object already stores as one.
+    Text(&'a str),
+    /// A value that had to be built to answer the pointer.
+    Owned(Value),
+}
+
+impl<'a> Extracted<'a> {
+    /// The string form, when the value is one — text, time and quantity
+    /// columns all want this and nothing else.
+    fn as_str(&self) -> Option<&str> {
+        match self {
+            Extracted::Text(s) => Some(s),
+            Extracted::Json(v) => v.as_str(),
+            Extracted::Owned(v) => v.as_str(),
+        }
+    }
+
+    /// Give up the borrow. Only [`extract`]'s owned callers pay this.
+    fn into_value(self) -> Value {
+        match self {
+            Extracted::Json(v) => v.clone(),
+            Extracted::Text(s) => Value::String(s.to_string()),
+            Extracted::Owned(v) => v,
+        }
+    }
+
+    /// The rendered cell — the one allocation the extraction path owes.
+    fn render(&self) -> String {
+        match self {
+            Extracted::Text(s) => (*s).into(),
+            Extracted::Json(v) => render_value(v),
+            Extracted::Owned(v) => render_value(v),
+        }
+    }
+
+    fn number(&self) -> Option<f64> {
+        match self {
+            Extracted::Text(s) => s.trim().parse().ok(),
+            Extracted::Json(v) => number_of(v),
+            Extracted::Owned(v) => number_of(v),
+        }
+    }
+
+    fn quantity(&self) -> Option<f64> {
+        match self {
+            Extracted::Text(s) => parse_quantity(s),
+            Extracted::Json(v) => quantity_of(v),
+            Extracted::Owned(v) => quantity_of(v),
+        }
+    }
+}
+
+/// [`extract`] without the clone. See [`Extracted`].
+pub(crate) fn extract_ref<'a>(obj: &'a DynamicObject, pointer: &str) -> Option<Extracted<'a>> {
     if let Some(rest) = pointer.strip_prefix("/metadata")
         && (rest.is_empty() || rest.starts_with('/'))
     {
@@ -420,43 +489,53 @@ pub fn extract(obj: &DynamicObject, pointer: &str) -> Option<Value> {
             return obj
                 .types
                 .as_ref()
-                .map(|t| Value::String(t.api_version.clone()));
+                .map(|t| Extracted::Text(t.api_version.as_str()));
         }
-        "/kind" => return obj.types.as_ref().map(|t| Value::String(t.kind.clone())),
+        "/kind" => return obj.types.as_ref().map(|t| Extracted::Text(t.kind.as_str())),
         _ => {}
     }
-    obj.data.pointer(pointer).cloned()
+    obj.data.pointer(pointer).map(Extracted::Json)
 }
 
 /// Resolve metadata without serializing the entire `ObjectMeta` for every
 /// custom-column cell. Complex or whole-metadata requests still serialize the
 /// selected value, preserving the exact JSON Pointer behavior and output.
-fn extract_metadata(meta: &kube::core::ObjectMeta, rest: &str) -> Option<Value> {
+fn extract_metadata<'a>(meta: &'a kube::core::ObjectMeta, rest: &str) -> Option<Extracted<'a>> {
     if rest.is_empty() {
-        return serde_json::to_value(meta).ok();
+        return serde_json::to_value(meta).ok().map(Extracted::Owned);
     }
     let path = rest.strip_prefix('/')?;
     let field = path.split_once('/').map_or(path, |(field, _)| field);
     let tail = &path[field.len()..];
 
+    // A `String` field ObjectMeta already holds: the cell is that string.
+    // A pointer that walks further into a JSON string matches nothing, which
+    // is what serializing it and walking `tail` used to conclude the long way.
+    macro_rules! text {
+        ($value:expr) => {{
+            let s: &str = $value;
+            tail.is_empty().then_some(Extracted::Text(s))
+        }};
+    }
+
     macro_rules! selected {
         ($value:expr) => {{
             let value = serde_json::to_value($value).ok()?;
             if tail.is_empty() {
-                Some(value)
+                Some(Extracted::Owned(value))
             } else {
-                value.pointer(tail).cloned()
+                value.pointer(tail).cloned().map(Extracted::Owned)
             }
         }};
     }
 
     match field {
-        "name" => selected!(meta.name.as_ref()?),
-        "namespace" => selected!(meta.namespace.as_ref()?),
-        "uid" => selected!(meta.uid.as_ref()?),
-        "resourceVersion" => selected!(meta.resource_version.as_ref()?),
-        "generateName" => selected!(meta.generate_name.as_ref()?),
-        "selfLink" => selected!(meta.self_link.as_ref()?),
+        "name" => text!(meta.name.as_ref()?),
+        "namespace" => text!(meta.namespace.as_ref()?),
+        "uid" => text!(meta.uid.as_ref()?),
+        "resourceVersion" => text!(meta.resource_version.as_ref()?),
+        "generateName" => text!(meta.generate_name.as_ref()?),
+        "selfLink" => text!(meta.self_link.as_ref()?),
         "generation" => selected!(meta.generation?),
         "deletionGracePeriodSeconds" => selected!(meta.deletion_grace_period_seconds?),
         "creationTimestamp" => selected!(meta.creation_timestamp.as_ref()?),
@@ -470,29 +549,31 @@ fn extract_metadata(meta: &kube::core::ObjectMeta, rest: &str) -> Option<Value> 
     }
 }
 
-fn extract_string_map(
-    map: &std::collections::BTreeMap<String, String>,
+fn extract_string_map<'a>(
+    map: &'a std::collections::BTreeMap<String, String>,
     tail: &str,
-) -> Option<Value> {
+) -> Option<Extracted<'a>> {
     if tail.is_empty() {
-        return serde_json::to_value(map).ok();
+        return serde_json::to_value(map).ok().map(Extracted::Owned);
     }
     let token = tail.strip_prefix('/')?;
     if token.contains('/') {
         return None;
     }
     // JSON Pointer unescapes `~1` before `~0`; doing so in this order also
-    // preserves the RFC-defined meaning of tokens such as `~01`.
+    // preserves the RFC-defined meaning of tokens such as `~01`. A label or
+    // annotation value is borrowed straight out of the map — the whole map
+    // used to be serialized to JSON to read one key out of it.
     if token.contains('~') {
         let key = token.replace("~1", "/").replace("~0", "~");
-        map.get(&key).cloned().map(Value::String)
+        map.get(&key).map(|v| Extracted::Text(v.as_str()))
     } else {
-        map.get(token).cloned().map(Value::String)
+        map.get(token).map(|v| Extracted::Text(v.as_str()))
     }
 }
 
 /// Render one custom column's cell. Missing values read as `<none>`.
-pub fn render_cell(obj: &DynamicObject, col: &UserColumn) -> String {
+pub fn render_cell(obj: &DynamicObject, col: &UserColumn, now: i64) -> String {
     if col.kind == ColumnKind::Condition {
         return condition_status(obj, &col.pointer).unwrap_or_else(|| "<none>".into());
     }
@@ -500,17 +581,17 @@ pub fn render_cell(obj: &DynamicObject, col: &UserColumn) -> String {
         return "<none>".into();
     };
     match col.kind {
-        ColumnKind::Time => render_time(&v),
-        _ => render_value(&v),
+        ColumnKind::Time => render_time(&v, now),
+        _ => v.render(),
     }
 }
 
 /// Value of a non-`Condition` column: a JSON Pointer extract, or a named
 /// field of a `status.conditions` entry looked up by type.
-fn cell_value(obj: &DynamicObject, col: &UserColumn) -> Option<Value> {
+fn cell_value<'a>(obj: &'a DynamicObject, col: &UserColumn) -> Option<Extracted<'a>> {
     match col.condition_field.as_deref() {
-        Some(field) => condition_value(obj, &col.pointer, field),
-        None => extract(obj, &col.pointer),
+        Some(field) => condition_value(obj, &col.pointer, field).map(Extracted::Json),
+        None => extract_ref(obj, &col.pointer),
     }
 }
 
@@ -524,14 +605,13 @@ pub fn condition_status(obj: &DynamicObject, cond_type: &str) -> Option<String> 
 
 /// One field of the `status.conditions` entry whose `type` is `cond_type`,
 /// found by name — array order isn't guaranteed by anything.
-fn condition_value(obj: &DynamicObject, cond_type: &str, field: &str) -> Option<Value> {
+fn condition_value<'a>(obj: &'a DynamicObject, cond_type: &str, field: &str) -> Option<&'a Value> {
     obj.data
         .pointer("/status/conditions")?
         .as_array()?
         .iter()
         .find(|c| c.get("type").and_then(Value::as_str) == Some(cond_type))?
         .get(field)
-        .cloned()
 }
 
 fn render_value(v: &Value) -> String {
@@ -547,27 +627,27 @@ fn render_value(v: &Value) -> String {
 /// Timestamps render as compact elapsed time (`3d4h`); a future timestamp
 /// (e.g. a certificate's `notAfter`) reads `in 30d`. Values that don't parse
 /// as RFC 3339 fall back to the raw string.
-fn render_time(v: &Value) -> String {
+fn render_time(v: &Extracted<'_>, now: i64) -> String {
     let Some(s) = v.as_str() else {
-        return render_value(v);
+        return v.render();
     };
     match s.parse::<Timestamp>() {
         Ok(ts) => {
-            let delta = Timestamp::now().as_second() - ts.as_second();
+            let delta = now - ts.as_second();
             if delta >= 0 {
                 crate::columns::humanize(delta)
             } else {
                 format!("in {}", crate::columns::humanize(-delta))
             }
         }
-        Err(_) => s.to_string(),
+        Err(_) => s.into(),
     }
 }
 
 /// Comparable value of a custom column's cell: numbers, quantities, and times
 /// sort by value (missing/unparseable last in ascending order), text sorts
 /// case-insensitively.
-pub fn sort_value(obj: &DynamicObject, col: &UserColumn) -> SortValue {
+pub fn sort_value(obj: &DynamicObject, col: &UserColumn, now: i64) -> SortValue {
     if col.kind == ColumnKind::Condition {
         return SortValue::Text(
             condition_status(obj, &col.pointer)
@@ -577,26 +657,29 @@ pub fn sort_value(obj: &DynamicObject, col: &UserColumn) -> SortValue {
     }
     let v = cell_value(obj, col);
     match col.kind {
-        ColumnKind::Number => SortValue::Num(v.as_ref().and_then(number_of).unwrap_or(f64::MAX)),
+        ColumnKind::Number => {
+            SortValue::Num(v.as_ref().and_then(Extracted::number).unwrap_or(f64::MAX))
+        }
         ColumnKind::Quantity => {
-            SortValue::Num(v.as_ref().and_then(quantity_of).unwrap_or(f64::MAX))
+            SortValue::Num(v.as_ref().and_then(Extracted::quantity).unwrap_or(f64::MAX))
         }
         // Elapsed seconds, like AGE: ascending = most recent (or furthest in
         // the future) first, unknowns last.
         ColumnKind::Time => SortValue::Num(
             v.as_ref()
-                .and_then(Value::as_str)
+                .and_then(Extracted::as_str)
                 .and_then(|s| s.parse::<Timestamp>().ok())
-                .map(|ts| (Timestamp::now().as_second() - ts.as_second()) as f64)
+                .map(|ts| (now - ts.as_second()) as f64)
                 .unwrap_or(f64::MAX),
         ),
         // Condition is handled above (its "pointer" is a condition name, not
         // something `extract` understands).
         ColumnKind::Text | ColumnKind::Status | ColumnKind::Condition => SortValue::Text(
             v.as_ref()
-                .map(render_value)
+                .map(Extracted::render)
                 .unwrap_or_default()
-                .to_lowercase(),
+                .to_lowercase()
+                .to_string(),
         ),
     }
 }
@@ -855,8 +938,8 @@ mod tests {
             ]}
         }))
         .unwrap();
-        assert_eq!(render_cell(&obj, col), "False");
-        match sort_value(&obj, col) {
+        assert_eq!(render_cell(&obj, col, crate::columns::now_secs()), "False");
+        match sort_value(&obj, col, crate::columns::now_secs()) {
             SortValue::Text(t) => assert_eq!(t, "false"),
             SortValue::Num(_) => panic!("conditions sort as text"),
         }
@@ -866,7 +949,10 @@ mod tests {
             "metadata": {"name": "new"}
         }))
         .unwrap();
-        assert_eq!(render_cell(&bare, col), "<none>");
+        assert_eq!(
+            render_cell(&bare, col, crate::columns::now_secs()),
+            "<none>"
+        );
     }
 
     #[test]
@@ -1225,6 +1311,142 @@ mod tests {
         );
     }
 
+    /// The borrowed extraction must answer every pointer exactly as the owned
+    /// one did — it is the same function now, so this pins the shapes that
+    /// actually get borrowed rather than cloned.
+    #[test]
+    fn borrowed_extraction_matches_the_owned_value_it_replaced() {
+        let big: Vec<Value> = (0..100).map(|i| json!({"i": i})).collect();
+        let o = obj(json!({
+            "apiVersion": "example.com/v1",
+            "kind": "Widget",
+            "metadata": {
+                "name": "w1",
+                "namespace": "team",
+                "labels": {"app": "web"},
+                "annotations": {"a.example.com/note": "hi", "with/slash": "s"},
+                "generation": 7,
+            },
+            "spec": {"size": 3, "tags": ["a", "b"], "items": big,
+                     "nested": {"deep": {"leaf": "found"}}},
+            "status": {"phase": "Ready"}
+        }));
+
+        // Borrowed straight out of the body: no subtree is cloned to read it.
+        assert!(matches!(
+            extract_ref(&o, "/spec/items"),
+            Some(Extracted::Json(_))
+        ));
+        assert!(matches!(
+            extract_ref(&o, "/spec/nested/deep"),
+            Some(Extracted::Json(_))
+        ));
+        // Borrowed straight out of ObjectMeta / a label map.
+        assert!(matches!(
+            extract_ref(&o, "/metadata/name"),
+            Some(Extracted::Text("w1"))
+        ));
+        assert!(matches!(
+            extract_ref(&o, "/metadata/labels/app"),
+            Some(Extracted::Text("web"))
+        ));
+        assert!(matches!(
+            extract_ref(&o, "/metadata/annotations/with~1slash"),
+            Some(Extracted::Text("s"))
+        ));
+        assert!(matches!(
+            extract_ref(&o, "/apiVersion"),
+            Some(Extracted::Text("example.com/v1"))
+        ));
+        // Still owned: these have to be built to answer the pointer at all.
+        assert!(matches!(
+            extract_ref(&o, "/metadata/generation"),
+            Some(Extracted::Owned(_))
+        ));
+        assert!(matches!(
+            extract_ref(&o, "/metadata/labels"),
+            Some(Extracted::Owned(_))
+        ));
+
+        // Whatever the representation, the owned answer is unchanged.
+        for pointer in [
+            "/spec/items",
+            "/spec/nested/deep",
+            "/spec/tags/1",
+            "/metadata/name",
+            "/metadata/namespace",
+            "/metadata/labels",
+            "/metadata/labels/app",
+            "/metadata/annotations/a.example.com~1note",
+            "/metadata/annotations/with~1slash",
+            "/metadata/generation",
+            "/metadata",
+            "/apiVersion",
+            "/kind",
+            "/status/phase",
+            // A pointer walking into a string still matches nothing.
+            "/metadata/name/nope",
+            "/metadata/labels/app/nope",
+            "/spec/missing",
+        ] {
+            let borrowed = extract_ref(&o, pointer).map(Extracted::into_value);
+            assert_eq!(borrowed, extract(&o, pointer), "pointer {pointer}");
+        }
+    }
+
+    /// Rendering and sorting read the borrowed value, so they must produce
+    /// what they produced when every extraction was a fresh `Value`.
+    #[test]
+    fn borrowed_cells_render_and_sort_unchanged() {
+        let o = obj(json!({
+            "apiVersion": "example.com/v1",
+            "kind": "Widget",
+            "metadata": {"name": "w1", "labels": {"replicas": "12"}},
+            "spec": {"tags": ["a", "b"], "cpu": "250m", "count": 42},
+            "status": {"phase": "Ready"}
+        }));
+        let now = crate::columns::now_secs();
+
+        assert_eq!(
+            render_cell(&o, &col("/metadata/name", ColumnKind::Text), now),
+            "w1"
+        );
+        assert_eq!(
+            render_cell(&o, &col("/status/phase", ColumnKind::Text), now),
+            "Ready"
+        );
+        assert_eq!(
+            render_cell(&o, &col("/spec/tags", ColumnKind::Text), now),
+            r#"["a","b"]"#
+        );
+        assert_eq!(
+            render_cell(&o, &col("/spec/count", ColumnKind::Number), now),
+            "42"
+        );
+        assert_eq!(
+            render_cell(&o, &col("/nope", ColumnKind::Text), now),
+            "<none>"
+        );
+
+        // A quantity and a number reached through a borrowed label string.
+        match sort_value(&o, &col("/spec/cpu", ColumnKind::Quantity), now) {
+            SortValue::Num(n) => assert_eq!(n, 0.25),
+            SortValue::Text(t) => panic!("quantity sorts numerically, got {t}"),
+        }
+        match sort_value(
+            &o,
+            &col("/metadata/labels/replicas", ColumnKind::Number),
+            now,
+        ) {
+            SortValue::Num(n) => assert_eq!(n, 12.0),
+            SortValue::Text(t) => panic!("number sorts numerically, got {t}"),
+        }
+        match sort_value(&o, &col("/metadata/name", ColumnKind::Text), now) {
+            SortValue::Text(t) => assert_eq!(t, "w1"),
+            SortValue::Num(n) => panic!("text sorts as text, got {n}"),
+        }
+    }
+
     #[test]
     fn extracts_pointers_across_metadata_typemeta_and_body() {
         let o = obj(json!({
@@ -1313,14 +1535,36 @@ mod tests {
             "metadata": {"name": "w1"},
             "spec": {"size": 3, "on": true, "tags": ["a"]}
         }));
-        assert_eq!(render_cell(&o, &col("/spec/size", ColumnKind::Text)), "3");
-        assert_eq!(render_cell(&o, &col("/spec/on", ColumnKind::Text)), "true");
         assert_eq!(
-            render_cell(&o, &col("/spec/tags", ColumnKind::Text)),
+            render_cell(
+                &o,
+                &col("/spec/size", ColumnKind::Text),
+                crate::columns::now_secs()
+            ),
+            "3"
+        );
+        assert_eq!(
+            render_cell(
+                &o,
+                &col("/spec/on", ColumnKind::Text),
+                crate::columns::now_secs()
+            ),
+            "true"
+        );
+        assert_eq!(
+            render_cell(
+                &o,
+                &col("/spec/tags", ColumnKind::Text),
+                crate::columns::now_secs()
+            ),
             "[\"a\"]"
         );
         assert_eq!(
-            render_cell(&o, &col("/spec/nope", ColumnKind::Text)),
+            render_cell(
+                &o,
+                &col("/spec/nope", ColumnKind::Text),
+                crate::columns::now_secs()
+            ),
             "<none>"
         );
     }
@@ -1338,13 +1582,28 @@ mod tests {
                 "junk": "not-a-time"
             }
         }));
-        assert_eq!(render_cell(&o, &col("/spec/past", ColumnKind::Time)), "1h");
         assert_eq!(
-            render_cell(&o, &col("/spec/future", ColumnKind::Time)),
+            render_cell(
+                &o,
+                &col("/spec/past", ColumnKind::Time),
+                crate::columns::now_secs()
+            ),
+            "1h"
+        );
+        assert_eq!(
+            render_cell(
+                &o,
+                &col("/spec/future", ColumnKind::Time),
+                crate::columns::now_secs()
+            ),
             "in 30d"
         );
         assert_eq!(
-            render_cell(&o, &col("/spec/junk", ColumnKind::Time)),
+            render_cell(
+                &o,
+                &col("/spec/junk", ColumnKind::Time),
+                crate::columns::now_secs()
+            ),
             "not-a-time"
         );
     }
@@ -1379,13 +1638,31 @@ mod tests {
             }
         }));
         // Lexically "1Gi" < "500m" — by value it must be the other way.
-        let q = |p: &str| num(sort_value(&o, &col(p, ColumnKind::Quantity)));
+        let q = |p: &str| {
+            num(sort_value(
+                &o,
+                &col(p, ColumnKind::Quantity),
+                crate::columns::now_secs(),
+            ))
+        };
         assert!(q("/spec/small") < q("/spec/big"));
         // Lexically "10" < "9".
-        let n = |p: &str| num(sort_value(&o, &col(p, ColumnKind::Number)));
+        let n = |p: &str| {
+            num(sort_value(
+                &o,
+                &col(p, ColumnKind::Number),
+                crate::columns::now_secs(),
+            ))
+        };
         assert!(n("/spec/nine") < n("/spec/ten"));
         // Ascending time = most recent first (smaller elapsed).
-        let t = |p: &str| num(sort_value(&o, &col(p, ColumnKind::Time)));
+        let t = |p: &str| {
+            num(sort_value(
+                &o,
+                &col(p, ColumnKind::Time),
+                crate::columns::now_secs(),
+            ))
+        };
         assert!(t("/spec/new") < t("/spec/old"));
         // Missing values sort last in ascending order.
         assert_eq!(q("/spec/missing"), f64::MAX);
@@ -1513,17 +1790,26 @@ mod tests {
                 }
             ]}
         }));
-        assert_eq!(render_cell(&obj, &view.columns[0]), "False");
-        assert_eq!(render_cell(&obj, &view.columns[1]), "DependencyNotReady");
-        assert_eq!(render_cell(&obj, &view.columns[2]), "waiting on source");
-        match sort_value(&obj, &view.columns[1]) {
+        assert_eq!(
+            render_cell(&obj, &view.columns[0], crate::columns::now_secs()),
+            "False"
+        );
+        assert_eq!(
+            render_cell(&obj, &view.columns[1], crate::columns::now_secs()),
+            "DependencyNotReady"
+        );
+        assert_eq!(
+            render_cell(&obj, &view.columns[2], crate::columns::now_secs()),
+            "waiting on source"
+        );
+        match sort_value(&obj, &view.columns[1], crate::columns::now_secs()) {
             SortValue::Text(t) => assert_eq!(t, "dependencynotready"),
             SortValue::Num(_) => panic!("reason sorts as text"),
         }
 
         let spec = crate::columns::build_spec("widgets", None, Some(&view), false);
         assert_eq!(spec.headers(), vec!["NAME", "A", "B", "C", "AGE"]);
-        let (cells, status_idx) = spec.cells(&obj);
+        let (cells, status_idx) = spec.cells(&obj, crate::columns::now_secs());
         assert_eq!(
             &cells[1..4],
             ["False", "DependencyNotReady", "waiting on source"]


### PR DESCRIPTION
## Summary

Implements the performance work no other open PR covers. Production code only —
no plan, no audit document, no prototype harness. Independent of #220–#228.

## What this changes, and by how much

Paired benchmarks: the shipped code and the code it replaced, in the same binary
and the same run, so the number is a ratio rather than a timing that only holds
at one thermal state.

| Change | Baseline | Now | Gain |
| --- | ---: | ---: | ---: |
| One clock reading per frame, not per elapsed cell — 2,000 AGE cells | 134.99 µs | 92.951 µs | **1.45x** |
| Log records without a JSON DOM — 10,000 records, 12 ingest fields | 19.441 ms | 8.096 ms | **2.40x** |
| Log records without a JSON DOM — 10,000 records, no extra fields | 5.563 ms | 3.451 ms | **1.61x** |
| Borrowed custom-column extraction — 100-element array, 2,000 objects | 1.757 ms | 796.40 µs | **2.21x** |
| Borrowed custom-column extraction — scalar | 669.36 µs | 547.67 µs | **1.22x** |
| Borrowed custom-column extraction — escaped annotation key | 532.61 µs | 448.64 µs | **1.19x** |
| SIMD base64 for the Helm payload's double decode | 353.60 ns | 195.75 ns | **1.81x** |

Dependency swaps:

| Change | Baseline | Now | Gain |
| --- | ---: | ---: | ---: |
| `foldhash` — look up every key in the store, 20,000 rows | 382.12 µs | 132.37 µs | **2.89x** |
| `foldhash` — same, 2,000 rows | 35.505 µs | 13.676 µs | **2.60x** |
| `nucleo` replaces the skim matcher — 20,000 names | 6.393 ms | 2.090 ms | **3.06x** |
| `compact_str` for table cells — 2,000 rows' worth | 213.82 µs | 119.90 µs | **1.78x** |

Memoized models, absolute timings — memo hits replacing a full rebuild on every
draw and again on every keystroke:

| Model | Now |
| --- | ---: |
| `display_headers` | 5.209 ns |
| `filtered_sort_entries` | 8.869 ns |
| `filtered_contexts`, 2,000 contexts | 8.108 µs |

Also: the gunzip buffer is pre-sized from the gzip ISIZE trailer, clamped so a
hostile Secret cannot turn a hint into a 4 GiB reservation; highlight positions
are memoized per name instead of rescored per visible row per frame; and a
typical pod row now allocates nothing, asserted by test.

## Dependencies

`+foldhash`, `+nucleo-matcher`, `+compact_str`, `−fuzzy-matcher`. The crate
graph shrinks by one: `foldhash` and `compact_str` were already compiled in
through `ratatui`, so only `nucleo-matcher` is new, and it displaces
`fuzzy-matcher` and its `thread_local`.

Case handling, match positions and filter syntax are held where they were; the
score scale changes, so equally-matching picker entries may order differently.
simd-json was tried and dropped — 1.05x, 0.97x and 0.94x over three runs on the
only large document sofka parses itself.

Environment: Apple M1, macOS/Darwin 25.6, AArch64. Criterion
`--warm-up-time 1 --measurement-time 2 --sample-size 20 --noplot`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` — 628 passed, 1 ignored (601 on `main`)

