### PR TITLE
perf: reduce state and cell extraction overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,10 @@ required-features = ["bench"]
 [[example]]
 name = "memprobe"
 required-features = ["bench", "dhat-heap"]
+
+# Fixed-size latency probe for state persistence. Unlike Criterion's adaptive
+# iteration count, this can time enqueue latency without building an unbounded
+# backlog faster than the filesystem worker can drain it.
+[[example]]
+name = "state_write_probe"
+required-features = ["bench"]

--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -11,6 +11,7 @@
 //! - `metadata`    -> 3.3 (typed field lookup vs whole-meta serialization)
 //! - `log_filter`  -> 4.1 (O(n*m) substring scan)
 //! - `log_wrap`    -> 2.3 / 4.2 (full-buffer re-measure per frame)
+//! - `cell_extract` / `provider_selection` -> Tier 2/3 follow-up baselines
 
 use std::hint::black_box;
 
@@ -291,6 +292,53 @@ fn helm_decode(c: &mut Criterion) {
     g.finish();
 }
 
+/// Tier 3 — targeted structured-filter extraction. The baseline forces the
+/// borrowed JSON string into an owned `String`, matching the old `sget ->
+/// String` contract; production consumes the `Cow::Borrowed` directly.
+fn cell_extract(c: &mut Criterion) {
+    let mut g = c.benchmark_group("cell_extract");
+    let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
+    let spec = columns::build_spec("pods", None, None, true);
+
+    g.bench_function("borrowed_ip_2000", |b| {
+        b.iter(|| {
+            for pod in &pods {
+                black_box(spec.cell_at(black_box(pod), 4).unwrap());
+            }
+        });
+    });
+    g.bench_function("owned_ip_baseline_2000", |b| {
+        b.iter(|| {
+            for pod in &pods {
+                black_box(spec.cell_at(black_box(pod), 4).unwrap().into_owned());
+            }
+        });
+    });
+    g.finish();
+}
+
+/// Tier 2 — provider autodiscovery. Both implementations use `min_by_key`;
+/// the baseline first collects every candidate into a `Vec`, while production
+/// feeds the filtered iterator directly into the minimum selection.
+fn provider_selection(c: &mut Criterion) {
+    let mut g = c.benchmark_group("provider_selection");
+    let services = bs::services(256);
+
+    g.bench_function("logs_streaming_256", |b| {
+        b.iter(|| black_box(bs::pick_log_service(black_box(&services))));
+    });
+    g.bench_function("logs_collected_baseline_256", |b| {
+        b.iter(|| black_box(bs::pick_log_service_collected(black_box(&services))));
+    });
+    g.bench_function("metrics_streaming_256", |b| {
+        b.iter(|| black_box(bs::pick_metrics_service(black_box(&services))));
+    });
+    g.bench_function("metrics_collected_baseline_256", |b| {
+        b.iter(|| black_box(bs::pick_metrics_service_collected(black_box(&services))));
+    });
+    g.finish();
+}
+
 criterion_group!(
     benches,
     rows_cache,
@@ -303,6 +351,8 @@ criterion_group!(
     metadata,
     log_filter,
     log_wrap,
-    log_viewport
+    log_viewport,
+    cell_extract,
+    provider_selection
 );
 criterion_main!(benches);

--- a/examples/state_write_probe.rs
+++ b/examples/state_write_probe.rs
@@ -1,4 +1,6 @@
-//! UI-latency and end-to-end comparison for asynchronous state persistence.
+//! UI-latency and logical-update burst comparison for asynchronous state
+//! persistence. The async worker may coalesce queued snapshots for the same
+//! file because only the newest UI state needs to reach disk.
 //!
 //! Run with:
 //!   cargo run --release --example state_write_probe --features bench
@@ -68,9 +70,9 @@ fn main() {
     println!("state writes ({WRITES} writes/sample, median of {SAMPLES})");
     println!("sync UI path:       {sync_ui:10.3} us/op");
     println!("async UI submit:    {async_submit:10.3} us/op");
-    println!("async total drain:  {async_total:10.3} us/op");
+    println!("async burst drain:  {async_total:10.3} us/op");
     println!("UI latency speedup: {:10.2}x", sync_ui / async_submit);
-    println!("total throughput:   {:10.2}x", sync_ui / async_total);
+    println!("logical throughput: {:10.2}x", sync_ui / async_total);
 
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/examples/state_write_probe.rs
+++ b/examples/state_write_probe.rs
@@ -1,0 +1,76 @@
+//! UI-latency and end-to-end comparison for asynchronous state persistence.
+//!
+//! Run with:
+//!   cargo run --release --example state_write_probe --features bench
+
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use sofka::sortmem::SortMemory;
+use sofka::state_writer::StateWriter;
+
+const WRITES: u32 = 200;
+const SAMPLES: usize = 21;
+
+fn state() -> SortMemory {
+    let mut state = SortMemory::default();
+    for i in 0usize..100 {
+        state.set(&format!("resource-{i}"), "AGE", i.is_multiple_of(2));
+    }
+    state
+}
+
+fn per_op(elapsed: Duration) -> f64 {
+    elapsed.as_secs_f64() * 1e6 / f64::from(WRITES)
+}
+
+fn median(mut samples: Vec<f64>) -> f64 {
+    samples.sort_by(f64::total_cmp);
+    samples[samples.len() / 2]
+}
+
+fn sample_dir() -> PathBuf {
+    std::env::temp_dir().join(format!("sofka-state-write-probe-{}", std::process::id()))
+}
+
+fn main() {
+    let dir = sample_dir();
+    let _ = std::fs::remove_dir_all(&dir);
+    let path = dir.join("sort.toml");
+    let state = state();
+    let mut sync_ui = Vec::with_capacity(SAMPLES);
+    let mut async_submit = Vec::with_capacity(SAMPLES);
+    let mut async_total = Vec::with_capacity(SAMPLES);
+
+    for _ in 0..SAMPLES {
+        let start = Instant::now();
+        for _ in 0..WRITES {
+            black_box(state.save(black_box(&path))).unwrap();
+        }
+        sync_ui.push(per_op(start.elapsed()));
+
+        let (ui_tx, _ui_rx) = tokio::sync::mpsc::channel(1);
+        let writer = StateWriter::new(ui_tx).unwrap();
+        let total_start = Instant::now();
+        let submit_start = Instant::now();
+        for _ in 0..WRITES {
+            black_box(writer.save_sort(black_box(state.clone()), black_box(path.clone()))).unwrap();
+        }
+        async_submit.push(per_op(submit_start.elapsed()));
+        drop(writer); // drains every accepted write
+        async_total.push(per_op(total_start.elapsed()));
+    }
+
+    let sync_ui = median(sync_ui);
+    let async_submit = median(async_submit);
+    let async_total = median(async_total);
+    println!("state writes ({WRITES} writes/sample, median of {SAMPLES})");
+    println!("sync UI path:       {sync_ui:10.3} us/op");
+    println!("async UI submit:    {async_submit:10.3} us/op");
+    println!("async total drain:  {async_total:10.3} us/op");
+    println!("UI latency speedup: {:10.2}x", sync_ui / async_submit);
+    println!("total throughput:   {:10.2}x", sync_ui / async_total);
+
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -116,6 +116,9 @@ impl App {
             "  state:     {}",
             crate::diagnostics::state_dir().display()
         ));
+        if let Some(e) = &self.last_state_write_error {
+            lines.push(format!("  last state write error: {e}"));
+        }
         lines.push(format!(
             "  snapshots: {}",
             crate::snapshot::snapshots_dir().display()

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -61,10 +61,14 @@ impl App {
             self.flash = format!("fleet + {ctx}");
         }
         self.flash_err = false;
-        if let Some(path) = self.fleet_marks_path.clone()
-            && let Err(e) = self.fleet_marks.save(&path)
-        {
-            self.flash_warn(&format!("fleet mark not saved: {e}"));
+        if let Some(path) = self.fleet_marks_path.clone() {
+            let result = match &self.state_writer {
+                Some(writer) => writer.save_fleet(self.fleet_marks.clone(), path),
+                None => self.fleet_marks.save(&path),
+            };
+            if let Err(e) = result {
+                self.flash_warn(&format!("fleet mark not saved: {e}"));
+            }
         }
     }
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -843,9 +843,12 @@ impl App {
                 self.last_error = Some(error.clone());
                 self.borrow_status(format!("error: {error}"), true);
             }
-            Msg::StateWriteFailed(error) => {
+            Msg::StateWriteFailed { id, error } => {
                 self.last_state_write_error = Some(error.clone());
                 self.borrow_status(format!("state not saved: {error}"), true);
+                if let Some(writer) = &self.state_writer {
+                    writer.acknowledge_failure(id);
+                }
             }
             Msg::Flash {
                 generation,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -844,7 +844,7 @@ impl App {
                 self.borrow_status(format!("error: {error}"), true);
             }
             Msg::StateWriteFailed(error) => {
-                self.last_error = Some(error.clone());
+                self.last_state_write_error = Some(error.clone());
                 self.borrow_status(format!("state not saved: {error}"), true);
             }
             Msg::Flash {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -843,6 +843,10 @@ impl App {
                 self.last_error = Some(error.clone());
                 self.borrow_status(format!("error: {error}"), true);
             }
+            Msg::StateWriteFailed(error) => {
+                self.last_error = Some(error.clone());
+                self.borrow_status(format!("state not saved: {error}"), true);
+            }
             Msg::Flash {
                 generation,
                 claim,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1548,6 +1548,10 @@ pub struct App {
     pub watch_errors: u64,
     /// The most recent error message, for `:info` diagnostics.
     pub last_error: Option<String>,
+    /// The most recent failure to persist a small UI-state file (namespace,
+    /// sort, fleet marks). Kept apart from [`Self::last_error`], which `:info`
+    /// reports under watch health — a disk problem is not a watch problem.
+    pub last_state_write_error: Option<String>,
     /// Whether the Metrics API has ever returned data this session.
     pub metrics_seen: bool,
     /// The metrics poll's most recent failure (`None` while it works), for
@@ -1824,6 +1828,7 @@ impl App {
             journal: crate::journal::Journal::default(),
             watch_errors: 0,
             last_error: None,
+            last_state_write_error: None,
             metrics_seen: false,
             metrics_error: None,
             rbac_allowed: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1366,6 +1366,9 @@ pub struct App {
     gen_flag: Arc<AtomicU64>,
     pub tasks: Vec<JoinHandle<()>>,
     pub tx: Sender<Msg>,
+    /// Ordered off-thread persistence for small UI state files. `None` keeps
+    /// unit tests and degraded startup on the synchronous fallback.
+    pub state_writer: Option<crate::state_writer::StateWriter>,
     stack: Vec<Frame>,
     /// Scope of the running watch, so its rows can be stashed under the right
     /// key when the user navigates away.
@@ -1738,6 +1741,7 @@ impl App {
             gen_flag: Arc::new(AtomicU64::new(0)),
             tasks: Vec::new(),
             tx,
+            state_writer: None,
             stack: Vec::new(),
             watch_key: None,
             view_cache: HashMap::new(),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -151,10 +151,14 @@ impl App {
         {
             return;
         }
-        if let Some(path) = self.namespace_memory_path.clone()
-            && let Err(e) = self.namespace_memory.save(&path)
-        {
-            self.flash_warn(&format!("failed to save namespace state: {e}"));
+        if let Some(path) = self.namespace_memory_path.clone() {
+            let result = match &self.state_writer {
+                Some(writer) => writer.save_namespace(self.namespace_memory.clone(), path),
+                None => self.namespace_memory.save(&path),
+            };
+            if let Err(e) = result {
+                self.flash_warn(&format!("failed to save namespace state: {e}"));
+            }
         }
     }
 

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -218,7 +218,7 @@ impl App {
             return Some(o.metadata.namespace.as_deref().unwrap_or("").into());
         }
         if let Some(i) = self.spec.header_index(key) {
-            return self.spec.cell_at(o, i).map(Cow::Owned);
+            return self.spec.cell_at(o, i);
         }
         if key.eq_ignore_ascii_case("status") {
             let phase = phase(o);
@@ -754,10 +754,14 @@ impl App {
             None if self.sort_memory.clear(&kind) => {}
             None => return, // nothing was remembered; skip the disk write
         }
-        if let Some(path) = self.sort_memory_path.clone()
-            && let Err(e) = self.sort_memory.save(&path)
-        {
-            self.flash_warn(&format!("failed to save sort state: {e}"));
+        if let Some(path) = self.sort_memory_path.clone() {
+            let result = match &self.state_writer {
+                Some(writer) => writer.save_sort(self.sort_memory.clone(), path),
+                None => self.sort_memory.save(&path),
+            };
+            if let Err(e) = result {
+                self.flash_warn(&format!("failed to save sort state: {e}"));
+            }
         }
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1964,7 +1964,10 @@ async fn panic_msg_flashes_regardless_of_generation() {
 #[tokio::test]
 async fn state_write_failure_stays_out_of_watch_health() {
     let (mut app, _rx) = test_app();
-    app.handle_msg(Msg::StateWriteFailed("sort.toml: Permission denied".into()));
+    app.handle_msg(Msg::StateWriteFailed {
+        id: 1,
+        error: "sort.toml: Permission denied".into(),
+    });
     assert!(app.flash_err);
     assert!(app.flash.contains("state not saved"), "{}", app.flash);
     assert_eq!(
@@ -1974,6 +1977,41 @@ async fn state_write_failure_stays_out_of_watch_health() {
     // `:info` files `last_error` under watch health; a disk problem there
     // would read as a broken watch.
     assert_eq!(app.last_error, None);
+}
+
+#[tokio::test]
+async fn handled_state_write_failure_is_acknowledged() {
+    let dir = std::env::temp_dir().join(format!("sofka-app-state-ack-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let parent_file = dir.join("not-a-directory");
+    std::fs::write(&parent_file, "x").unwrap();
+    let impossible_path = parent_file.join("sort.toml");
+    let (mut app, mut rx) = test_app();
+    app.state_writer = Some(crate::state_writer::StateWriter::new(app.tx.clone()).unwrap());
+
+    app.state_writer
+        .as_ref()
+        .unwrap()
+        .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
+        .unwrap();
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("state failure notification timed out")
+        .expect("state failure notification channel closed");
+    assert_eq!(
+        app.state_writer.as_ref().unwrap().pending_failure_count(),
+        1
+    );
+
+    app.handle_msg(msg);
+    assert_eq!(
+        app.state_writer.as_ref().unwrap().pending_failure_count(),
+        0
+    );
+
+    app.state_writer.take();
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1962,6 +1962,21 @@ async fn panic_msg_flashes_regardless_of_generation() {
 }
 
 #[tokio::test]
+async fn state_write_failure_stays_out_of_watch_health() {
+    let (mut app, _rx) = test_app();
+    app.handle_msg(Msg::StateWriteFailed("sort.toml: Permission denied".into()));
+    assert!(app.flash_err);
+    assert!(app.flash.contains("state not saved"), "{}", app.flash);
+    assert_eq!(
+        app.last_state_write_error.as_deref(),
+        Some("sort.toml: Permission denied")
+    );
+    // `:info` files `last_error` under watch health; a disk problem there
+    // would read as a broken watch.
+    assert_eq!(app.last_error, None);
+}
+
+#[tokio::test]
 async fn logs_pause_freezes_and_survives_new_lines() {
     let (mut app, _rx) = test_app();
     app.mode = Mode::Logs;

--- a/src/atomicfile.rs
+++ b/src/atomicfile.rs
@@ -1,0 +1,137 @@
+//! Crash-safe replacement of the small state files sofka rewrites.
+//!
+//! Sort, namespace, and fleet choices are rewritten whole every time one
+//! changes. Writing them in place is not safe: `File::create` truncates the
+//! target before the new bytes land, so a crash, a power loss, or a second
+//! sofka writing the same file can leave a half-written mix that `load()`
+//! then silently discards as unparsable — the user's remembered choices gone
+//! because the process died at the wrong microsecond. Renaming a finished
+//! temp file over the target has no such window.
+
+use std::ffi::OsString;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Separates concurrent writes from this process; see [`temp_path`].
+static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+/// Write `contents` to `path` as one indivisible replacement, creating the
+/// parent directory if it is missing.
+///
+/// The bytes go to a sibling temp file that is flushed and then renamed over
+/// the target. `rename` replaces atomically, so every reader — another sofka,
+/// a `cat`, this process on its next launch — sees either the whole previous
+/// file or the whole new one, never a tear.
+pub fn write(path: &Path, contents: &str) -> Result<(), String> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    let temp = temp_path(path);
+    write_then_rename(&temp, path, contents).map_err(|e| {
+        // A failed attempt must not litter the state directory with a
+        // `sort.toml.tmp…` nobody will ever clean up.
+        let _ = std::fs::remove_file(&temp);
+        e.to_string()
+    })
+}
+
+fn write_then_rename(temp: &Path, path: &Path, contents: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(temp)?;
+    file.write_all(contents.as_bytes())?;
+    // Without this the rename can reach disk before the bytes it publishes,
+    // so a power loss leaves the target pointing at a zero-filled file —
+    // exactly the tear the rename is here to prevent. The directory entry is
+    // deliberately left unsynced: if the rename itself is lost, the previous
+    // complete file survives, which is a fine outcome for remembered UI state
+    // and saves a second flush on every keystroke that changes a sort.
+    file.sync_all()?;
+    drop(file);
+    std::fs::rename(temp, path)
+}
+
+/// A sibling of `path` — `rename` is only atomic within one filesystem, so the
+/// temp file cannot live in `/tmp` — that no concurrent writer can collide
+/// with: another sofka has another pid, and the counter separates writes
+/// racing inside this process.
+fn temp_path(path: &Path) -> PathBuf {
+    let n = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+    let mut name = OsString::from(path.as_os_str());
+    name.push(format!(".tmp{}.{n}", std::process::id()));
+    PathBuf::from(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "sofka-atomicfile-{}-{tag}-{}",
+            std::process::id(),
+            NEXT_TEMP.load(Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn creates_missing_parents_and_replaces_in_place() {
+        let dir = scratch("replace");
+        let path = dir.join("nested").join("sort.toml");
+        write(&path, "first").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first");
+        write(&path, "second").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "second");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn leaves_no_temp_file_behind() {
+        let dir = scratch("cleanup");
+        let path = dir.join("sort.toml");
+        write(&path, "a").unwrap();
+        write(&path, "bb").unwrap();
+        let left: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(left, vec![OsString::from("sort.toml")]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn failed_write_keeps_the_old_file_and_cleans_up() {
+        let dir = scratch("failure");
+        // Renaming a file over a directory fails, which stands in for any
+        // mid-write failure: the point is that the target is untouched.
+        let good = dir.join("sort.toml");
+        write(&good, "kept").unwrap();
+        let blocked = dir.join("blocked.toml");
+        std::fs::create_dir(&blocked).unwrap();
+
+        assert!(write(&blocked, "never lands").is_err());
+        assert_eq!(std::fs::read_to_string(&good).unwrap(), "kept");
+        assert!(blocked.is_dir(), "target survives the failed write");
+        let mut left: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        left.sort();
+        assert_eq!(
+            left,
+            vec![OsString::from("blocked.toml"), OsString::from("sort.toml")]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn temp_paths_are_siblings_and_unique() {
+        let path = Path::new("/var/state/sofka/sort.toml");
+        let a = temp_path(path);
+        let b = temp_path(path);
+        assert_ne!(a, b);
+        assert_eq!(a.parent(), path.parent());
+        assert_eq!(b.parent(), path.parent());
+    }
+}

--- a/src/atomicfile.rs
+++ b/src/atomicfile.rs
@@ -16,6 +16,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Separates concurrent writes from this process; see [`temp_path`].
 static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
 
+/// How many names one write may try before giving up. A collision means
+/// another writer holds that exact name right now, which the next candidate
+/// escapes; the bound is here so a directory that refuses every create fails
+/// fast instead of spinning.
+const TEMP_ATTEMPTS: u32 = 16;
+
 /// Write `contents` to `path` as one indivisible replacement, creating the
 /// parent directory if it is missing.
 ///
@@ -24,20 +30,74 @@ static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
 /// a `cat`, this process on its next launch — sees either the whole previous
 /// file or the whole new one, never a tear.
 pub fn write(path: &Path, contents: &str) -> Result<(), String> {
+    write_with(path, contents, temp_path)
+}
+
+/// [`write`], with the temp-name sequence injectable so the collision path can
+/// be driven from a test — the real names mix in a clock reading and cannot be
+/// predicted from outside.
+fn write_with(
+    path: &Path,
+    contents: &str,
+    mut candidate: impl FnMut(&Path) -> PathBuf,
+) -> Result<(), String> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
     }
-    let temp = temp_path(path);
-    write_then_rename(&temp, path, contents).map_err(|e| {
+    let (file, temp) = create_temp(path, &mut candidate).map_err(|e| e.to_string())?;
+    write_then_rename(file, &temp, path, contents).map_err(|e| {
         // A failed attempt must not litter the state directory with a
-        // `sort.toml.tmp…` nobody will ever clean up.
+        // `sort.toml.tmp…` nobody will ever clean up. Only ever this
+        // process's own temp file: `create_new` below refused every name that
+        // already existed, so nothing here can delete a file we did not make.
         let _ = std::fs::remove_file(&temp);
         e.to_string()
     })
 }
 
-fn write_then_rename(temp: &Path, path: &Path, contents: &str) -> std::io::Result<()> {
-    let mut file = std::fs::File::create(temp)?;
+/// Claim a temp name nobody else holds, and return it already open.
+///
+/// `create_new` is the whole point: `File::create` would *truncate* a name
+/// another writer is using, and pid plus a process-local counter is not enough
+/// to rule that out — two sofkas sharing a state directory over NFS, or in
+/// separate pid namespaces, can reach the same pid and the same counter. The
+/// loser of that race would then write through its still-open handle into an
+/// inode the winner had already renamed into place, tearing the published file
+/// that the rename exists to keep whole. Refusing an existing name turns that
+/// corruption into a retry.
+fn create_temp(
+    path: &Path,
+    candidate: &mut impl FnMut(&Path) -> PathBuf,
+) -> std::io::Result<(std::fs::File, PathBuf)> {
+    let mut taken = None;
+    for _ in 0..TEMP_ATTEMPTS {
+        let temp = candidate(path);
+        match std::fs::File::options()
+            .write(true)
+            .create_new(true)
+            .open(&temp)
+        {
+            Ok(file) => return Ok((file, temp)),
+            // Somebody else's, mid-write. Not ours to truncate, and not ours
+            // to clean up either — take the next name instead.
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => taken = Some(e),
+            Err(e) => return Err(e),
+        }
+    }
+    Err(taken.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "no free temp name beside the state file",
+        )
+    }))
+}
+
+fn write_then_rename(
+    mut file: std::fs::File,
+    temp: &Path,
+    path: &Path,
+    contents: &str,
+) -> std::io::Result<()> {
     file.write_all(contents.as_bytes())?;
     // Without this the rename can reach disk before the bytes it publishes,
     // so a power loss leaves the target pointing at a zero-filled file —
@@ -51,13 +111,21 @@ fn write_then_rename(temp: &Path, path: &Path, contents: &str) -> std::io::Resul
 }
 
 /// A sibling of `path` — `rename` is only atomic within one filesystem, so the
-/// temp file cannot live in `/tmp` — that no concurrent writer can collide
-/// with: another sofka has another pid, and the counter separates writes
-/// racing inside this process.
+/// temp file cannot live in `/tmp`.
+///
+/// Three things separate this name from another writer's: the pid, the counter
+/// that separates writes racing inside this process, and a clock reading for
+/// the case the other two match, which across hosts sharing a state directory
+/// and across pid namespaces they can. None of the three is a guarantee, which
+/// is why [`create_temp`] refuses a name that already exists; this only has to
+/// make that retry rare.
 fn temp_path(path: &Path) -> PathBuf {
     let n = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.subsec_nanos());
     let mut name = OsString::from(path.as_os_str());
-    name.push(format!(".tmp{}.{n}", std::process::id()));
+    name.push(format!(".tmp{}.{n:x}.{nanos:x}", std::process::id()));
     PathBuf::from(name)
 }
 
@@ -133,5 +201,74 @@ mod tests {
         assert_ne!(a, b);
         assert_eq!(a.parent(), path.parent());
         assert_eq!(b.parent(), path.parent());
+    }
+
+    /// Hands `write` a name another writer already holds. `File::create` used
+    /// to truncate that file to zero and publish through the loser's still-open
+    /// handle; the write must step over the name instead, leaving the bytes
+    /// untouched.
+    #[test]
+    fn a_colliding_temp_file_is_neither_truncated_nor_removed() {
+        let dir = scratch("collision");
+        let path = dir.join("sort.toml");
+        write(&path, "published").unwrap();
+
+        let theirs = dir.join("sort.toml.tmp-theirs");
+        std::fs::write(&theirs, "their in-flight bytes").unwrap();
+        let ours = dir.join("sort.toml.tmp-ours");
+
+        let names = [theirs.clone(), ours.clone()];
+        let mut handed = 0;
+        write_with(&path, "second", |_| {
+            let next = names[handed.min(names.len() - 1)].clone();
+            handed += 1;
+            next
+        })
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "second");
+        assert_eq!(
+            std::fs::read_to_string(&theirs).unwrap(),
+            "their in-flight bytes",
+            "the other writer's temp file was truncated"
+        );
+        assert!(!ours.exists(), "our own temp file outlived the rename");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The cleanup after a failed write may only remove the temp file that
+    /// write created. It never opened the other writer's, so it must not
+    /// delete it on the way out.
+    #[test]
+    fn a_failed_write_leaves_another_writers_temp_file_alone() {
+        let dir = scratch("collision-failure");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Renaming over a directory fails, so the write claims a temp file and
+        // then loses it at the rename — the path that runs the cleanup.
+        let blocked = dir.join("blocked.toml");
+        std::fs::create_dir(&blocked).unwrap();
+
+        let theirs = dir.join("blocked.toml.tmp-theirs");
+        std::fs::write(&theirs, "their in-flight bytes").unwrap();
+        let ours = dir.join("blocked.toml.tmp-ours");
+
+        let names = [theirs.clone(), ours.clone()];
+        let mut handed = 0;
+        assert!(
+            write_with(&blocked, "never lands", |_| {
+                let next = names[handed.min(names.len() - 1)].clone();
+                handed += 1;
+                next
+            })
+            .is_err()
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(&theirs).unwrap(),
+            "their in-flight bytes",
+            "cleanup deleted a temp file this write never created"
+        );
+        assert!(!ours.exists(), "our own temp file was left behind");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/benchsupport.rs
+++ b/src/benchsupport.rs
@@ -11,6 +11,7 @@
 //! `pod_summary` walks that array and a fixture without it would measure an
 //! empty loop.
 
+use k8s_openapi::api::core::v1::Service;
 use kube::core::DynamicObject;
 use serde_json::json;
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -316,4 +317,89 @@ pub fn log_lines_wide(n: usize) -> Vec<String> {
 /// Sender factory for benches that need to construct messages directly.
 pub fn channel() -> (Sender<Msg>, Receiver<Msg>) {
     mpsc::channel(4096)
+}
+
+/// Service-discovery input with many usable candidates. Reverse namespaces
+/// ensure the minimum is not an accidental first-item fast path.
+pub fn services(n: usize) -> Vec<Service> {
+    (0..n)
+        .map(|i| {
+            serde_json::from_value(json!({
+                "metadata": {
+                    "name": format!("backend-{i:04}"),
+                    "namespace": format!("ns-{:04}", n - i),
+                },
+                "spec": {
+                    "ports": [
+                        {"name": "metrics", "port": 8080},
+                        {"port": if i.is_multiple_of(2) { 9428 } else { 9090 }},
+                    ]
+                }
+            }))
+            .expect("bench Service fixture is valid")
+        })
+        .collect()
+}
+
+/// Production one-pass VictoriaLogs candidate selection.
+pub fn pick_log_service(services: &[Service]) -> Option<(String, String, i32)> {
+    crate::providers::bench_pick_log_service(services)
+}
+
+/// Production one-pass Prometheus/VictoriaMetrics candidate selection.
+pub fn pick_metrics_service(services: &[Service]) -> Option<(String, String, i32)> {
+    crate::providers::bench_pick_metrics_service(services)
+}
+
+/// The allocation-heavy provider-selection implementation before this
+/// follow-up: materialize every usable candidate, then call `min_by_key`.
+pub fn pick_log_service_collected(services: &[Service]) -> Option<(String, String, i32)> {
+    let candidates: Vec<(&Service, i32)> = services
+        .iter()
+        .filter_map(|service| {
+            let ports = service.spec.as_ref()?.ports.as_ref()?;
+            let port = ports
+                .iter()
+                .find(|port| port.name.as_deref() == Some("http"))
+                .or_else(|| ports.iter().find(|port| port.port == 9428))
+                .or_else(|| ports.first())?;
+            Some((service, port.port))
+        })
+        .collect();
+    finish_collected(candidates)
+}
+
+/// Metrics-provider form of the former collected implementation.
+pub fn pick_metrics_service_collected(services: &[Service]) -> Option<(String, String, i32)> {
+    let candidates: Vec<(&Service, i32)> = services
+        .iter()
+        .filter_map(|service| {
+            let ports = service.spec.as_ref()?.ports.as_ref()?;
+            let port = ports
+                .iter()
+                .find(|port| port.name.as_deref() == Some("http"))
+                .or_else(|| {
+                    ports
+                        .iter()
+                        .find(|port| matches!(port.port, 9090 | 8428 | 8429))
+                })
+                .or_else(|| ports.first())?;
+            Some((service, port.port))
+        })
+        .collect();
+    finish_collected(candidates)
+}
+
+fn finish_collected(candidates: Vec<(&Service, i32)>) -> Option<(String, String, i32)> {
+    let (service, port) = candidates.iter().min_by_key(|(service, _)| {
+        (
+            service.metadata.namespace.as_deref().unwrap_or_default(),
+            service.metadata.name.as_deref().unwrap_or_default(),
+        )
+    })?;
+    Some((
+        service.metadata.namespace.clone().unwrap_or_default(),
+        service.metadata.name.clone().unwrap_or_default(),
+        *port,
+    ))
 }

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -4,13 +4,17 @@
 //! hand-written renderer per resource, known kinds get curated columns and
 //! everything else falls back to NAME/AGE pulled from metadata.
 
+use std::borrow::Cow;
 use std::cell::OnceCell;
 
 use k8s_openapi::jiff::Timestamp;
 use kube::core::DynamicObject;
 use serde_json::Value;
 
-type CellFn = for<'a> fn(&CellContext<'a>) -> String;
+/// Curated extractors borrow values that already live in the Kubernetes
+/// object and own only derived/formatted values. Cached full rows convert the
+/// result once; one-column filter/sort probes can consume borrowed text.
+type CellFn = for<'a> fn(&CellContext<'a>) -> Cow<'a, str>;
 
 struct Column {
     header: &'static str,
@@ -358,7 +362,10 @@ pub fn headers(plural: &str) -> Vec<&'static str> {
 pub fn cells(obj: &DynamicObject, plural: &str) -> (Vec<String>, Option<usize>) {
     let ctx = CellContext::new(obj);
     let columns = columns_for(plural);
-    let values = columns.iter().map(|c| (c.extract)(&ctx)).collect();
+    let values = columns
+        .iter()
+        .map(|c| (c.extract)(&ctx).into_owned())
+        .collect();
     let status_idx = columns.iter().position(|c| c.is_status);
     (values, status_idx)
 }
@@ -473,7 +480,7 @@ impl ViewSpec {
             .columns
             .iter()
             .map(|c| match &c.source {
-                SpecSource::Curated(extract) => extract(&ctx),
+                SpecSource::Curated(extract) => extract(&ctx).into_owned(),
                 SpecSource::User(uc) => crate::views::render_cell(obj, uc),
             })
             .collect();
@@ -503,11 +510,12 @@ impl ViewSpec {
 
     /// The single cell at `idx` for one object. Filter comparisons read one
     /// column of every object — extracting the full row per object per
-    /// rebuild is what this avoids.
-    pub fn cell_at(&self, obj: &DynamicObject, idx: usize) -> Option<String> {
+    /// rebuild is what this avoids. Curated JSON/name cells borrow from
+    /// `obj`; user columns and computed curated cells remain owned.
+    pub fn cell_at<'a>(&self, obj: &'a DynamicObject, idx: usize) -> Option<Cow<'a, str>> {
         let col = self.columns.get(idx)?;
         Some(match &col.source {
-            SpecSource::User(uc) => crate::views::render_cell(obj, uc),
+            SpecSource::User(uc) => Cow::Owned(crate::views::render_cell(obj, uc)),
             SpecSource::Curated(extract) => {
                 let ctx = CellContext::new(obj);
                 extract(&ctx)
@@ -607,112 +615,124 @@ pub fn volatile_cell(obj: &DynamicObject, plural: &str, header: &str) -> Option<
     }
 }
 
-fn col_name(ctx: &CellContext<'_>) -> String {
-    ctx.name.to_string()
+fn col_name<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(ctx.name)
 }
 
-fn col_age(ctx: &CellContext<'_>) -> String {
-    ctx.age().to_string()
+fn col_age<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(ctx.age().to_string())
 }
 
-fn col_pod_ready(ctx: &CellContext<'_>) -> String {
-    ctx.pod().0.clone()
+fn col_pod_ready<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(ctx.pod().0.clone())
 }
 
-fn col_pod_status(ctx: &CellContext<'_>) -> String {
-    ctx.pod().1.clone()
+fn col_pod_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(ctx.pod().1.clone())
 }
 
-fn col_pod_restarts(ctx: &CellContext<'_>) -> String {
-    ctx.pod().2.clone()
+fn col_pod_restarts<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(ctx.pod().2.clone())
 }
 
-fn col_pod_ip(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["status", "podIP"]).unwrap_or_else(|| "<none>".into())
+fn col_pod_ip<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "podIP"]).unwrap_or("<none>"))
 }
 
-fn col_pod_node(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "nodeName"]).unwrap_or_else(|| "<none>".into())
+fn col_pod_node<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "nodeName"]).unwrap_or("<none>"))
 }
 
-fn col_deploy_ready(ctx: &CellContext<'_>) -> String {
-    format!(
+fn col_deploy_ready<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(format!(
         "{}/{}",
         iget(ctx.data, &["status", "readyReplicas"]),
         iget(ctx.data, &["status", "replicas"])
-    )
+    ))
 }
 
-fn col_deploy_updated(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "updatedReplicas"]).to_string()
+fn col_deploy_updated<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "updatedReplicas"]).to_string())
 }
 
-fn col_deploy_available(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "availableReplicas"]).to_string()
+fn col_deploy_available<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "availableReplicas"]).to_string())
 }
 
-fn col_rs_desired(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["spec", "replicas"]).to_string()
+fn col_rs_desired<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["spec", "replicas"]).to_string())
 }
 
-fn col_rs_current(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "replicas"]).to_string()
+fn col_rs_current<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "replicas"]).to_string())
 }
 
-fn col_rs_ready(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "readyReplicas"]).to_string()
+fn col_rs_ready<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "readyReplicas"]).to_string())
 }
 
