### PR TITLE
fix: sort text values in natural order

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1156,12 +1156,65 @@ impl SortKey {
         use std::cmp::Ordering;
         match (self, other) {
             (SortKey::Num(a), SortKey::Num(b)) => a.partial_cmp(b).unwrap_or(Ordering::Equal),
-            (SortKey::Text(a), SortKey::Text(b)) => a.cmp(b),
+            (SortKey::Text(a), SortKey::Text(b)) => natural_cmp(a, b),
             // Mixed kinds shouldn't occur within one column; keep it stable.
             (SortKey::Num(_), SortKey::Text(_)) => Ordering::Less,
             (SortKey::Text(_), SortKey::Num(_)) => Ordering::Greater,
         }
     }
+}
+
+fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    let (mut ai, mut bi) = (0, 0);
+
+    while ai < a.len() && bi < b.len() {
+        if a[ai].is_ascii_digit() && b[bi].is_ascii_digit() {
+            let a_end = digit_run_end(a, ai);
+            let b_end = digit_run_end(b, bi);
+            let a_sig = significant_digits(&a[ai..a_end]);
+            let b_sig = significant_digits(&b[bi..b_end]);
+            let ord = a_sig.len().cmp(&b_sig.len()).then_with(|| a_sig.cmp(b_sig));
+            if ord != Ordering::Equal {
+                return ord;
+            }
+            ai = a_end;
+            bi = b_end;
+        } else {
+            let ord = a[ai].cmp(&b[bi]);
+            if ord != Ordering::Equal {
+                return ord;
+            }
+            ai += 1;
+            bi += 1;
+        }
+    }
+
+    match (ai == a.len(), bi == b.len()) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        (true, true) => a.len().cmp(&b.len()).then_with(|| a.cmp(b)),
+        (false, false) => unreachable!(),
+    }
+}
+
+fn digit_run_end(bytes: &[u8], start: usize) -> usize {
+    let mut end = start;
+    while end < bytes.len() && bytes[end].is_ascii_digit() {
+        end += 1;
+    }
+    end
+}
+
+fn significant_digits(digits: &[u8]) -> &[u8] {
+    let first = digits
+        .iter()
+        .position(|digit| *digit != b'0')
+        .unwrap_or(digits.len());
+    &digits[first..]
 }
 
 /// Maximum previous object revisions retained for the session diff.

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -367,7 +367,7 @@ impl App {
                 ord = ord.reverse();
             }
             // Ties always fall back to namespace/name ascending.
-            ord.then_with(|| a.1.cmp(&b.1))
+            ord.then_with(|| natural_cmp(a.1.0, b.1.0).then_with(|| natural_cmp(a.1.1, b.1.1)))
         });
         cache.keys = entries.into_iter().map(|(_, _, k)| k.clone()).collect();
         cache.dirty = false;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4823,6 +4823,58 @@ async fn sort_by_numeric_column_and_invert() {
 }
 
 #[tokio::test]
+async fn name_sort_uses_natural_numeric_segments() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for name in ["pod-10", "pod-2", "pod-11", "pod-0", "pod-9", "pod-1"] {
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": name, "namespace": "default"}
+            }),
+        );
+    }
+    let names = |app: &App| -> Vec<String> {
+        app.rows()
+            .iter()
+            .map(|object| object.metadata.name.clone().unwrap())
+            .collect()
+    };
+
+    assert_eq!(
+        names(&app),
+        ["pod-0", "pod-1", "pod-2", "pod-9", "pod-10", "pod-11"]
+    );
+
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    app.sort_picker_state.select(Some(1));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.sort_column, Some(0));
+    assert_eq!(
+        names(&app),
+        ["pod-0", "pod-1", "pod-2", "pod-9", "pod-10", "pod-11"]
+    );
+
+    app.handle_key(press(KeyCode::Char('I'))).unwrap();
+    assert_eq!(
+        names(&app),
+        ["pod-11", "pod-10", "pod-9", "pod-2", "pod-1", "pod-0"]
+    );
+}
+
+#[test]
+fn natural_comparison_handles_leading_zeroes_and_large_numbers() {
+    assert_eq!(natural_cmp("pod-2", "pod-02"), std::cmp::Ordering::Less);
+    assert_eq!(natural_cmp("pod-02a", "pod-2b"), std::cmp::Ordering::Less);
+    assert_eq!(
+        natural_cmp("pod-99999999999999999999", "pod-100000000000000000000"),
+        std::cmp::Ordering::Less
+    );
+}
+
+#[tokio::test]
 async fn sorted_order_updates_when_an_object_changes() {
     // Sort keys are cached per resourceVersion; an update must invalidate the
     // changed row's cached key (via invalidate_row) and re-sort with the new


### PR DESCRIPTION
## Summary

- compare numeric segments naturally for text sort keys, so `pod-2` sorts before `pod-10`
- apply the same ordering to the default namespace/name fallback and explicit text-column sorting
- compare digit runs without integer conversion, avoiding overflow for arbitrarily long numeric suffixes
- keep deterministic ordering for equivalent numbers with leading zeroes

## Tests

- added a key-driven regression test covering default order, sorting by `NAME`, and descending order
- added edge cases for leading zeroes and numeric segments larger than integer types
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet` — 603 passed, 1 ignored
- `cargo test --all-features --quiet` — 603 passed, 1 ignored

Closes #229
