### PR TITLE
feat: add support ArgoCD Applications and ApplicationSets sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ architecture. The short version:
 - **Flux CD built in** - `t` suspends, resumes, and reconciles through native API
   patches. No `flux` binary. Plus a native Helm inspector that decodes release
   Secrets itself.
+- **Argo CD built in** - `t` suspends, resumes, and syncs ArgoCD Applications
+  and ApplicationSets through native API patches. No `argocd` binary.
 - **It tells you why something is broken** - `X` opens a deterministic,
   evidence-based incident view. No AI, no external service.
 - **Bulk actions** - `space` marks rows for delete, kill, or Flux actions across
@@ -125,7 +127,7 @@ The essentials. `?` in the app shows everything, or see the
 | `X` / `T`            | explain why it's unhealthy / state-change timeline                                                |
 | `s` / `e` / `a`      | shell or scale / edit in `$EDITOR` / attach                                                       |
 | `f`                  | port-forward, in the background (`:pf` manages them)                                              |
-| `t`                  | Flux menu · CronJob trigger · pod file transfer                                                   |
+| `t`                  | Flux/ArgoCD menu · CronJob trigger · pod file transfer                                                   |
 | `r` / `i`            | rollout restart / set container image                                                             |
 | `ctrl-d` / `ctrl-k`  | delete / force-delete (marked rows, or current)                                                   |
 | `S` / `w` / `ctrl-e` | sort picker / wide columns / compact mode                                                         |

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -20,7 +20,7 @@ written to disk.
 ## Diff (`:diff`)
 
 A unified diff of the live object against its `last-applied-configuration`. When
-that annotation is missing - as it is for every Flux- or Helm-managed object,
+that annotation is missing - as it is for every Flux-, ArgoCD-, or Helm-managed object,
 which nothing ever `kubectl apply`s - sofka diffs against the previous revision
 this session's watch saw instead, so "what just changed?" has an answer on GitOps
 clusters. The last revision of up to 256 changed objects is kept in memory.

--- a/docs/features.md
+++ b/docs/features.md
@@ -109,10 +109,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   rolls back.
 - **Argo CD controls** (`t`) - a suspend/resume/sync-now menu for ArgoCD
   Applications, and a suspend/resume menu for ApplicationSets, built on native
-  Kubernetes API patches. Suspend removes `spec.syncPolicy.automated`, resume
-  restores it, and sync-now patches the top-level `operation` field — the same
-  mechanism the ArgoCD API server uses internally. No `argocd` binary needed.
-  Works with bulk multiselect.
+  Kubernetes API patches. Suspend removes `spec.syncPolicy.automated` and
+  stashes the original value (including `prune`/`selfHeal`/`allowEmpty`) as a
+  base64 annotation so resume restores it exactly; ApplicationSet suspend sets
+  `applicationsSync` to `create-only` (no `none` mode exists) and stashes the
+  original value the same way. Sync-now patches the top-level `operation`
+  field. No `argocd` binary needed. Works with bulk multiselect.
 - **GitOps view** (`:gitops` / `:flux`) - the Flux ownership and reconciliation
   chain for the selection: the owning Kustomization/HelmRelease, its source
   (GitRepository/OCIRepository/HelmRepository) with applied and latest revision,

--- a/docs/features.md
+++ b/docs/features.md
@@ -107,6 +107,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   (resolved the way helm-controller composes `releaseName`/`storageNamespace`):
   `⏎` shows a revision's values, `y` the rendered manifest, `d` the NOTES, `r`
   rolls back.
+- **Argo CD controls** (`t`) - a suspend/resume/sync-now menu for ArgoCD
+  Applications, and a suspend/resume menu for ApplicationSets, built on native
+  Kubernetes API patches. Suspend removes `spec.syncPolicy.automated`, resume
+  restores it, and sync-now patches the top-level `operation` field — the same
+  mechanism the ArgoCD API server uses internally. No `argocd` binary needed.
+  Works with bulk multiselect.
 - **GitOps view** (`:gitops` / `:flux`) - the Flux ownership and reconciliation
   chain for the selection: the owning Kustomization/HelmRelease, its source
   (GitRepository/OCIRepository/HelmRepository) with applied and latest revision,

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -50,7 +50,7 @@ plugin, bookmark, and workspace chords.
 | `i`                                           | set container image                                                                                                                   |
 | `r`                                           | rollout restart (workloads) / force-sync (ExternalSecrets/PushSecrets) / refresh (elsewhere)                                          |
 | `f` / `shift-f`                               | port-forward (pods/services) - runs in the background                                                                                 |
-| `t`                                           | Flux: suspend/resume/reconcile menu · CronJobs: trigger/suspend/resume · pods: file transfer (`kubectl cp`)                           |
+| `t`                                           | Flux: suspend/resume/reconcile menu · ArgoCD App/AppSet: suspend/resume (App: + sync) · CronJobs: trigger/suspend/resume · pods: file transfer (`kubectl cp`)                           |
 | `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                      |
 | `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
 | `w`                                           | toggle wide-only columns (kubectl `-o wide`)                                                                                          |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,7 @@ Milestone status. Longer-form thinking on direction lives in
 - [x] Action-aware authorization checks.
 - [x] Declarative guardrails.
 - [x] Local action journal.
+- [x] ArgoCD Application suspend/resume/sync controls.
 
 ## Milestone 5: debugging and collaboration
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -50,8 +50,8 @@ max_bulk = 1                     # no bulk deletes in kube-system
 
 ## Managed-resource mutation warnings
 
-Before you edit, delete, scale, or otherwise change an object that Flux (or
-another controller) owns, sofka warns you that the next reconcile will revert the
+Before you edit, delete, scale, or otherwise change an object that Flux, ArgoCD,
+(or another controller) owns, sofka warns you that the next reconcile will revert the
 change or recreate the object. The point is to send you to the source instead of
 fighting the controller.
 

--- a/docs/vs-k9s.md
+++ b/docs/vs-k9s.md
@@ -15,18 +15,21 @@ For measured start time, memory use, command start time, and binary size, see th
   function that turns a `DynamicObject` into cells, with curated columns for
   common kinds and a NAME/AGE fallback for everything else. A CRD with no
   renderer still lists, sorts, and filters correctly on day one.
-- **Flux CD is built in, not a plugin.** `t` opens a
-  suspend/resume/reconcile-now menu for Kustomizations, HelmReleases,
+- **Flux CD and Argo CD are built in, not plugins.** `t` opens a
+  suspend/resume/reconcile-now menu for Flux Kustomizations, HelmReleases,
   git/helm/oci repositories, buckets, image automation, and notification alerts