-fn col_sts_ready(ctx: &CellContext<'_>) -> String {
-    format!(
+fn col_sts_ready<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(format!(
         "{}/{}",
         iget(ctx.data, &["status", "readyReplicas"]),
         iget(ctx.data, &["spec", "replicas"])
-    )
+    ))
 }
 
-fn col_ds_desired(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "desiredNumberScheduled"]).to_string()
+fn col_ds_desired<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "desiredNumberScheduled"]).to_string())
 }
 
-fn col_ds_current(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "currentNumberScheduled"]).to_string()
+fn col_ds_current<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "currentNumberScheduled"]).to_string())
 }
 
-fn col_ds_ready(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "numberReady"]).to_string()
+fn col_ds_ready<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "numberReady"]).to_string())
 }
 
-fn col_ds_available(ctx: &CellContext<'_>) -> String {
-    iget(ctx.data, &["status", "numberAvailable"]).to_string()
+fn col_ds_available<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(iget(ctx.data, &["status", "numberAvailable"]).to_string())
 }
 
-fn col_deploy_status(ctx: &CellContext<'_>) -> String {
+fn col_deploy_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     if ctx.obj.metadata.deletion_timestamp.is_some() {
         return "Terminating".into();
     }
-    workload_status(ctx.data, WorkloadCounts::deployment(ctx.data))
+    Cow::Owned(workload_status(
+        ctx.data,
+        WorkloadCounts::deployment(ctx.data),
+    ))
 }
 
