### PR TITLE
fix: show ^d delete hint for deployments, statefulsets and nodes

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -421,6 +421,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             hint_line(&[("s", "scale"), ("r", "restart"), ("i", "image")]),
             hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
             hint_line(&[("X", "explain"), ("T", "timeline"), ("f", "port-fwd")]),
+            hint_line(&[("^d", "delete")]),
         ],
         "daemonsets" => vec![
             hint_line(&[("⏎", "pods"), ("l", "logs"), ("E", "events")]),
@@ -441,6 +442,7 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
         "nodes" => vec![
             hint_line(&[("⏎", "pods"), ("y", "yaml"), ("d", "describe")]),
             hint_line(&[("C", "cordon"), ("U", "uncordon"), ("D", "drain")]),
+            hint_line(&[("^d", "delete")]),
         ],
         "namespaces" => vec![
             hint_line(&[("⏎", "switch to"), ("y", "yaml"), ("d", "describe")]),


### PR DESCRIPTION
## Summary

The `:deployments` (and `:statefulsets`, `:nodes`) header hint block never listed `^d delete`, even though `ctrl-d` is bound for every table kind. Users saw the shortcut advertised on other screens and assumed it was unsupported here.

The hint lists are hand-written per kind in `header_hints` (`src/ui.rs`); this adds the missing `^d delete` line to the three kinds that lacked it. Both blocks stay within the header's 5-row cap.

Closes #192

## Testing

- `cargo test`: 518 passed
- `cargo clippy --all-targets` and `cargo fmt --check` clean (also run by the lefthook pre-commit hook)
