### PR TITLE
fix: keep document scroll within viewport

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1047,9 +1047,7 @@ impl App {
                 target.scroll = 0;
                 target.hscroll = 0;
             }
-            KeyCode::Char('G') | KeyCode::End => {
-                target.scroll = target.lines.len().saturating_sub(1)
-            }
+            KeyCode::Char('G') | KeyCode::End => target.scroll_to_bottom(),
             // k9s: `w` toggles line wrap; folding long lines is the other way to
             // read content that runs past the right edge.
             KeyCode::Char('w') => {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1169,10 +1169,6 @@ impl App {
                 // one it replaces, which would otherwise leave a stale
                 // search-match cache behind.
                 self.detail.replace_lines(lines.into());
-                self.detail.scroll = self
-                    .detail
-                    .scroll
-                    .min(self.detail.lines.len().saturating_sub(1));
             }
             Msg::TransferDone {
                 generation,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -415,10 +415,14 @@ enum PromptKind {
 pub struct Scrollable {
     pub title: String,
     pub lines: VecDeque<String>,
-    /// Scroll offset in display rows. `usize` on purpose: a paused log buffer
-    /// (100k lines, wrapped) far exceeds `u16`; views that hand this to a
-    /// ratatui `Paragraph` clamp at the edge instead.
+    /// Vertical scroll offset. Document views count source lines; logs count
+    /// rendered display rows. `usize` on purpose: a paused wrapped log buffer
+    /// can far exceed `u16`.
     pub scroll: usize,
+    /// Last rendered document viewport. Zero height means it has not been drawn
+    /// yet, so scrolling falls back to the final source line.
+    viewport_w: usize,
+    viewport_h: usize,
     /// Horizontal scroll offset in columns, for views (`describe`, events) whose
     /// lines run past the right edge. Ignored while `wrap` is on.
     pub hscroll: usize,
@@ -638,9 +642,38 @@ impl Scrollable {
         Self::default()
     }
     pub fn scroll_by(&mut self, delta: i32) {
-        let max = self.lines.len().saturating_sub(1) as i64;
+        let max = self.max_scroll() as i64;
         self.scroll = (self.scroll as i64 + delta as i64).clamp(0, max) as usize;
     }
+
+    pub(crate) fn scroll_to_bottom(&mut self) {
+        self.scroll = self.max_scroll();
+    }
+
+    pub(crate) fn set_viewport(&mut self, width: usize, height: usize) {
+        self.viewport_w = width.max(1);
+        self.viewport_h = height;
+        self.scroll = self.scroll.min(self.max_scroll());
+    }
+
+    fn max_scroll(&self) -> usize {
+        if self.viewport_h == 0 {
+            return self.lines.len().saturating_sub(1);
+        }
+        if !self.wrap {
+            return self.lines.len().saturating_sub(self.viewport_h);
+        }
+
+        let mut rows = 0usize;
+        for (i, line) in self.lines.iter().enumerate().rev() {
+            rows = rows.saturating_add(crate::ui::wrapped_height(line, self.viewport_w));
+            if rows >= self.viewport_h {
+                return i;
+            }
+        }
+        0
+    }
+
     /// Scroll horizontally by `delta` columns, clamped to the widest line. A
     /// no-op while wrapping, since wrapped lines have no off-screen right edge.
     pub fn scroll_h(&mut self, delta: i32) {
@@ -663,6 +696,7 @@ impl Scrollable {
         if self.wrap {
             self.hscroll = 0;
         }
+        self.scroll = self.scroll.min(self.max_scroll());
         self.wrap
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -415,18 +415,16 @@ enum PromptKind {
 pub struct Scrollable {
     pub title: String,
     pub lines: VecDeque<String>,
-    /// Vertical scroll offset. Document views count source lines; logs count
-    /// rendered display rows. `usize` on purpose: a paused wrapped log buffer
-    /// can far exceed `u16`.
+    /// Vertical scroll offset in rendered display rows. `usize` on purpose: a
+    /// paused wrapped log buffer can far exceed `u16`.
     pub scroll: usize,
-    /// Last rendered document viewport. Zero height means it has not been drawn
-    /// yet, so scrolling falls back to the final source line.
-    viewport_w: usize,
-    viewport_h: usize,
+    /// Cached document layout from the last draw. Logs keep their equivalent
+    /// viewport and wrapping index in [`LogsView`] instead.
+    viewport: Option<DocumentViewport>,
     /// Horizontal scroll offset in columns, for views (`describe`, events) whose
     /// lines run past the right edge. Ignored while `wrap` is on.
     pub hscroll: usize,
-    /// Word-wrap toggle. When on, long lines fold instead of being clipped, and
+    /// Line-wrap toggle. When on, long lines fold instead of being clipped, and
     /// horizontal scrolling is disabled.
     pub wrap: bool,
     /// Case-insensitive substring search (`/`), vim-style: the full document
@@ -456,6 +454,32 @@ struct MatchCache {
     revision: u64,
     line_count: usize,
     matches: Vec<usize>,
+}
+
+struct DocumentViewport {
+    width: usize,
+    height: usize,
+    wrap: bool,
+    revision: u64,
+    line_count: usize,
+    /// Cumulative display-row end for every source line.
+    ends: Vec<usize>,
+}
+
+impl DocumentViewport {
+    fn total_rows(&self) -> usize {
+        self.ends.last().copied().unwrap_or(0)
+    }
+
+    fn line_at_row(&self, row: usize) -> usize {
+        self.ends.partition_point(|&end| end <= row)
+    }
+
+    fn line_start(&self, line: usize) -> usize {
+        line.checked_sub(1)
+            .and_then(|i| self.ends.get(i).copied())
+            .unwrap_or(0)
+    }
 }
 
 /// One command-palette suggestion — a built-in command (`:ctx`, `:pulse`), a
@@ -651,27 +675,81 @@ impl Scrollable {
     }
 
     pub(crate) fn set_viewport(&mut self, width: usize, height: usize) {
-        self.viewport_w = width.max(1);
-        self.viewport_h = height;
+        let width = width.max(1);
+        let stale = self.viewport.as_ref().is_none_or(|viewport| {
+            viewport.width != width
+                || viewport.wrap != self.wrap
+                || viewport.revision != self.revision
+                || viewport.line_count != self.lines.len()
+        });
+        if stale {
+            let mut rows = 0usize;
+            let ends = self
+                .lines
+                .iter()
+                .map(|line| {
+                    let line_rows = if self.wrap {
+                        crate::ui::wrapped_height(line, width)
+                    } else {
+                        1
+                    };
+                    rows = rows.saturating_add(line_rows);
+                    rows
+                })
+                .collect();
+            self.viewport = Some(DocumentViewport {
+                width,
+                height,
+                wrap: self.wrap,
+                revision: self.revision,
+                line_count: self.lines.len(),
+                ends,
+            });
+        } else if let Some(viewport) = self.viewport.as_mut() {
+            viewport.height = height;
+        }
         self.scroll = self.scroll.min(self.max_scroll());
     }
 
-    fn max_scroll(&self) -> usize {
-        if self.viewport_h == 0 {
-            return self.lines.len().saturating_sub(1);
-        }
-        if !self.wrap {
-            return self.lines.len().saturating_sub(self.viewport_h);
+    pub(crate) fn visible_source_window(&self) -> (usize, usize, usize) {
+        let Some(viewport) = self.viewport.as_ref() else {
+            let start = self.scroll.min(self.lines.len());
+            return (start, self.lines.len(), 0);
+        };
+        if viewport.height == 0 {
+            return (0, 0, 0);
         }
 
-        let mut rows = 0usize;
-        for (i, line) in self.lines.iter().enumerate().rev() {
-            rows = rows.saturating_add(crate::ui::wrapped_height(line, self.viewport_w));
-            if rows >= self.viewport_h {
-                return i;
-            }
-        }
-        0
+        let start = viewport.line_at_row(self.scroll).min(self.lines.len());
+        let row_offset = self.scroll.saturating_sub(viewport.line_start(start));
+        let visible_end = self.scroll.saturating_add(viewport.height);
+        let end = viewport
+            .ends
+            .partition_point(|&line_end| line_end < visible_end)
+            .saturating_add(1)
+            .min(self.lines.len());
+        (start, end, row_offset)
+    }
+
+    fn max_scroll(&self) -> usize {
+        self.viewport.as_ref().map_or_else(
+            || self.lines.len().saturating_sub(1),
+            |viewport| viewport.total_rows().saturating_sub(viewport.height),
+        )
+    }
+
+    fn scroll_to_line(&mut self, line: usize) {
+        let row = self
+            .viewport
+            .as_ref()
+            .map_or(line, |viewport| viewport.line_start(line));
+        self.scroll = row.min(self.max_scroll());
+    }
+
+    fn source_line_at_scroll(&self) -> usize {
+        self.viewport
+            .as_ref()
+            .map_or(self.scroll, |viewport| viewport.line_at_row(self.scroll))
     }
 
     /// Scroll horizontally by `delta` columns, clamped to the widest line. A
@@ -689,14 +767,23 @@ impl Scrollable {
         let max = widest.saturating_sub(1) as i64;
         self.hscroll = (self.hscroll as i64 + delta as i64).clamp(0, max) as usize;
     }
-    /// Toggle word wrap. Turning it on resets the horizontal offset so the view
+    /// Toggle line wrap. Turning it on resets the horizontal offset so the view
     /// snaps back to the left margin. Returns the new state.
     pub fn toggle_wrap(&mut self) -> bool {
+        let current_line = self.source_line_at_scroll();
+        let dimensions = self
+            .viewport
+            .as_ref()
+            .map(|viewport| (viewport.width, viewport.height));
         self.wrap = !self.wrap;
         if self.wrap {
             self.hscroll = 0;
         }
-        self.scroll = self.scroll.min(self.max_scroll());
+        self.viewport = None;
+        if let Some((width, height)) = dimensions {
+            self.set_viewport(width, height);
+            self.scroll_to_line(current_line);
+        }
         self.wrap
     }
 
@@ -723,12 +810,14 @@ impl Scrollable {
     pub fn drain_front(&mut self, n: usize) {
         self.lines.drain(0..n);
         self.revision = self.revision.wrapping_add(1);
+        self.viewport = None;
     }
 
     /// Drop every line.
     pub fn clear_lines(&mut self) {
         self.lines.clear();
         self.revision = self.revision.wrapping_add(1);
+        self.viewport = None;
     }
 
     /// Replace the document, invalidating the search-match cache.
@@ -738,8 +827,18 @@ impl Scrollable {
     /// live view — a refreshed events list — where the new document can have
     /// the same line count as the old one.
     pub fn replace_lines(&mut self, lines: VecDeque<String>) {
+        let dimensions = self
+            .viewport
+            .as_ref()
+            .map(|viewport| (viewport.width, viewport.height));
         self.lines = lines;
         self.revision = self.revision.wrapping_add(1);
+        self.viewport = None;
+        if let Some((width, height)) = dimensions {
+            self.set_viewport(width, height);
+        } else {
+            self.scroll = self.scroll.min(self.max_scroll());
+        }
     }
 
     /// Line indices (0-based) containing the active search query, matched
@@ -790,9 +889,10 @@ impl Scrollable {
         if matches.is_empty() {
             return;
         }
-        let pos = matches.iter().position(|&i| i >= self.scroll).unwrap_or(0);
+        let current_line = self.source_line_at_scroll();
+        let pos = matches.iter().position(|&i| i >= current_line).unwrap_or(0);
         self.match_idx = pos;
-        self.scroll = matches[pos];
+        self.scroll_to_line(matches[pos]);
     }
 
     /// Step to the next (`forward`) or previous match, wrapping around, and
@@ -809,7 +909,7 @@ impl Scrollable {
         } else {
             (cur + n - 1) % n
         };
-        self.scroll = matches[self.match_idx];
+        self.scroll_to_line(matches[self.match_idx]);
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -857,6 +857,37 @@ async fn document_scroll_keeps_the_last_page_filled() {
     app.handle_key(press(KeyCode::Char('G'))).unwrap();
     app.handle_key(press(KeyCode::Char('j'))).unwrap();
     assert_eq!(app.detail.scroll, 0, "a short document never scrolls");
+
+    // A single source line may occupy more display rows than the viewport.
+    // Bottom navigation must reach its final wrapped rows, not stop at the
+    // source line's first row.
+    app.detail = Scrollable {
+        title: "wrapped document".into(),
+        lines: vec![format!("{}LAST", "x".repeat(18 * 19))].into(),
+        wrap: true,
+        ..Default::default()
+    };
+    let mut term = Terminal::new(TestBackend::new(20, 24)).unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    app.handle_key(press(KeyCode::Char('G'))).unwrap();
+    assert_eq!(app.detail.scroll, 7, "bottom uses wrapped display rows");
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    assert_eq!(app.detail.scroll, 7, "wrapped bottom remains clamped");
+
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let buffer = term.backend().buffer();
+    let screen = (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        screen.contains("LAST"),
+        "last wrapped row missing:\n{screen}"
+    );
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -821,6 +821,45 @@ async fn ctrl_f_and_ctrl_b_page_document_views() {
 }
 
 #[tokio::test]
+async fn document_scroll_keeps_the_last_page_filled() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Detail;
+    app.detail = Scrollable {
+        title: "document".into(),
+        lines: (0..30).map(|i| format!("line {i}")).collect(),
+        ..Default::default()
+    };
+
+    // A 24-row terminal leaves 13 content rows after the standard header,
+    // footer, prompt, and document border.
+    let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+
+    app.handle_key(press(KeyCode::Char('G'))).unwrap();
+    assert_eq!(app.detail.scroll, 17, "bottom keeps a full viewport");
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    assert_eq!(app.detail.scroll, 17, "cannot scroll past the last page");
+    app.handle_key(press(KeyCode::Char('k'))).unwrap();
+    assert_eq!(
+        app.detail.scroll, 16,
+        "up moves immediately from the bottom"
+    );
+
+    app.detail = Scrollable {
+        title: "short document".into(),
+        lines: (0..10).map(|i| format!("line {i}")).collect(),
+        ..Default::default()
+    };
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    app.handle_key(press(KeyCode::Char('G'))).unwrap();
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    assert_eq!(app.detail.scroll, 0, "a short document never scrolls");
+}
+
+#[tokio::test]
 async fn switching_kind_resets_stale_selection_to_top() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -893,6 +893,24 @@ async fn document_scroll_keeps_the_last_page_filled() {
         screen.contains("LAST"),
         "last wrapped row missing:\n{screen}"
     );
+
+    app.detail = Scrollable {
+        title: "tabbed document".into(),
+        lines: vec![format!(
+            "{}{}TABS",
+            "\t".repeat(18 * 10),
+            "x".repeat(18 * 19)
+        )]
+        .into(),
+        wrap: true,
+        ..Default::default()
+    };
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    app.handle_key(press(KeyCode::Char('G'))).unwrap();
+    assert_eq!(
+        app.detail.scroll, 7,
+        "tabs must not inflate the wrapped bottom offset"
+    );
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -859,11 +859,16 @@ async fn document_scroll_keeps_the_last_page_filled() {
     assert_eq!(app.detail.scroll, 0, "a short document never scrolls");
 
     // A single source line may occupy more display rows than the viewport.
-    // Bottom navigation must reach its final wrapped rows, not stop at the
-    // source line's first row.
+    // ANSI sequences consume zero columns in both the cached layout and the
+    // rendered rows, so they cannot hide the line's tail from navigation.
     app.detail = Scrollable {
         title: "wrapped document".into(),
-        lines: vec![format!("{}LAST", "x".repeat(18 * 19))].into(),
+        lines: vec![format!(
+            "{}{}LAST\x1b[0m",
+            "\x1b[31m".repeat(20),
+            "x".repeat(18 * 19)
+        )]
+        .into(),
         wrap: true,
         ..Default::default()
     };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -129,19 +129,19 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     match app.mode {
-        Mode::Detail => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
-        Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
-        Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
+        Mode::Detail => draw_scrollable(frame, &mut app.detail, chunks[1], theme::sky()),
+        Mode::Diff => draw_diff(frame, &mut app.detail, chunks[1]),
+        Mode::Events => draw_scrollable(frame, &mut app.detail, chunks[1], theme::peach()),
         Mode::Logs | Mode::LogFilter => draw_logs(frame, app, chunks[1]),
         // The lookback prompt opens from the logs view — keep it underneath.
         Mode::Prompt if app.prompt_over_logs() => draw_logs(frame, app, chunks[1]),
         // While typing a doc search, keep drawing the view it was opened from
         // so the matches narrow live under the prompt.
         Mode::DocFilter => match app.doc_filter_return {
-            Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
-            Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
+            Mode::Diff => draw_diff(frame, &mut app.detail, chunks[1]),
+            Mode::Events => draw_scrollable(frame, &mut app.detail, chunks[1], theme::peach()),
             Mode::Help => draw_help(frame, app, chunks[1]),
-            _ => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
+            _ => draw_scrollable(frame, &mut app.detail, chunks[1], theme::sky()),
         },
         Mode::Help => draw_help(frame, app, chunks[1]),
         Mode::Pulse => draw_pulse(frame, app, chunks[1]),
@@ -155,9 +155,9 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         // While the palette is open, keep drawing the view it was opened
         // from, so a global `:` never flashes the table underneath it.
         Mode::Command => match app.palette_return {
-            Mode::Diff => draw_diff(frame, &app.detail, chunks[1]),
-            Mode::Events => draw_scrollable(frame, &app.detail, chunks[1], theme::peach()),
-            Mode::Detail => draw_scrollable(frame, &app.detail, chunks[1], theme::sky()),
+            Mode::Diff => draw_diff(frame, &mut app.detail, chunks[1]),
+            Mode::Events => draw_scrollable(frame, &mut app.detail, chunks[1], theme::peach()),
+            Mode::Detail => draw_scrollable(frame, &mut app.detail, chunks[1], theme::sky()),
             Mode::Logs => draw_logs(frame, app, chunks[1]),
             Mode::Help => draw_help(frame, app, chunks[1]),
             Mode::Pulse => draw_pulse(frame, app, chunks[1]),
@@ -1099,12 +1099,14 @@ fn render_name_cell(app: &App, name: &str, base: Color) -> Cell<'static> {
 
 fn draw_scrollable(
     frame: &mut Frame,
-    view: &crate::app::Scrollable,
+    view: &mut crate::app::Scrollable,
     area: Rect,
     accent: ratatui::style::Color,
 ) {
+    let inner_w = area.width.saturating_sub(2) as usize;
     let inner_h = area.height.saturating_sub(2) as usize;
-    let scroll = view.scroll.min(view.lines.len().saturating_sub(1));
+    view.set_viewport(inner_w, inner_h);
+    let scroll = view.scroll;
     let (start, end) = visible_line_window(view.lines.len(), scroll, inner_h);
     let text: Vec<Line> = view
         .lines
@@ -1771,9 +1773,11 @@ fn klog_level(l: &str, level: char) -> bool {
 }
 
 /// Unified-diff view with +/- line coloring.
-fn draw_diff(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
+fn draw_diff(frame: &mut Frame, view: &mut crate::app::Scrollable, area: Rect) {
+    let inner_w = area.width.saturating_sub(2) as usize;
     let inner_h = area.height.saturating_sub(2) as usize;
-    let scroll = view.scroll.min(view.lines.len().saturating_sub(1));
+    view.set_viewport(inner_w, inner_h);
+    let scroll = view.scroll;
     let (start, end) = visible_line_window(view.lines.len(), scroll, inner_h);
     let lines: Vec<Line> = view
         .lines

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
-    Paragraph, Row, Table, Wrap,
+    Paragraph, Row, Table,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -1106,8 +1106,7 @@ fn draw_scrollable(
     let inner_w = area.width.saturating_sub(2) as usize;
     let inner_h = area.height.saturating_sub(2) as usize;
     view.set_viewport(inner_w, inner_h);
-    let scroll = view.scroll;
-    let (start, end) = visible_line_window(view.lines.len(), scroll, inner_h);
+    let (start, end, row_offset) = view.visible_source_window();
     let text: Vec<Line> = view
         .lines
         .iter()
@@ -1115,20 +1114,39 @@ fn draw_scrollable(
         .take(end - start)
         .map(|l| highlight_matches(Line::from(highlight_yaml(l)), &view.filter))
         .collect();
+    let text = if view.wrap {
+        visible_wrapped_rows(text, inner_w, row_offset, inner_h)
+    } else {
+        text
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(accent))
         .title(Span::styled(doc_title(view), theme::title()));
     let p = Paragraph::new(text).block(block);
-    // Wrap folds long lines; otherwise honor the horizontal offset so content
-    // past the right edge can be scrolled into view.
+    // Wrapped lines are already sliced to the exact visible display rows;
+    // otherwise honor the horizontal offset for content past the right edge.
     let p = if view.wrap {
-        p.wrap(Wrap { trim: false })
+        p
     } else {
         p.scroll((0, view.hscroll.min(u16::MAX as usize) as u16))
     };
     frame.render_widget(p, area);
+}
+
+fn visible_wrapped_rows(
+    lines: Vec<Line<'static>>,
+    width: usize,
+    row_offset: usize,
+    height: usize,
+) -> Vec<Line<'static>> {
+    lines
+        .into_iter()
+        .flat_map(|line| wrap_line(line, width))
+        .skip(row_offset)
+        .take(height)
+        .collect()
 }
 
 /// Logs view with optional substring filter + match highlighting.
@@ -1777,8 +1795,7 @@ fn draw_diff(frame: &mut Frame, view: &mut crate::app::Scrollable, area: Rect) {
     let inner_w = area.width.saturating_sub(2) as usize;
     let inner_h = area.height.saturating_sub(2) as usize;
     view.set_viewport(inner_w, inner_h);
-    let scroll = view.scroll;
-    let (start, end) = visible_line_window(view.lines.len(), scroll, inner_h);
+    let (start, end, row_offset) = view.visible_source_window();
     let lines: Vec<Line> = view
         .lines
         .iter()
@@ -1794,6 +1811,11 @@ fn draw_diff(frame: &mut Frame, view: &mut crate::app::Scrollable, area: Rect) {
             highlight_matches(line, &view.filter)
         })
         .collect();
+    let lines = if view.wrap {
+        visible_wrapped_rows(lines, inner_w, row_offset, inner_h)
+    } else {
+        lines
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -1801,17 +1823,11 @@ fn draw_diff(frame: &mut Frame, view: &mut crate::app::Scrollable, area: Rect) {
         .title(Span::styled(doc_title(view), theme::title()));
     let p = Paragraph::new(lines).block(block);
     let p = if view.wrap {
-        p.wrap(Wrap { trim: false })
+        p
     } else {
         p.scroll((0, view.hscroll.min(u16::MAX as usize) as u16))
     };
     frame.render_widget(p, area);
-}
-
-fn visible_line_window(len: usize, scroll: usize, height: usize) -> (usize, usize) {
-    let start = scroll.min(len);
-    let end = start.saturating_add(height).min(len);
-    (start, end)
 }
 
 /// Doc-view title, extended with the active search query and the current
@@ -3752,14 +3768,6 @@ mod tests {
         assert_eq!(wrapped_height("五五五五五五", 10), 2);
         // ANSI escapes don't consume columns.
         assert_eq!(wrapped_height("\x1b[31maaaaaaaaaa\x1b[0m", 10), 1);
-    }
-
-    #[test]
-    fn visible_line_window_clamps_to_viewport() {
-        assert_eq!(visible_line_window(100, 10, 20), (10, 30));
-        assert_eq!(visible_line_window(100, 95, 20), (95, 100));
-        assert_eq!(visible_line_window(100, 150, 20), (100, 100));
-        assert_eq!(visible_line_window(100, 10, 0), (10, 10));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1112,7 +1112,10 @@ fn draw_scrollable(
         .iter()
         .skip(start)
         .take(end - start)
-        .map(|l| highlight_matches(Line::from(highlight_yaml(l)), &view.filter))
+        .map(|l| {
+            let line = strip_ansi_if_present(l);
+            highlight_matches(Line::from(highlight_yaml(&line)), &view.filter)
+        })
         .collect();
     let text = if view.wrap {
         visible_wrapped_rows(text, inner_w, row_offset, inner_h)
@@ -1575,6 +1578,14 @@ fn strip_ansi(s: &str) -> String {
     ansi_runs(s).into_iter().map(|r| r.text).collect()
 }
 
+fn strip_ansi_if_present(s: &str) -> std::borrow::Cow<'_, str> {
+    if memchr::memchr(0x1b, s.as_bytes()).is_some() {
+        std::borrow::Cow::Owned(strip_ansi(s))
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
+}
+
 /// Split a string into styled runs by parsing ANSI SGR (`\x1b[…m`) sequences,
 /// dropping the escape bytes. Non-SGR CSI sequences (cursor moves, etc.) are
 /// swallowed too. Standard 8/16 foreground colors map onto the active skin so
@@ -1802,12 +1813,13 @@ fn draw_diff(frame: &mut Frame, view: &mut crate::app::Scrollable, area: Rect) {
         .skip(start)
         .take(end - start)
         .map(|l| {
-            let color = match l.chars().next() {
+            let line = strip_ansi_if_present(l);
+            let color = match line.chars().next() {
                 Some('+') => theme::green(),
                 Some('-') => theme::red(),
                 _ => theme::overlay1(),
             };
-            let line = Line::from(Span::styled(l.clone(), Style::default().fg(color)));
+            let line = Line::from(Span::styled(line.into_owned(), Style::default().fg(color)));
             highlight_matches(line, &view.filter)
         })
         .collect();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1309,11 +1309,10 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
 /// [`wrap_line`] performs — the scroll math depends on them agreeing.
 pub(crate) fn wrapped_height(raw: &str, width: usize) -> usize {
     let width = width.max(1);
-    // Fast path: plain ASCII with no escapes wraps at exactly `width` chars.
-    // `memchr` vectorizes the escape scan (SSE2/AVX2 on x86-64, NEON on
-    // aarch64) where `<[u8]>::contains` is a scalar `iter().any()`; this runs
-    // over the whole log buffer, so the difference is not academic.
-    if raw.is_ascii() && memchr::memchr(0x1b, raw.as_bytes()).is_none() {
+    // Fast path: printable ASCII wraps at exactly `width` bytes. Control
+    // characters stay on the general path because ratatui assigns them no
+    // display width; counting a tab as one byte would drift from `wrap_line`.
+    if raw.is_ascii() && !raw.bytes().any(|b| b.is_ascii_control()) {
         return raw.len().div_ceil(width).max(1);
     }
     let mut rows = 1usize;
@@ -3748,6 +3747,8 @@ mod tests {
             "short",
             "exactly-ten",
             "a much longer plain ascii log line that wraps a few times over",
+            // Tabs and other ASCII controls are zero-width.
+            "column\tvalue\tthat wraps near a boundary",
             // ANSI escapes are zero-width.
             "\x1b[33mwarn\x1b[0m something colorful happened in the reconcile loop",
             // Wide CJK glyphs take two columns and never straddle a break.


### PR DESCRIPTION
## Summary

- clamp document scrolling to the deepest offset that still fills the viewport
- keep bottom navigation correct for both plain and wrapped document views
- cover long and shorter-than-viewport documents with a regression test

## Root cause

Document navigation used the final source line as its maximum scroll offset. That allowed `G`, repeated `j`, page navigation, and mouse scrolling to place the last line at the top of the pane, leaving the rest of the viewport empty.

The document renderer now records its viewport geometry, and navigation derives the last useful offset from that geometry.

## Testing

- `just check`
- lefthook pre-commit: Rust formatting, Clippy, and 602 tests

Closes #217
