### PR TITLE
fix: enable kube http-proxy so HTTPS_PROXY works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,13 +1270,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1321,6 +1324,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ hyper = { version = "1.10.1", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "native-tokio", "ring", "tls12"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
 k8s-openapi = { version = "0.28", features = ["latest"] }
-kube = { version = "4.0.0", features = ["runtime", "client", "derive", "ws"] }
+kube = { version = "4.2.0", features = ["runtime", "client", "derive", "ws", "http-proxy"] }
 memchr = "2.8.3"
 ratatui = "0.30.1"
 regex = "1"


### PR DESCRIPTION
Fixes #202.

kube reads `HTTPS_PROXY` / `https_proxy` into the client config, but building the client for an `http://` proxy needs the `http-proxy` feature. We didn't enable it, so anyone behind a proxy got `requires the disabled feature "kube/http-proxy"` and couldn't connect at all.

- enabled `http-proxy` on kube
- bumped the kube manifest version to 4.2.0 to match the lockfile (already latest)

Checked with `https_proxy` pointed at a dead port - the "disabled feature" error is gone and the client builds. Tests pass.

Heads up: kube itself ignores `no_proxy` and `HTTP_PROXY`, only `HTTPS_PROXY` is honoured. That's upstream.
