### PR TITLE
fix: restore navigation after explain evidence

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -27,7 +27,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `pulse`, `xray`, `explain`, `timeline`, `gitops`, `can-i`, `journal`, `debug`,
   `debug-clean`, `bundle`, `bundle-save`, `snapshot`, `snapshots`, `diff`,
   `events`, `pf`, `notify`, `find`, `vlogs`, `rightsize`, `fleet`, `skin`,
-  `reload`, `config`, `info`).
+  `reload`, `config`, `info`). `:` and `?` open the palette and help from every
+  navigation screen, then close back to the screen where they were opened.
 - **Filtering** (`/`) with matched-character highlighting: fuzzy text, `!text`
   inverse match, `-l`/`-f` label and field selectors (evaluated server-side on
   ⏎), and typed column comparisons (`status=CrashLoopBackOff`, `cpu>500m`,
@@ -86,7 +87,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   conditions, blocking pods and their container failure reasons
   (ImagePullBackOff, CrashLoopBackOff, OOMKilled, unschedulable, failed probes),
   and recent Warning events. No AI, no external service. `⏎`, `E`, or `l` jumps
-  from a finding to the pod, its events, or its logs.
+  from a finding to the pod, its events, or its logs. After opening evidence,
+  `esc` returns to Explain before another `esc` returns to the table.
 - **Session-local timeline** (`T` / `:timeline`) - a per-object timestamped log
   of every state change the watch saw: generation bumps, replica and readiness
   changes, pod phase, restarts, waiting reasons, condition flips. Computed from

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,7 +1,9 @@
 # Key reference
 
 The full keymap. `?` inside sofka shows the same thing, including your own
-plugin, bookmark, and workspace chords.
+plugin, bookmark, and workspace chords. `:` and `?` work from every navigation
+screen; closing either returns to the screen where it was opened. Text-entry
+pickers keep both characters available as input.
 
 ## Table views
 
@@ -79,8 +81,9 @@ the document. `esc` backs out - the first press clears an active search. In the
 ## Explain view (`X`)
 
 `j` / `k` move, `⏎` goes to the resource behind a finding (a blocking pod), `E`
-its events, `l` its logs, `r` gathers again, `esc` goes back. A finding you can
-drill into has a trailing `→`.
+its events, `l` its logs, `r` gathers again, `esc` goes back. After opening
+logs or events, one `esc` returns to Explain and another returns to the table. A
+finding you can drill into has a trailing `→`.
 
 ## Text inputs (palette, filters, prompts)
 

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -20,6 +20,7 @@ impl App {
             return;
         };
         self.set_return_mode();
+        self.explain_return = self.return_mode;
         let name = obj.metadata.name.clone().unwrap_or_default();
         self.explain_title = format!("{name} — explain");
         self.explain_items.clear();
@@ -114,8 +115,10 @@ impl App {
         let len = self.explain_items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.mode = self.return_mode;
-                if self.return_mode == Mode::Table {
+                let destination = self.explain_return;
+                self.mode = destination;
+                self.explain_return = Mode::Table;
+                if destination == Mode::Table {
                     self.restore_selection();
                 }
             }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -60,6 +60,25 @@ impl App {
             return Ok(());
         }
 
+        // Navigation screens share the command-palette and help bindings.
+        // Text-entry pickers deliberately stay out of this path so `:` and `?`
+        // remain ordinary input while filtering or filling a prompt.
+        let plain = !key.modifiers.contains(KeyModifiers::CONTROL)
+            && !key.modifiers.contains(KeyModifiers::ALT);
+        if plain && self.has_global_view_shortcuts() {
+            match key.code {
+                KeyCode::Char(':') => {
+                    self.open_palette();
+                    return Ok(());
+                }
+                KeyCode::Char('?') if self.mode != Mode::Help => {
+                    self.open_help();
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+
         match self.mode {
             Mode::Table => self.key_table(key),
             Mode::Command => self.key_command(key),
@@ -93,9 +112,40 @@ impl App {
         Ok(())
     }
 
+    fn has_global_view_shortcuts(&self) -> bool {
+        matches!(
+            self.mode,
+            Mode::Table
+                | Mode::Detail
+                | Mode::Logs
+                | Mode::Help
+                | Mode::Containers
+                | Mode::Confirm
+                | Mode::Pulse
+                | Mode::Xray
+                | Mode::Explain
+                | Mode::Timeline
+                | Mode::Gitops
+                | Mode::Diff
+                | Mode::Events
+                | Mode::FluxMenu
+                | Mode::TransferMenu
+                | Mode::PortForwards
+                | Mode::Skins
+                | Mode::Snapshots
+                | Mode::Fleet
+                | Mode::Find
+        )
+    }
+
+    fn open_help(&mut self) {
+        self.help_return = self.mode;
+        self.help_filter.clear();
+        self.mode = Mode::Help;
+    }
+
     pub(super) fn key_table(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Char(':') => self.open_palette(),
             KeyCode::Char('/') => self.mode = Mode::Filter,
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Esc => {
@@ -224,10 +274,6 @@ impl App {
                 } else {
                     self.request_flux_menu();
                 }
-            }
-            KeyCode::Char('?') => {
-                self.help_filter.clear();
-                self.mode = Mode::Help;
             }
             // User-defined bindings fall through here (built-ins take
             // priority): bookmarks first, then plugins. Any unhandled key — a
@@ -968,9 +1014,6 @@ impl App {
                 self.doc_filter_return = self.mode;
                 self.mode = Mode::DocFilter;
             }
-            // The command palette works from document views too — switching
-            // away doesn't require backing out to the table first.
-            KeyCode::Char(':') => self.open_palette(),
             // Jump to the next / previous search match (vim `n`/`N`). No-op
             // when no search is active.
             KeyCode::Char('n') if detail => target.step_match(true),
@@ -1016,11 +1059,6 @@ impl App {
             return;
         }
         match key.code {
-            // The command palette works from the logs view too.
-            KeyCode::Char(':') => {
-                self.open_palette();
-                return;
-            }
             // k9s: `s` toggles autoscroll/follow (we also accept `f`).
             KeyCode::Char('s') | KeyCode::Char('f') => {
                 self.logs.follow = !self.logs.follow;
@@ -1202,7 +1240,10 @@ impl App {
         match key.code {
             // Esc backs out of an active search first, then closes help.
             KeyCode::Esc if !self.help_filter.is_empty() => self.help_filter.clear(),
-            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.mode = Mode::Table,
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
+                self.mode = self.help_return;
+                self.help_return = Mode::Table;
+            }
             KeyCode::Char('/') => {
                 self.doc_filter_return = self.mode;
                 self.mode = Mode::DocFilter;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -552,12 +552,19 @@ impl App {
         self.mode = Mode::Table;
         self.command.clear();
         // Dispatch leaves the view the palette was opened from behind,
-        // so run the cleanup its own esc path would have done.
-        match self.palette_return {
+        // so run the cleanup its own esc path would have done. Help can sit
+        // between the palette and that view, so unwrap its return destination.
+        let source = if self.palette_return == Mode::Help {
+            self.help_return
+        } else {
+            self.palette_return
+        };
+        match source {
             Mode::Logs => self.stop_log_stream(),
             Mode::Events => self.stop_event_stream(),
             _ => {}
         }
+        self.help_return = Mode::Table;
         self.palette_return = Mode::Table;
         // `:kind namespace` switches both at once (`:deploy social`,
         // `:cephclusters all`); only the first word selects the kind.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1303,13 +1303,14 @@ pub struct App {
     /// Search query for the help view (`?`), which has no backing
     /// [`Scrollable`] — its lines are built at render time.
     pub help_filter: String,
+    /// Which view help was opened from, so closing it returns to that view.
+    pub help_return: Mode,
     /// Which doc view (`Detail`/`Diff`/`Events`/`Help`) the `/` search prompt
     /// was opened from, so the renderer keeps drawing it underneath and
     /// enter/esc return to it.
     pub doc_filter_return: Mode,
-    /// Which view the `:` command palette was opened from (the table or a
-    /// document view — detail/diff/events/logs), so esc returns there and the
-    /// renderer keeps drawing it underneath the suggestion popup.
+    /// Which navigation view the `:` command palette was opened from, so esc
+    /// returns there and the renderer keeps drawing it underneath the popup.
     pub palette_return: Mode,
     pub logs: LogsView,
 
@@ -1504,6 +1505,9 @@ pub struct App {
     pub explain_title: String,
     /// The object the explain view is investigating, kept so `r` can re-gather.
     pub explain_source: Option<DynamicObject>,
+    /// Parent of the explain view. Kept separately because an evidence view
+    /// (logs/events) temporarily uses `return_mode` to return to Explain.
+    explain_return: Mode,
     /// GitOps view: the reconciliation-chain findings, cursor, title, and the
     /// object being investigated (kept so `r` can re-gather).
     pub gitops_items: Vec<crate::explain::Finding>,
@@ -1635,6 +1639,7 @@ impl App {
             last_action_error: None,
             detail: Scrollable::empty(),
             help_filter: String::new(),
+            help_return: Mode::Table,
             doc_filter_return: Mode::Detail,
             palette_return: Mode::Table,
             logs: LogsView::default(),
@@ -1724,6 +1729,7 @@ impl App {
             explain_state: ListState::default(),
             explain_title: String::new(),
             explain_source: None,
+            explain_return: Mode::Table,
             gitops_items: Vec::new(),
             gitops_state: ListState::default(),
             gitops_title: String::new(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1035,6 +1035,44 @@ async fn navigation_views_share_palette_and_help_shortcuts() {
 }
 
 #[tokio::test]
+async fn palette_from_help_cleans_up_the_underlying_stream() {
+    for source in [Mode::Logs, Mode::Events] {
+        let (mut app, _rx) = test_app();
+        let log_gen = app.log_gen;
+        let event_gen = app.event_gen;
+        match source {
+            Mode::Logs => app.log_tasks.push(tokio::spawn(std::future::pending())),
+            Mode::Events => {
+                app.event_task = Some(tokio::spawn(std::future::pending()));
+            }
+            _ => unreachable!(),
+        }
+        app.mode = source;
+
+        app.handle_key(press(KeyCode::Char('?'))).unwrap();
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for c in "skin".chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+
+        assert_eq!(app.mode, Mode::Skins);
+        assert_eq!(app.help_return, Mode::Table);
+        match source {
+            Mode::Logs => {
+                assert!(app.log_tasks.is_empty());
+                assert_eq!(app.log_gen, log_gen + 1);
+            }
+            Mode::Events => {
+                assert!(app.event_task.is_none());
+                assert_eq!(app.event_gen, event_gen + 1);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[tokio::test]
 async fn explain_evidence_escape_walks_back_to_the_table() {
     for (key, evidence_mode) in [('l', Mode::Logs), ('E', Mode::Events)] {
         let (mut app, _rx) = test_app();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -979,6 +979,91 @@ async fn palette_opens_from_document_views() {
 }
 
 #[tokio::test]
+async fn navigation_views_share_palette_and_help_shortcuts() {
+    let (mut app, _rx) = test_app();
+
+    for source in [
+        Mode::Table,
+        Mode::Detail,
+        Mode::Logs,
+        Mode::Containers,
+        Mode::Confirm,
+        Mode::Pulse,
+        Mode::Xray,
+        Mode::Explain,
+        Mode::Timeline,
+        Mode::Gitops,
+        Mode::Diff,
+        Mode::Events,
+        Mode::FluxMenu,
+        Mode::TransferMenu,
+        Mode::PortForwards,
+        Mode::Skins,
+        Mode::Snapshots,
+        Mode::Fleet,
+        Mode::Find,
+    ] {
+        app.mode = source;
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        assert_eq!(app.mode, Mode::Command, "palette from {source:?}");
+        assert_eq!(app.palette_return, source);
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode, source, "palette return to {source:?}");
+
+        app.handle_key(press(KeyCode::Char('?'))).unwrap();
+        assert_eq!(app.mode, Mode::Help, "help from {source:?}");
+        assert_eq!(app.help_return, source);
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode, source, "help return to {source:?}");
+    }
+
+    app.mode = Mode::Help;
+    app.help_return = Mode::Explain;
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert_eq!(app.mode, Mode::Command);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Help);
+    app.handle_key(press(KeyCode::Char('?'))).unwrap();
+    assert_eq!(app.mode, Mode::Explain);
+
+    app.mode = Mode::Namespaces;
+    app.ns_filter.clear();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    app.handle_key(press(KeyCode::Char('?'))).unwrap();
+    assert_eq!(app.mode, Mode::Namespaces);
+    assert_eq!(app.ns_filter, ":?");
+}
+
+#[tokio::test]
+async fn explain_evidence_escape_walks_back_to_the_table() {
+    for (key, evidence_mode) in [('l', Mode::Logs), ('E', Mode::Events)] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "api-1", "namespace": "prod"},
+                "spec": {"containers": [{"name": "app"}]}
+            }),
+        );
+        app.table_state.select(Some(0));
+
+        app.handle_key(press(KeyCode::Char('X'))).unwrap();
+        assert_eq!(app.mode, Mode::Explain);
+        app.handle_key(press(KeyCode::Char(key))).unwrap();
+        assert_eq!(app.mode, evidence_mode);
+
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode, Mode::Explain);
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode, Mode::Table);
+        assert_eq!(app.table_state.selected(), Some(0));
+    }
+}
+
+#[tokio::test]
 async fn skin_palette_command_opens_picker() {
     let (mut app, _rx) = test_app();
     assert!(app.run_palette_command("skin"));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -153,12 +153,45 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::Fleet => draw_fleet(frame, app, chunks[1]),
         Mode::Find => draw_find(frame, app, chunks[1]),
         // While the palette is open, keep drawing the view it was opened
-        // from, so `:` from a document view doesn't flash the table.
+        // from, so a global `:` never flashes the table underneath it.
         Mode::Command => match app.palette_return {
             Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
             Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
             Mode::Detail => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
             Mode::Logs => draw_logs(frame, app, chunks[1]),
+            Mode::Help => draw_help(frame, app, chunks[1]),
+            Mode::Pulse => draw_pulse(frame, app, chunks[1]),
+            Mode::Xray => draw_xray(frame, app, chunks[1]),
+            Mode::Explain => draw_explain(frame, app, chunks[1]),
+            Mode::Gitops => draw_gitops(frame, app, chunks[1]),
+            Mode::Timeline => draw_timeline(frame, app, chunks[1]),
+            Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
+            Mode::Fleet => draw_fleet(frame, app, chunks[1]),
+            Mode::Find => draw_find(frame, app, chunks[1]),
+            Mode::Containers => {
+                draw_table(frame, app, chunks[1]);
+                draw_containers(frame, app, chunks[1]);
+            }
+            Mode::Confirm => {
+                draw_table(frame, app, chunks[1]);
+                draw_confirm(frame, app, chunks[1]);
+            }
+            Mode::FluxMenu => {
+                draw_table(frame, app, chunks[1]);
+                draw_flux_menu(frame, app, chunks[1]);
+            }
+            Mode::TransferMenu => {
+                draw_table(frame, app, chunks[1]);
+                draw_transfer_menu(frame, app, chunks[1]);
+            }
+            Mode::Skins => {
+                draw_table(frame, app, chunks[1]);
+                draw_skins(frame, app, chunks[1]);
+            }
+            Mode::Snapshots => {
+                draw_table(frame, app, chunks[1]);
+                draw_snapshots(frame, app, chunks[1]);
+            }
             _ => draw_table(frame, app, chunks[1]),
         },
         _ => draw_table(frame, app, chunks[1]),
@@ -1908,7 +1941,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(Span::styled("  Navigation", theme::title())),
         bind(
             ":<resource>",
-            "command palette — fuzzy over kinds + commands (tab/↑↓)",
+            "global command palette — fuzzy over kinds + commands (tab/↑↓)",
         ),
         bind(
             ":<res> <ns>",
@@ -2066,7 +2099,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         Line::from(""),
         bind(":q / ctrl-c", "quit"),
-        bind("?", "toggle help"),
+        bind("?", "global help — close to return to the previous screen"),
     ];
     // Config-defined plugins, with their (possibly modified) key chords.
     if !app.plugins.is_empty() {


### PR DESCRIPTION
## Summary

- preserve Explain's parent view while logs or events use the transient return path
- make `:` and `?` available across navigation views and return to the originating screen
- keep both characters usable in text-entry pickers
- update the in-app help and documentation, with regression coverage for logs and events

## Root cause

Explain used the shared transient `return_mode` for its own parent. Opening logs or events from Explain replaced that value with `Mode::Explain`, so returning from the evidence view left Explain pointing back to itself and `esc` could no longer reach the table.

## Testing

The pre-commit hook passed:

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 599 passed, 1 ignored
- `oxfmt` for the changed Markdown files

Closes #208
