### PR TITLE
perf: accept gzip-compressed API responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +450,23 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "convert_case"
@@ -3280,13 +3309,18 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
  "http",
  "http-body",
+ "http-body-util",
  "mime",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ hyper = { version = "1.10.1", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "native-tokio", "ring", "tls12"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
 k8s-openapi = { version = "0.28", features = ["latest"] }
-kube = { version = "4.2.0", features = ["runtime", "client", "derive", "ws", "http-proxy"] }
+kube = { version = "4.2.0", features = ["runtime", "client", "derive", "ws", "http-proxy", "gzip"] }
 memchr = "2.8.3"
 ratatui = "0.30.1"
 regex = "1"

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -272,6 +272,72 @@ async fn await_counts(rx: &mut Receiver<Msg>, want: &[(&str, usize)]) {
     assert!(seen.is_ok(), "never saw counts {want:?}");
 }
 
+/// A stand-in API server that gzip-encodes its list response and records the
+/// request headers it was asked with. Enabling the `gzip` cargo feature is the
+/// entire change: kube installs its decompression layer inside
+/// `Client::try_from`, which is what `Cluster::from_config` calls — so nothing
+/// in this repo constructs the middleware. That makes it worth pinning from the
+/// outside rather than trusting the feature flag.
+async fn mock_gzip_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+    use std::io::Write;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    const POD_LIST: &str = concat!(
+        r#"{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"7"},"items":["#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","resourceVersion":"1"},"spec":{"nodeName":"node-a"},"status":{"phase":"Running"}},"#,
+        r#"{"apiVersion":"v1","kind":"Pod","metadata":{"name":"b","namespace":"default","resourceVersion":"2"},"spec":{"nodeName":"node-b"},"status":{"phase":"Running"}}"#,
+        r#"]}"#
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock gzip api");
+    let addr = listener.local_addr().expect("local addr");
+    let headers = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = Arc::clone(&headers);
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let seen = Arc::clone(&seen);
+            tokio::spawn(async move {
+                let (r, mut w) = sock.split();
+                let mut reader = BufReader::new(r);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).await.unwrap_or(0) == 0 {
+                    return;
+                }
+                loop {
+                    let mut header = String::new();
+                    if reader.read_line(&mut header).await.unwrap_or(0) == 0 || header == "\r\n" {
+                        break;
+                    }
+                    seen.lock()
+                        .unwrap()
+                        .push(header.trim().to_ascii_lowercase());
+                }
+                // A watch would be answered uncompressed by a real apiserver;
+                // this mock only has to serve the list the watcher opens with.
+                if request_line.contains("watch=true") {
+                    std::future::pending::<()>().await;
+                }
+                let mut enc =
+                    flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+                enc.write_all(POD_LIST.as_bytes()).expect("gzip");
+                let body = enc.finish().expect("gzip finish");
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-encoding: gzip\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = w.write_all(head.as_bytes()).await;
+                let _ = w.write_all(&body).await;
+            });
+        }
+    });
+    (format!("http://{addr}"), headers)
+}
+
 /// A `Cluster` whose client talks to `url` instead of a real API server.
 fn mock_cluster(url: &str) -> Cluster {
     let mut config = kube::Config::new(url.parse().expect("mock url"));
@@ -437,6 +503,29 @@ async fn node_pods_backs_off_when_the_initial_list_keeps_failing() {
     assert!(
         gaps[1] > gaps[0],
         "retry interval did not grow, backoff is being reset: {gaps:?}"
+    );
+}
+
+/// Compression is transparent: the `gzip` cargo feature is the only change, and
+/// it has to survive a dependency bump that reshuffles kube's client stack.
+/// Both halves are checked — the request advertises gzip, and a gzip-encoded
+/// body is inflated before deserialization. Without the feature the second
+/// assertion fails first, because serde is handed the raw deflate stream.
+#[tokio::test]
+async fn the_client_negotiates_and_inflates_gzip() {
+    let (url, headers) = mock_gzip_api().await;
+    let (tx, mut rx) = mpsc::channel(1024);
+    let mut app = App::new(mock_cluster(&url), tx);
+
+    app.spawn_node_pods_poll();
+
+    // Counts can only be right if the compressed body round-tripped.
+    await_counts(&mut rx, &[("node-a", 1), ("node-b", 1)]).await;
+
+    let seen = headers.lock().unwrap();
+    assert!(
+        seen.iter().any(|h| h == "accept-encoding: gzip"),
+        "client did not ask for gzip; headers: {seen:?}"
     );
 }
 


### PR DESCRIPTION
**Offtopic:**
Interesting thing: this is only for legacy fallback that uses LISTS not new watch
as WATCH does not support GZIP in kubernetes, instead it seems to have protobuf
BUT

The kube-rs issue is kube-rs/kube#371 (https://github.com/kube-rs/kube/issues/371) — "protobuf encoding exploration", opened 
  Jan 2021 and now closed. Two structural blockers, per the maintainer:

  1. Kubernetes' protobuf field-ordering tags live in Go struct tags and aren't in the OpenAPI/Swagger schemas that k8s-openapi
     generates Rust types from — so the ordering metadata simply isn't available.
  2. Generated protobuf structs would collide with the existing k8s-openapi structs with no way to associate them. "Unless 
     there's a way to associate these structs with the ones from k8s-openapi structs of the same name, this would be hard. Sounds
     like another codegen project if it is possible."
     
https://github.com/kube-rs/kube/issues/725
**But it might worth review this as this was 5 years ago, as it brings benefits in gzip + zero copy deserialization for watch that rust ecosystem does not have now**
---
**PR Desc**
Enables kube's `gzip` feature. No source change: kube installs its decompression
layer inside `Client::try_from`, which `Cluster::from_config` already calls, so the
client starts advertising `Accept-Encoding: gzip` and inflating responses.

Measured against a local cluster — 771 pods, 1,222 configmaps, k8s 1.36 — reading
wire bytes straight off the apiserver. Times are transfer + inflate, median of 9:

| endpoint | plain | gzip | ratio | loopback |
| --- | ---: | ---: | ---: | ---: |
| `/api/v1/pods` | 3.88 MB | 202 KB | 19.2× | 75 → 45 ms |
| `/api/v1/configmaps` | 3.05 MB | 121 KB | 25.3× | 55 → 33 ms |
| `/api/v1/secrets` | 1.47 MB | 46 KB | 31.7× | 28 → 20 ms |
| `/api/v1/events` | 823 KB | 66 KB | 12.5× | 22 → 17 ms |
| `/apis/apps/v1/deployments` | 254 KB | 18 KB | 13.8× | 14 → 10 ms |

Loopback is the worst case for compression and it still wins by 1.7×. Projected
from the byte counts, the pods list takes 3,105 → 165 ms on a 10 Mbit link and
310 → 19 ms on 100 Mbit. Break-even is around 9 Gbit/s.

Cost: 0.7–3.3 ms to inflate (flate2 — 3.28 ms for the 3.8 MB pods list), +33 KB on
the stripped release binary (+0.23%), 3 transitive crates.

Two limits worth knowing:

- The apiserver only compresses responses over **128 KB**, so aggregated discovery
  (28 KB here), namespaces and nodes are untouched.
- **Watches are never compressed.** The main table view uses `streaming_lists()`
  (`src/k8s.rs:335`), so its initial sync — 3.93 MB here — saves nothing. The wins
  are `:find`, `:pulse`, the nodes view, the 5s metrics poll, events and `:fleet`.

`the_client_negotiates_and_inflates_gzip` covers both halves: the request carries
`accept-encoding: gzip`, and a gzip-encoded body is inflated before deserialization.
It fails without the feature flag.

`Cargo.lock` is included because `release.yaml` builds with `--locked`.
