### PR TITLE
feat: page through tables with ctrl-f/ctrl-b

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The essentials. `?` in the app shows everything, or see the
 | `/`                  | filter: fuzzy · `!inverse` · `-l`/`-f` selectors · `status=X` `cpu>500m` `age<2h`                 |
 | `enter` / `esc`      | drill down / go back                                                                              |
 | `j`/`k`, `g`/`G`     | navigate                                                                                          |
+| `ctrl-f` / `ctrl-b`  | page forward / back (also `PgDn` / `PgUp`)                                                        |
 | `n` / `0` / `:ctx`   | namespace switcher / all namespaces / context switcher                                            |
 | `space`              | mark row for bulk actions                                                                         |
 | `y` / `d` / `E`      | YAML / describe / live events                                                                     |

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -14,6 +14,7 @@ plugin, bookmark, and workspace chords.
 | `enter`                                       | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources)                               |
 | `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                             |
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                              |
+| `ctrl-f` / `ctrl-b`, `PgDn` / `PgUp`          | page forward / back - one screenful at a time                                                                                         |
 | `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction — remembered per kind across views and restarts    |
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                              |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                      |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -30,11 +30,15 @@ impl App {
                     self.start_watch();
                     return Ok(());
                 }
-                KeyCode::Char('f') if self.mode == Mode::Table => {
+                KeyCode::Char('f')
+                    if self.mode == Mode::Table && key.modifiers == KeyModifiers::CONTROL =>
+                {
                     self.move_page(1);
                     return Ok(());
                 }
-                KeyCode::Char('b') if self.mode == Mode::Table => {
+                KeyCode::Char('b')
+                    if self.mode == Mode::Table && key.modifiers == KeyModifiers::CONTROL =>
+                {
                     self.move_page(-1);
                     return Ok(());
                 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -30,6 +30,14 @@ impl App {
                     self.start_watch();
                     return Ok(());
                 }
+                KeyCode::Char('f') if self.mode == Mode::Table => {
+                    self.move_page(1);
+                    return Ok(());
+                }
+                KeyCode::Char('b') if self.mode == Mode::Table => {
+                    self.move_page(-1);
+                    return Ok(());
+                }
                 _ => {}
             }
         }
@@ -108,8 +116,8 @@ impl App {
                     self.table_state.select(Some(len - 1));
                 }
             }
-            KeyCode::PageDown => self.move_selection(10),
-            KeyCode::PageUp => self.move_selection(-10),
+            KeyCode::PageDown => self.move_page(1),
+            KeyCode::PageUp => self.move_page(-1),
             // Horizontal column scroll for narrow panes: the NAMESPACE/NAME
             // prefix stays anchored, → hides the next column after it, ←
             // brings one back.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1196,6 +1196,7 @@ pub struct App {
 
     pub mode: Mode,
     pub table_state: TableState,
+    pub table_page_rows: usize,
     /// Row keys (`ns/name`) marked for bulk actions via SPACE. Cleared whenever
     /// the view is (re)watched. Bulk actions target this set if non-empty, else
     /// the current selection.
