### PR TITLE
docs: show custom node columns

### DIFF
--- a/docs/views.md
+++ b/docs/views.md
@@ -47,6 +47,38 @@ the layout. By default columns overlay the curated ones: a matching header
 replaces it in place, new columns go before AGE. Invalid entries are skipped with
 a warning in the app - they never take down the TUI.
 
+### Pods and nodes
+
+Custom columns also overlay sofka's curated core-resource views. Pods already
+show `IP` and `NODE` after toggling wide mode with `w`, and nodes always show
+`VERSION`. Extra node topology and provisioning details can come from labels:
+
+```toml
+# Karpenter example; adjust provider-specific NODEPOOL and TYPE label names.
+[views."v1/nodes"]
+
+[[views."v1/nodes".columns]]
+name = "NODEPOOL"
+path = "/metadata/labels/karpenter.sh~1nodepool"
+
+[[views."v1/nodes".columns]]
+name = "ZONE"
+path = "/metadata/labels/topology.kubernetes.io~1zone"
+
+[[views."v1/nodes".columns]]
+name = "INSTANCE"
+path = "/metadata/labels/node.kubernetes.io~1instance-type"
+
+[[views."v1/nodes".columns]]
+name = "TYPE"
+path = "/metadata/labels/karpenter.sh~1capacity-type"
+```
+
+In a JSON Pointer, `/` inside a label name must be escaped as `~1`. For example,
+EKS commonly uses `eks.amazonaws.com~1nodegroup` for `NODEPOOL` and
+`eks.amazonaws.com~1capacityType` for `TYPE`. Add `wide = true` to any custom
+column that should appear only after pressing `w`.
+
 ### CRD printer columns
 
 A custom resource with no explicit view picks up its CRD

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6691,6 +6691,68 @@ async fn user_view_overlays_columns_and_applies_initial_sort() {
 }
 
 #[tokio::test]
+async fn user_view_adds_provider_label_columns_to_curated_nodes() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [[views."v1/nodes".columns]]
+        name = "NODEPOOL"
+        path = "/metadata/labels/karpenter.sh~1nodepool"
+
+        [[views."v1/nodes".columns]]
+        name = "ZONE"
+        path = "/metadata/labels/topology.kubernetes.io~1zone"
+
+        [[views."v1/nodes".columns]]
+        name = "INSTANCE"
+        path = "/metadata/labels/node.kubernetes.io~1instance-type"
+
+        [[views."v1/nodes".columns]]
+        name = "TYPE"
+        path = "/metadata/labels/karpenter.sh~1capacity-type"
+        "#,
+    );
+    app.switch_kind("nodes");
+
+    assert_eq!(
+        app.display_headers(),
+        [
+            "NAME", "STATUS", "ROLES", "TAINTS", "VERSION", "NODEPOOL", "ZONE", "INSTANCE", "TYPE",
+            "AGE", "PODS", "CPU", "MEM", "%CPU", "%MEM"
+        ]
+    );
+
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "name": "worker-1",
+                "labels": {
+                    "karpenter.sh/nodepool": "general",
+                    "topology.kubernetes.io/zone": "eu-west-1a",
+                    "node.kubernetes.io/instance-type": "m7i.large",
+                    "karpenter.sh/capacity-type": "spot"
+                }
+            },
+            "status": {
+                "nodeInfo": {"kubeletVersion": "v1.33.4"}
+            }
+        }),
+    );
+
+    let rows = app.rows();
+    app.ensure_table_cell_cache(&rows);
+    let key = row_key(rows[0]);
+    let cache = app.table_cell_cache();
+    let (cells, _) = cache.get(&key).unwrap();
+    assert_eq!(cells[4], "v1.33.4");
+    assert_eq!(&cells[5..9], ["general", "eu-west-1a", "m7i.large", "spot"]);
+}
+
+#[tokio::test]
 async fn user_view_replace_swaps_out_curated_columns() {
     let (mut app, _rx) = test_app();
     install_views(


### PR DESCRIPTION
## Summary

- document how custom view overlays apply to core pod and node views
- add a Karpenter node-label example for node pool, zone, instance type, and capacity type
- explain JSON Pointer escaping and EKS label alternatives
- add end-to-end coverage for configured node columns while preserving the curated Kubernetes version column

## Testing

- `just check`
- lefthook pre-commit: Markdown formatting, Rust formatting, clippy, and full test suite (548 passed, 1 ignored)

Closes #196
