### PR TITLE
feat: drill from a CronJob into its Jobs on enter

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -20,8 +20,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   automatically. `w` toggles wide-only columns (kubectl `-o wide`). See
   [Views and thresholds](views.md).
 - **Drill-down navigation** with a breadcrumb stack: workload/service → pods,
-  node → its pods, pod → containers, namespace → re-scope, CRD → its custom
-  resources. `esc` goes back.
+  cronjob → its jobs, node → its pods, pod → containers, namespace → re-scope,
+  CRD → its custom resources. `esc` goes back.
 - **Command palette** (`:`) - fuzzy search over the full resource catalog, your
   saved bookmarks and workspaces, and the built-in commands (`ctx`, `helm`,
   `pulse`, `xray`, `explain`, `timeline`, `gitops`, `can-i`, `journal`, `debug`,

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -5,60 +5,60 @@ plugin, bookmark, and workspace chords.
 
 ## Table views
 
-| Key                                           | Action                                                                                                                                |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `:<resource>`                                 | command palette - fuzzy over kinds and built-in commands                                                                              |
-| `:<resource> <ns>`                            | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                         |
-| `[` / `]`                                     | view history - back / forward through visited kind+namespace views                                                                    |
-| `Tab` / `shift-Tab`                           | cycle views of the active workspace (when one is open)                                                                                |
-| `enter`                                       | drill down (workload/svc → pods, node → its pods, pod → containers, ns → re-scope, CRD → its resources, or per [views](views.md))     |
-| `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                             |
-| `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                              |
-| `ctrl-f` / `ctrl-b`, `PgDn` / `PgUp`          | page forward / back - one screenful at a time                                                                                         |
-| `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction — remembered per kind across views and restarts    |
-| `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                              |
-| `space`                                       | mark/unmark row for bulk actions                                                                                                      |
-| `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |
-| `n` / `0`                                     | namespace switcher / all namespaces                                                                                                   |
-| `shift-j`                                     | jump to owner/controller                                                                                                              |
-| `o`                                           | show the node the selected row names (pods built in; other kinds via `[views."…"].node`)                                              |
-| `ctrl-r`                                      | refresh the watch                                                                                                                     |
-| `y` / `d` / `E`                               | view YAML / describe (`kubectl`) / live events                                                                                        |
-| `x`                                           | secrets: show `data` base64-decoded (as `stringData`)                                                                                 |
-| `X` / `T`                                     | explain why the selection is unhealthy / session-local state-change timeline                                                          |
-| `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                  |
-| `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                              |
-| `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                |
-| `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                             |
-| `:ctx` / `:ctx <name>`                        | context switcher popup (type to filter, `r` renames, `space` toggles fleet membership) / switch directly (the name tab-completes)     |
-| `:helm`                                       | Helm releases (native storage-Secret decode): ⏎ history → values · `y` manifest · `d` notes · `r` rollback                            |
-| `:fleet`                                      | cross-context health dashboard (opt-in: `[fleet]` contexts or `space` in `:ctx`; `⏎` switches, `r` refreshes)                         |
-| `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                    |
-| `:reload` / `:config` / `:info`               | reload config from disk · config sources + warnings · runtime diagnostics                                                             |
-| `l` / `p`                                     | logs (workload = all matching pods) / previous-container logs                                                                         |
-| `L` / `:vlogs`                                | VictoriaLogs history for the selection (pod, container, workload, service, namespace)                                                 |
-| `c`                                           | copy resource name to clipboard                                                                                                       |
-| `Y`                                           | copy any cell of the selected row: picker over the displayed columns (type to match a column name or value), `⏎` copies               |
-| `e`                                           | edit in `$EDITOR` (`kubectl edit`)                                                                                                    |
-| `s`                                           | shell into pod / scale a workload (context-dependent)                                                                                 |
-| `a`                                           | attach to pod                                                                                                                         |
-| `:debug`                                      | pod: ephemeral debug container (`d` in the picker targets one) · node: privileged debug pod (previewed + confirmed)                   |
-| `:debug-clean`                                | delete the node debugger pods launched this session                                                                                   |
-| `:bundle` / `:bundle-save`                    | assemble a redacted diagnostic bundle for the selection · write the previewed bundle to a file                                        |
-| `:snapshot [text\|json\|yaml]` / `:snapshots` | capture the current view to a file · browse, open, and delete saved snapshots                                                         |
-| `:notify`                                     | toggle watch notifications on the selected object                                                                                     |
-| `:find <text>`                                | global fuzzy find over object names across common kinds, all namespaces                                                               |
-| `i`                                           | set container image                                                                                                                   |
-| `r`                                           | rollout restart (workloads) / force-sync (ExternalSecrets/PushSecrets) / refresh (elsewhere)                                          |
-| `f` / `shift-f`                               | port-forward (pods/services) - runs in the background                                                                                 |
-| `t`                                           | Flux: suspend/resume/reconcile menu · ArgoCD App/AppSet: suspend/resume (App: + sync) · CronJobs: trigger/suspend/resume · pods: file transfer (`kubectl cp`)                           |
-| `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                      |
-| `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan) |
-| `w`                                           | toggle wide-only columns (kubectl `-o wide`)                                                                                          |
-| `←` / `→`                                     | scroll columns horizontally (NAMESPACE/NAME stay anchored) — for narrow panes                                                         |
-| `:q`, `ctrl-c`                                | quit                                                                                                                                  |
-| `?`                                           | help                                                                                                                                  |
-| _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                           |
+| Key                                           | Action                                                                                                                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:<resource>`                                 | command palette - fuzzy over kinds and built-in commands                                                                                                      |
+| `:<resource> <ns>`                            | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                                                 |
+| `[` / `]`                                     | view history - back / forward through visited kind+namespace views                                                                                            |
+| `Tab` / `shift-Tab`                           | cycle views of the active workspace (when one is open)                                                                                                        |
+| `enter`                                       | drill down (workload/svc → pods, cronjob → jobs, node → pods, pod → containers, ns → re-scope, CRD → resources, or [views](views.md))                         |
+| `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                                                     |
+| `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                                                      |
+| `ctrl-f` / `ctrl-b`, `PgDn` / `PgUp`          | page forward / back - one screenful at a time                                                                                                                 |
+| `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction — remembered per kind across views and restarts                            |
+| `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                                                      |
+| `space`                                       | mark/unmark row for bulk actions                                                                                                                              |
+| `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                                                     |
+| `n` / `0`                                     | namespace switcher / all namespaces                                                                                                                           |
+| `shift-j`                                     | jump to owner/controller                                                                                                                                      |
+| `o`                                           | show the node the selected row names (pods built in; other kinds via `[views."…"].node`)                                                                      |
+| `ctrl-r`                                      | refresh the watch                                                                                                                                             |
+| `y` / `d` / `E`                               | view YAML / describe (`kubectl`) / live events                                                                                                                |
+| `x`                                           | secrets: show `data` base64-decoded (as `stringData`)                                                                                                         |
+| `X` / `T`                                     | explain why the selection is unhealthy / session-local state-change timeline                                                                                  |
+| `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                                          |
+| `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                                                      |
+| `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                                        |
+| `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                                                     |
+| `:ctx` / `:ctx <name>`                        | context switcher popup (type to filter, `r` renames, `space` toggles fleet membership) / switch directly (the name tab-completes)                             |
+| `:helm`                                       | Helm releases (native storage-Secret decode): ⏎ history → values · `y` manifest · `d` notes · `r` rollback                                                    |
+| `:fleet`                                      | cross-context health dashboard (opt-in: `[fleet]` contexts or `space` in `:ctx`; `⏎` switches, `r` refreshes)                                                 |
+| `:skin`                                       | switch the color skin live (`:skin gruvbox-dark` applies directly)                                                                                            |
+| `:reload` / `:config` / `:info`               | reload config from disk · config sources + warnings · runtime diagnostics                                                                                     |
+| `l` / `p`                                     | logs (workload = all matching pods) / previous-container logs                                                                                                 |
+| `L` / `:vlogs`                                | VictoriaLogs history for the selection (pod, container, workload, service, namespace)                                                                         |
+| `c`                                           | copy resource name to clipboard                                                                                                                               |
+| `Y`                                           | copy any cell of the selected row: picker over the displayed columns (type to match a column name or value), `⏎` copies                                       |
+| `e`                                           | edit in `$EDITOR` (`kubectl edit`)                                                                                                                            |
+| `s`                                           | shell into pod / scale a workload (context-dependent)                                                                                                         |
+| `a`                                           | attach to pod                                                                                                                                                 |
+| `:debug`                                      | pod: ephemeral debug container (`d` in the picker targets one) · node: privileged debug pod (previewed + confirmed)                                           |
+| `:debug-clean`                                | delete the node debugger pods launched this session                                                                                                           |
+| `:bundle` / `:bundle-save`                    | assemble a redacted diagnostic bundle for the selection · write the previewed bundle to a file                                                                |
+| `:snapshot [text\|json\|yaml]` / `:snapshots` | capture the current view to a file · browse, open, and delete saved snapshots                                                                                 |
+| `:notify`                                     | toggle watch notifications on the selected object                                                                                                             |
+| `:find <text>`                                | global fuzzy find over object names across common kinds, all namespaces                                                                                       |
+| `i`                                           | set container image                                                                                                                                           |
+| `r`                                           | rollout restart (workloads) / force-sync (ExternalSecrets/PushSecrets) / refresh (elsewhere)                                                                  |
+| `f` / `shift-f`                               | port-forward (pods/services) - runs in the background                                                                                                         |
+| `t`                                           | Flux: suspend/resume/reconcile menu · ArgoCD App/AppSet: suspend/resume (App: + sync) · CronJobs: trigger/suspend/resume · pods: file transfer (`kubectl cp`) |
+| `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                                              |
+| `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan)                         |
+| `w`                                           | toggle wide-only columns (kubectl `-o wide`)                                                                                                                  |
+| `←` / `→`                                     | scroll columns horizontally (NAMESPACE/NAME stay anchored) — for narrow panes                                                                                 |
+| `:q`, `ctrl-c`                                | quit                                                                                                                                                          |
+| `?`                                           | help                                                                                                                                                          |
+| _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                                                   |
 
 ## Logs view
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -486,6 +486,7 @@ impl App {
         self.namespace = ns;
         self.labels = None;
         self.fields = Some(format!("metadata.name={owner_name}"));
+        self.owner = None;
         self.scope_label = Some(format!("owner of {child_name}"));
         self.filter.clear();
         self.reset_sort();

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -189,6 +189,7 @@ impl App {
             // k9s: 0 = all namespaces.
             KeyCode::Char('0') => {
                 self.namespace.clear();
+                self.drop_owner_scope();
                 self.remember_namespace();
                 self.flash = "namespace: all namespaces".into();
                 self.flash_err = false;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -62,6 +62,7 @@ impl App {
         self.kind = Some(kind);
         self.labels = None;
         self.fields = None;
+        self.owner = None;
         self.scope_label = None;
         self.filter.clear();
         self.reset_sort();
@@ -82,6 +83,7 @@ impl App {
         self.kind_plural = "helm".into();
         self.labels = Some("owner=helm".into());
         self.fields = Some("type=helm.sh/release.v1".into());
+        self.owner = None;
         self.scope_label = None;
         self.filter.clear();
         self.reset_sort();
@@ -217,6 +219,7 @@ impl App {
             namespace: self.namespace.clone(),
             labels: self.labels.clone(),
             fields: self.fields.clone(),
+            owner: self.owner.clone(),
             filter: self.filter.clone(),
             scope_label: self.scope_label.clone(),
             selected: self.table_state.selected(),
@@ -229,6 +232,7 @@ impl App {
         self.namespace = f.namespace;
         self.labels = f.labels;
         self.fields = f.fields;
+        self.owner = f.owner;
         self.filter = f.filter;
         self.scope_label = f.scope_label;
         self.reset_sort();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1173,6 +1173,35 @@ struct ViewEntry {
     namespace: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnerScope {
+    pub kind: String,
+    pub name: String,
+    pub uid: Option<String>,
+}
+
+impl OwnerScope {
+    pub fn owns(&self, obj: &DynamicObject) -> bool {
+        let refs = obj.metadata.owner_references.as_deref().unwrap_or_default();
+        if refs.is_empty() {
+            let prefix = format!("{}-", self.name);
+            return obj
+                .metadata
+                .name
+                .as_deref()
+                .is_some_and(|n| n.starts_with(&prefix));
+        }
+        refs.iter().any(|r| {
+            r.kind.eq_ignore_ascii_case(&self.kind)
+                && r.name == self.name
+                && match &self.uid {
+                    Some(uid) if !r.uid.is_empty() => r.uid == *uid,
+                    _ => true,
+                }
+        })
+    }
+}
+
 /// A saved view, pushed onto the stack when drilling down.
 struct Frame {
     kind: Option<Kind>,
@@ -1180,6 +1209,7 @@ struct Frame {
     namespace: String,
     labels: Option<String>,
     fields: Option<String>,
+    owner: Option<OwnerScope>,
     filter: String,
     scope_label: Option<String>,
     selected: Option<usize>,
@@ -1194,6 +1224,7 @@ pub struct App {
     pub namespace: String,
     pub labels: Option<String>,
     pub fields: Option<String>,
+    pub owner: Option<OwnerScope>,
     /// Drill-down breadcrumb shown in the header, e.g. "deploy/foo".
     pub scope_label: Option<String>,
 
@@ -1563,6 +1594,7 @@ impl App {
             namespace,
             labels: None,
             fields: None,
+            owner: None,
             scope_label: None,
             generation: 0,
             gen_flag: Arc::new(AtomicU64::new(0)),

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -35,6 +35,7 @@ impl App {
                 None => self.flash_warn("service has no selector"),
             },
             "pods" => self.open_containers(&obj),
+            "cronjobs" => self.drill_into_cronjob_jobs(&obj),
             // enter on a CRD lists its custom resources, not its YAML.
             "customresourcedefinitions" => self.drill_into_crd(&obj),
             // Helm: release -> every revision, revision -> its values.
@@ -86,6 +87,33 @@ impl App {
         );
     }
 
+    pub(super) fn drill_into_cronjob_jobs(&mut self, obj: &DynamicObject) {
+        let Some(jobs) = self.cluster.resolve("jobs") else {
+            self.flash_warn("jobs kind unavailable");
+            return;
+        };
+        let name = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        self.push_frame();
+        self.kind = Some(jobs);
+        self.kind_plural = "jobs".into();
+        self.namespace = ns;
+        self.labels = None;
+        self.fields = None;
+        self.owner = Some(OwnerScope {
+            kind: "CronJob".into(),
+            name: name.clone(),
+            uid: obj.metadata.uid.clone(),
+        });
+        self.scope_label = Some(format!("cronjob/{name}"));
+        self.filter.clear();
+        self.reset_sort();
+        self.table_state.select(Some(0));
+        self.flash = format!("↳ jobs of {name}");
+        self.flash_err = false;
+        self.start_watch();
+    }
+
     /// Drill from a Flux `HelmRelease` row into the revision history of the
     /// Helm release it manages — the same view `:helm` → enter reaches, so
     /// values (`⏎`), manifest (`y`), notes (`d`), and rollback (`r`) all work
@@ -107,6 +135,7 @@ impl App {
         self.namespace = ns;
         self.labels = Some(format!("owner=helm,name={release}"));
         self.fields = Some("type=helm.sh/release.v1".into());
+        self.owner = None;
         self.scope_label = Some(format!("helm/{release}"));
         self.filter.clear();
         self.reset_sort();
@@ -132,6 +161,7 @@ impl App {
         self.namespace = ns;
         self.labels = Some(format!("owner=helm,name={release}"));
         self.fields = Some("type=helm.sh/release.v1".into());
+        self.owner = None;
         self.scope_label = Some(format!("helm/{release}"));
         self.filter.clear();
         self.reset_sort();
@@ -224,6 +254,7 @@ impl App {
         self.namespace = String::new(); // list across all namespaces
         self.labels = None;
         self.fields = None;
+        self.owner = None;
         self.scope_label = Some(format!("crd/{crd_name}"));
         self.filter.clear();
         self.reset_sort();
@@ -265,6 +296,7 @@ impl App {
         self.kind_plural = plural.clone();
         self.labels = labels;
         self.fields = fields;
+        self.owner = None;
         self.scope_label = Some(scope);
         self.filter.clear();
         self.reset_sort();
@@ -300,6 +332,7 @@ impl App {
         self.namespace = t.namespace.clone().unwrap_or_default();
         self.labels = None;
         self.fields = Some(format!("metadata.name={}", t.name));
+        self.owner = None;
         self.scope_label = Some(t.name.clone());
         self.filter.clear();
         self.reset_sort();
@@ -325,6 +358,7 @@ impl App {
             self.kind_plural = "pods".into();
             self.labels = None;
             self.fields = None;
+            self.owner = None;
             self.scope_label = None;
             self.filter.clear();
             self.reset_sort();

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -87,6 +87,12 @@ impl App {
         );
     }
 
+    pub(super) fn drop_owner_scope(&mut self) {
+        if self.owner.take().is_some() {
+            self.scope_label = None;
+        }
+    }
+
     pub(super) fn drill_into_cronjob_jobs(&mut self, obj: &DynamicObject) {
         let Some(jobs) = self.cluster.resolve("jobs") else {
             self.flash_warn("jobs kind unavailable");

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -765,6 +765,7 @@ impl App {
         self.kind_plural.clear();
         self.labels = None;
         self.fields = None;
+        self.owner = None;
         self.scope_label = None;
         self.filter.clear();
         // The old cluster's namespaces don't apply here — drop them so palette

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -444,6 +444,7 @@ impl App {
 
     pub(super) fn set_namespace(&mut self, sel: String) {
         self.namespace = normalize_ns(&sel);
+        self.drop_owner_scope();
         self.note_recent_namespace(&sel);
         self.remember_namespace();
         self.set_flash(format!("namespace: {}", self.namespace_label()));

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -310,6 +310,11 @@ impl App {
             {
                 continue;
             }
+            if let Some(owner) = &self.owner
+                && !owner.owns(o)
+            {
+                continue;
+            }
             if !self.matches_filter_cached(o, k, &parsed, cells) {
                 continue;
             }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -29,7 +29,11 @@ impl App {
         let mut cache = self.rows_cache.borrow_mut();
         cache.cells.remove(key);
         cache.sort_keys.remove(key);
-        if !self.filter.is_empty() || self.sort_column.is_some() || self.kind_plural == "helm" {
+        if !self.filter.is_empty()
+            || self.sort_column.is_some()
+            || self.owner.is_some()
+            || self.kind_plural == "helm"
+        {
             cache.dirty = true;
         }
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2198,6 +2198,122 @@ async fn configured_drill_wins_over_node_on_enter_but_o_still_jumps() {
 }
 
 #[tokio::test]
+async fn cronjob_enter_drills_into_owned_jobs() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("cronjobs");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "batch/v1", "kind": "CronJob",
+            "metadata": {"name": "backup", "namespace": "ops", "uid": "cj-1"},
+            "spec": {"schedule": "* * * * *", "jobTemplate": {"spec": {}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "jobs");
+    assert_eq!(app.namespace, "ops");
+    assert_eq!(app.labels, None);
+    assert_eq!(app.fields, None);
+    assert_eq!(app.scope_label.as_deref(), Some("cronjob/backup"));
+    assert_eq!(
+        app.owner,
+        Some(OwnerScope {
+            kind: "CronJob".into(),
+            name: "backup".into(),
+            uid: Some("cj-1".into()),
+        })
+    );
+    assert_eq!(app.stack.len(), 1);
+
+    let job = |name: &str, owners: serde_json::Value| {
+        json!({
+            "apiVersion": "batch/v1", "kind": "Job",
+            "metadata": {"name": name, "namespace": "ops", "ownerReferences": owners},
+            "spec": {}
+        })
+    };
+    let owned_by = |kind: &str, name: &str, uid: &str| json!([{"apiVersion": "batch/v1", "kind": kind, "name": name, "uid": uid}]);
+    apply(
+        &mut app,
+        job("backup-28900000", owned_by("CronJob", "backup", "cj-1")),
+    );
+    apply(&mut app, job("backup-manual-abc", json!([])));
+    apply(
+        &mut app,
+        job("backup-28900001", owned_by("CronJob", "backup", "cj-old")),
+    );
+    apply(
+        &mut app,
+        job(
+            "backup-full-28900000",
+            owned_by("CronJob", "backup-full", "cj-2"),
+        ),
+    );
+    apply(&mut app, job("backups", json!([])));
+    apply(&mut app, job("cleanup-1", json!([])));
+
+    assert_eq!(
+        row_names(&app),
+        vec!["backup-28900000", "backup-manual-abc"]
+    );
+
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "cronjobs");
+    assert_eq!(app.owner, None);
+    assert!(app.stack.is_empty());
+}
+
+#[tokio::test]
+async fn cronjob_jobs_then_job_drills_into_pods_and_pops_back() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("cronjobs");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "batch/v1", "kind": "CronJob",
+            "metadata": {"name": "backup", "namespace": "ops"},
+            "spec": {"schedule": "* * * * *", "jobTemplate": {"spec": {}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "jobs");
+
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "batch/v1", "kind": "Job",
+            "metadata": {
+                "name": "backup-1", "namespace": "ops",
+                "ownerReferences": [{"apiVersion": "batch/v1", "kind": "CronJob", "name": "backup", "uid": "x"}]
+            },
+            "spec": {"selector": {"matchLabels": {"batch.kubernetes.io/controller-uid": "j1"}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.owner, None);
+    assert_eq!(
+        app.labels.as_deref(),
+        Some("batch.kubernetes.io/controller-uid=j1")
+    );
+    assert_eq!(app.scope_label.as_deref(), Some("job/backup-1"));
+    assert_eq!(app.stack.len(), 2);
+
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "jobs");
+    assert_eq!(app.scope_label.as_deref(), Some("cronjob/backup"));
+    assert!(app.owner.is_some());
+
+    app.switch_kind("jobs");
+    assert_eq!(app.owner, None);
+    assert!(app.stack.is_empty());
+}
+
+#[tokio::test]
 async fn root_switch_clears_drill_stack() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2266,6 +2266,90 @@ async fn cronjob_enter_drills_into_owned_jobs() {
 }
 
 #[tokio::test]
+async fn cronjob_jobs_owner_change_drops_the_row() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("cronjobs");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "batch/v1", "kind": "CronJob",
+            "metadata": {"name": "backup", "namespace": "ops", "uid": "cj-1"},
+            "spec": {"schedule": "* * * * *", "jobTemplate": {"spec": {}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "jobs");
+
+    let job = |owner: &str, rv: &str| {
+        json!({
+            "apiVersion": "batch/v1", "kind": "Job",
+            "metadata": {
+                "name": "run-1", "namespace": "ops", "resourceVersion": rv,
+                "ownerReferences": [{"apiVersion": "batch/v1", "kind": "CronJob", "name": owner, "uid": "cj-1"}]
+            },
+            "spec": {}
+        })
+    };
+    apply(&mut app, job("backup", "1"));
+    assert_eq!(row_names(&app), vec!["run-1"]);
+
+    apply(&mut app, job("other", "2"));
+    assert!(row_names(&app).is_empty());
+
+    apply(&mut app, job("backup", "3"));
+    assert_eq!(row_names(&app), vec!["run-1"]);
+}
+
+#[tokio::test]
+async fn namespace_switch_drops_the_cronjob_owner_scope() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("cronjobs");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "batch/v1", "kind": "CronJob",
+            "metadata": {"name": "backup", "namespace": "ops"},
+            "spec": {"schedule": "* * * * *", "jobTemplate": {"spec": {}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.owner.is_some());
+
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    assert_eq!(app.kind_plural, "jobs");
+    assert!(app.all_namespaces());
+    assert_eq!(app.owner, None);
+    assert_eq!(app.scope_label, None);
+    apply(
+        &mut app,
+        json!({"apiVersion": "batch/v1", "kind": "Job",
+               "metadata": {"name": "unrelated", "namespace": "other"}, "spec": {}}),
+    );
+    assert_eq!(row_names(&app), vec!["unrelated"]);
+
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "cronjobs");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "batch/v1", "kind": "CronJob",
+            "metadata": {"name": "backup", "namespace": "ops"},
+            "spec": {"schedule": "* * * * *", "jobTemplate": {"spec": {}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.owner.is_some());
+
+    app.set_namespace("other".into());
+    assert_eq!(app.namespace, "other");
+    assert_eq!(app.owner, None);
+    assert_eq!(app.scope_label, None);
+}
+
+#[tokio::test]
 async fn cronjob_jobs_then_job_drills_into_pods_and_pops_back() {
     let (mut app, _rx) = test_app();
     app.switch_kind("cronjobs");

--- a/src/views.rs
+++ b/src/views.rs
@@ -133,6 +133,7 @@ pub const BUILTIN_DRILLS: &[&str] = &[
     "daemonsets",
     "replicasets",
     "jobs",
+    "cronjobs",
     "services",
     "pods",
     "customresourcedefinitions",


### PR DESCRIPTION
Closes #209

## What

`enter` on a CronJob row now pushes a Jobs view scoped to that CronJob, with the same breadcrumb / `esc` / `[` `]` behaviour as the other drill-downs. From there `enter` on a Job drills into its pods as before:

```
CronJob/foo  →  Jobs owned by foo  →  pods of that Job
```

## Why it's client-side

Jobs can't be narrowed to a CronJob on the server: `ownerReferences` isn't a field selector and the CronJob controller sets no owner label. So the drill starts a plain Jobs watch for the CronJob's namespace and filters rows in the row cache with an owner scope carried in the breadcrumb frame. Matching follows the order suggested in the issue:

1. a Job whose `ownerReferences` names kind `CronJob` with the same name (uid-checked when both sides have one)
2. fallback for Jobs with no owner references at all: name prefixed with `<cronjob>-`

Jobs owned by a different CronJob, or with an unrelated name, are hidden. Every other view switch (root `:jobs`, other drills, `shift-j`, context switch, history replay) clears the scope so it can't leak.

`cronjobs` joins `BUILTIN_DRILLS`, so a `[views."…"].drill` configured on it gets the existing "ignored" warning.

## Not included

The optional follow-up from the issue (jump into the Jobs view after a successful `t` trigger) is left out. It needs a new message from the async create task and switches the view under the user asynchronously, so it deserves its own discussion.

## Docs note

The pre-commit `oxfmt` hook re-flowed the whole `docs/keys.md` table. Upstream's file isn't stable under the formatter either (the `t` row is wider than the column), so any commit touching that file gets the same reflow. Happy to drop that hunk if you'd rather keep the hand alignment.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`: clean, 595 passed
- New tests: `cronjob_enter_drills_into_owned_jobs` (owner match, uid mismatch, prefix fallback, unrelated names, `esc` restores) and `cronjob_jobs_then_job_drills_into_pods_and_pops_back`