-fn col_sts_status(ctx: &CellContext<'_>) -> String {
+fn col_sts_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     if ctx.obj.metadata.deletion_timestamp.is_some() {
         return "Terminating".into();
     }
-    workload_status(ctx.data, WorkloadCounts::statefulset(ctx.data))
+    Cow::Owned(workload_status(
+        ctx.data,
+        WorkloadCounts::statefulset(ctx.data),
+    ))
 }
 
-fn col_rs_status(ctx: &CellContext<'_>) -> String {
+fn col_rs_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     if ctx.obj.metadata.deletion_timestamp.is_some() {
         return "Terminating".into();
     }
-    workload_status(ctx.data, WorkloadCounts::replicaset(ctx.data))
+    Cow::Owned(workload_status(
+        ctx.data,
+        WorkloadCounts::replicaset(ctx.data),
+    ))
 }
 
-fn col_ds_status(ctx: &CellContext<'_>) -> String {
+fn col_ds_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     if ctx.obj.metadata.deletion_timestamp.is_some() {
         return "Terminating".into();
     }
-    workload_status(ctx.data, WorkloadCounts::daemonset(ctx.data))
+    Cow::Owned(workload_status(
+        ctx.data,
+        WorkloadCounts::daemonset(ctx.data),
+    ))
 }
 
 /// The replica counts a workload's health is judged by, normalized across
@@ -828,210 +848,216 @@ fn condition<'a>(d: &'a Value, ty: &str) -> Option<&'a Value> {
         .find(|c| c.get("type").and_then(Value::as_str) == Some(ty))
 }
 
-fn col_service_type(ctx: &CellContext<'_>) -> String {
-    service_type(ctx.data)
+fn col_service_type<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(service_type(ctx.data))
 }
 
-fn col_service_cluster_ip(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "clusterIP"]).unwrap_or_else(|| "<none>".into())
+fn col_service_cluster_ip<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "clusterIP"]).unwrap_or("<none>"))
 }
 
-fn col_service_external_ip(ctx: &CellContext<'_>) -> String {
-    external_ip(ctx.data, &service_type(ctx.data))
+fn col_service_external_ip<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(external_ip(ctx.data, service_type(ctx.data)))
 }
 
-fn col_service_ports(ctx: &CellContext<'_>) -> String {
-    svc_ports(ctx.data)
+fn col_service_ports<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(svc_ports(ctx.data))
 }
 
-fn col_node_status(ctx: &CellContext<'_>) -> String {
-    node_ready(ctx.data)
+fn col_node_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(node_ready(ctx.data))
 }
 
-fn col_node_roles(ctx: &CellContext<'_>) -> String {
-    node_roles(ctx.obj)
+fn col_node_roles<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(node_roles(ctx.obj))
 }
 
-fn col_node_taints(ctx: &CellContext<'_>) -> String {
-    count_arr(ctx.data, &["spec", "taints"]).to_string()
+fn col_node_taints<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(count_arr(ctx.data, &["spec", "taints"]).to_string())
 }
 
-fn col_node_version(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["status", "nodeInfo", "kubeletVersion"]).unwrap_or_default()
+fn col_node_version<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "nodeInfo", "kubeletVersion"]).unwrap_or_default())
 }
 
-fn col_namespace_status(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["status", "phase"]).unwrap_or_else(|| "Active".into())
+fn col_namespace_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "phase"]).unwrap_or("Active"))
 }
 
-fn col_configmap_data(ctx: &CellContext<'_>) -> String {
-    (count_obj(ctx.data, &["data"]) + count_obj(ctx.data, &["binaryData"])).to_string()
+fn col_configmap_data<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned((count_obj(ctx.data, &["data"]) + count_obj(ctx.data, &["binaryData"])).to_string())
 }
 
-fn col_secret_type(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["type"]).unwrap_or_else(|| "Opaque".into())
+fn col_secret_type<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["type"]).unwrap_or("Opaque"))
 }
 
-fn col_secret_data(ctx: &CellContext<'_>) -> String {
-    count_obj(ctx.data, &["data"]).to_string()
+fn col_secret_data<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(count_obj(ctx.data, &["data"]).to_string())
 }
 
-fn col_job_completions(ctx: &CellContext<'_>) -> String {
-    format!(
+fn col_job_completions<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(format!(
         "{}/{}",
         iget(ctx.data, &["status", "succeeded"]),
         iget(ctx.data, &["spec", "completions"]).max(1)
-    )
+    ))
 }
 
-fn col_job_duration(ctx: &CellContext<'_>) -> String {
-    job_duration(ctx.data)
+fn col_job_duration<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(job_duration(ctx.data))
 }
 
-fn col_cronjob_schedule(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "schedule"]).unwrap_or_default()
+fn col_cronjob_schedule<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "schedule"]).unwrap_or_default())
 }
 
-fn col_cronjob_suspend(ctx: &CellContext<'_>) -> String {
-    bget(ctx.data, &["spec", "suspend"]).to_string()
+fn col_cronjob_suspend<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(bget(ctx.data, &["spec", "suspend"]).to_string())
 }
 
-fn col_cronjob_active(ctx: &CellContext<'_>) -> String {
-    count_arr(ctx.data, &["status", "active"]).to_string()
+fn col_cronjob_active<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(count_arr(ctx.data, &["status", "active"]).to_string())
 }
 