@@ -1551,6 +1552,7 @@ impl App {
             history_pos: 0,
             mode: Mode::Table,
             table_state: TableState::default(),
+            table_page_rows: 10,
             marked: HashSet::new(),
             sort_column: None,
             sort_desc: false,

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -925,4 +925,9 @@ impl App {
         let next = (cur + delta).clamp(0, len - 1);
         self.table_state.select(Some(next as usize));
     }
+
+    pub(super) fn move_page(&mut self, pages: i32) {
+        let page = self.table_page_rows.max(1) as i32;
+        self.move_selection(pages.saturating_mul(page));
+    }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -743,6 +743,44 @@ async fn move_selection_from_none_lands_on_first_row_not_second() {
 }
 
 #[tokio::test]
+async fn ctrl_f_and_ctrl_b_page_by_the_drawn_viewport_height() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in 0..25 {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": format!("p{n:02}"), "namespace": "default"}}),
+        );
+    }
+    app.table_state.select(Some(0));
+    app.table_page_rows = 8;
+
+    app.handle_key(ctrl(KeyCode::Char('f'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(8));
+    app.handle_key(ctrl(KeyCode::Char('f'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(16));
+    app.handle_key(ctrl(KeyCode::Char('f'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(24), "clamps at the end");
+
+    app.handle_key(ctrl(KeyCode::Char('b'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(16));
+    app.handle_key(ctrl(KeyCode::Char('b'))).unwrap();
+    app.handle_key(ctrl(KeyCode::Char('b'))).unwrap();
+    app.handle_key(ctrl(KeyCode::Char('b'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(0), "clamps at the top");
+
+    app.handle_key(press(KeyCode::PageDown)).unwrap();
+    assert_eq!(app.table_state.selected(), Some(8));
+    app.handle_key(press(KeyCode::PageUp)).unwrap();
+    assert_eq!(app.table_state.selected(), Some(0));
+
+    app.table_page_rows = 20;
+    app.handle_key(ctrl(KeyCode::Char('f'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(20));
+}
+
+#[tokio::test]
 async fn switching_kind_resets_stale_selection_to_top() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -778,6 +778,14 @@ async fn ctrl_f_and_ctrl_b_page_by_the_drawn_viewport_height() {
     app.table_page_rows = 20;
     app.handle_key(ctrl(KeyCode::Char('f'))).unwrap();
     assert_eq!(app.table_state.selected(), Some(20));
+
+    // ctrl-alt-f is a distinct chord left to plugins, not a page move.
+    let ctrl_alt_f = KeyEvent::new(
+        KeyCode::Char('f'),
+        KeyModifiers::CONTROL | KeyModifiers::ALT,
+    );
+    app.handle_key(ctrl_alt_f).unwrap();
+    assert_eq!(app.table_state.selected(), Some(20));
 }
 
 #[tokio::test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -577,6 +577,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let count = app.row_count();
     let visible_rows = area.height.saturating_sub(3).max(1) as usize;
+    app.table_page_rows = visible_rows;
     if count == 0 {
         *app.table_state.offset_mut() = 0;
     } else {
@@ -1943,6 +1944,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("←/→", "scroll columns (NAMESPACE/NAME stay anchored)"),
         bind("esc", "go back / pop view / clear filter"),
         bind("j/k g/G", "move · top/bottom"),
+        bind("ctrl-f/ctrl-b", "page forward/back (also PgDn/PgUp)"),
         bind("S · I", "sort by column (fuzzy picker) · invert direction"),
         bind("w", "toggle wide columns (kubectl -o wide)"),
         bind(


### PR DESCRIPTION
Closes #199

## What

`ctrl-f` / `ctrl-b` (and `PgDn` / `PgUp`) move the table selection by one screenful.

## Why

`PgDn`/`PgUp` jumped a fixed 10 rows regardless of pane height, and the k9s/vim `ctrl-f`/`ctrl-b` chords fell through to the plugin-chord router and did nothing. There was no middle ground between `j`/`k` and `g`/`G` for scanning a long list.

## How

- `draw_table` records the rows it rendered on the last frame in `App::table_page_rows`.
- `App::move_page(±1)` multiplies that by the direction and reuses `move_selection`, so it clamps at both ends the same way.
- `ctrl-f`/`ctrl-b` are handled as reserved table built-ins next to `ctrl-d`/`ctrl-k`/`ctrl-r`, so they are never swallowed as unmatched plugin chords. A user plugin bound to either chord is now shadowed.
- Help overlay, `docs/keys.md`, and the README key table list the new bindings.

## Not included

`page_next` / `page_prev` are not exposed under `[keys]`; that section only covers palette bindings today and the issue listed rebinding as a future nice-to-have.

## Testing

- New test `ctrl_f_and_ctrl_b_page_by_the_drawn_viewport_height` covers forward/back paging, clamping at both ends, `PgDn`/`PgUp` parity, and a taller pane paging further.
- lefthook pre-commit ran fmt, clippy, and the full suite: 553 passed.