-  and receivers. sofka patches `spec.suspend` and the
-  `reconcile.fluxcd.io/requestedAt` annotation through the Kubernetes API - no
-  `flux` binary. Works with bulk multiselect too.
+  and receivers, and a suspend/resume/sync-now menu for ArgoCD Applications
+  (suspend/resume only for ApplicationSets).
+  sofka patches `spec.suspend`, `spec.syncPolicy.automated`, the
+  `reconcile.fluxcd.io/requestedAt` annotation, and the ArgoCD `operation`
+  field through the Kubernetes API - no `flux` or `argocd` binary. Works with
+  bulk multiselect too.
 - **Port-forwards run in the background.** Starting one doesn't freeze the TUI
   for its lifetime. `:pf` lists the active forwards and stops them individually
   while the others keep running. sofka tears all of them down on quit instead of
   orphaning them.
 - **Bulk actions with multiselect.** `space` marks rows for delete, kill, or
-  Flux suspend/resume/reconcile across many resources at once.
+  Flux/ArgoCD suspend/resume/reconcile/sync across many resources at once.
 - **CRD rows drill into their custom resources**, not their YAML. `enter` on a
   CustomResourceDefinition resolves its served version and lists the actual
   objects.
@@ -68,9 +71,9 @@ Design choices you can verify in the source, not marketing numbers.
   data or the filter text changes, guarded by a dirty flag - not on every frame
   or every keystroke across the full object set.
 - **No subprocess overhead on hot paths.** Delete, scale,
-  suspend/resume/reconcile, and CRD drill-down are direct kube API calls (JSON
-  merge-patches over the existing client). No forking `kubectl` or `flux` per
-  action.
+  suspend/resume/reconcile/sync, and CRD drill-down are direct kube API calls
+  (JSON merge-patches over the existing client). No forking `kubectl`, `flux`,
+  or `argocd` per action.
 - **Generation-tagged streams.** Changing views doesn't wait for the old watcher
   to tear down. A generation tag identifies stale messages and sofka drops them
   the instant a newer watch takes over, so navigation never stalls behind a slow

--- a/docs/vs-k9s.md
+++ b/docs/vs-k9s.md
@@ -19,11 +19,12 @@ For measured start time, memory use, command start time, and binary size, see th
   suspend/resume/reconcile-now menu for Flux Kustomizations, HelmReleases,
   git/helm/oci repositories, buckets, image automation, and notification alerts
   and receivers, and a suspend/resume/sync-now menu for ArgoCD Applications
-  (suspend/resume only for ApplicationSets).
-  sofka patches `spec.suspend`, `spec.syncPolicy.automated`, the
-  `reconcile.fluxcd.io/requestedAt` annotation, and the ArgoCD `operation`
-  field through the Kubernetes API - no `flux` or `argocd` binary. Works with
-  bulk multiselect too.
+  (suspend/resume only for ApplicationSets). sofka patches `spec.suspend`,
+  `spec.syncPolicy.automated`, the `reconcile.fluxcd.io/requestedAt` annotation,
+  and the ArgoCD `operation` field through the Kubernetes API - no `flux` or
+  `argocd` binary. ArgoCD suspend/resume stashes the original sync policy as a
+  base64 annotation so `prune`, `selfHeal`, and `allowEmpty` survive the
+  round-trip. Works with bulk multiselect too.
 - **Port-forwards run in the background.** Starting one doesn't freeze the TUI
   for its lifetime. `:pf` lists the active forwards and stops them individually
   while the others keep running. sofka tears all of them down on quit instead of

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1959,10 +1959,11 @@ impl App {
     }
 
     /// Suspend/resume an ArgoCD Application or ApplicationSet. Applications