-fn col_cronjob_last_schedule(ctx: &CellContext<'_>) -> String {
-    time_since(ctx.data, &["status", "lastScheduleTime"])
+fn col_cronjob_last_schedule<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(time_since(ctx.data, &["status", "lastScheduleTime"]))
 }
 
-fn col_event_type(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["type"]).unwrap_or_default()
+fn col_event_type<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["type"]).unwrap_or_default())
 }
 
-fn col_event_reason(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["reason"]).unwrap_or_default()
+fn col_event_reason<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["reason"]).unwrap_or_default())
 }
 
-fn col_event_object(ctx: &CellContext<'_>) -> String {
+fn col_event_object<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     event_object(ctx.data)
 }
 
-fn col_event_message(ctx: &CellContext<'_>) -> String {
+fn col_event_message<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     event_message(ctx.data)
 }
 
-fn col_event_count(ctx: &CellContext<'_>) -> String {
-    event_count(ctx.data).to_string()
+fn col_event_count<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(event_count(ctx.data).to_string())
 }
 
-fn col_hpa_reference(ctx: &CellContext<'_>) -> String {
+fn col_hpa_reference<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     hpa_reference(ctx.data)
 }
 
-fn col_hpa_targets(ctx: &CellContext<'_>) -> String {
-    hpa_targets(ctx.data)
+fn col_hpa_targets<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(hpa_targets(ctx.data))
 }
 
-fn col_hpa_minpods(ctx: &CellContext<'_>) -> String {
-    iopt(ctx.data, &["spec", "minReplicas"])
-        .unwrap_or(1)
-        .to_string()
+fn col_hpa_minpods<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(
+        iopt(ctx.data, &["spec", "minReplicas"])
+            .unwrap_or(1)
+            .to_string(),
+    )
 }
 
-fn col_hpa_maxpods(ctx: &CellContext<'_>) -> String {
-    iopt(ctx.data, &["spec", "maxReplicas"])
-        .map(|n| n.to_string())
-        .unwrap_or_default()
+fn col_hpa_maxpods<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(
+        iopt(ctx.data, &["spec", "maxReplicas"])
+            .map(|n| n.to_string())
+            .unwrap_or_default(),
+    )
 }
 
-fn col_hpa_replicas(ctx: &CellContext<'_>) -> String {
-    iopt(ctx.data, &["status", "currentReplicas"])
-        .unwrap_or(0)
-        .to_string()
+fn col_hpa_replicas<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(
+        iopt(ctx.data, &["status", "currentReplicas"])
+            .unwrap_or(0)
+            .to_string(),
+    )
 }
 
-fn col_pvc_status(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["status", "phase"]).unwrap_or_default()
+fn col_pvc_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "phase"]).unwrap_or_default())
 }
 
-fn col_pvc_volume(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "volumeName"]).unwrap_or_default()
+fn col_pvc_volume<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "volumeName"]).unwrap_or_default())
 }
 
-fn col_pvc_capacity(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["status", "capacity", "storage"]).unwrap_or_default()
+fn col_pvc_capacity<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "capacity", "storage"]).unwrap_or_default())
 }
 
-fn col_pv_capacity(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "capacity", "storage"]).unwrap_or_default()
+fn col_pv_capacity<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "capacity", "storage"]).unwrap_or_default())
 }
 
-fn col_pv_status(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["status", "phase"]).unwrap_or_default()
+fn col_pv_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "phase"]).unwrap_or_default())
 }
 
-fn col_pv_claim(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "claimRef", "name"]).unwrap_or_default()
+fn col_pv_claim<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "claimRef", "name"]).unwrap_or_default())
 }
 
-fn col_ingress_class(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "ingressClassName"]).unwrap_or_else(|| "<none>".into())
+fn col_ingress_class<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "ingressClassName"]).unwrap_or("<none>"))
 }
 
-fn col_ingress_hosts(ctx: &CellContext<'_>) -> String {
-    ingress_hosts(ctx.data)
+fn col_ingress_hosts<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(ingress_hosts(ctx.data))
 }
 
-fn col_ingress_address(ctx: &CellContext<'_>) -> String {
-    ingress_address(ctx.data)
+fn col_ingress_address<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(ingress_address(ctx.data))
 }
 
-fn col_httproute_hostnames(ctx: &CellContext<'_>) -> String {
-    httproute_hostnames(ctx.data)
+fn col_httproute_hostnames<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(httproute_hostnames(ctx.data))
 }
 
-fn col_endpoint_count(ctx: &CellContext<'_>) -> String {
+fn col_endpoint_count<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     count_endpoints(ctx.data)
 }
 
-fn col_crd_group(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "group"]).unwrap_or_default()
+fn col_crd_group<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "group"]).unwrap_or_default())
 }
 
-fn col_crd_kind(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "names", "kind"]).unwrap_or_default()
+fn col_crd_kind<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "names", "kind"]).unwrap_or_default())
 }
 
-fn col_crd_versions(ctx: &CellContext<'_>) -> String {
-    crd_versions(ctx.data)
+fn col_crd_versions<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(crd_versions(ctx.data))
 }
 
-fn col_crd_scope(ctx: &CellContext<'_>) -> String {
-    sget(ctx.data, &["spec", "scope"]).unwrap_or_default()
+fn col_crd_scope<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["spec", "scope"]).unwrap_or_default())
 }
 
-fn col_flux_ready(ctx: &CellContext<'_>) -> String {
-    ready_condition(ctx.data).0
+fn col_flux_ready<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(ready_condition(ctx.data).0)
 }
 
-fn col_flux_message(ctx: &CellContext<'_>) -> String {
-    ready_condition(ctx.data).1
+fn col_flux_message<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(ready_condition(ctx.data).1)
 }
 
-fn col_flux_revision(ctx: &CellContext<'_>) -> String {
-    flux_revision(ctx.data)
+fn col_flux_revision<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(flux_revision(ctx.data))
 }
 
-fn col_flux_source_revision(ctx: &CellContext<'_>) -> String {
-    flux_source_revision(ctx.data)
+fn col_flux_source_revision<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(flux_source_revision(ctx.data))
 }
 
-fn col_flux_source_url(ctx: &CellContext<'_>) -> String {
+fn col_flux_source_url<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     flux_source_url(ctx.data)
 }
 
-fn col_flux_suspended(ctx: &CellContext<'_>) -> String {
-    bget(ctx.data, &["spec", "suspend"]).to_string()
+fn col_flux_suspended<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(bget(ctx.data, &["spec", "suspend"]).to_string())
 }
 
 // A Helm release row's underlying object is the raw storage `Secret`
@@ -1039,54 +1065,60 @@ fn col_flux_suspended(ctx: &CellContext<'_>) -> String {
 // name), never the release itself — every cell here goes through
 // `crate::helm` instead of `ctx.name`/`ctx.data`.
 
-fn col_helm_name(ctx: &CellContext<'_>) -> String {
-    crate::helm::release_name(ctx.obj)
-        .unwrap_or(ctx.name)
-        .to_string()
+fn col_helm_name<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(crate::helm::release_name(ctx.obj).unwrap_or(ctx.name))
 }
 
-fn col_helm_revision(ctx: &CellContext<'_>) -> String {
-    crate::helm::revision(ctx.obj)
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "-".into())
+fn col_helm_revision<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(
+        crate::helm::revision(ctx.obj)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".into()),
+    )
 }
 
-fn col_helm_status(ctx: &CellContext<'_>) -> String {
-    ctx.helm()
-        .map(|r| r.status.clone())
-        .unwrap_or_else(|| "<invalid>".into())
+fn col_helm_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(
+        ctx.helm()
+            .map(|r| r.status.clone())
+            .unwrap_or_else(|| "<invalid>".into()),
+    )
 }
 
-fn col_helm_chart(ctx: &CellContext<'_>) -> String {
-    match ctx.helm() {
+fn col_helm_chart<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(match ctx.helm() {
         Some(r) if !r.chart_name.is_empty() => format!("{}-{}", r.chart_name, r.chart_version),
         _ => "<unknown>".into(),
-    }
+    })
 }
 
-fn col_helm_app_version(ctx: &CellContext<'_>) -> String {
-    ctx.helm()
-        .map(|r| r.app_version.clone())
-        .unwrap_or_default()
+fn col_helm_app_version<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(
+        ctx.helm()
+            .map(|r| r.app_version.clone())
+            .unwrap_or_default(),
+    )
 }
 
-fn col_helm_description(ctx: &CellContext<'_>) -> String {
-    ctx.helm()
-        .map(|r| r.description.clone())
-        .unwrap_or_default()
+fn col_helm_description<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(
+        ctx.helm()
+            .map(|r| r.description.clone())
+            .unwrap_or_default(),
+    )
 }
 
-fn col_helm_updated(ctx: &CellContext<'_>) -> String {
-    match ctx.helm().and_then(|r| r.last_deployed_secs) {
+fn col_helm_updated<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(match ctx.helm().and_then(|r| r.last_deployed_secs) {
         Some(secs) => humanize((Timestamp::now().as_second() - secs).max(0)),
         None => "<unknown>".into(),
-    }
+    })
 }
 
 // ----- helpers ------------------------------------------------------------
 
