### PR TITLE
fix: support Ubuntu 22.04 release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,9 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
@@ -76,6 +76,25 @@ jobs:
 
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Verify Linux compatibility
+        if: runner.os == 'Linux'
+        run: |
+          bin="target/${{ matrix.target }}/release/sofka"
+          "$bin" --version
+
+          max_glibc="$(
+            objdump -T "$bin" \
+              | grep -oE 'GLIBC_[0-9]+\.[0-9]+' \
+              | sort -Vu \
+              | tail -1
+          )"
+          echo "Maximum required glibc: $max_glibc"
+          if ! dpkg --compare-versions "${max_glibc#GLIBC_}" le 2.35; then
+            echo "::error::$bin requires $max_glibc;" \
+              "expected GLIBC_2.35 or older"
+            exit 1
+          fi
 
       - name: Package
         run: |
@@ -169,7 +188,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Nix
-        uses: ./.github/actions/setup-nix
+        uses: ./.github/actions/setup-nix # zizmor: ignore[self-repository]
 
       # CI no longer runs any Nix job, so this is where flake/packaging
       # breakage surfaces.


### PR DESCRIPTION
## Summary

- build x86_64 and aarch64 GNU/Linux release artifacts on Ubuntu 22.04
- run each Linux binary before packaging it
- reject release binaries requiring a glibc version newer than 2.35

## Root cause

The Linux release matrix used Ubuntu 24.04 runners. Rust's process implementation linked weak `pidfd_spawnp` and `pidfd_getpid` imports at `GLIBC_2.39`, so the resulting binaries failed in the dynamic loader on Ubuntu 22.04 before sofka could start.

Building against Ubuntu 22.04 establishes a glibc 2.35 ABI floor. Newer glibc releases retain those symbol versions, so the same GNU binaries remain compatible with newer Ubuntu releases without switching to musl.

The workflow retains its existing checked-out local Nix action syntax. Current zizmor newly recommends GitHub's self-repository syntax, while the repository's YAML validator does not yet recognize it, so the existing trusted release-tag usage is explicitly ignored.

## Validation

- `oxfmt .github/workflows/release.yaml`
- `zizmor --offline --min-confidence medium --min-severity low .github/workflows/release.yaml`
- lefthook pre-commit checks passed; Rust checks were correctly skipped for the YAML-only change

Closes #215
