### PR TITLE
fix: page through document views with ctrl-f/ctrl-b

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -164,7 +164,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   side by side. Contexts come from config or `space` in the `:ctx` switcher.
   See [Providers](providers.md#fleet-dashboard).
 - **YAML view** (`y`), **describe** (`d`, via `kubectl`), **events**
-  (`:events` / `E`, filtered by UID when available), and **diff** (`:diff`).
+  (`:events` / `E`, filtered by UID when available), and **diff** (`:diff`), with
+  `ctrl-f` / `ctrl-b` (or `PgDn` / `PgUp`) paging through each document.
 - **Diff on GitOps clusters** - `:diff` shows a unified diff of the live object
   against its `last-applied-configuration`. When that annotation is missing - as
   it is for every Flux- or Helm-managed object, which nothing ever

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -73,6 +73,7 @@ viewport.
 
 ## Document views (YAML, describe, diff, events)
 
+`ctrl-f` / `ctrl-b` page forward or back, with `PgDn` / `PgUp` as aliases.
 `/` searches like vim: the whole document stays on screen and every match is
 highlighted. `n` / `N` go to the next or previous match. `w` wraps. `c` copies
 the document. `esc` backs out - the first press clears an active search. In the

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1041,6 +1041,8 @@ impl App {
             KeyCode::Char('l') | KeyCode::Right => target.scroll_h(5),
             KeyCode::PageDown | KeyCode::Char(' ') => target.scroll_by(20),
             KeyCode::PageUp => target.scroll_by(-20),
+            KeyCode::Char('f') if key.modifiers == KeyModifiers::CONTROL => target.scroll_by(20),
+            KeyCode::Char('b') if key.modifiers == KeyModifiers::CONTROL => target.scroll_by(-20),
             KeyCode::Char('g') | KeyCode::Home => {
                 target.scroll = 0;
                 target.hscroll = 0;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -789,6 +789,38 @@ async fn ctrl_f_and_ctrl_b_page_by_the_drawn_viewport_height() {
 }
 
 #[tokio::test]
+async fn ctrl_f_and_ctrl_b_page_document_views() {
+    let (mut app, _rx) = test_app();
+    app.detail = Scrollable {
+        title: "document".into(),
+        lines: (0..100).map(|i| format!("line {i}")).collect(),
+        ..Default::default()
+    };
+
+    for mode in [Mode::Detail, Mode::Diff, Mode::Events] {
+        app.mode = mode;
+        app.detail.scroll = 0;
+
+        app.handle_key(press(KeyCode::PageDown)).unwrap();
+        assert_eq!(app.detail.scroll, 20);
+        app.handle_key(ctrl(KeyCode::Char('f'))).unwrap();
+        assert_eq!(app.detail.scroll, 40);
+        app.handle_key(press(KeyCode::PageUp)).unwrap();
+        assert_eq!(app.detail.scroll, 20);
+        app.handle_key(ctrl(KeyCode::Char('b'))).unwrap();
+        assert_eq!(app.detail.scroll, 0);
+    }
+
+    // Keep ctrl-alt-f distinct from the exact ctrl-f built-in.
+    let ctrl_alt_f = KeyEvent::new(
+        KeyCode::Char('f'),
+        KeyModifiers::CONTROL | KeyModifiers::ALT,
+    );
+    app.handle_key(ctrl_alt_f).unwrap();
+    assert_eq!(app.detail.scroll, 0);
+}
+
+#[tokio::test]
 async fn switching_kind_resets_stale_selection_to_top() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1980,7 +1980,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind("←/→", "scroll columns (NAMESPACE/NAME stay anchored)"),
         bind("esc", "go back / pop view / clear filter"),
         bind("j/k g/G", "move · top/bottom"),
-        bind("ctrl-f/ctrl-b", "page forward/back (also PgDn/PgUp)"),
+        bind(
+            "ctrl-f/ctrl-b",
+            "page tables and documents forward/back (also PgDn/PgUp)",
+        ),
         bind("S · I", "sort by column (fuzzy picker) · invert direction"),
         bind("w", "toggle wide columns (kubectl -o wide)"),
         bind(
@@ -3354,9 +3357,9 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         Mode::Detail | Mode::Events | Mode::Diff => {
             // The `x` decode binding only applies to a secret's document view.
             let hint = if app.mode == Mode::Detail && app.kind_plural == "secrets" {
-                "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  x:decode  esc:back"
+                "  j/k:scroll  ^f/^b:page  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  x:decode  esc:back"
             } else {
-                "  j/k:scroll  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  esc:back"
+                "  j/k:scroll  ^f/^b:page  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  esc:back"
             };
             Line::from(Span::styled(hint, theme::dim()))
         }


### PR DESCRIPTION
Follow-up to #200 and the request in https://github.com/nklmilojevic/sofka/issues/199#issuecomment-5549905399.

## What

- Make `ctrl-f` / `ctrl-b` page forward and back in YAML, describe, diff, and events views.
- Keep the existing `PgDn` / `PgUp` behavior as equivalent navigation.
- Update the document-view hints, help text, and key documentation.

## Why

PR #200 reserved the exact control chords only while `Mode::Table` was active. Document views already handled `PgDn` / `PgUp`, but `ctrl-f` / `ctrl-b` reached their input handler without matching a scrolling action.

The hotfix maps only the exact control chords, so combinations such as `ctrl-alt-f` remain distinct.

## Testing

- `cargo test ctrl_f_and_ctrl_b -- --nocapture`
- `just check`: formatting, clippy with warnings denied, and 601 tests passed (1 ignored)
- Lefthook pre-commit: Markdown/Rust formatting, clippy, and full tests passed