-    /// toggle `spec.syncPolicy.automated` (remove to suspend, restore to
-    /// resume); ApplicationSets toggle `spec.syncPolicy.applicationsSync`
-    /// (`"none"` to suspend, `"sync"` to resume) — different field, same
-    /// `argocd app suspend`/`resume` intent.
+    /// stash `spec.syncPolicy.automated` into a base64 annotation on suspend
+    /// and restore it on resume — so `prune`, `selfHeal`, and `allowEmpty`
+    /// survive the round-trip. ApplicationSets stash `applicationsSync` and set
+    /// it to `create-only` on suspend (no `none` mode exists). Each target is
+    /// GET-then-patched so the stash is built from the live object.
     pub(super) fn do_argocd_suspend(&mut self, targets: Vec<(String, String)>, suspend: bool) {
         let Some(kind) = self.kind.clone() else {
             return;
@@ -1986,13 +1987,60 @@ impl App {
         } else {
             format!("{verb_done} {} {}", targets.len(), self.kind_plural)
         };
-        let patch = if self.argocd_app_kind() {
-            Patch::Merge(argocd_suspend_patch(suspend))
-        } else {
-            Patch::Merge(argocd_appset_suspend_patch(suspend))
-        };
-        self.spawn_patch_action(kind, targets, patch, claim, ok_message, move |name, e| {
-            format!("{verb} {name} failed: {e}")
+        let is_app = self.argocd_app_kind();
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let mut failed = false;
+            for (name, ns) in targets {
+                let api: Api<DynamicObject> = if kind.namespaced && !ns.is_empty() {
+                    Api::namespaced_with(client.clone(), &ns, &kind.ar)
+                } else {
+                    Api::all_with(client.clone(), &kind.ar)
+                };
+                let obj = match api.get(&name).await {
+                    Ok(o) => o,
+                    Err(e) => {
+                        failed = true;
+                        let _ = tx
+                            .send(Msg::Flash {
+                                generation: genr,
+                                claim,
+                                message: format!("{verb} {name} failed: {e}"),
+                                err: true,
+                            })
+                            .await;
+                        continue;
+                    }
+                };
+                let patch = if is_app {
+                    Patch::Merge(argocd_suspend_patch(&obj, suspend))
+                } else {
+                    Patch::Merge(argocd_appset_suspend_patch(&obj, suspend))
+                };
+                if let Err(e) = api.patch(&name, &PatchParams::default(), &patch).await {
+                    failed = true;
+                    let _ = tx
+                        .send(Msg::Flash {
+                            generation: genr,
+                            claim,
+                            message: format!("{verb} {name} failed: {e}"),
+                            err: true,
+                        })
+                        .await;
+                }
+            }
+            if !failed {
+                let _ = tx
+                    .send(Msg::Flash {
+                        generation: genr,
+                        claim,
+                        message: ok_message,
+                        err: false,
+                    })
+                    .await;
+            }
         });
     }
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1821,8 +1821,8 @@ impl App {
         if self.deny_readonly() {
             return;
         }
-        if !self.flux_suspendable() && !self.cronjob_kind() {
-            self.flash_warn("suspend/resume only applies to CronJobs and Flux resources (ks/hr/git-, helm-, oci-repos, buckets, image automation, alerts, receivers)");
+        if !self.flux_suspendable() && !self.cronjob_kind() && !self.argocd_kind() {
+            self.flash_warn("suspend/resume only applies to CronJobs, Flux resources (ks/hr/git-, helm-, oci-repos, buckets, image automation, alerts, receivers), and ArgoCD Applications/ApplicationSets");
             return;
         }
         if self.action_targets().is_empty() {
@@ -1849,15 +1849,27 @@ impl App {
                 match choice {
                     Some("Suspend") => {
                         let targets = self.action_targets();
-                        self.do_set_suspend(targets, true);
+                        if self.argocd_kind() {
+                            self.do_argocd_suspend(targets, true);
+                        } else {
+                            self.do_flux_suspend(targets, true);
+                        }
                     }
                     Some("Resume") => {
                         let targets = self.action_targets();
-                        self.do_set_suspend(targets, false);
+                        if self.argocd_kind() {
+                            self.do_argocd_suspend(targets, false);
+                        } else {
+                            self.do_flux_suspend(targets, false);
+                        }
                     }
                     Some("Reconcile now") => {
                         let targets = self.action_targets();
-                        self.do_reconcile(targets);
+                        self.do_flux_reconcile(targets);
+                    }
+                    Some("Sync now") => {
+                        let targets = self.action_targets();
+                        self.do_argocd_sync(targets);
                     }
                     Some("Trigger now") => self.do_trigger_cronjobs(),
                     _ => {} // "Cancel" or nothing selected — do nothing.
@@ -1867,7 +1879,7 @@ impl App {
         }
     }
 
-    pub(super) fn do_set_suspend(&mut self, targets: Vec<(String, String)>, suspend: bool) {
+    pub(super) fn do_flux_suspend(&mut self, targets: Vec<(String, String)>, suspend: bool) {
         let Some(kind) = self.kind.clone() else {
             return;
         };
@@ -1907,12 +1919,12 @@ impl App {
     /// Force an immediate Flux reconciliation, bypassing the normal interval —
     /// patches `reconcile.fluxcd.io/requestedAt`, the same annotation `flux
     /// reconcile` sets, watched by every toolkit controller.
-    pub(super) fn do_reconcile(&mut self, targets: Vec<(String, String)>) {
+    pub(super) fn do_flux_reconcile(&mut self, targets: Vec<(String, String)>) {
         let Some(kind) = self.kind.clone() else {
             return;
         };
         if targets.is_empty() {
-            return; // see `do_set_suspend`
+            return; // see `do_flux_suspend`
         }
         let now = k8s_openapi::jiff::Timestamp::now().to_string();
         let label = self.action_label(&targets);
@@ -1943,6 +1955,78 @@ impl App {
             claim,
             ok_message,
             |name, e| format!("reconcile {name} failed: {e}"),
+        );
+    }
+
+    /// Suspend/resume an ArgoCD Application or ApplicationSet. Applications
+    /// toggle `spec.syncPolicy.automated` (remove to suspend, restore to
+    /// resume); ApplicationSets toggle `spec.syncPolicy.applicationsSync`
+    /// (`"none"` to suspend, `"sync"` to resume) — different field, same
+    /// `argocd app suspend`/`resume` intent.
+    pub(super) fn do_argocd_suspend(&mut self, targets: Vec<(String, String)>, suspend: bool) {
+        let Some(kind) = self.kind.clone() else {
+            return;
+        };
+        if targets.is_empty() {
+            return; // see `do_flux_suspend`
+        }
+        let label = self.action_label(&targets);
+        self.note_action(if suspend { "suspend" } else { "resume" }, label);
+        let verb = if suspend { "suspending" } else { "resuming" };
+        let verb_done = if suspend { "suspended" } else { "resumed" };
+        let progress = if targets.len() == 1 {
+            format!("{verb} {}…", targets[0].0)
+        } else {
+            format!("{verb} {} {}…", targets.len(), self.kind_plural)
+        };
+        let claim = self.claim_status(progress);
+        self.marked.clear();
+        let ok_message = if targets.len() == 1 {
+            format!("{verb_done} {}", targets[0].0)
+        } else {
+            format!("{verb_done} {} {}", targets.len(), self.kind_plural)
+        };
+        let patch = if self.argocd_app_kind() {
+            Patch::Merge(argocd_suspend_patch(suspend))
+        } else {
+            Patch::Merge(argocd_appset_suspend_patch(suspend))
+        };
+        self.spawn_patch_action(kind, targets, patch, claim, ok_message, move |name, e| {
+            format!("{verb} {name} failed: {e}")
+        });
+    }
+
+    /// Trigger an ArgoCD Application sync by patching the top-level `operation`
+    /// field — the same mechanism the ArgoCD API server's `SyncApplication`
+    /// endpoint uses. The controller fills in the revision from `spec.source`.
+    pub(super) fn do_argocd_sync(&mut self, targets: Vec<(String, String)>) {
+        let Some(kind) = self.kind.clone() else {
+            return;
+        };
+        if targets.is_empty() {
+            return; // see `do_flux_suspend`
+        }
+        let label = self.action_label(&targets);
+        self.note_action("sync", label);
+        let progress = if targets.len() == 1 {
+            format!("syncing {}…", targets[0].0)
+        } else {
+            format!("syncing {} {}…", targets.len(), self.kind_plural)
+        };
+        let claim = self.claim_status(progress);
+        self.marked.clear();
+        let ok_message = if targets.len() == 1 {
+            format!("sync requested: {}", targets[0].0)
+        } else {
+            format!("sync requested: {} {}", targets.len(), self.kind_plural)
+        };
+        self.spawn_patch_action(
+            kind,
+            targets,
+            Patch::Merge(argocd_sync_patch()),
+            claim,
+            ok_message,
+            |name, e| format!("sync {name} failed: {e}"),
         );
     }
 

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -33,6 +33,37 @@ pub(super) fn reconcile_patch(requested_at: &str) -> Value {
     })
 }
 
+/// ArgoCD Application suspend/resume patch. Suspend removes
+/// `spec.syncPolicy.automated` (merge-patch `null` deletes the field), resume
+/// restores it as an empty object — the same `argocd app suspend`/`resume`
+/// semantics.
+pub(super) fn argocd_suspend_patch(suspend: bool) -> Value {
+    if suspend {
+        json!({ "spec": { "syncPolicy": { "automated": null } } })
+    } else {
+        json!({ "spec": { "syncPolicy": { "automated": {} } } })
+    }
+}
+
+/// ArgoCD ApplicationSet suspend/resume patch. ApplicationSet has no
+/// `automated` field — it uses `spec.syncPolicy.applicationsSync` (a string:
+/// `sync`, `create-only`, `create-update`, `create-delete`). Suspend removes
+/// the field entirely (merge-patch `null`), resume restores it to `sync`.
+pub(super) fn argocd_appset_suspend_patch(suspend: bool) -> Value {
+    if suspend {
+        json!({ "spec": { "syncPolicy": { "applicationsSync": null } } })
+    } else {
+        json!({ "spec": { "syncPolicy": { "applicationsSync": "sync" } } })
+    }
+}
+
+/// ArgoCD sync patch. Setting the top-level `operation.sync` field triggers a
+/// manual sync — the same mechanism the ArgoCD API server's `SyncApplication`
+/// endpoint uses. The controller fills in the revision from `spec.source`.
+pub(super) fn argocd_sync_patch() -> Value {
+    json!({ "operation": { "sync": {} } })
+}
+
 pub(super) fn external_secret_refresh_patch(force_sync: &str) -> Value {
     json!({
         "metadata": { "annotations": { "force-sync": force_sync } }
@@ -322,6 +353,30 @@ impl App {
         FLUX_SUSPENDABLE_KINDS.contains(&self.kind_plural.as_str())
     }
 
+    /// Whether the current kind is an ArgoCD CRD (Application or
+    /// ApplicationSet, group `argoproj.io`). The plurals are generic, so the
+    /// group is checked too — only the real ArgoCD CRDs get the `t` menu.
+    pub fn argocd_kind(&self) -> bool {
+        matches!(
+            self.kind_plural.as_str(),
+            "applications" | "applicationsets"
+        ) && self
+            .kind
+            .as_ref()
+            .is_some_and(|k| k.ar.group == ARGOCD_GROUP)
+    }
+
+    /// Whether the current kind is an ArgoCD Application (not ApplicationSet).
+    /// Gates "Sync now", which patches the `operation` field — ApplicationSet
+    /// has no such field.
+    pub fn argocd_app_kind(&self) -> bool {
+        self.kind_plural == "applications"
+            && self
+                .kind
+                .as_ref()
+                .is_some_and(|k| k.ar.group == ARGOCD_GROUP)
+    }
+
     /// Whether the current kind is CronJobs, which get their own `t` menu
     /// (trigger/suspend/resume).
     pub fn cronjob_kind(&self) -> bool {
@@ -332,6 +387,10 @@ impl App {
     pub fn action_menu_items(&self) -> &'static [&'static str] {
         if self.cronjob_kind() {
             CRONJOB_MENU_ITEMS
+        } else if self.argocd_app_kind() {
+            ARGOCD_MENU_ITEMS
+        } else if self.argocd_kind() {
+            ARGOCD_APPSET_MENU_ITEMS
         } else {
             FLUX_MENU_ITEMS
         }

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -33,27 +33,101 @@ pub(super) fn reconcile_patch(requested_at: &str) -> Value {
     })
 }
 
-/// ArgoCD Application suspend/resume patch. Suspend removes
-/// `spec.syncPolicy.automated` (merge-patch `null` deletes the field), resume
-/// restores it as an empty object — the same `argocd app suspend`/`resume`
-/// semantics.
-pub(super) fn argocd_suspend_patch(suspend: bool) -> Value {
+/// Annotation key for stashing an Application's `automated` block on suspend.
+const ARGOCD_AUTOMATED_STASH: &str = "sofka.io/argocd-automated";
+
+/// Annotation key for stashing an ApplicationSet's `applicationsSync` mode.
+const ARGOCD_APPSYNC_STASH: &str = "sofka.io/argocd-applications-sync";
+
+/// ArgoCD Application suspend/resume patch, built from the live object.
+///
+/// **Suspend** base64-encodes the current `spec.syncPolicy.automated` object
+/// into an annotation, then removes the field — so `prune`, `selfHeal`, and
+/// `allowEmpty` survive the round-trip. **Resume** decodes the annotation and
+/// restores the original object, then removes the annotation. When the
+/// annotation is absent (the Application was suspended by someone else), resume
+/// falls back to an empty `automated: {}`.
+pub(super) fn argocd_suspend_patch(obj: &DynamicObject, suspend: bool) -> Value {
+    use base64::Engine;
     if suspend {
-        json!({ "spec": { "syncPolicy": { "automated": null } } })
+        let stash = obj.data.pointer("/spec/syncPolicy/automated").map(|v| {
+            base64::engine::general_purpose::STANDARD
+                .encode(serde_json::to_string(v).unwrap_or_default().as_bytes())
+        });
+        let mut patch = json!({"spec": {"syncPolicy": {"automated": null}}});
+        if let Some(s) = stash {
+            patch["metadata"]["annotations"][ARGOCD_AUTOMATED_STASH] = json!(s);
+        }
+        patch
     } else {
-        json!({ "spec": { "syncPolicy": { "automated": {} } } })
+        let annotation = obj
+            .metadata
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get(ARGOCD_AUTOMATED_STASH));
+        match annotation {
+            Some(s) => {
+                let decoded = base64::engine::general_purpose::STANDARD
+                    .decode(s)
+                    .ok()
+                    .and_then(|b| serde_json::from_slice::<Value>(&b).ok());
+                let mut patch =
+                    json!({"metadata": {"annotations": {ARGOCD_AUTOMATED_STASH: null}}});
+                patch["spec"]["syncPolicy"]["automated"] = decoded.unwrap_or_else(|| json!({}));
+                patch
+            }
+            None => json!({"spec": {"syncPolicy": {"automated": {}}}}),
+        }
     }
 }
 
-/// ArgoCD ApplicationSet suspend/resume patch. ApplicationSet has no
-/// `automated` field — it uses `spec.syncPolicy.applicationsSync` (a string:
-/// `sync`, `create-only`, `create-update`, `create-delete`). Suspend removes
-/// the field entirely (merge-patch `null`), resume restores it to `sync`.
-pub(super) fn argocd_appset_suspend_patch(suspend: bool) -> Value {
+/// ArgoCD ApplicationSet suspend/resume patch, built from the live object.
+///
+/// ApplicationSet has no `automated` field — it uses `spec.syncPolicy.applicationsSync`
+/// (a string: `sync`, `create-only`, `create-update`, `create-delete`). There is
+/// no `none`/`disabled` mode, so suspend sets it to `create-only` (closest to
+/// suspended — stops updates/deletes of existing child Applications). The
+/// original value is base64-stashed into an annotation so resume restores it
+/// exactly. When the annotation is absent, resume falls back to `"sync"`.
+pub(super) fn argocd_appset_suspend_patch(obj: &DynamicObject, suspend: bool) -> Value {
+    use base64::Engine;
+    const SUSPEND_MODE: &str = "create-only";
     if suspend {
-        json!({ "spec": { "syncPolicy": { "applicationsSync": null } } })
+        let current = obj
+            .data
+            .pointer("/spec/syncPolicy/applicationsSync")
+            .and_then(Value::as_str)
+            .unwrap_or("sync");
+        let stash = base64::engine::general_purpose::STANDARD.encode(
+            serde_json::to_string(current)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+        json!({
+            "spec": {"syncPolicy": {"applicationsSync": SUSPEND_MODE}},
+            "metadata": {"annotations": {ARGOCD_APPSYNC_STASH: stash}}
+        })
     } else {
-        json!({ "spec": { "syncPolicy": { "applicationsSync": "sync" } } })
+        let annotation = obj
+            .metadata
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get(ARGOCD_APPSYNC_STASH));
+        match annotation {
+            Some(s) => {
+                let decoded = base64::engine::general_purpose::STANDARD
+                    .decode(s)
+                    .ok()
+                    .and_then(|b| serde_json::from_slice::<Value>(&b).ok())
+                    .and_then(|v| v.as_str().map(String::from));
+                let restored = decoded.unwrap_or_else(|| "sync".into());
+                json!({
+                    "spec": {"syncPolicy": {"applicationsSync": restored}},
+                    "metadata": {"annotations": {ARGOCD_APPSYNC_STASH: null}}
+                })
+            }
+            None => json!({"spec": {"syncPolicy": {"applicationsSync": "sync"}}}),
+        }
     }
 }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -202,8 +202,9 @@ impl App {
                 }
             }
             // Action menu on the marked rows, or current: Flux
-            // suspend/resume/reconcile, CronJob trigger/suspend/resume. On
-            // pods, `t` is the file-transfer menu (kubectl cp) instead.
+            // suspend/resume/reconcile, ArgoCD Application suspend/resume/sync,
+            // ArgoCD ApplicationSet suspend/resume, CronJob trigger/suspend/resume.
+            // On pods, `t` is the file-transfer menu (kubectl cp) instead.
             KeyCode::Char('t') => {
                 if self.kind_plural == "pods" {
                     self.request_transfer();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -103,17 +103,21 @@ pub const FLUX_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Reconcile now", "Ca
 pub const CRONJOB_MENU_ITEMS: &[&str] = &["Trigger now", "Suspend", "Resume", "Cancel"];
 
 /// Items in the ArgoCD Application action menu (`t`), in display order. "Suspend"
-/// disables auto-sync by removing `spec.syncPolicy.automated` (the same merge
-/// patch `argocd app suspend` applies); "Resume" re-enables it with an empty
-/// `automated` object (the `argocd app resume` default). "Sync now" patches
-/// the top-level `operation` field with a sync request, which the ArgoCD
-/// application controller picks up and processes — the same mechanism the
-/// `argocd app sync` API endpoint uses internally. No `argocd` binary.
+/// disables auto-sync by removing `spec.syncPolicy.automated` and stashing the
+/// original value (including `prune`/`selfHeal`/`allowEmpty`) as a base64
+/// annotation; "Resume" restores it from the annotation, or defaults to an
+/// empty `automated: {}` when the annotation is absent. "Sync now" patches
+/// the top-level `operation` field, which the ArgoCD application controller
+/// picks up — the same mechanism the `argocd app sync` API endpoint uses.
+/// No `argocd` binary.
 pub const ARGOCD_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Sync now", "Cancel"];
 
 /// Items in the ArgoCD ApplicationSet action menu (`t`). Suspend/Resume
-/// toggle `spec.syncPolicy.automated` exactly like Application. There is no
-/// "Sync now" — ApplicationSet has no `operation` field; it generates
+/// toggle `spec.syncPolicy.applicationsSync`. There is no `none`/`disabled`
+/// mode — suspend sets it to `create-only` (stops updates/deletes of existing
+/// child Applications) and stashes the original value as a base64 annotation;
+/// resume restores it from the annotation, or defaults to `"sync"`. There is
+/// no "Sync now" — ApplicationSet has no `operation` field; it generates
 /// Applications on its own schedule, and syncing those individually is an
 /// Application-level action.
 pub const ARGOCD_APPSET_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Cancel"];

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -85,6 +85,10 @@ const FLUX_SUSPENDABLE_KINDS: &[&str] = &[
     "receivers",
 ];
 
+/// The ArgoCD CRD group. Used to disambiguate the very generic `applications`
+/// and `applicationsets` plurals — only `argoproj.io` kinds get the `t` menu.
+const ARGOCD_GROUP: &str = "argoproj.io";
+
 /// Items in the Flux action menu (`t`), in display order. Deliberately a menu
 /// — not a single-key toggle — so suspending something always takes an
 /// explicit, visible choice rather than one accidental keystroke. "Reconcile
@@ -97,6 +101,22 @@ pub const FLUX_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Reconcile now", "Ca
 /// job --from=cronjob/…` does; Suspend/Resume patch `spec.suspend` exactly
 /// like the Flux menu (CronJobs share the field).
 pub const CRONJOB_MENU_ITEMS: &[&str] = &["Trigger now", "Suspend", "Resume", "Cancel"];
+
+/// Items in the ArgoCD Application action menu (`t`), in display order. "Suspend"
+/// disables auto-sync by removing `spec.syncPolicy.automated` (the same merge
+/// patch `argocd app suspend` applies); "Resume" re-enables it with an empty
+/// `automated` object (the `argocd app resume` default). "Sync now" patches
+/// the top-level `operation` field with a sync request, which the ArgoCD
+/// application controller picks up and processes — the same mechanism the
+/// `argocd app sync` API endpoint uses internally. No `argocd` binary.
+pub const ARGOCD_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Sync now", "Cancel"];
+
+/// Items in the ArgoCD ApplicationSet action menu (`t`). Suspend/Resume
+/// toggle `spec.syncPolicy.automated` exactly like Application. There is no
+/// "Sync now" — ApplicationSet has no `operation` field; it generates
+/// Applications on its own schedule, and syncing those individually is an
+/// Application-level action.
+pub const ARGOCD_APPSET_MENU_ITEMS: &[&str] = &["Suspend", "Resume", "Cancel"];
 
 /// Items in the pod file-transfer menu (`t` on a pod), in display order. Both
 /// directions shell out to `kubectl cp` (which needs `tar` in the container),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3012,7 +3012,10 @@ async fn argocd_menu_cancel_item_does_nothing() {
     apply(&mut app, argocd_app("guestbook"));
     let flash_before = app.flash.clone();
     app.request_flux_menu();
-    let cancel = ARGOCD_MENU_ITEMS.iter().position(|s| *s == "Cancel").unwrap();
+    let cancel = ARGOCD_MENU_ITEMS
+        .iter()
+        .position(|s| *s == "Cancel")
+        .unwrap();
     app.flux_menu_state.select(Some(cancel));
     app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Table);
@@ -3037,33 +3040,130 @@ async fn argocd_menu_requires_explicit_choice_not_a_single_key() {
 }
 
 #[test]
-fn argocd_suspend_patch_removes_automated() {
-    let p = argocd_suspend_patch(true);
-    assert_eq!(p, json!({"spec": {"syncPolicy": {"automated": null}}}));
+fn argocd_suspend_stashes_automated_and_removes_field() {
+    let o = obj(argocd_app("guestbook"));
+    let p = argocd_suspend_patch(&o, true);
+    assert_eq!(p["spec"]["syncPolicy"]["automated"], json!(null));
+    let stash = p["metadata"]["annotations"]["sofka.io/argocd-automated"]
+        .as_str()
+        .unwrap();
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(stash)
+        .unwrap();
+    let restored: Value = serde_json::from_slice(&decoded).unwrap();
+    assert_eq!(restored, json!({"prune": true, "selfHeal": true}));
 }
 
 #[test]
-fn argocd_resume_patch_restores_automated() {
-    let p = argocd_suspend_patch(false);
-    assert_eq!(p, json!({"spec": {"syncPolicy": {"automated": {}}}}));
+fn argocd_suspend_with_no_automated_does_not_stash() {
+    let mut o = obj(argocd_app("guestbook"));
+    if let Some(v) = o.data.pointer_mut("/spec/syncPolicy") {
+        v.as_object_mut().unwrap().remove("automated");
+    }
+    let p = argocd_suspend_patch(&o, true);
+    assert_eq!(p["spec"]["syncPolicy"]["automated"], json!(null));
+    assert!(p["metadata"]["annotations"].is_null());
 }
 
 #[test]
-fn argocd_appset_suspend_patch_removes_field() {
-    let p = argocd_appset_suspend_patch(true);
+fn argocd_resume_restores_from_annotation() {
+    use base64::Engine;
+    let stash =
+        base64::engine::general_purpose::STANDARD.encode(r#"{"prune":true,"selfHeal":true}"#);
+    let o = obj(json!({
+        "apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
+        "metadata": {"name": "guestbook", "namespace": "argocd",
+                     "annotations": {"sofka.io/argocd-automated": stash}},
+        "spec": {"syncPolicy": {}}
+    }));
+    let p = argocd_suspend_patch(&o, false);
     assert_eq!(
-        p,
-        json!({"spec": {"syncPolicy": {"applicationsSync": null}}})
+        p["spec"]["syncPolicy"]["automated"],
+        json!({"prune": true, "selfHeal": true})
+    );
+    assert_eq!(
+        p["metadata"]["annotations"]["sofka.io/argocd-automated"],
+        json!(null)
     );
 }
 
 #[test]
-fn argocd_appset_resume_patch_sets_sync() {
-    let p = argocd_appset_suspend_patch(false);
+fn argocd_resume_without_annotation_defaults_to_empty() {
+    let o = obj(argocd_app("guestbook"));
+    let p = argocd_suspend_patch(&o, false);
+    assert_eq!(p["spec"]["syncPolicy"]["automated"], json!({}));
+    assert!(p["metadata"].is_null() || p["metadata"]["annotations"].is_null());
+}
+
+#[test]
+fn argocd_appset_suspend_stashes_and_sets_create_only() {
+    let o = obj(argocd_appset("guestbook-set"));
+    let p = argocd_appset_suspend_patch(&o, true);
     assert_eq!(
-        p,
-        json!({"spec": {"syncPolicy": {"applicationsSync": "sync"}}})
+        p["spec"]["syncPolicy"]["applicationsSync"],
+        json!("create-only")
     );
+    let stash = p["metadata"]["annotations"]["sofka.io/argocd-applications-sync"]
+        .as_str()
+        .unwrap();
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(stash)
+        .unwrap();
+    let restored: Value = serde_json::from_slice(&decoded).unwrap();
+    assert_eq!(restored, json!("sync"));
+}
+
+#[test]
+fn argocd_appset_suspend_defaults_stash_to_sync_when_absent() {
+    let mut o = obj(argocd_appset("guestbook-set"));
+    if let Some(v) = o.data.pointer_mut("/spec/syncPolicy") {
+        v.as_object_mut().unwrap().remove("applicationsSync");
+    }
+    let p = argocd_appset_suspend_patch(&o, true);
+    assert_eq!(
+        p["spec"]["syncPolicy"]["applicationsSync"],
+        json!("create-only")
+    );
+    let stash = p["metadata"]["annotations"]["sofka.io/argocd-applications-sync"]
+        .as_str()
+        .unwrap();
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(stash)
+        .unwrap();
+    let restored: Value = serde_json::from_slice(&decoded).unwrap();
+    assert_eq!(restored, json!("sync"));
+}
+
+#[test]
+fn argocd_appset_resume_restores_from_annotation() {
+    use base64::Engine;
+    let stash = base64::engine::general_purpose::STANDARD.encode(r#""create-update""#);
+    let o = obj(json!({
+        "apiVersion": "argoproj.io/v1alpha1", "kind": "ApplicationSet",
+        "metadata": {"name": "guestbook-set", "namespace": "argocd",
+                     "annotations": {"sofka.io/argocd-applications-sync": stash}},
+        "spec": {"syncPolicy": {"applicationsSync": "create-only"}}
+    }));
+    let p = argocd_appset_suspend_patch(&o, false);
+    assert_eq!(
+        p["spec"]["syncPolicy"]["applicationsSync"],
+        json!("create-update")
+    );
+    assert_eq!(
+        p["metadata"]["annotations"]["sofka.io/argocd-applications-sync"],
+        json!(null)
+    );
+}
+
+#[test]
+fn argocd_appset_resume_without_annotation_defaults_to_sync() {
+    let o = obj(argocd_appset("guestbook-set"));
+    let p = argocd_appset_suspend_patch(&o, false);
+    assert_eq!(p["spec"]["syncPolicy"]["applicationsSync"], json!("sync"));
+    assert!(p["metadata"].is_null() || p["metadata"]["annotations"].is_null());
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2203,10 +2203,10 @@ async fn action_progress_flashes_keep_the_ellipsis_convention() {
     );
     assert!(app.flash.ends_with('…'), "set-image: {}", app.flash);
 
-    app.do_set_suspend(targets.clone(), true);
+    app.do_flux_suspend(targets.clone(), true);
     assert!(app.flash.ends_with('…'), "suspend: {}", app.flash);
 
-    app.do_reconcile(targets.clone());
+    app.do_flux_reconcile(targets.clone());
     assert!(app.flash.ends_with('…'), "reconcile: {}", app.flash);
 
     app.do_refresh_es(targets);
@@ -2240,9 +2240,9 @@ async fn an_action_with_no_targets_claims_nothing() {
 
     // `request_flux_menu` guards this, but the menu stays open across watch
     // updates — the selected row can be gone by the time Enter lands.
-    app.do_set_suspend(Vec::new(), true);
+    app.do_flux_suspend(Vec::new(), true);
     assert!(app.flash.is_empty(), "{}", app.flash);
-    app.do_reconcile(Vec::new());
+    app.do_flux_reconcile(Vec::new());
     assert!(app.flash.is_empty(), "{}", app.flash);
 }
 
@@ -2896,6 +2896,267 @@ async fn cronjob_trigger_acts_on_marked_rows() {
     app.handle_key(press(KeyCode::Enter)).unwrap(); // "Trigger now"
     assert!(app.flash.contains("triggering 2 cronjobs"), "{}", app.flash);
     assert!(app.marked.is_empty()); // cleared after the bulk action
+}
+
+fn argocd_app(name: &str) -> serde_json::Value {
+    json!({
+        "apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
+        "metadata": {"name": name, "namespace": "argocd"},
+        "spec": {
+            "source": {"repoURL": "https://github.com/example/repo", "targetRevision": "HEAD",
+                       "path": "manifests"},
+            "destination": {"server": "https://kubernetes.default.svc", "namespace": "default"},
+            "syncPolicy": {"automated": {"prune": true, "selfHeal": true}}
+        }
+    })
+}
+
+#[tokio::test]
+async fn argocd_menu_opens_with_sync_items() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.mode, Mode::FluxMenu);
+    assert_eq!(app.action_menu_items(), ARGOCD_MENU_ITEMS);
+    assert_eq!(app.flux_menu_state.selected(), Some(0)); // "Suspend"
+}
+
+#[tokio::test]
+async fn argocd_menu_suspend() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // "Suspend"
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("suspending guestbook"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn argocd_menu_resume() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    let idx = ARGOCD_MENU_ITEMS
+        .iter()
+        .position(|s| *s == "Resume")
+        .unwrap();
+    app.flux_menu_state.select(Some(idx));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("resuming guestbook"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn argocd_menu_sync_now() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    let idx = ARGOCD_MENU_ITEMS
+        .iter()
+        .position(|s| *s == "Sync now")
+        .unwrap();
+    app.flux_menu_state.select(Some(idx));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("syncing guestbook"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn argocd_menu_suspend_acts_on_marked_rows() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+    apply(&mut app, argocd_app("frontend"));
+    app.marked.insert("argocd/guestbook".into());
+    app.marked.insert("argocd/frontend".into());
+
+    app.request_flux_menu();
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // "Suspend"
+    assert!(
+        app.flash.contains("suspending 2 applications"),
+        "{}",
+        app.flash
+    );
+    assert!(app.marked.is_empty());
+}
+
+#[tokio::test]
+async fn argocd_menu_rejects_non_argocd_applications() {
+    let (mut app, _rx) = test_app();
+    // "applications" from a non-argoproj group should not get the ArgoCD menu.
+    // The fake cluster only registers argoproj.io/applications, so a different
+    // group would need its own registration — here we verify that a known
+    // non-ArgoCD kind is rejected.
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "a", "namespace": "default"}}),
+    );
+    app.request_flux_menu();
+    assert!(app.flash_err);
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn argocd_menu_cancel_item_does_nothing() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+    let flash_before = app.flash.clone();
+    app.request_flux_menu();
+    let cancel = ARGOCD_MENU_ITEMS.iter().position(|s| *s == "Cancel").unwrap();
+    app.flux_menu_state.select(Some(cancel));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.flash, flash_before);
+}
+
+#[tokio::test]
+async fn argocd_menu_requires_explicit_choice_not_a_single_key() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+
+    // `t` opens the menu — nothing is patched yet.
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.mode, Mode::FluxMenu);
+    assert_eq!(app.flux_menu_state.selected(), Some(0)); // "Suspend"
+
+    // Esc backs out without doing anything.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(!app.flash.contains("suspending"));
+}
+
+#[test]
+fn argocd_suspend_patch_removes_automated() {
+    let p = argocd_suspend_patch(true);
+    assert_eq!(p, json!({"spec": {"syncPolicy": {"automated": null}}}));
+}
+
+#[test]
+fn argocd_resume_patch_restores_automated() {
+    let p = argocd_suspend_patch(false);
+    assert_eq!(p, json!({"spec": {"syncPolicy": {"automated": {}}}}));
+}
+
+#[test]
+fn argocd_appset_suspend_patch_removes_field() {
+    let p = argocd_appset_suspend_patch(true);
+    assert_eq!(
+        p,
+        json!({"spec": {"syncPolicy": {"applicationsSync": null}}})
+    );
+}
+
+#[test]
+fn argocd_appset_resume_patch_sets_sync() {
+    let p = argocd_appset_suspend_patch(false);
+    assert_eq!(
+        p,
+        json!({"spec": {"syncPolicy": {"applicationsSync": "sync"}}})
+    );
+}
+
+#[test]
+fn argocd_sync_patch_sets_operation() {
+    let p = argocd_sync_patch();
+    assert_eq!(p, json!({"operation": {"sync": {}}}));
+}
+
+fn argocd_appset(name: &str) -> serde_json::Value {
+    json!({
+        "apiVersion": "argoproj.io/v1alpha1", "kind": "ApplicationSet",
+        "metadata": {"name": name, "namespace": "argocd"},
+        "spec": {
+            "generators": [{"list": {"elements": [{"cluster": "dev-weu", "url": "https://kubernetes.default.svc"}]}}],
+            "template": {
+                "metadata": {"name": "app-{{cluster}}"},
+                "spec": {
+                    "source": {"repoURL": "https://github.com/example/repo", "path": "manifests"},
+                    "destination": {"server": "{{url}}", "namespace": "default"},
+                    "syncPolicy": {"automated": {"prune": true}}
+                }
+            },
+            "syncPolicy": {"applicationsSync": "sync"}
+        }
+    })
+}
+
+#[tokio::test]
+async fn argocd_appset_menu_opens_without_sync() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applicationsets");
+    apply(&mut app, argocd_appset("guestbook-set"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.mode, Mode::FluxMenu);
+    assert_eq!(app.action_menu_items(), ARGOCD_APPSET_MENU_ITEMS);
+    // No "Sync now" in the menu.
+    assert!(!ARGOCD_APPSET_MENU_ITEMS.contains(&"Sync now"));
+}
+
+#[tokio::test]
+async fn argocd_appset_menu_suspend() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applicationsets");
+    apply(&mut app, argocd_appset("guestbook-set"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // "Suspend"
+    assert_eq!(app.mode, Mode::Table);
+    assert!(
+        app.flash.contains("suspending guestbook-set"),
+        "{}",
+        app.flash
+    );
+}
+
+#[tokio::test]
+async fn argocd_appset_menu_resume() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applicationsets");
+    apply(&mut app, argocd_appset("guestbook-set"));
+
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    let idx = ARGOCD_APPSET_MENU_ITEMS
+        .iter()
+        .position(|s| *s == "Resume")
+        .unwrap();
+    app.flux_menu_state.select(Some(idx));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(
+        app.flash.contains("resuming guestbook-set"),
+        "{}",
+        app.flash
+    );
+}
+
+#[tokio::test]
+async fn argocd_appset_suspend_acts_on_marked_rows() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applicationsets");
+    apply(&mut app, argocd_appset("set-a"));
+    apply(&mut app, argocd_appset("set-b"));
+    app.marked.insert("argocd/set-a".into());
+    app.marked.insert("argocd/set-b".into());
+
+    app.request_flux_menu();
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // "Suspend"
+    assert!(
+        app.flash.contains("suspending 2 applicationsets"),
+        "{}",
+        app.flash
+    );
+    assert!(app.marked.is_empty());
 }
 
 #[test]

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -663,9 +663,20 @@ impl Cluster {
             "snapshots".to_string(),
             mk("kopiur.home-operations.com", "Snapshot", "snapshots", true),
         );
+        // ArgoCD CRDs, for the `t` suspend/resume/sync menu.
+        registry.insert(
+            "applications".to_string(),
+            mk("argoproj.io", "Application", "applications", true),
+        );
+        registry.insert(
+            "applicationsets".to_string(),
+            mk("argoproj.io", "ApplicationSet", "applicationsets", true),
+        );
         // Mirror discover(): catalogued kinds with a group also resolve by
         // (and are listed under) their group-qualified name.
         let mut catalog: Vec<String> = [
+            "applications",
+            "applicationsets",
             "certificates",
             "deployments",
             "events",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -488,6 +488,9 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
     if app.flux_suspendable() {
         lines.push(hint_line(&[("t", "flux menu")]));
     }
+    if app.argocd_kind() {
+        lines.push(hint_line(&[("t", "suspend/sync")]));
+    }
     if app.kind_plural == "helmreleases" {
         lines.push(hint_line(&[("⏎", "helm history")]));
     }
@@ -2032,7 +2035,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind(
             "t",
-            "pods: file transfer (kubectl cp, in picker targets a container) · flux: suspend/resume/reconcile · cronjobs: trigger/suspend/resume",
+            "pods: file transfer (kubectl cp, in picker targets a container) · flux: suspend/resume/reconcile · argocd apps: suspend/resume/sync, appsets: suspend/resume · cronjobs: trigger/suspend/resume",
         ),
         bind("C · U · D", "nodes: cordon · uncordon · drain"),
         bind("space", "mark/unmark row for bulk actions (esc clears)"),
@@ -2326,7 +2329,7 @@ fn draw_flux_menu(frame: &mut Frame, app: &mut App, area: Rect) {
         .map(|label| {
             let color = match *label {
                 "Suspend" => theme::peach(),
-                "Resume" | "Trigger now" => theme::green(),
+                "Resume" | "Trigger now" | "Sync now" => theme::green(),
                 _ => theme::overlay1(),
             };
             ListItem::new(Span::styled(*label, Style::default().fg(color)))
@@ -2334,6 +2337,8 @@ fn draw_flux_menu(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     let subject = if app.cronjob_kind() {
         "CronJob"
+    } else if app.argocd_kind() {
+        "ArgoCD"
     } else {
         "Flux"
     };


### PR DESCRIPTION
Adds native `t` menu support for ArgoCD, the same pattern as the existing for Flux CD controls. No `argocd` binary; all actions are Kubernetes API merge-patches over the existing client.

Applications (`:applications` → `t`):
- **Suspend** - removes `spec.syncPolicy.automated` (disables auto-sync)
- **Resume** - restores `spec.syncPolicy.automated` as an empty object
- **Sync now** - patches the top-level operation field to trigger a manual sync

ApplicationSets (`:applicationsets` → `t`):
- **Suspend** - removes `spec.syncPolicy.applicationsSync` (stops the controller from creating/updating child Applications)
- **Resume**- restores `applicationsSync` to "sync"

Also renames `do_set_suspend` → `do_flux_suspend` and `do_reconcile` → `do_flux_reconcile` for clarity alongside the new `do_argocd_suspend` and `do_argocd_sync`.