-fn service_type(d: &Value) -> String {
-    sget(d, &["spec", "type"]).unwrap_or_else(|| "ClusterIP".into())
+fn service_type(d: &Value) -> &str {
+    sget(d, &["spec", "type"]).unwrap_or("ClusterIP")
 }
 
 /// Comma-joined CRD version names (`spec.versions[].name`), e.g. `v1,v1beta1`.
@@ -1110,7 +1142,7 @@ fn crd_versions(d: &Value) -> String {
 /// (status, message) of the `Ready` condition, the health summary Flux (and
 /// most condition-based CRDs) maintain. Missing condition reads as Unknown —
 /// e.g. a Kustomization the controller hasn't reconciled yet.
-fn ready_condition(d: &Value) -> (String, String) {
+fn ready_condition(d: &Value) -> (&str, &str) {
     d.pointer("/status/conditions")
         .and_then(Value::as_array)
         .and_then(|conds| {
@@ -1120,63 +1152,55 @@ fn ready_condition(d: &Value) -> (String, String) {
         })
         .map(|c| {
             (
-                c.get("status")
-                    .and_then(Value::as_str)
-                    .unwrap_or("Unknown")
-                    .to_string(),
-                c.get("message")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
+                c.get("status").and_then(Value::as_str).unwrap_or("Unknown"),
+                c.get("message").and_then(Value::as_str).unwrap_or_default(),
             )
         })
-        .unwrap_or_else(|| ("Unknown".into(), String::new()))
+        .unwrap_or(("Unknown", ""))
 }
 
 /// Last applied revision of a Flux object: Kustomizations (and HelmRelease
 /// v2beta*) expose `lastAppliedRevision`; HelmRelease v2 GA moved it into
 /// `history`, with `lastAttemptedRevision` as the pre-first-success fallback.
-fn flux_revision(d: &Value) -> String {
+fn flux_revision(d: &Value) -> &str {
     sget(d, &["status", "lastAppliedRevision"])
         .or_else(|| {
             d.pointer("/status/history/0/chartVersion")
                 .and_then(Value::as_str)
-                .map(String::from)
         })
         .or_else(|| sget(d, &["status", "lastAttemptedRevision"]))
         .unwrap_or_default()
 }
 
-fn flux_source_revision(d: &Value) -> String {
+fn flux_source_revision(d: &Value) -> &str {
     sget(d, &["status", "artifact", "revision"])
         .or_else(|| sget(d, &["status", "lastAppliedRevision"]))
         .or_else(|| sget(d, &["status", "lastAttemptedRevision"]))
         .unwrap_or_default()
 }
 
-fn flux_source_url(d: &Value) -> String {
-    sget(d, &["spec", "url"])
-        .or_else(|| {
-            let endpoint = sget(d, &["spec", "endpoint"]);
-            let bucket = sget(d, &["spec", "bucketName"]);
-            match (endpoint, bucket) {
-                (Some(endpoint), Some(bucket)) => {
-                    Some(format!("{}/{}", endpoint.trim_end_matches('/'), bucket))
-                }
-                (Some(endpoint), None) => Some(endpoint),
-                (None, Some(bucket)) => Some(bucket),
-                (None, None) => None,
-            }
-        })
-        .unwrap_or_default()
+fn flux_source_url(d: &Value) -> Cow<'_, str> {
+    if let Some(url) = sget(d, &["spec", "url"]) {
+        return Cow::Borrowed(url);
+    }
+    let endpoint = sget(d, &["spec", "endpoint"]);
+    let bucket = sget(d, &["spec", "bucketName"]);
+    match (endpoint, bucket) {
+        (Some(endpoint), Some(bucket)) => {
+            Cow::Owned(format!("{}/{}", endpoint.trim_end_matches('/'), bucket))
+        }
+        (Some(endpoint), None) => Cow::Borrowed(endpoint),
+        (None, Some(bucket)) => Cow::Borrowed(bucket),
+        (None, None) => Cow::Borrowed(""),
+    }
 }
 
-fn sget(v: &Value, path: &[&str]) -> Option<String> {
+fn sget<'a>(v: &'a Value, path: &[&str]) -> Option<&'a str> {
     let mut cur = v;
     for p in path {
         cur = cur.get(p)?;
     }
-    cur.as_str().map(|s| s.to_string())
+    cur.as_str()
 }
 
 fn iopt(v: &Value, path: &[&str]) -> Option<i64> {
@@ -1342,7 +1366,7 @@ fn pod_summary(obj: &DynamicObject) -> (String, String, String) {
         }
     }
 
-    let phase = sget(d, &["status", "phase"]).unwrap_or_else(|| "Unknown".into());
+    let phase = sget(d, &["status", "phase"]).unwrap_or("Unknown");
     let status = if obj.metadata.deletion_timestamp.is_some() {
         "Terminating".to_string()
     } else if let Some(r) = waiting_reason {
@@ -1350,7 +1374,7 @@ fn pod_summary(obj: &DynamicObject) -> (String, String, String) {
     } else if let Some(r) = terminated_reason {
         r
     } else {
-        phase
+        phase.to_string()
     };
 
     (format!("{ready}/{total}"), status, restarts.to_string())
@@ -1398,7 +1422,7 @@ fn svc_ports(d: &Value) -> String {
         .unwrap_or_else(|| "<none>".into())
 }
 
-fn node_ready(d: &Value) -> String {
+fn node_ready(d: &Value) -> &'static str {
     d.pointer("/status/conditions")
         .and_then(Value::as_array)
         .and_then(|conds| {
@@ -1408,12 +1432,12 @@ fn node_ready(d: &Value) -> String {
         })
         .map(|c| {
             if c.get("status").and_then(Value::as_str) == Some("True") {
-                "Ready".to_string()
+                "Ready"
             } else {
-                "NotReady".to_string()
+                "NotReady"
             }
         })
-        .unwrap_or_else(|| "Unknown".into())
+        .unwrap_or("Unknown")
 }
 
 fn node_roles(obj: &DynamicObject) -> String {
@@ -1483,7 +1507,7 @@ fn httproute_hostnames(d: &Value) -> String {
         .unwrap_or_else(|| "*".into())
 }
 
-fn count_endpoints(d: &Value) -> String {
+fn count_endpoints(d: &Value) -> Cow<'_, str> {
     let n: usize = d
         .pointer("/subsets")
         .and_then(Value::as_array)
@@ -1501,31 +1525,35 @@ fn count_endpoints(d: &Value) -> String {
         })
         .unwrap_or(0);
     if n == 0 {
-        "<none>".into()
+        Cow::Borrowed("<none>")
     } else {
-        n.to_string()
+        Cow::Owned(n.to_string())
     }
 }
 
-fn event_object(d: &Value) -> String {
+fn event_object(d: &Value) -> Cow<'_, str> {
     let Some(obj) = d.get("regarding").or_else(|| d.get("involvedObject")) else {
-        return "<none>".into();
+        return Cow::Borrowed("<none>");
     };
     let kind = obj.get("kind").and_then(Value::as_str).unwrap_or_default();
     let name = obj.get("name").and_then(Value::as_str).unwrap_or_default();
     match (kind.is_empty(), name.is_empty()) {
-        (false, false) => format!("{kind}/{name}"),
-        (false, true) => kind.to_string(),
-        (true, false) => name.to_string(),
-        (true, true) => "<none>".into(),
+        (false, false) => Cow::Owned(format!("{kind}/{name}")),
+        (false, true) => Cow::Borrowed(kind),
+        (true, false) => Cow::Borrowed(name),
+        (true, true) => Cow::Borrowed("<none>"),
     }
 }
 
-fn event_message(d: &Value) -> String {
-    sget(d, &["message"])
+fn event_message(d: &Value) -> Cow<'_, str> {
+    let message = sget(d, &["message"])
         .or_else(|| sget(d, &["note"]))
-        .unwrap_or_default()
-        .replace(['\n', '\r'], " ")
+        .unwrap_or_default();
+    if message.contains(['\n', '\r']) {
+        Cow::Owned(message.replace(['\n', '\r'], " "))
+    } else {
+        Cow::Borrowed(message)
+    }
 }
 
 fn event_count(d: &Value) -> i64 {
@@ -1535,14 +1563,14 @@ fn event_count(d: &Value) -> i64 {
         .unwrap_or(1)
 }
 
-fn hpa_reference(d: &Value) -> String {
+fn hpa_reference(d: &Value) -> Cow<'_, str> {
     let kind = sget(d, &["spec", "scaleTargetRef", "kind"]).unwrap_or_default();
     let name = sget(d, &["spec", "scaleTargetRef", "name"]).unwrap_or_default();
     match (kind.is_empty(), name.is_empty()) {
-        (false, false) => format!("{kind}/{name}"),
-        (false, true) => kind,
-        (true, false) => name,
-        (true, true) => "<none>".into(),
+        (false, false) => Cow::Owned(format!("{kind}/{name}")),
+        (false, true) => Cow::Borrowed(kind),
+        (true, false) => Cow::Borrowed(name),
+        (true, true) => Cow::Borrowed("<none>"),
     }
 }
 
@@ -2499,6 +2527,29 @@ mod tests {
             SortValue::Text(t) => panic!("expected numeric sort, got '{t}'"),
         }
         assert!(spec.sort_value(&o, "MISSING").is_none());
+    }
+
+    #[test]
+    fn curated_cell_borrows_existing_object_strings() {
+        let pod = obj(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "pod-a"},
+            "status": {
+                "podIP": "10.0.0.7",
+                "containerStatuses": []
+            }
+        }));
+        let spec = build_spec("pods", None, None, true);
+
+        assert!(matches!(
+            spec.cell_at(&pod, 0),
+            Some(Cow::Borrowed("pod-a"))
+        ));
+        assert!(matches!(
+            spec.cell_at(&pod, 4),
+            Some(Cow::Borrowed("10.0.0.7"))
+        ));
+        assert!(matches!(spec.cell_at(&pod, 1), Some(Cow::Owned(_))));
     }
 
     #[test]

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -41,12 +41,12 @@ impl FleetMarks {
             .unwrap_or_default()
     }
 
+    /// Persist to `path`. The file is replaced atomically, so a crash or a
+    /// second sofka writing at the same moment cannot leave a torn file that
+    /// [`Self::load`] would quietly read as empty.
     pub fn save(&self, path: &Path) -> Result<(), String> {
-        if let Some(dir) = path.parent() {
-            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
-        }
         let text = toml::to_string(self).map_err(|e| e.to_string())?;
-        std::fs::write(path, text).map_err(|e| e.to_string())
+        crate::atomicfile::write(path, &text)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod altscroll;
 pub mod app;
+pub mod atomicfile;
 #[cfg(feature = "bench")]
 pub mod benchsupport;
 pub mod bundle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod providers;
 pub mod rightsize;
 pub mod snapshot;
 pub mod sortmem;
+pub mod state_writer;
 pub mod store;
 pub mod text;
 pub mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,13 @@ async fn run_main(args: Args) -> Result<()> {
     let (tx, mut rx) = mpsc::channel(EVENT_CHANNEL_CAP);
     let panic_tx = tx.clone();
     let mut app = App::new(cluster, tx);
+    match sofka::state_writer::StateWriter::new(app.tx.clone()) {
+        Ok(writer) => app.state_writer = Some(writer),
+        Err(e) => {
+            eprintln!("warning: {e}; state writes will run synchronously");
+            config_warnings.push(e);
+        }
+    }
     // Fleet marks (`space` in `:ctx`) persist under the state dir, overlaying
     // the `[fleet] contexts` config list across restarts.
     let fleet_marks_path = fleet::FleetMarks::default_path();

--- a/src/nsmem.rs
+++ b/src/nsmem.rs
@@ -39,12 +39,12 @@ impl NamespaceMemory {
             .unwrap_or_default()
     }
 
+    /// Persist to `path`. The file is replaced atomically, so a crash or a
+    /// second sofka writing at the same moment cannot leave a torn file that
+    /// [`Self::load`] would quietly read as empty.
     pub fn save(&self, path: &Path) -> Result<(), String> {
-        if let Some(dir) = path.parent() {
-            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
-        }
         let text = toml::to_string(self).map_err(|e| e.to_string())?;
-        std::fs::write(path, text).map_err(|e| e.to_string())
+        crate::atomicfile::write(path, &text)
     }
 
     /// Remember `namespace` (empty = all namespaces) for `context`. Returns

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -421,7 +421,9 @@ pub async fn discover(client: kube::Client, base: &LogProvider) -> Result<LogPro
 /// `http` win, then literal 9428 (the VictoriaLogs default), then the first
 /// declared port.
 fn pick_service(services: &[Service]) -> Option<(String, String, i32)> {
-    let candidates: Vec<(&Service, i32)> = services
+    // Consume the filtered iterator directly: `min_by_key` is O(n), and no
+    // temporary candidates allocation is needed for the one selected item.
+    let (svc, port) = services
         .iter()
         .filter_map(|s| {
             let ports = s.spec.as_ref()?.ports.as_ref()?;
@@ -432,20 +434,16 @@ fn pick_service(services: &[Service]) -> Option<(String, String, i32)> {
                 .or_else(|| ports.first())?;
             Some((s, port.port))
         })
-        .collect();
-    // Only the first candidate is used, so pick the minimum directly rather
-    // than sorting the whole list — and compare borrowed, instead of cloning
-    // two `String`s per comparison.
-    let (svc, port) = candidates.iter().min_by_key(|(s, _)| {
-        (
-            s.metadata.namespace.as_deref().unwrap_or_default(),
-            s.metadata.name.as_deref().unwrap_or_default(),
-        )
-    })?;
+        .min_by_key(|(s, _)| {
+            (
+                s.metadata.namespace.as_deref().unwrap_or_default(),
+                s.metadata.name.as_deref().unwrap_or_default(),
+            )
+        })?;
     Some((
         svc.metadata.namespace.clone().unwrap_or_default(),
         svc.metadata.name.clone().unwrap_or_default(),
-        *port,
+        port,
     ))
 }
 
@@ -1051,7 +1049,8 @@ pub async fn discover_metrics(
 /// First (by namespace/name) service with a usable port, preferring `http`,
 /// then the well-known query ports (Prometheus 9090, VM single 8428/8429).
 fn pick_metrics_service(services: &[Service]) -> Option<(String, String, i32)> {
-    let candidates: Vec<(&Service, i32)> = services
+    // As above, select in one pass without materializing every candidate.
+    let (svc, port) = services
         .iter()
         .filter_map(|s| {
             let ports = s.spec.as_ref()?.ports.as_ref()?;
@@ -1062,20 +1061,16 @@ fn pick_metrics_service(services: &[Service]) -> Option<(String, String, i32)> {
                 .or_else(|| ports.first())?;
             Some((s, port.port))
         })
-        .collect();
-    // Only the first candidate is used, so pick the minimum directly rather
-    // than sorting the whole list — and compare borrowed, instead of cloning
-    // two `String`s per comparison.
-    let (svc, port) = candidates.iter().min_by_key(|(s, _)| {
-        (
-            s.metadata.namespace.as_deref().unwrap_or_default(),
-            s.metadata.name.as_deref().unwrap_or_default(),
-        )
-    })?;
+        .min_by_key(|(s, _)| {
+            (
+                s.metadata.namespace.as_deref().unwrap_or_default(),
+                s.metadata.name.as_deref().unwrap_or_default(),
+            )
+        })?;
     Some((
         svc.metadata.namespace.clone().unwrap_or_default(),
         svc.metadata.name.clone().unwrap_or_default(),
-        *port,
+        port,
     ))
 }
 
@@ -1356,6 +1351,33 @@ mod tests {
         .unwrap();
         assert_eq!(pick_service(&[bare]), None);
         assert_eq!(pick_service(&[]), None);
+    }
+
+    #[test]
+    fn pick_metrics_service_is_deterministic_and_prefers_query_ports() {
+        let ordinary = svc("z-monitoring", "prom", serde_json::json!([{"port": 8080}]));
+        let query = svc(
+            "a-monitoring",
+            "victoria-metrics",
+            serde_json::json!([{"port": 8080}, {"port": 8428}]),
+        );
+        assert_eq!(
+            pick_metrics_service(&[ordinary, query]),
+            Some(("a-monitoring".into(), "victoria-metrics".into(), 8428))
+        );
+
+        let named = svc(
+            "monitoring",
+            "prometheus",
+            serde_json::json!([
+                {"port": 9090},
+                {"name": "http", "port": 8081}
+            ]),
+        );
+        assert_eq!(
+            pick_metrics_service(&[named]),
+            Some(("monitoring".into(), "prometheus".into(), 8081))
+        );
     }
 
     #[tokio::test]

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1074,6 +1074,16 @@ fn pick_metrics_service(services: &[Service]) -> Option<(String, String, i32)> {
     ))
 }
 
+#[cfg(feature = "bench")]
+pub fn bench_pick_log_service(services: &[Service]) -> Option<(String, String, i32)> {
+    pick_service(services)
+}
+
+#[cfg(feature = "bench")]
+pub fn bench_pick_metrics_service(services: &[Service]) -> Option<(String, String, i32)> {
+    pick_metrics_service(services)
+}
+
 impl MetricsProvider {
     /// Whether the transport still needs [`discover_metrics`].
     pub fn needs_discovery(&self) -> bool {

--- a/src/sortmem.rs
+++ b/src/sortmem.rs
@@ -37,12 +37,12 @@ impl SortMemory {
             .unwrap_or_default()
     }
 
+    /// Persist to `path`. The file is replaced atomically, so a crash or a
+    /// second sofka writing at the same moment cannot leave a torn file that
+    /// [`Self::load`] would quietly read as empty.
     pub fn save(&self, path: &Path) -> Result<(), String> {
-        if let Some(dir) = path.parent() {
-            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
-        }
         let text = toml::to_string(self).map_err(|e| e.to_string())?;
-        std::fs::write(path, text).map_err(|e| e.to_string())
+        crate::atomicfile::write(path, &text)
     }
 
     /// Remember `header` (+ direction) for `kind`.

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -195,10 +195,12 @@ impl StateWriter {
         self.send(Write::Sort(state, path))
     }
 
-    /// Distinct failures the worker could not put in front of the user yet.
+    /// Shared view of the failures the worker could not put in front of the
+    /// user. A handle rather than a snapshot so a test can still read it after
+    /// teardown, which is when most of them are recorded.
     #[cfg(test)]
-    fn unreported_failures(&self) -> Vec<String> {
-        self.unreported.lock().unwrap().iter().cloned().collect()
+    fn unreported_handle(&self) -> Unreported {
+        Arc::clone(&self.unreported)
     }
 
     #[cfg(test)]
@@ -349,10 +351,10 @@ mod tests {
             .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
             .unwrap();
 
+        let unreported = writer.unreported_handle();
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            let failures = writer.unreported_failures();
-            if let Some(error) = failures.first() {
+            if let Some(error) = unreported.lock().unwrap().first() {
                 assert!(error.contains("sort.toml"), "{error}");
                 break;
             }
@@ -360,6 +362,45 @@ mod tests {
             std::thread::sleep(Duration::from_millis(5));
         }
         drop(writer);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// The case the old `reports_background_write_failures_to_the_ui` was
+    /// accidentally covering: a write that only fails once teardown has begun.
+    /// Nothing drains the event channel by then, so the notice has to end up in
+    /// the exit summary instead of being posted into a channel no one reads.
+    #[test]
+    fn failures_during_the_shutdown_drain_reach_the_exit_summary() {
+        let dir = std::env::temp_dir().join(format!("sofka-state-drain-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let parent_file = dir.join("not-a-directory");
+        std::fs::write(&parent_file, "x").unwrap();
+        let impossible_path = parent_file.join("sort.toml");
+        // Roomy channel and a generous grace: neither a full channel nor an
+        // expired deadline can be what redirects this failure.
+        let (ui_tx, mut ui_rx) = tokio::sync::mpsc::channel(8);
+        let writer = StateWriter::with_grace(ui_tx, Duration::from_secs(5)).unwrap();
+        let unreported = writer.unreported_handle();
+
+        // Hold the worker so the failing write is still queued when `drop`
+        // runs, and therefore only reaches disk during the drain.
+        writer
+            .stall(Duration::from_millis(50), PathBuf::from("/stall"))
+            .unwrap();
+        writer
+            .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
+            .unwrap();
+        drop(writer);
+
+        let failures = unreported.lock().unwrap().clone();
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        let error = failures.first().expect("one recorded failure");
+        assert!(error.contains("sort.toml"), "{error}");
+        assert!(
+            ui_rx.try_recv().is_err(),
+            "posted a notice to a channel nothing is reading"
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -3,10 +3,11 @@
 //! Namespace, sort, and fleet choices are changed from input handlers on the
 //! render/event-loop thread. Filesystems can stall unpredictably, so the live
 //! app hands snapshots to one ordered worker instead of doing TOML encoding,
-//! directory creation, and writes inline. A single queue also prevents two
-//! rapid changes to the same file from completing out of order.
+//! directory creation, and writes inline. A single queue prevents two rapid
+//! changes to the same file from completing out of order and coalesces a
+//! queued burst to its newest snapshot per destination.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Sender};
 use std::thread::JoinHandle;
 
@@ -21,6 +22,12 @@ enum Write {
 }
 
 impl Write {
+    fn path(&self) -> &Path {
+        match self {
+            Write::Fleet(_, path) | Write::Namespace(_, path) | Write::Sort(_, path) => path,
+        }
+    }
+
     fn run(self) -> Result<(), String> {
         match self {
             Write::Fleet(state, path) => state
@@ -48,10 +55,32 @@ impl StateWriter {
         let worker = std::thread::Builder::new()
             .name("sofka-state-writer".into())
             .spawn(move || {
-                for write in rx {
-                    if let Err(error) = write.run() {
-                        eprintln!("warning: state not saved: {error}");
-                        let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
+                while let Ok(first) = rx.recv() {
+                    let Ok(second) = rx.try_recv() else {
+                        if let Err(error) = first.run() {
+                            eprintln!("warning: state not saved: {error}");
+                            let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
+                        }
+                        continue;
+                    };
+                    let mut pending = vec![first];
+                    // Only the newest snapshot for a file matters. Drain the
+                    // burst already waiting behind `first` before touching
+                    // disk, while retaining independent state files.
+                    for next in std::iter::once(second).chain(rx.try_iter()) {
+                        if let Some(slot) =
+                            pending.iter_mut().find(|write| write.path() == next.path())
+                        {
+                            *slot = next;
+                        } else {
+                            pending.push(next);
+                        }
+                    }
+                    for write in pending {
+                        if let Err(error) = write.run() {
+                            eprintln!("warning: state not saved: {error}");
+                            let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
+                        }
                     }
                 }
             })
@@ -107,7 +136,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn drains_writes_in_submission_order_on_shutdown() {
+    fn coalescing_keeps_the_latest_snapshot_on_shutdown() {
         let dir = std::env::temp_dir().join(format!("sofka-state-writer-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let path = dir.join("namespaces.toml");
@@ -124,6 +153,34 @@ mod tests {
 
         drop(writer);
         assert_eq!(crate::nsmem::NamespaceMemory::load(&path), latest);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn coalescing_retains_independent_destination_files() {
+        let dir = std::env::temp_dir().join(format!("sofka-state-files-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let namespace_path = dir.join("namespaces.toml");
+        let sort_path = dir.join("sort.toml");
+        let (ui_tx, _ui_rx) = tokio::sync::mpsc::channel(1);
+        let writer = StateWriter::new(ui_tx).unwrap();
+
+        let mut namespaces = crate::nsmem::NamespaceMemory::default();
+        namespaces.set("prod", "payments");
+        writer
+            .save_namespace(namespaces.clone(), namespace_path.clone())
+            .unwrap();
+
+        let mut sorts = crate::sortmem::SortMemory::default();
+        sorts.set("pods", "AGE", true);
+        writer.save_sort(sorts.clone(), sort_path.clone()).unwrap();
+
+        drop(writer);
+        assert_eq!(
+            crate::nsmem::NamespaceMemory::load(&namespace_path),
+            namespaces
+        );
+        assert_eq!(crate::sortmem::SortMemory::load(&sort_path), sorts);
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -43,6 +43,19 @@ impl Write {
     }
 }
 
+/// Perform one write, routing a failure to the status line.
+///
+/// Deliberately never touches stderr. This runs on a background thread for as
+/// long as the session lasts, and by then the TUI owns the alternate screen;
+/// ratatui only repaints cells it sees change, so a stray line would stay
+/// smeared across the table until something else happened to overwrite it.
+/// `Msg` is the one channel that reaches the user safely.
+fn report(write: Write, ui_tx: &UiSender<Msg>) {
+    if let Err(error) = write.run() {
+        let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
+    }
+}
+
 /// Handle to the ordered state-write worker.
 pub struct StateWriter {
     tx: Option<Sender<Write>>,
@@ -57,10 +70,7 @@ impl StateWriter {
             .spawn(move || {
                 while let Ok(first) = rx.recv() {
                     let Ok(second) = rx.try_recv() else {
-                        if let Err(error) = first.run() {
-                            eprintln!("warning: state not saved: {error}");
-                            let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
-                        }
+                        report(first, &ui_tx);
                         continue;
                     };
                     let mut pending = vec![first];
@@ -77,10 +87,7 @@ impl StateWriter {
                         }
                     }
                     for write in pending {
-                        if let Err(error) = write.run() {
-                            eprintln!("warning: state not saved: {error}");
-                            let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
-                        }
+                        report(write, &ui_tx);
                     }
                 }
             })

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -11,9 +11,9 @@
 //! stalled network filesystem must not hold the process open after the TUI has
 //! handed the terminal back.
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -66,9 +66,10 @@ impl Write {
     }
 }
 
-/// Distinct failures the worker could not put in front of the user, for
-/// [`StateWriter::drop`] to print once the terminal is back.
-type Unreported = Arc<Mutex<BTreeSet<String>>>;
+/// Failures the UI has not acknowledged handling, for [`StateWriter::drop`]
+/// to print once the terminal is back. Each occurrence gets its own id so an
+/// acknowledgement for one repeated error cannot hide a later one.
+type PendingFailures = Arc<Mutex<BTreeMap<u64, String>>>;
 
 /// How the worker thread gets a failed write in front of the user.
 struct Reporting {
@@ -76,7 +77,8 @@ struct Reporting {
     /// Set by [`StateWriter::drop`] before the queue closes: past that point
     /// nothing drains the UI channel, so `Msg` would go nowhere.
     draining: Arc<AtomicBool>,
-    unreported: Unreported,
+    pending_failures: PendingFailures,
+    next_failure_id: AtomicU64,
 }
 
 impl Reporting {
@@ -88,23 +90,22 @@ impl Reporting {
     /// something else happened to overwrite it. The status line is the one
     /// channel that reaches the user safely.
     ///
-    /// It can fail to reach even that — a full event channel, or a write that
-    /// only completes after teardown began — and losing the notice would leave
-    /// a discarded namespace, sort, or fleet choice with no trace at all. Those
-    /// are stashed for `Drop` to print after the TUI releases the terminal.
+    /// Enqueue success is not proof of delivery: the event loop may stop before
+    /// handling a queued message. Record the failure first and let the UI
+    /// acknowledge it only when `App::handle_msg` actually processes it. Any
+    /// failure still pending at teardown is printed after the TUI releases the
+    /// terminal.
     fn report(&self, write: Write) {
         let Err(error) = write.run() else { return };
-        // Relaxed: the flag guards nothing but itself. Reading it stale can
-        // only lose the notice for a write that failed in the nanoseconds
-        // between the check and teardown setting it, which the stderr summary
-        // would not have printed any sooner.
-        let delivered = !self.draining.load(Ordering::Relaxed)
-            && self
-                .ui_tx
-                .try_send(Msg::StateWriteFailed(error.clone()))
-                .is_ok();
-        if !delivered && let Ok(mut unreported) = self.unreported.lock() {
-            unreported.insert(error);
+        let id = self.next_failure_id.fetch_add(1, Ordering::Relaxed);
+        self.pending_failures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(id, error.clone());
+        // This flag only avoids a useless send. A stale read is harmless:
+        // without an acknowledgement the retained failure still survives.
+        if !self.draining.load(Ordering::Relaxed) {
+            let _ = self.ui_tx.try_send(Msg::StateWriteFailed { id, error });
         }
     }
 }
@@ -117,7 +118,7 @@ pub struct StateWriter {
     /// on [`JoinHandle::join`], which has no deadline.
     finished: Receiver<()>,
     draining: Arc<AtomicBool>,
-    unreported: Unreported,
+    pending_failures: PendingFailures,
     grace: Duration,
 }
 
@@ -130,11 +131,12 @@ impl StateWriter {
         let (tx, rx) = mpsc::channel::<Write>();
         let (finished_tx, finished) = mpsc::channel::<()>();
         let draining = Arc::new(AtomicBool::new(false));
-        let unreported: Unreported = Arc::new(Mutex::new(BTreeSet::new()));
+        let pending_failures: PendingFailures = Arc::new(Mutex::new(BTreeMap::new()));
         let reporting = Reporting {
             ui_tx,
             draining: Arc::clone(&draining),
-            unreported: Arc::clone(&unreported),
+            pending_failures: Arc::clone(&pending_failures),
+            next_failure_id: AtomicU64::new(1),
         };
         let worker = std::thread::Builder::new()
             .name("sofka-state-writer".into())
@@ -170,7 +172,7 @@ impl StateWriter {
             worker: Some(worker),
             finished,
             draining,
-            unreported,
+            pending_failures,
             grace,
         })
     }
@@ -195,12 +197,30 @@ impl StateWriter {
         self.send(Write::Sort(state, path))
     }
 
-    /// Shared view of the failures the worker could not put in front of the
-    /// user. A handle rather than a snapshot so a test can still read it after
-    /// teardown, which is when most of them are recorded.
+    /// Mark a failure notice as handled by the live UI. Until this happens the
+    /// worker retains it for the exit summary, even when channel enqueue
+    /// succeeded.
+    pub(crate) fn acknowledge_failure(&self, id: u64) {
+        self.pending_failures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&id);
+    }
+
+    /// Shared view of failures not yet acknowledged by the UI. A handle rather
+    /// than a snapshot lets tests inspect it after teardown, when shutdown-only
+    /// failures are recorded.
     #[cfg(test)]
-    fn unreported_handle(&self) -> Unreported {
-        Arc::clone(&self.unreported)
+    fn pending_failures_handle(&self) -> PendingFailures {
+        Arc::clone(&self.pending_failures)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_failure_count(&self) -> usize {
+        self.pending_failures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
     }
 
     #[cfg(test)]
@@ -250,10 +270,12 @@ impl Drop for StateWriter {
         // stderr is safe here and only here: `App` is dropped after the TUI
         // has released the terminal, so this lands on the user's shell rather
         // than smearing across a live alternate screen.
-        if let Ok(unreported) = self.unreported.lock() {
-            for error in unreported.iter() {
-                eprintln!("warning: state not saved: {error}");
-            }
+        let pending_failures = self
+            .pending_failures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for error in pending_failures.values() {
+            eprintln!("warning: state not saved: {error}");
         }
     }
 }
@@ -343,7 +365,10 @@ mod tests {
         // the failure has nowhere to go but the exit summary.
         let (ui_tx, _ui_rx) = tokio::sync::mpsc::channel(1);
         ui_tx
-            .try_send(Msg::StateWriteFailed("filler".into()))
+            .try_send(Msg::StateWriteFailed {
+                id: 0,
+                error: "filler".into(),
+            })
             .unwrap();
         let writer = StateWriter::new(ui_tx).unwrap();
 
@@ -351,10 +376,10 @@ mod tests {
             .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
             .unwrap();
 
-        let unreported = writer.unreported_handle();
+        let pending_failures = writer.pending_failures_handle();
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            if let Some(error) = unreported.lock().unwrap().first() {
+            if let Some(error) = pending_failures.lock().unwrap().values().next() {
                 assert!(error.contains("sort.toml"), "{error}");
                 break;
             }
@@ -381,7 +406,7 @@ mod tests {
         // expired deadline can be what redirects this failure.
         let (ui_tx, mut ui_rx) = tokio::sync::mpsc::channel(8);
         let writer = StateWriter::with_grace(ui_tx, Duration::from_secs(5)).unwrap();
-        let unreported = writer.unreported_handle();
+        let pending_failures = writer.pending_failures_handle();
 
         // Hold the worker so the failing write is still queued when `drop`
         // runs, and therefore only reaches disk during the drain.
@@ -393,9 +418,9 @@ mod tests {
             .unwrap();
         drop(writer);
 
-        let failures = unreported.lock().unwrap().clone();
+        let failures = pending_failures.lock().unwrap().clone();
         assert_eq!(failures.len(), 1, "{failures:?}");
-        let error = failures.first().expect("one recorded failure");
+        let error = failures.values().next().expect("one recorded failure");
         assert!(error.contains("sort.toml"), "{error}");
         assert!(
             ui_rx.try_recv().is_err(),
@@ -414,6 +439,7 @@ mod tests {
         let impossible_path = parent_file.join("sort.toml");
         let (ui_tx, mut ui_rx) = tokio::sync::mpsc::channel(1);
         let writer = StateWriter::new(ui_tx).unwrap();
+        let pending_failures = writer.pending_failures_handle();
 
         writer
             .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
@@ -423,9 +449,9 @@ mod tests {
         // the opposite path: teardown stops using the UI channel precisely
         // because nothing drains it once the event loop has stopped.
         let deadline = Instant::now() + Duration::from_secs(5);
-        let error = loop {
+        let (id, error) = loop {
             match ui_rx.try_recv() {
-                Ok(Msg::StateWriteFailed(error)) => break error,
+                Ok(Msg::StateWriteFailed { id, error }) => break (id, error),
                 Ok(_) => panic!("expected a state-write failure"),
                 Err(_) => {
                     assert!(Instant::now() < deadline, "no failure reported");
@@ -434,8 +460,56 @@ mod tests {
             }
         };
         assert!(error.contains("sort.toml"), "{error}");
+        assert_eq!(pending_failures.lock().unwrap().get(&id), Some(&error));
+
+        // `App::handle_msg` performs this acknowledgement after it has
+        // actually processed the notice.
+        writer.acknowledge_failure(id);
+        assert!(pending_failures.lock().unwrap().is_empty());
 
         drop(writer);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Regression test for the shutdown race: putting a notice in the channel
+    /// does not mean the event loop handled it. If quit wins the event-loop
+    /// select, the queued notice must remain pending for the exit summary.
+    #[test]
+    fn queued_but_unhandled_failure_is_kept_for_the_exit_summary() {
+        let dir = std::env::temp_dir().join(format!("sofka-state-queued-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let parent_file = dir.join("not-a-directory");
+        std::fs::write(&parent_file, "x").unwrap();
+        let impossible_path = parent_file.join("sort.toml");
+        let (ui_tx, mut ui_rx) = tokio::sync::mpsc::channel(8);
+        let writer = StateWriter::new(ui_tx).unwrap();
+        let pending_failures = writer.pending_failures_handle();
+
+        writer
+            .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
+            .unwrap();
+
+        // Wait until `try_send` has succeeded, but deliberately do not receive
+        // or acknowledge the event, matching an event loop that already quit.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while ui_rx.len() != 1 {
+            assert!(Instant::now() < deadline, "failure notice was not queued");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        drop(writer);
+
+        let failures = pending_failures.lock().unwrap().clone();
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        let (id, error) = failures.first_key_value().expect("one pending failure");
+        assert!(error.contains("sort.toml"), "{error}");
+        assert!(matches!(
+            ui_rx.try_recv(),
+            Ok(Msg::StateWriteFailed {
+                id: queued_id,
+                error: queued_error,
+            }) if queued_id == *id && queued_error.as_str() == error
+        ));
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -1,0 +1,152 @@
+//! Serialized off-thread writes for small pieces of persistent UI state.
+//!
+//! Namespace, sort, and fleet choices are changed from input handlers on the
+//! render/event-loop thread. Filesystems can stall unpredictably, so the live
+//! app hands snapshots to one ordered worker instead of doing TOML encoding,
+//! directory creation, and writes inline. A single queue also prevents two
+//! rapid changes to the same file from completing out of order.
+
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Sender};
+use std::thread::JoinHandle;
+
+use tokio::sync::mpsc::Sender as UiSender;
+
+use crate::store::Msg;
+
+enum Write {
+    Fleet(crate::fleet::FleetMarks, PathBuf),
+    Namespace(crate::nsmem::NamespaceMemory, PathBuf),
+    Sort(crate::sortmem::SortMemory, PathBuf),
+}
+
+impl Write {
+    fn run(self) -> Result<(), String> {
+        match self {
+            Write::Fleet(state, path) => state
+                .save(&path)
+                .map_err(|e| format!("{}: {e}", path.display())),
+            Write::Namespace(state, path) => state
+                .save(&path)
+                .map_err(|e| format!("{}: {e}", path.display())),
+            Write::Sort(state, path) => state
+                .save(&path)
+                .map_err(|e| format!("{}: {e}", path.display())),
+        }
+    }
+}
+
+/// Handle to the ordered state-write worker.
+pub struct StateWriter {
+    tx: Option<Sender<Write>>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl StateWriter {
+    pub fn new(ui_tx: UiSender<Msg>) -> Result<Self, String> {
+        let (tx, rx) = mpsc::channel::<Write>();
+        let worker = std::thread::Builder::new()
+            .name("sofka-state-writer".into())
+            .spawn(move || {
+                for write in rx {
+                    if let Err(error) = write.run() {
+                        eprintln!("warning: state not saved: {error}");
+                        let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
+                    }
+                }
+            })
+            .map_err(|e| format!("failed to start state writer: {e}"))?;
+        Ok(Self {
+            tx: Some(tx),
+            worker: Some(worker),
+        })
+    }
+
+    pub fn save_fleet(&self, state: crate::fleet::FleetMarks, path: PathBuf) -> Result<(), String> {
+        self.send(Write::Fleet(state, path))
+    }
+
+    pub fn save_namespace(
+        &self,
+        state: crate::nsmem::NamespaceMemory,
+        path: PathBuf,
+    ) -> Result<(), String> {
+        self.send(Write::Namespace(state, path))
+    }
+
+    pub fn save_sort(
+        &self,
+        state: crate::sortmem::SortMemory,
+        path: PathBuf,
+    ) -> Result<(), String> {
+        self.send(Write::Sort(state, path))
+    }
+
+    fn send(&self, write: Write) -> Result<(), String> {
+        self.tx
+            .as_ref()
+            .ok_or_else(|| "state writer is shutting down".to_string())?
+            .send(write)
+            .map_err(|_| "state writer stopped".to_string())
+    }
+}
+
+impl Drop for StateWriter {
+    fn drop(&mut self) {
+        // Closing the queue lets the worker drain every accepted snapshot.
+        // Joining here makes the last UI choice durable before process exit.
+        self.tx.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drains_writes_in_submission_order_on_shutdown() {
+        let dir = std::env::temp_dir().join(format!("sofka-state-writer-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("namespaces.toml");
+        let (ui_tx, _ui_rx) = tokio::sync::mpsc::channel(1);
+        let writer = StateWriter::new(ui_tx).unwrap();
+
+        let mut first = crate::nsmem::NamespaceMemory::default();
+        first.set("prod", "one");
+        writer.save_namespace(first, path.clone()).unwrap();
+
+        let mut latest = crate::nsmem::NamespaceMemory::default();
+        latest.set("prod", "two");
+        writer.save_namespace(latest.clone(), path.clone()).unwrap();
+
+        drop(writer);
+        assert_eq!(crate::nsmem::NamespaceMemory::load(&path), latest);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn reports_background_write_failures_to_the_ui() {
+        let dir = std::env::temp_dir().join(format!("sofka-state-error-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let parent_file = dir.join("not-a-directory");
+        std::fs::write(&parent_file, "x").unwrap();
+        let impossible_path = parent_file.join("sort.toml");
+        let (ui_tx, mut ui_rx) = tokio::sync::mpsc::channel(1);
+        let writer = StateWriter::new(ui_tx).unwrap();
+
+        writer
+            .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
+            .unwrap();
+        drop(writer);
+
+        match ui_rx.blocking_recv().unwrap() {
+            Msg::StateWriteFailed(error) => assert!(error.contains("sort.toml")),
+            _ => panic!("expected state-write failure"),
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -6,30 +6,53 @@
 //! directory creation, and writes inline. A single queue prevents two rapid
 //! changes to the same file from completing out of order and coalesces a
 //! queued burst to its newest snapshot per destination.
+//!
+//! Teardown drains the queue but never waits forever: a state directory on a
+//! stalled network filesystem must not hold the process open after the TUI has
+//! handed the terminal back.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{self, Sender};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use tokio::sync::mpsc::Sender as UiSender;
 
 use crate::store::Msg;
 
+/// How long teardown waits for the worker to finish its queue before giving up
+/// and letting the process exit without it.
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
+
 enum Write {
     Fleet(crate::fleet::FleetMarks, PathBuf),
     Namespace(crate::nsmem::NamespaceMemory, PathBuf),
     Sort(crate::sortmem::SortMemory, PathBuf),
+    /// Test-only: a write of known duration, so teardown's grace period can be
+    /// observed without a genuinely stalled filesystem.
+    #[cfg(test)]
+    Stall(Duration, PathBuf),
 }
 
 impl Write {
     fn path(&self) -> &Path {
         match self {
             Write::Fleet(_, path) | Write::Namespace(_, path) | Write::Sort(_, path) => path,
+            #[cfg(test)]
+            Write::Stall(_, path) => path,
         }
     }
 
     fn run(self) -> Result<(), String> {
         match self {
+            #[cfg(test)]
+            Write::Stall(duration, _) => {
+                std::thread::sleep(duration);
+                Ok(())
+            }
             Write::Fleet(state, path) => state
                 .save(&path)
                 .map_err(|e| format!("{}: {e}", path.display())),
@@ -43,16 +66,46 @@ impl Write {
     }
 }
 
-/// Perform one write, routing a failure to the status line.
-///
-/// Deliberately never touches stderr. This runs on a background thread for as
-/// long as the session lasts, and by then the TUI owns the alternate screen;
-/// ratatui only repaints cells it sees change, so a stray line would stay
-/// smeared across the table until something else happened to overwrite it.
-/// `Msg` is the one channel that reaches the user safely.
-fn report(write: Write, ui_tx: &UiSender<Msg>) {
-    if let Err(error) = write.run() {
-        let _ = ui_tx.try_send(Msg::StateWriteFailed(error));
+/// Distinct failures the worker could not put in front of the user, for
+/// [`StateWriter::drop`] to print once the terminal is back.
+type Unreported = Arc<Mutex<BTreeSet<String>>>;
+
+/// How the worker thread gets a failed write in front of the user.
+struct Reporting {
+    ui_tx: UiSender<Msg>,
+    /// Set by [`StateWriter::drop`] before the queue closes: past that point
+    /// nothing drains the UI channel, so `Msg` would go nowhere.
+    draining: Arc<AtomicBool>,
+    unreported: Unreported,
+}
+
+impl Reporting {
+    /// Perform one write, making sure a failure is recorded somewhere.
+    ///
+    /// This thread deliberately never touches stderr while the app is live:
+    /// the TUI owns the alternate screen, and ratatui only repaints cells it
+    /// sees change, so a stray line would stay smeared across the table until
+    /// something else happened to overwrite it. The status line is the one
+    /// channel that reaches the user safely.
+    ///
+    /// It can fail to reach even that — a full event channel, or a write that
+    /// only completes after teardown began — and losing the notice would leave
+    /// a discarded namespace, sort, or fleet choice with no trace at all. Those
+    /// are stashed for `Drop` to print after the TUI releases the terminal.
+    fn report(&self, write: Write) {
+        let Err(error) = write.run() else { return };
+        // Relaxed: the flag guards nothing but itself. Reading it stale can
+        // only lose the notice for a write that failed in the nanoseconds
+        // between the check and teardown setting it, which the stderr summary
+        // would not have printed any sooner.
+        let delivered = !self.draining.load(Ordering::Relaxed)
+            && self
+                .ui_tx
+                .try_send(Msg::StateWriteFailed(error.clone()))
+                .is_ok();
+        if !delivered && let Ok(mut unreported) = self.unreported.lock() {
+            unreported.insert(error);
+        }
     }
 }
 
@@ -60,17 +113,37 @@ fn report(write: Write, ui_tx: &UiSender<Msg>) {
 pub struct StateWriter {
     tx: Option<Sender<Write>>,
     worker: Option<JoinHandle<()>>,
+    /// Disconnects when the worker returns. Teardown waits on this rather than
+    /// on [`JoinHandle::join`], which has no deadline.
+    finished: Receiver<()>,
+    draining: Arc<AtomicBool>,
+    unreported: Unreported,
+    grace: Duration,
 }
 
 impl StateWriter {
     pub fn new(ui_tx: UiSender<Msg>) -> Result<Self, String> {
+        Self::with_grace(ui_tx, SHUTDOWN_GRACE)
+    }
+
+    fn with_grace(ui_tx: UiSender<Msg>, grace: Duration) -> Result<Self, String> {
         let (tx, rx) = mpsc::channel::<Write>();
+        let (finished_tx, finished) = mpsc::channel::<()>();
+        let draining = Arc::new(AtomicBool::new(false));
+        let unreported: Unreported = Arc::new(Mutex::new(BTreeSet::new()));
+        let reporting = Reporting {
+            ui_tx,
+            draining: Arc::clone(&draining),
+            unreported: Arc::clone(&unreported),
+        };
         let worker = std::thread::Builder::new()
             .name("sofka-state-writer".into())
             .spawn(move || {
+                // Never sent on; dropping it with the thread is the signal.
+                let _finished_tx = finished_tx;
                 while let Ok(first) = rx.recv() {
                     let Ok(second) = rx.try_recv() else {
-                        report(first, &ui_tx);
+                        reporting.report(first);
                         continue;
                     };
                     let mut pending = vec![first];
@@ -87,7 +160,7 @@ impl StateWriter {
                         }
                     }
                     for write in pending {
-                        report(write, &ui_tx);
+                        reporting.report(write);
                     }
                 }
             })
@@ -95,6 +168,10 @@ impl StateWriter {
         Ok(Self {
             tx: Some(tx),
             worker: Some(worker),
+            finished,
+            draining,
+            unreported,
+            grace,
         })
     }
 
@@ -118,6 +195,17 @@ impl StateWriter {
         self.send(Write::Sort(state, path))
     }
 
+    /// Distinct failures the worker could not put in front of the user yet.
+    #[cfg(test)]
+    fn unreported_failures(&self) -> Vec<String> {
+        self.unreported.lock().unwrap().iter().cloned().collect()
+    }
+
+    #[cfg(test)]
+    fn stall(&self, duration: Duration, path: PathBuf) -> Result<(), String> {
+        self.send(Write::Stall(duration, path))
+    }
+
     fn send(&self, write: Write) -> Result<(), String> {
         self.tx
             .as_ref()
@@ -129,17 +217,49 @@ impl StateWriter {
 
 impl Drop for StateWriter {
     fn drop(&mut self) {
+        // Nothing reads the UI channel from here on, so failures have to be
+        // stashed for the summary below instead of sent as `Msg`.
+        self.draining.store(true, Ordering::Relaxed);
         // Closing the queue lets the worker drain every accepted snapshot.
-        // Joining here makes the last UI choice durable before process exit.
+        // Waiting for it makes the last UI choice durable before process exit.
         self.tx.take();
-        if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+        // But only for so long. `join` would wait forever, and a state
+        // directory on a stalled network filesystem would then hang the
+        // process after the terminal had already been handed back — a quit
+        // that never finishes, with nothing on screen to explain it. Past the
+        // grace period the worker is left detached and the process exits;
+        // whatever it was writing is lost, which is what a kill would have
+        // done anyway.
+        match self.finished.recv_timeout(self.grace) {
+            Err(RecvTimeoutError::Timeout) => {
+                self.worker.take();
+                eprintln!(
+                    "warning: state writer still busy after {:?}; the last \
+                     namespace, sort, or fleet change may not be saved",
+                    self.grace
+                );
+            }
+            _ => {
+                if let Some(worker) = self.worker.take() {
+                    let _ = worker.join();
+                }
+            }
+        }
+        // stderr is safe here and only here: `App` is dropped after the TUI
+        // has released the terminal, so this lands on the user's shell rather
+        // than smearing across a live alternate screen.
+        if let Ok(unreported) = self.unreported.lock() {
+            for error in unreported.iter() {
+                eprintln!("warning: state not saved: {error}");
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
 
     #[test]
@@ -192,6 +312,58 @@ mod tests {
     }
 
     #[test]
+    fn teardown_gives_up_on_a_stalled_worker() {
+        let (ui_tx, _ui_rx) = tokio::sync::mpsc::channel(1);
+        let writer = StateWriter::with_grace(ui_tx, Duration::from_millis(50)).unwrap();
+        // Stands in for a state directory on an unresponsive network mount.
+        writer
+            .stall(Duration::from_secs(10), PathBuf::from("/stalled"))
+            .unwrap();
+
+        let start = Instant::now();
+        drop(writer);
+        let waited = start.elapsed();
+        assert!(
+            waited < Duration::from_secs(5),
+            "teardown blocked for {waited:?} behind a stalled write"
+        );
+    }
+
+    #[test]
+    fn failures_the_ui_cannot_take_are_kept_for_the_exit_summary() {
+        let dir = std::env::temp_dir().join(format!("sofka-state-lost-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let parent_file = dir.join("not-a-directory");
+        std::fs::write(&parent_file, "x").unwrap();
+        let impossible_path = parent_file.join("sort.toml");
+        // One slot, already occupied: the worker's `try_send` cannot land, so
+        // the failure has nowhere to go but the exit summary.
+        let (ui_tx, _ui_rx) = tokio::sync::mpsc::channel(1);
+        ui_tx
+            .try_send(Msg::StateWriteFailed("filler".into()))
+            .unwrap();
+        let writer = StateWriter::new(ui_tx).unwrap();
+
+        writer
+            .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let failures = writer.unreported_failures();
+            if let Some(error) = failures.first() {
+                assert!(error.contains("sort.toml"), "{error}");
+                break;
+            }
+            assert!(Instant::now() < deadline, "the failure was dropped");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        drop(writer);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn reports_background_write_failures_to_the_ui() {
         let dir = std::env::temp_dir().join(format!("sofka-state-error-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -205,12 +377,24 @@ mod tests {
         writer
             .save_sort(crate::sortmem::SortMemory::default(), impossible_path)
             .unwrap();
-        drop(writer);
 
-        match ui_rx.blocking_recv().unwrap() {
-            Msg::StateWriteFailed(error) => assert!(error.contains("sort.toml")),
-            _ => panic!("expected state-write failure"),
-        }
+        // Read while the writer is still live. Dropping it first would test
+        // the opposite path: teardown stops using the UI channel precisely
+        // because nothing drains it once the event loop has stopped.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let error = loop {
+            match ui_rx.try_recv() {
+                Ok(Msg::StateWriteFailed(error)) => break error,
+                Ok(_) => panic!("expected a state-write failure"),
+                Err(_) => {
+                    assert!(Instant::now() < deadline, "no failure reported");
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+            }
+        };
+        assert!(error.contains("sort.toml"), "{error}");
+
+        drop(writer);
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/state_writer.rs
+++ b/src/state_writer.rs
@@ -11,7 +11,7 @@
 //! stalled network filesystem must not hold the process open after the TUI has
 //! handed the terminal back.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
@@ -215,6 +215,18 @@ impl StateWriter {
         Arc::clone(&self.pending_failures)
     }
 
+    /// The exit summary's lines. Per-occurrence ids keep acknowledgement
+    /// precise, but a user staring at a broken disk wants one line per
+    /// distinct problem, not one per failed keystroke.
+    fn failure_summary(&self) -> BTreeSet<String> {
+        self.pending_failures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect()
+    }
+
     #[cfg(test)]
     pub(crate) fn pending_failure_count(&self) -> usize {
         self.pending_failures
@@ -270,11 +282,7 @@ impl Drop for StateWriter {
         // stderr is safe here and only here: `App` is dropped after the TUI
         // has released the terminal, so this lands on the user's shell rather
         // than smearing across a live alternate screen.
-        let pending_failures = self
-            .pending_failures
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        for error in pending_failures.values() {
+        for error in self.failure_summary() {
             eprintln!("warning: state not saved: {error}");
         }
     }
@@ -469,6 +477,31 @@ mod tests {
 
         drop(writer);
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn the_exit_summary_collapses_repeats_of_the_same_problem() {
+        let (ui_tx, _ui_rx) = tokio::sync::mpsc::channel(1);
+        let writer = StateWriter::new(ui_tx).unwrap();
+        // One unreachable state file written repeatedly is one problem, however
+        // many keystrokes hit it.
+        let pending = writer.pending_failures_handle();
+        {
+            let mut pending = pending.lock().unwrap();
+            pending.insert(1, "sort.toml: Permission denied".into());
+            pending.insert(2, "sort.toml: Permission denied".into());
+            pending.insert(3, "namespaces.toml: Permission denied".into());
+        }
+
+        // Acknowledgement still tracks every occurrence separately.
+        assert_eq!(writer.pending_failure_count(), 3);
+        assert_eq!(
+            writer.failure_summary().into_iter().collect::<Vec<_>>(),
+            vec![
+                "namespaces.toml: Permission denied".to_string(),
+                "sort.toml: Permission denied".to_string(),
+            ]
+        );
     }
 
     /// Regression test for the shutdown race: putting a notice in the channel

--- a/src/store.rs
+++ b/src/store.rs
@@ -228,8 +228,13 @@ pub enum Msg {
         generation: u64,
         error: String,
     },
-    /// A generation-independent persistent UI-state write failed.
-    StateWriteFailed(String),
+    /// A generation-independent persistent UI-state write failed. The id lets
+    /// the UI acknowledge that it actually handled the notice; merely putting
+    /// it in the event channel is not delivery during shutdown.
+    StateWriteFailed {
+        id: u64,
+        error: String,
+    },
     /// A background action (delete, restart, scale, drain, helm op, …)
     /// finished; replaces its "…ing" progress flash with a result. Also
     /// carries `:can-i` verdicts, which are the same thing: a one-line answer

--- a/src/store.rs
+++ b/src/store.rs
@@ -228,6 +228,8 @@ pub enum Msg {
         generation: u64,
         error: String,
     },
+    /// A generation-independent persistent UI-state write failed.
+    StateWriteFailed(String),
     /// A background action (delete, restart, scale, drain, helm op, …)
     /// finished; replaces its "…ing" progress flash with a result. Also
     /// carries `:can-i` verdicts, which are the same thing: a one-line answer


### PR DESCRIPTION
Part 3 of 3 from the first optimization plan (I have a second one as well). Rebased onto current main (v0.23.0)

Three changes: curated cell extraction borrows instead of allocating, provider discovery drops a temporary vector, and UI state persistence moves off the render thread.

## What each change is actually worth

**`Cow<str>` cell extraction — the real hot-path win.**

Curated column extractors returned `String`. Filtering and sorting read *one* column of *every* object on every rebuild, so each keystroke in a structured filter allocated a `String` per row and dropped it immediately. They now return `Cow<str>`, borrowing values that already live in the Kubernetes object. Cached full rows call `into_owned()` and pay exactly what they paid before, so the full-row path is unchanged — the saving is confined to the one-column probes (`column_cell`, `sort_value`) that run per object per rebuild.

**State persistence off the render thread — a tail-latency fix, not a throughput one.**

Namespace, sort, and fleet changes used to TOML-encode and write inline in the input handler, on the render/event-loop thread. On a healthy filesystem that costs ~56µs, which nobody can perceive. The reason to move it is the tail: `create_dir_all` + `fs::write` on a stalled NFS mount, a fuse filesystem, or a synced home directory can block for seconds — and it was blocking *rendering and input*, so the whole TUI froze mid-keystroke. Writes now go to one ordered worker, which also coalesces a queued burst to the newest snapshot per destination file.

The table below reports 18x on UI latency. That number is real, but it measures the mean, which was never the problem. The claim worth reviewing is that a slow disk can no longer freeze the UI.

**Provider selection — marginal, kept for readability.**

`pick_service` / `pick_metrics_service` collected every candidate into a `Vec` before calling `min_by_key`; they now feed the filtered iterator straight in. Selection and port precedence are unchanged (`Iterator::min_by_key` returns the first minimum in both forms). This runs once per log-view or rightsize open and is dominated by a network round-trip, so the measured ~1.2x is worth nothing on its own — the code is just shorter.

## What going async cost

Moving the write off-thread relocated the stall rather than removing it. Most of the review so far has been about that, not about the optimization:

- **Teardown could hang.** `Drop` joined the worker unconditionally, so a stalled filesystem hung the process *after* the terminal had been restored — a quit that never returns, with nothing on screen to explain it. Teardown now waits on a channel the worker disconnects when it returns, which gives the wait a deadline that `JoinHandle::join` cannot have. Past 500ms the worker is detached and the process exits.

- **Failure notices could vanish.** The worker cannot write to stderr — it runs under the TUI's alternate screen, and ratatui only repaints cells it sees change, so a stray line stays smeared across the table. So notices go to the status line over the event channel. But a successful `try_send` is not proof of delivery: if the event loop stops before handling a queued message, the notice is lost and nothing records it. Failures are now recorded when they happen and cleared only when `App::handle_msg` acknowledges the notice by id; whatever is still pending at teardown is printed from `Drop`, which runs after the terminal is restored and so can safely use stderr. Ids are per occurrence, so an acknowledgement for one cannot clear a later, still-unhandled one — and the exit summary collapses them back to one line per distinct problem.

State-write failures also got their own diagnostics field. `:info` previously filed them under **Watch health**, next to the watch error count, where a disk permission error read as a broken watch.

## A latent bug found on the way: torn state files

Independent of everything above, and worth more than the microseconds: `save()` wrote in place. `File::create` truncates the target before the new TOML lands, so a crash, a power loss, or a second sofka writing the same file in that window leaves a half-written mix — and `load()` treats an unparsable file as an empty one, so the user's remembered sorts, namespaces, or fleet marks are silently gone. Moving the writes off the render thread widened that window; it did not open it. The inline version on main has the same hole.

The bytes now go to a sibling temp file that is flushed and renamed over the target. `rename` replaces atomically, so a reader sees the whole old file or the whole new one, never a tear. The temp file is fsynced, because otherwise the rename can reach disk before the bytes it publishes and a power loss leaves the target pointing at a zero-filled file — exactly the tear the rename is there to prevent. The directory entry is deliberately *not* synced: if the rename itself is lost, the previous complete file survives, which is a fine outcome for remembered UI state and saves a second flush per keystroke that changes a sort.

All three `save()` bodies were byte-identical, so this is one `atomicfile::write` rather than the same eight lines pasted three times. It sits in its own module rather than in `state_writer` so that `atomicfile::write` at a call site cannot be misread as enqueueing to the state-write worker. Four tests cover it: replace-in-place with parent creation, no temp litter after repeated writes, and a forced-failure case (renaming over a directory) asserting the old file survives untouched and the temp is cleaned up.

**Not converted:** `app/actions.rs`, `app/bundle.rs`, and `app/snapshot.rs` still use plain `fs::write`. Those are one-shot user-initiated exports to fresh paths, not state files rewritten under the app's own feet, so the tearing risk there is different in kind — and they are on the async side, so converting them needs a `spawn_blocking` wrapper or a duplicate async path. Happy to do it in a follow-up if you want the guarantee to be uniform.

## Benchmarks

| Benchmark | Baseline | Optimized | Result |
|---|---:|---:|---:|
| Cell extraction, 2,000 pod IPs | 167.23 µs | 111.31 µs | 1.50× faster |
| Log provider selection, 256 services | 4.688 µs | 4.029 µs | 1.16× faster |
| Metrics provider selection, 256 services | 4.867 µs | 4.074 µs | 1.19× faster |
| State UI latency, 200 writes/sample | 61.766 µs/write | 3.277 µs/write | 18.85× faster |
| State burst completion, 200 writes/sample | 61.766 µs/write | 3.901 µs/write | 15.83× faster |

`cargo bench --features bench --bench hot_paths -- "cell_extract|provider_selection"` and `cargo run --release --example state_write_probe --features bench`.

## Review notes

`state_writer.rs` is 291 lines of implementation plus 257 of tests, replacing three inline `save()` calls. That is a lot of machinery for a write that happens a few dozen times a session, and it is the part of this PR most worth pushing back on. The tail-latency argument is what justifies it — if you don't buy that, the `Cow` change stands on its own and this piece can be dropped without touching it.

617 tests passing, `clippy -D warnings` and `cargo fmt --check` clean. The behaviours that are easy to regress are pinned by tests that were checked against mutations — removing the teardown deadline, the drain redirect, or the summary dedup each fails its test rather than passing quietly.



