### PR TITLE
feat: add optional Trivy integration

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -27,8 +27,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `pulse`, `xray`, `explain`, `timeline`, `gitops`, `can-i`, `journal`, `debug`,
   `debug-clean`, `bundle`, `bundle-save`, `snapshot`, `snapshots`, `diff`,
   `events`, `pf`, `notify`, `find`, `vlogs`, `rightsize`, `fleet`, `skin`,
-  `reload`, `config`, `info`). `:` and `?` open the palette and help from every
-  navigation screen, then close back to the screen where they were opened.
+  `reload`, `config`, `info`, plus `trivy` when the Trivy CLI is installed). `:`
+  and `?` open the palette and help from every navigation screen, then close
+  back to the screen where they were opened.
 - **Filtering** (`/`) with matched-character highlighting: fuzzy text, `!text`
   inverse match, `-l`/`-f` label and field selectors (evaluated server-side on
   ⏎), and typed column comparisons (`status=CrashLoopBackOff`, `cpu>500m`,
@@ -66,6 +67,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Metrics and health
 
+- **Trivy integration** (`:trivy`) - when `trivy` is executable on `PATH`, scan
+  the active context and current namespace (or all namespaces in all-namespace
+  mode) and show its parsed Kubernetes JSON report in a searchable document
+  view. Availability is checked at startup and rescanned by `:reload`. Scans use
+  one worker, disable the node collector, time out after five minutes, and cap
+  rendered reports with a visible truncation marker.
 - **Live CPU and MEM columns** for pods and nodes from the metrics API, colored
   on unusual values. Nodes also get **%CPU and %MEM of allocatable**
   (`status.allocatable` - the pool the scheduler hands out), colored by the

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -32,6 +32,7 @@ pickers keep both characters available as input.
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                                                      |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                                        |
 | `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                                                     |
+| `:trivy`                                      | run Trivy for the active context and namespace; shown only when `trivy` is executable on `PATH`                                                               |
 | `:ctx` / `:ctx <name>`                        | context switcher popup (type to filter, `r` renames, `space` toggles fleet membership) / switch directly (the name tab-completes)                             |
 | `:helm`                                       | Helm releases (native storage-Secret decode): ⏎ history → values · `y` manifest · `d` notes · `r` rollback                                                    |
 | `:fleet`                                      | cross-context health dashboard (opt-in: `[fleet]` contexts or `space` in `:ctx`; `⏎` switches, `r` refreshes)                                                 |

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1408,6 +1408,10 @@ impl App {
     /// view. A reload that fails validation keeps the last known-good config
     /// active and reports the precise error (file, key, what's wrong) instead.
     pub(super) fn reload_config(&mut self) {
+        // Tool availability is independent of config validity. Always rescan
+        // first so a newly installed Trivy appears even if this config edit
+        // happens to be invalid.
+        self.rescan_trivy();
         let loader = match self.config.reload() {
             Ok(l) => l,
             Err(e) => {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -667,6 +667,7 @@ impl App {
             PaletteAction::Skin => self.open_skins(),
             PaletteAction::Helm => self.open_helm_releases(),
             PaletteAction::Notify => self.toggle_notify(),
+            PaletteAction::Trivy => self.open_trivy(),
             PaletteAction::Reload => self.reload_config(),
             PaletteAction::ConfigInfo => self.open_config_info(),
         }
@@ -736,7 +737,7 @@ impl App {
         }
         let action = PALETTE_COMMANDS
             .iter()
-            .find(|c| c.names.contains(&cmd))
+            .find(|c| c.names.contains(&cmd) && self.palette_action_available(c.action))
             .map(|c| c.action);
         match action {
             Some(a) => {
@@ -780,6 +781,9 @@ impl App {
         // Skipped for an empty query so they don't pre-empt the resource list.
         if !q.is_empty() {
             for c in PALETTE_COMMANDS {
+                if !self.palette_action_available(c.action) {
+                    continue;
+                }
                 let best = c
                     .names
                     .iter()
@@ -891,6 +895,10 @@ impl App {
         rank_completions(&mut scored, |s| s.label.as_str(), !q.is_empty());
         self.cmd_suggestions = scored.into_iter().take(100).map(|(_, s)| s).collect();
         self.cmd_sel = 0;
+    }
+
+    fn palette_action_available(&self, action: PaletteAction) -> bool {
+        !matches!(action, PaletteAction::Trivy) || self.trivy_path.is_some()
     }
 
     /// Palette completions for `:<kind> <ns>`: cached namespaces fuzzy-matched

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -266,6 +266,7 @@ impl App {
         };
         self.applied_filter_labels = filter_labels;
         self.applied_filter_fields = filter_fields;
+        self.stop_trivy();
         self.clear_progress_flash();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
@@ -782,6 +783,7 @@ impl App {
 
     pub(super) fn bump_generation(&mut self) {
         self.stop_event_stream();
+        self.stop_trivy();
         self.clear_progress_flash();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
@@ -1065,6 +1067,39 @@ impl App {
                         ),
                         true,
                     );
+                }
+            }
+            Msg::Trivy {
+                generation,
+                run,
+                claim,
+                result,
+            } if generation == self.generation && run == self.trivy_run => {
+                self.trivy_task = None;
+                match result {
+                    Ok(report) => {
+                        let summary = if report.truncated {
+                            format!(
+                                "Trivy: at least {} findings ({} critical, {} high)",
+                                report.findings, report.critical, report.high
+                            )
+                        } else {
+                            format!(
+                                "Trivy: {} findings ({} critical, {} high)",
+                                report.findings, report.critical, report.high
+                            )
+                        };
+                        self.detail = Scrollable {
+                            title: report.title,
+                            lines: report.lines.into(),
+                            ..Default::default()
+                        };
+                        self.mode = Mode::Detail;
+                        self.set_claimed_status(claim, summary, false);
+                    }
+                    Err(error) => {
+                        self.set_claimed_status(claim, format!("Trivy scan failed: {error}"), true);
+                    }
                 }
             }
             Msg::DebuggersCleaned {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -542,6 +542,7 @@ enum PaletteAction {
     Skin,
     Helm,
     Notify,
+    Trivy,
     Reload,
     ConfigInfo,
 }
@@ -610,6 +611,10 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Notify,
         names: &["notify", "bell"],
+    },
+    PaletteCommand {
+        action: PaletteAction::Trivy,
+        names: &["trivy"],
     },
     PaletteCommand {
         action: PaletteAction::Find,
@@ -1585,6 +1590,17 @@ pub struct App {
     pub forwards_cfg: Vec<crate::config::Forward>,
     /// `[notify]` delivery options (bell, desktop-notification protocol).
     pub notify_cfg: crate::config::NotifyConfig,
+    /// Resolved once at startup and on `:reload`. `None` keeps the optional
+    /// command out of both palette completion and dispatch.
+    pub trivy_path: Option<std::path::PathBuf>,
+    /// At most one scan is live. Aborting this handle drops and kills the
+    /// subprocess because the command is configured with `kill_on_drop`.
+    trivy_task: Option<JoinHandle<()>>,
+    trivy_run: u64,
+    #[cfg(test)]
+    trivy_test_path: Option<std::ffi::OsString>,
+    #[cfg(test)]
+    trivy_test_timeout: Option<Duration>,
     /// Compiled `[keys]` palette-completion bindings.
     pub palette_keys: crate::config::PaletteKeys,
 
@@ -1724,6 +1740,10 @@ pub struct App {
 impl App {
     pub fn new(cluster: Cluster, tx: Sender<Msg>) -> Self {
         let namespace = cluster.default_namespace.clone();
+        #[cfg(not(test))]
+        let trivy_path = crate::trivy::detect();
+        #[cfg(test)]
+        let trivy_path = None;
         Self {
             cluster,
             store: Store::default(),
@@ -1835,6 +1855,13 @@ impl App {
             port_forwards: Vec::new(),
             forwards_cfg: Vec::new(),
             notify_cfg: crate::config::NotifyConfig::default(),
+            trivy_path,
+            trivy_task: None,
+            trivy_run: 0,
+            #[cfg(test)]
+            trivy_test_path: None,
+            #[cfg(test)]
+            trivy_test_timeout: None,
             palette_keys: crate::config::PaletteKeys::default(),
             pf_state: ListState::default(),
             skin_list: crate::theme::BUILTIN_NAMES
@@ -1958,6 +1985,7 @@ mod rightsize;
 mod rows;
 mod snapshot;
 mod timeline;
+mod trivy;
 mod workspaces;
 
 use helpers::*;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1060,6 +1060,221 @@ async fn palette_merges_commands_with_resources() {
 }
 
 #[tokio::test]
+async fn trivy_command_is_visible_only_when_detected() {
+    let (mut app, _rx) = test_app();
+    app.trivy_path = None;
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "trivy".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    assert!(
+        app.cmd_suggestions
+            .iter()
+            .all(|suggestion| suggestion.label != "trivy")
+    );
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.trivy_task.is_none());
+
+    app.trivy_path = Some("/test/bin/trivy".into());
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "trivy".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    assert!(
+        app.cmd_suggestions.iter().any(
+            |suggestion| suggestion.kind == SuggestKind::Command && suggestion.label == "trivy"
+        )
+    );
+}
+
+#[cfg(unix)]
+fn write_fake_trivy_response(path: &std::path::Path, report: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = format!(
+        "#!/bin/sh\ncase \" $* \" in\n  *\" kubernetes --format json --report summary --quiet --disable-telemetry --skip-version-check --no-progress --parallel 1 --list-all-pkgs=false --disable-node-collector --timeout 5m --include-namespaces default test \"*) printf '%s\\n' '{report}' ;;\n  *) echo 'wrong scan arguments' >&2; exit 9 ;;\nesac\n"
+    );
+    std::fs::write(path, script).unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(unix)]
+fn write_fake_trivy(path: &std::path::Path) {
+    let report = r#"{"SchemaVersion":2,"ClusterName":"test-cluster","Findings":[{"Namespace":"default","Kind":"Deployment","Name":"web","Results":[{"Vulnerabilities":[{"VulnerabilityID":"CVE-2026-1234","PkgName":"openssl","InstalledVersion":"1.0","FixedVersion":"1.1","Title":"Example vulnerability","Severity":"CRITICAL"}],"Misconfigurations":[{"ID":"AVD-KSV-0001","Title":"Runs as root","Severity":"HIGH","Status":"FAIL"}]}]}]}"#;
+    write_fake_trivy_response(path, report);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn trivy_command_runs_and_opens_parsed_report() {
+    let dir = std::env::temp_dir().join(format!(
+        "sofka-app-trivy-run-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let executable = dir.join("trivy");
+    write_fake_trivy(&executable);
+    let (mut app, mut rx) = test_app();
+    app.trivy_path = Some(executable);
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "trivy".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("Trivy: scanning"), "{}", app.flash);
+
+    loop {
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("Trivy result timed out")
+            .expect("message channel closed");
+        let finished = matches!(&msg, Msg::Trivy { .. });
+        app.handle_msg(msg);
+        if finished {
+            break;
+        }
+    }
+    assert_eq!(app.mode, Mode::Detail);
+    assert_eq!(app.detail.title, "trivy — 2 findings");
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|line| line.contains("CRITICAL CVE-2026-1234"))
+    );
+    assert_eq!(app.flash, "Trivy: 2 findings (1 critical, 1 high)");
+
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn trivy_command_marks_an_oversized_report_as_truncated() {
+    let dir = std::env::temp_dir().join(format!(
+        "sofka-app-trivy-limit-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let executable = dir.join("trivy");
+    let vulnerabilities = (0..300)
+        .map(|index| {
+            json!({
+                "VulnerabilityID": format!("CVE-2026-{index:04}"),
+                "Severity": "HIGH"
+            })
+        })
+        .collect::<Vec<_>>();
+    let report = json!({
+        "SchemaVersion": 2,
+        "ClusterName": "test-cluster",
+        "Findings": [{
+            "Namespace": "default",
+            "Kind": "Deployment",
+            "Name": "web",
+            "Results": [{"Vulnerabilities": vulnerabilities}]
+        }]
+    })
+    .to_string();
+    write_fake_trivy_response(&executable, &report);
+    let (mut app, mut rx) = test_app();
+    app.trivy_path = Some(executable);
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "trivy".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(3), rx.recv())
+        .await
+        .expect("Trivy result timed out")
+        .expect("message channel closed");
+    app.handle_msg(msg);
+
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.title.ends_with("+ findings"));
+    assert_eq!(
+        app.detail.lines.back().map(String::as_str),
+        Some("… report truncated to protect memory")
+    );
+    assert!(app.detail.lines.len() <= 256);
+    assert!(app.flash.contains("at least"), "{}", app.flash);
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn trivy_command_times_out_a_hung_scan() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join(format!(
+        "sofka-app-trivy-hung-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let executable = dir.join("trivy");
+    std::fs::write(&executable, "#!/bin/sh\nexec sleep 60\n").unwrap();
+    std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let (mut app, mut rx) = test_app();
+    app.trivy_path = Some(executable);
+    app.trivy_test_timeout = Some(std::time::Duration::from_millis(25));
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "trivy".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(3), rx.recv())
+        .await
+        .expect("Trivy timeout result was not delivered")
+        .expect("message channel closed");
+    app.handle_msg(msg);
+
+    assert!(app.flash_err);
+    assert!(app.flash.contains("Trivy scan timed out"), "{}", app.flash);
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn reload_redetects_a_new_trivy_install_through_key_handling() {
+    let dir = std::env::temp_dir().join(format!(
+        "sofka-app-trivy-reload-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let executable = dir.join("trivy");
+    let (mut app, _rx) = test_app();
+    app.trivy_test_path = Some(dir.as_os_str().to_owned());
+    assert!(app.trivy_path.is_none());
+
+    write_fake_trivy(&executable);
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "reload".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.trivy_path.as_deref(), Some(executable.as_path()));
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "trivy".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    assert!(
+        app.cmd_suggestions
+            .iter()
+            .any(|suggestion| suggestion.label == "trivy")
+    );
+
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[tokio::test]
 async fn palette_command_dispatch() {
     let (mut app, _rx) = test_app();
     assert!(app.run_palette_command("q")); // alias for quit
@@ -3287,6 +3502,22 @@ async fn every_async_result_is_scoped_to_its_own_operation() {
     assert_eq!(app.flash, "deleting 3 pods…");
     // The results still land, only the status is scoped.
     assert_eq!(app.find_query, "foo");
+
+    app.handle_msg(Msg::Trivy {
+        generation: app.generation,
+        run: app.trivy_run,
+        claim: find,
+        result: Ok(crate::trivy::ReportView {
+            title: "trivy — 0 findings".into(),
+            lines: vec!["Summary".into()],
+            findings: 0,
+            critical: 0,
+            high: 0,
+            truncated: false,
+        }),
+    });
+    assert_eq!(app.flash, "deleting 3 pods…");
+    assert_eq!(app.detail.title, "trivy — 0 findings");
 
     app.handle_msg(Msg::TransferDone {
         generation: app.generation,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1088,15 +1088,31 @@ async fn trivy_command_is_visible_only_when_detected() {
     );
 }
 
+/// Everything `:trivy` passes before the namespace and context arguments.
 #[cfg(unix)]
-fn write_fake_trivy_response(path: &std::path::Path, report: &str) {
+const TRIVY_SCAN_ARGS: &str = "kubernetes --format json --report summary --quiet --disable-telemetry --skip-version-check --no-progress --parallel 1 --list-all-pkgs=false --disable-node-collector --timeout 5m";
+
+/// A fake Trivy that answers with `report` only for the exact argv the test
+/// expects. The match is anchored on both ends so a missing or extra trailing
+/// argument — the context among them — fails the scan instead of passing.
+#[cfg(unix)]
+fn write_fake_trivy_matching(path: &std::path::Path, expected_args: &str, report: &str) {
     use std::os::unix::fs::PermissionsExt;
 
     let script = format!(
-        "#!/bin/sh\ncase \" $* \" in\n  *\" kubernetes --format json --report summary --quiet --disable-telemetry --skip-version-check --no-progress --parallel 1 --list-all-pkgs=false --disable-node-collector --timeout 5m --include-namespaces default test \"*) printf '%s\\n' '{report}' ;;\n  *) echo 'wrong scan arguments' >&2; exit 9 ;;\nesac\n"
+        "#!/bin/sh\ncase \" $* \" in\n  \" {expected_args} \") printf '%s\\n' '{report}' ;;\n  *) echo \"wrong scan arguments: $*\" >&2; exit 9 ;;\nesac\n"
     );
     std::fs::write(path, script).unwrap();
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(unix)]
+fn write_fake_trivy_response(path: &std::path::Path, report: &str) {
+    write_fake_trivy_matching(
+        path,
+        &format!("{TRIVY_SCAN_ARGS} --include-namespaces default test"),
+        report,
+    );
 }
 
 #[cfg(unix)]
@@ -1146,6 +1162,60 @@ async fn trivy_command_runs_and_opens_parsed_report() {
             .any(|line| line.contains("CRITICAL CVE-2026-1234"))
     );
     assert_eq!(app.flash, "Trivy: 2 findings (1 critical, 1 high)");
+
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn trivy_command_omits_the_context_when_none_is_named() {
+    let dir = std::env::temp_dir().join(format!(
+        "sofka-app-trivy-nocontext-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let executable = dir.join("trivy");
+    let report = r#"{"SchemaVersion":2,"ClusterName":"test-cluster","Findings":[{"Namespace":"default","Kind":"Deployment","Name":"web","Results":[{"Misconfigurations":[{"ID":"AVD-KSV-0001","Title":"Runs as root","Severity":"HIGH","Status":"FAIL"}]}]}]}"#;
+    write_fake_trivy_matching(
+        &executable,
+        &format!("{TRIVY_SCAN_ARGS} --include-namespaces default"),
+        report,
+    );
+    let (mut app, mut rx) = test_app();
+    // In-cluster and current-context-less kubeconfigs both display as the
+    // synthetic "default"; Trivy cannot resolve that as a context name.
+    app.cluster.forget_cli_context();
+    app.cluster.context = "default".into();
+    app.trivy_path = Some(executable);
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "trivy".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("Trivy result timed out")
+            .expect("message channel closed");
+        let finished = matches!(&msg, Msg::Trivy { .. });
+        app.handle_msg(msg);
+        if finished {
+            break;
+        }
+    }
+    assert_eq!(app.mode, Mode::Detail);
+    assert_eq!(app.detail.title, "trivy — 1 findings");
+    assert!(
+        !app.detail
+            .lines
+            .iter()
+            .any(|line| line.contains("context:")),
+        "{:?}",
+        app.detail.lines
+    );
 
     std::fs::remove_dir_all(dir).unwrap();
 }

--- a/src/app/trivy.rs
+++ b/src/app/trivy.rs
@@ -13,7 +13,14 @@ impl App {
         self.trivy_run = self.trivy_run.wrapping_add(1);
         let run = self.trivy_run;
         let generation = self.generation;
-        let context = self.cluster.context.clone();
+        // The display context can be the synthetic "default" sofka shows when
+        // the kubeconfig names no current context. Only a real context name is
+        // resolvable by Trivy; without one it must infer the config itself.
+        let context = self
+            .cluster
+            .kubectl_context()
+            .unwrap_or_default()
+            .to_string();
         let namespace = self.namespace.clone();
         let claim = if namespace.is_empty() {
             self.claim_status("Trivy: scanning all namespaces…")

--- a/src/app/trivy.rs
+++ b/src/app/trivy.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+impl App {
+    pub(super) fn open_trivy(&mut self) {
+        let Some(executable) = self.trivy_path.clone() else {
+            self.flash_warn("Trivy is not installed on PATH");
+            return;
+        };
+        self.set_return_mode();
+        if let Some(task) = self.trivy_task.take() {
+            task.abort();
+        }
+        self.trivy_run = self.trivy_run.wrapping_add(1);
+        let run = self.trivy_run;
+        let generation = self.generation;
+        let context = self.cluster.context.clone();
+        let namespace = self.namespace.clone();
+        let claim = if namespace.is_empty() {
+            self.claim_status("Trivy: scanning all namespaces…")
+        } else {
+            self.claim_status(format!("Trivy: scanning {namespace}…"))
+        };
+        let tx = self.tx.clone();
+        #[cfg(test)]
+        let test_timeout = self.trivy_test_timeout;
+        self.trivy_task = Some(tokio::spawn(async move {
+            #[cfg(not(test))]
+            let result = crate::trivy::scan(executable, context, namespace).await;
+            #[cfg(test)]
+            let result = if let Some(timeout) = test_timeout {
+                crate::trivy::scan_with_timeout(executable, context, namespace, timeout).await
+            } else {
+                crate::trivy::scan(executable, context, namespace).await
+            };
+            let _ = tx
+                .send(Msg::Trivy {
+                    generation,
+                    run,
+                    claim,
+                    result,
+                })
+                .await;
+        }));
+    }
+
+    /// Refresh the optional command cache. The test-only override avoids
+    /// mutating global PATH while the unit suite runs in parallel.
+    pub(super) fn rescan_trivy(&mut self) {
+        #[cfg(test)]
+        let detected = self
+            .trivy_test_path
+            .as_deref()
+            .and_then(crate::trivy::detect_in_path);
+        #[cfg(not(test))]
+        let detected = crate::trivy::detect();
+        self.trivy_path = detected;
+    }
+
+    pub(super) fn stop_trivy(&mut self) {
+        if let Some(task) = self.trivy_task.take() {
+            task.abort();
+        }
+        self.trivy_run = self.trivy_run.wrapping_add(1);
+    }
+}

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -572,6 +572,13 @@ pub const ALIASES: &[(&str, &str)] = &[
 
 #[cfg(any(test, feature = "bench"))]
 impl Cluster {
+    /// Model a connection with no named kubeconfig context (in-cluster, or a
+    /// kubeconfig without a current-context): the display context stays
+    /// synthetic while shell-outs have no name to pin.
+    pub fn forget_cli_context(&mut self) {
+        self.cli_context = None;
+    }
+
     /// A connectionless cluster for unit tests: the client points at a dummy
     /// URL (no I/O happens until a request is actually made) and the registry
     /// is a small hand-built set of common kinds.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,5 +35,6 @@ pub mod text;
 pub mod theme;
 pub mod thresholds;
 pub mod timeline;
+pub mod trivy;
 pub mod ui;
 pub mod views;

--- a/src/store.rs
+++ b/src/store.rs
@@ -104,6 +104,13 @@ pub enum Msg {
         ok: usize,
         failed: Vec<String>,
     },
+    /// Parsed output of an optional Trivy Kubernetes scan.
+    Trivy {
+        generation: u64,
+        run: u64,
+        claim: StatusClaim,
+        result: Result<crate::trivy::ReportView, String>,
+    },
     /// Result of an off-thread `kubectl describe` (or its YAML fallback).
     Detail {
         generation: u64,

--- a/src/trivy.rs
+++ b/src/trivy.rs
@@ -1,0 +1,1008 @@
+//! Optional Trivy CLI discovery, execution, and Kubernetes report parsing.
+
+use std::ffi::OsStr;
+use std::fmt::Write as _;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+const EXECUTABLE: &str = "trivy";
+const SCAN_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const STDERR_MAX_BYTES: usize = 64 * 1024;
+const STDERR_CHUNK_BYTES: usize = 8 * 1024;
+#[cfg(not(test))]
+const REPORT_MAX_LINES: usize = 10_000;
+#[cfg(test)]
+const REPORT_MAX_LINES: usize = 256;
+#[cfg(not(test))]
+const REPORT_MAX_BYTES: usize = 4 * 1024 * 1024;
+#[cfg(test)]
+const REPORT_MAX_BYTES: usize = 64 * 1024;
+const TRUNCATION_LINE: &str = "… report truncated to protect memory";
+
+/// A report already reduced to what the document view needs.
+#[derive(Debug)]
+pub struct ReportView {
+    pub title: String,
+    pub lines: Vec<String>,
+    pub findings: usize,
+    pub critical: usize,
+    pub high: usize,
+    pub truncated: bool,
+}
+
+/// Find Trivy on the process PATH.
+pub fn detect() -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|path| detect_in_path(&path))
+}
+
+/// PATH-parameterized detection keeps reload behavior testable without
+/// mutating the process environment shared by Rust's parallel test runner.
+pub fn detect_in_path(path: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path)
+        .map(|dir| dir.join(EXECUTABLE))
+        .find(|candidate| is_executable(candidate))
+        .map(absolute)
+}
+
+fn absolute(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&path))
+            .unwrap_or(path)
+    }
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn configure_command(command: &mut tokio::process::Command, context: &str, namespace: &str) {
+    command.args([
+        "kubernetes",
+        "--format",
+        "json",
+        "--report",
+        "summary",
+        "--quiet",
+        "--disable-telemetry",
+        "--skip-version-check",
+        "--no-progress",
+        "--parallel",
+        "1",
+        "--list-all-pkgs=false",
+        "--disable-node-collector",
+        "--timeout",
+        "5m",
+    ]);
+    if !namespace.is_empty() {
+        command.arg("--include-namespaces").arg(namespace);
+    }
+    if !context.is_empty() {
+        command.arg(context);
+    }
+}
+
+/// Run Trivy with bounded output memory and a hard deadline. JSON is parsed
+/// directly from the child pipe on one blocking worker so no full document or
+/// intermediate chunk queue is allocated.
+pub async fn scan(
+    executable: PathBuf,
+    context: String,
+    namespace: String,
+) -> Result<ReportView, String> {
+    scan_with_timeout(executable, context, namespace, SCAN_TIMEOUT).await
+}
+
+pub(crate) async fn scan_with_timeout(
+    executable: PathBuf,
+    context: String,
+    namespace: String,
+    timeout: Duration,
+) -> Result<ReportView, String> {
+    tokio::time::timeout(timeout, scan_inner(executable, context, namespace))
+        .await
+        .map_err(|_| format!("Trivy scan timed out after {} seconds", timeout.as_secs()))?
+}
+
+async fn scan_inner(
+    executable: PathBuf,
+    context: String,
+    namespace: String,
+) -> Result<ReportView, String> {
+    let mut command = tokio::process::Command::new(&executable);
+    configure_command(&mut command, &context, &namespace);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to start {}: {e}", executable.display()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture Trivy stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "failed to capture Trivy stderr".to_string())?;
+
+    let runtime = tokio::runtime::Handle::current();
+    let parse_task = tokio::task::spawn_blocking(move || {
+        parse_reader(BlockingReader::new(stdout, runtime), &context, &namespace)
+    });
+    let stderr_task = tokio::spawn(read_stderr(stderr));
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("failed while waiting for Trivy: {e}"))?;
+    let stderr = stderr_task
+        .await
+        .map_err(|e| format!("Trivy error reader failed: {e}"))?
+        .unwrap_or_default();
+    let parsed = parse_task
+        .await
+        .map_err(|e| format!("Trivy JSON parser failed: {e}"))?;
+
+    if !status.success() {
+        let detail = first_line(&stderr).unwrap_or("no error output");
+        return Err(format!("Trivy exited {status}: {detail}"));
+    }
+    parsed
+}
+
+async fn read_stderr(mut stderr: tokio::process::ChildStderr) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let mut chunk = [0; STDERR_CHUNK_BYTES];
+    loop {
+        let read = stderr.read(&mut chunk).await?;
+        if read == 0 {
+            return Ok(bytes);
+        }
+        let keep = read.min(STDERR_MAX_BYTES.saturating_sub(bytes.len()));
+        bytes.extend_from_slice(&chunk[..keep]);
+    }
+}
+
+fn first_line(bytes: &[u8]) -> Option<&str> {
+    std::str::from_utf8(bytes)
+        .ok()?
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+}
+
+struct BlockingReader<R> {
+    inner: R,
+    runtime: tokio::runtime::Handle,
+}
+
+impl<R> BlockingReader<R> {
+    fn new(inner: R, runtime: tokio::runtime::Handle) -> Self {
+        Self { inner, runtime }
+    }
+}
+
+impl<R: AsyncRead + Unpin> Read for BlockingReader<R> {
+    fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+        self.runtime.block_on(self.inner.read(bytes))
+    }
+}
+
+struct BoundedLines {
+    lines: Vec<String>,
+    bytes: usize,
+    max_lines: usize,
+    max_bytes: usize,
+    truncated: bool,
+}
+
+impl Default for BoundedLines {
+    fn default() -> Self {
+        Self::with_limits(REPORT_MAX_LINES, REPORT_MAX_BYTES)
+    }
+}
+
+impl BoundedLines {
+    fn with_limits(max_lines: usize, max_bytes: usize) -> Self {
+        Self {
+            lines: Vec::new(),
+            bytes: 0,
+            max_lines,
+            max_bytes,
+            truncated: false,
+        }
+    }
+
+    fn accepting(&self) -> bool {
+        !self.truncated && self.can_push(0)
+    }
+
+    fn can_push(&self, len: usize) -> bool {
+        self.lines.len() < self.max_lines.saturating_sub(1)
+            && self
+                .bytes
+                .checked_add(len)
+                .is_some_and(|bytes| bytes <= self.max_bytes.saturating_sub(TRUNCATION_LINE.len()))
+    }
+
+    fn push(&mut self, line: String) -> bool {
+        if self.truncated || !self.can_push(line.len()) {
+            self.truncated = true;
+            return false;
+        }
+        self.bytes += line.len();
+        self.lines.push(line);
+        true
+    }
+
+    fn push_static(&mut self, line: &str) -> bool {
+        if self.truncated || !self.can_push(line.len()) {
+            self.truncated = true;
+            return false;
+        }
+        self.bytes += line.len();
+        self.lines.push(line.into());
+        true
+    }
+
+    fn push_prefixed(&mut self, prefix: &str, mut value: String) -> bool {
+        let Some(len) = prefix.len().checked_add(value.len()) else {
+            self.truncated = true;
+            return false;
+        };
+        if self.truncated || !self.can_push(len) {
+            self.truncated = true;
+            return false;
+        }
+        value.reserve(prefix.len());
+        value.insert_str(0, prefix);
+        self.bytes += value.len();
+        self.lines.push(value);
+        true
+    }
+
+    fn append(&mut self, other: Self) {
+        let other_truncated = other.truncated;
+        for line in other.lines {
+            if !self.push(line) {
+                break;
+            }
+        }
+        self.truncated |= other_truncated;
+    }
+
+    fn truncate(&mut self) {
+        self.truncated = true;
+    }
+
+    fn finish(mut self) -> Vec<String> {
+        if self.truncated
+            && self.lines.len() < self.max_lines
+            && self.bytes + TRUNCATION_LINE.len() <= self.max_bytes
+        {
+            self.lines.push(TRUNCATION_LINE.into());
+        }
+        self.lines
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+enum Severity {
+    #[serde(rename = "CRITICAL")]
+    Critical,
+    #[serde(rename = "HIGH")]
+    High,
+    #[serde(rename = "MEDIUM")]
+    Medium,
+    #[serde(rename = "LOW")]
+    Low,
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+impl Severity {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Critical => "CRITICAL",
+            Self::High => "HIGH",
+            Self::Medium => "MEDIUM",
+            Self::Low => "LOW",
+            Self::Unknown => "UNKNOWN",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct Counts {
+    vulnerabilities: usize,
+    misconfigurations: usize,
+    secrets: usize,
+    errors: usize,
+    critical: usize,
+    high: usize,
+    medium: usize,
+    low: usize,
+    unknown: usize,
+}
+
+impl Counts {
+    fn record(&mut self, kind: FindingKind, severity: Severity) {
+        match kind {
+            FindingKind::Vulnerability => self.vulnerabilities += 1,
+            FindingKind::Misconfiguration => self.misconfigurations += 1,
+            FindingKind::Secret => self.secrets += 1,
+        }
+        match severity {
+            Severity::Critical => self.critical += 1,
+            Severity::High => self.high += 1,
+            Severity::Medium => self.medium += 1,
+            Severity::Low => self.low += 1,
+            Severity::Unknown => self.unknown += 1,
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.vulnerabilities += other.vulnerabilities;
+        self.misconfigurations += other.misconfigurations;
+        self.secrets += other.secrets;
+        self.errors += other.errors;
+        self.critical += other.critical;
+        self.high += other.high;
+        self.medium += other.medium;
+        self.low += other.low;
+        self.unknown += other.unknown;
+    }
+
+    fn findings(self) -> usize {
+        self.vulnerabilities + self.misconfigurations + self.secrets
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FindingKind {
+    Vulnerability,
+    Misconfiguration,
+    Secret,
+}
+
+#[derive(Deserialize)]
+struct Envelope {
+    #[serde(rename = "ClusterName", default)]
+    cluster_name: String,
+    #[serde(rename = "Findings", alias = "Resources", default)]
+    findings: RenderedFindings,
+}
+
+#[derive(Default)]
+struct RenderedFindings {
+    lines: BoundedLines,
+    counts: Counts,
+    resources: usize,
+}
+
+impl<'de> Deserialize<'de> for RenderedFindings {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FindingsVisitor;
+
+        impl<'de> Visitor<'de> for FindingsVisitor {
+            type Value = RenderedFindings;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Trivy findings array")
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+            where
+                S: SeqAccess<'de>,
+            {
+                let mut rendered = RenderedFindings::default();
+                while rendered.lines.accepting() {
+                    let Some(finding) = seq.next_element::<Finding>()? else {
+                        return Ok(rendered);
+                    };
+                    render_finding(&mut rendered, finding);
+                }
+                if seq.next_element::<IgnoredAny>()?.is_some() {
+                    rendered.lines.truncate();
+                    while seq.next_element::<IgnoredAny>()?.is_some() {}
+                }
+                Ok(rendered)
+            }
+        }
+
+        deserializer.deserialize_seq(FindingsVisitor)
+    }
+}
+
+#[derive(Deserialize)]
+struct Finding {
+    #[serde(rename = "Namespace", default)]
+    namespace: String,
+    #[serde(rename = "Kind", default)]
+    kind: String,
+    #[serde(rename = "Name", default)]
+    name: String,
+    #[serde(rename = "Results", default)]
+    results: RenderedResults,
+    #[serde(rename = "Error", default)]
+    error: String,
+}
+
+#[derive(Default)]
+struct RenderedResults {
+    lines: BoundedLines,
+    counts: Counts,
+}
+
+impl<'de> Deserialize<'de> for RenderedResults {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ResultsVisitor;
+
+        impl<'de> Visitor<'de> for ResultsVisitor {
+            type Value = RenderedResults;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Trivy results array")
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+            where
+                S: SeqAccess<'de>,
+            {
+                let mut rendered = RenderedResults::default();
+                while rendered.lines.accepting() {
+                    let Some(result) = seq.next_element::<ScanResult>()? else {
+                        return Ok(rendered);
+                    };
+                    rendered.counts.merge(result.counts);
+                    rendered.lines.append(result.lines);
+                }
+                if seq.next_element::<IgnoredAny>()?.is_some() {
+                    rendered.lines.truncate();
+                    while seq.next_element::<IgnoredAny>()?.is_some() {}
+                }
+                Ok(rendered)
+            }
+        }
+
+        deserializer.deserialize_seq(ResultsVisitor)
+    }
+}
+
+struct ScanResult {
+    lines: BoundedLines,
+    counts: Counts,
+}
+
+#[derive(Deserialize)]
+#[serde(field_identifier)]
+enum ResultField {
+    #[serde(rename = "Vulnerabilities")]
+    Vulnerabilities,
+    #[serde(rename = "Misconfigurations")]
+    Misconfigurations,
+    #[serde(rename = "Secrets")]
+    Secrets,
+    #[serde(other)]
+    Other,
+}
+
+impl<'de> Deserialize<'de> for ScanResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ResultVisitor;
+
+        impl<'de> Visitor<'de> for ResultVisitor {
+            type Value = ScanResult;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Trivy result object")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut lines = BoundedLines::default();
+                let mut counts = Counts::default();
+                while let Some(field) = map.next_key()? {
+                    match field {
+                        ResultField::Vulnerabilities => {
+                            map.next_value_seed(DetectionSeed {
+                                kind: FindingKind::Vulnerability,
+                                lines: &mut lines,
+                                counts: &mut counts,
+                            })?;
+                        }
+                        ResultField::Misconfigurations => {
+                            map.next_value_seed(DetectionSeed {
+                                kind: FindingKind::Misconfiguration,
+                                lines: &mut lines,
+                                counts: &mut counts,
+                            })?;
+                        }
+                        ResultField::Secrets => {
+                            map.next_value_seed(DetectionSeed {
+                                kind: FindingKind::Secret,
+                                lines: &mut lines,
+                                counts: &mut counts,
+                            })?;
+                        }
+                        ResultField::Other => {
+                            map.next_value::<IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(ScanResult { lines, counts })
+            }
+        }
+
+        deserializer.deserialize_map(ResultVisitor)
+    }
+}
+
+struct DetectionSeed<'a> {
+    kind: FindingKind,
+    lines: &'a mut BoundedLines,
+    counts: &'a mut Counts,
+}
+
+impl<'de> DeserializeSeed<'de> for DetectionSeed<'_> {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DetectionVisitor<'a> {
+            kind: FindingKind,
+            lines: &'a mut BoundedLines,
+            counts: &'a mut Counts,
+        }
+
+        impl<'de> Visitor<'de> for DetectionVisitor<'_> {
+            type Value = ();
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Trivy detections array")
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+            where
+                S: SeqAccess<'de>,
+            {
+                while self.lines.accepting() {
+                    match self.kind {
+                        FindingKind::Vulnerability => {
+                            let Some(item) = seq.next_element::<Vulnerability>()? else {
+                                return Ok(());
+                            };
+                            self.counts.record(self.kind, item.severity);
+                            render_vulnerability(self.lines, item);
+                        }
+                        FindingKind::Misconfiguration => {
+                            let Some(item) = seq.next_element::<Misconfiguration>()? else {
+                                return Ok(());
+                            };
+                            if !item.status.eq_ignore_ascii_case("PASS") {
+                                self.counts.record(self.kind, item.severity);
+                                render_misconfiguration(self.lines, item);
+                            }
+                        }
+                        FindingKind::Secret => {
+                            let Some(item) = seq.next_element::<Secret>()? else {
+                                return Ok(());
+                            };
+                            self.counts.record(self.kind, item.severity);
+                            render_secret(self.lines, item);
+                        }
+                    }
+                }
+                if seq.next_element::<IgnoredAny>()?.is_some() {
+                    self.lines.truncate();
+                    while seq.next_element::<IgnoredAny>()?.is_some() {}
+                }
+                Ok(())
+            }
+        }
+
+        deserializer.deserialize_seq(DetectionVisitor {
+            kind: self.kind,
+            lines: self.lines,
+            counts: self.counts,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct Vulnerability {
+    #[serde(rename = "VulnerabilityID", default)]
+    id: String,
+    #[serde(rename = "PkgName", default)]
+    package: String,
+    #[serde(rename = "InstalledVersion", default)]
+    installed: String,
+    #[serde(rename = "FixedVersion", default)]
+    fixed: String,
+    #[serde(rename = "Title", default)]
+    title: String,
+    #[serde(rename = "Severity", default)]
+    severity: Severity,
+}
+
+#[derive(Deserialize)]
+struct Misconfiguration {
+    #[serde(rename = "ID", default)]
+    id: String,
+    #[serde(rename = "Title", default)]
+    title: String,
+    #[serde(rename = "Message", default)]
+    message: String,
+    #[serde(rename = "Severity", default)]
+    severity: Severity,
+    #[serde(rename = "Status", default)]
+    status: String,
+}
+
+#[derive(Deserialize)]
+struct Secret {
+    #[serde(rename = "RuleID", default)]
+    id: String,
+    #[serde(rename = "Title", default)]
+    title: String,
+    #[serde(rename = "Category", default)]
+    category: String,
+    #[serde(rename = "Severity", default)]
+    severity: Severity,
+}
+
+fn render_vulnerability(lines: &mut BoundedLines, item: Vulnerability) {
+    let mut line = format!("  [vulnerability] {} {}", item.severity.label(), item.id);
+    if !item.package.is_empty() {
+        let _ = write!(line, " · {}@{}", item.package, item.installed);
+    }
+    if !item.fixed.is_empty() {
+        let _ = write!(line, " → {}", item.fixed);
+    }
+    if !item.title.is_empty() {
+        let _ = write!(line, " — {}", item.title);
+    }
+    lines.push(line);
+}
+
+fn render_misconfiguration(lines: &mut BoundedLines, item: Misconfiguration) {
+    let mut line = format!("  [misconfiguration] {} {}", item.severity.label(), item.id);
+    if !item.title.is_empty() {
+        let _ = write!(line, " — {}", item.title);
+    } else if !item.message.is_empty() {
+        let _ = write!(line, " — {}", item.message);
+    }
+    lines.push(line);
+}
+
+fn render_secret(lines: &mut BoundedLines, item: Secret) {
+    let mut line = format!("  [secret] {} {}", item.severity.label(), item.id);
+    if !item.title.is_empty() {
+        let _ = write!(line, " — {}", item.title);
+    } else if !item.category.is_empty() {
+        let _ = write!(line, " — {}", item.category);
+    }
+    lines.push(line);
+}
+
+fn render_finding(rendered: &mut RenderedFindings, finding: Finding) {
+    let mut counts = finding.results.counts;
+    if !finding.error.is_empty() {
+        counts.errors += 1;
+    }
+    if counts.findings() == 0 && counts.errors == 0 {
+        return;
+    }
+
+    rendered.resources += 1;
+    rendered.counts.merge(counts);
+    if !rendered.lines.push_static("") {
+        return;
+    }
+    let mut heading = String::new();
+    if !finding.namespace.is_empty() {
+        let _ = write!(heading, "{} · ", finding.namespace);
+    }
+    let _ = write!(heading, "{}/{}", finding.kind, finding.name);
+    if !rendered.lines.push(heading) {
+        return;
+    }
+    if !rendered.lines.push(format!(
+        "  {} vulnerabilities · {} misconfigurations · {} secrets · C {} H {} M {} L {} U {}",
+        counts.vulnerabilities,
+        counts.misconfigurations,
+        counts.secrets,
+        counts.critical,
+        counts.high,
+        counts.medium,
+        counts.low,
+        counts.unknown
+    )) {
+        return;
+    }
+    rendered.lines.append(finding.results.lines);
+    if !finding.error.is_empty() {
+        rendered.lines.push_prefixed("  ERROR ", finding.error);
+    }
+}
+
+fn parse_reader(
+    reader: impl Read,
+    requested_context: &str,
+    requested_namespace: &str,
+) -> Result<ReportView, String> {
+    let envelope: Envelope =
+        serde_json::from_reader(reader).map_err(|e| format!("invalid JSON from Trivy: {e}"))?;
+    Ok(format_report(
+        envelope,
+        requested_context,
+        requested_namespace,
+    ))
+}
+
+fn format_report(
+    envelope: Envelope,
+    requested_context: &str,
+    requested_namespace: &str,
+) -> ReportView {
+    let findings = envelope.findings.counts.findings();
+    let critical = envelope.findings.counts.critical;
+    let high = envelope.findings.counts.high;
+    let mut lines = BoundedLines::default();
+    lines.push_static("Summary");
+    if !envelope.cluster_name.is_empty() {
+        lines.push_prefixed("  cluster:     ", envelope.cluster_name);
+    }
+    if !requested_context.is_empty() {
+        lines.push(format!("  context:     {requested_context}"));
+    }
+    lines.push(format!(
+        "  namespace:   {}",
+        if requested_namespace.is_empty() {
+            "all"
+        } else {
+            requested_namespace
+        }
+    ));
+    lines.push(format!(
+        "  resources:   {} affected",
+        envelope.findings.resources
+    ));
+    lines.push(format!("  findings:    {findings}"));
+    lines.push(format!(
+        "  severity:    critical {} · high {} · medium {} · low {} · unknown {}",
+        critical,
+        high,
+        envelope.findings.counts.medium,
+        envelope.findings.counts.low,
+        envelope.findings.counts.unknown
+    ));
+    lines.push(format!(
+        "  categories:  vulnerabilities {} · misconfigurations {} · secrets {}",
+        envelope.findings.counts.vulnerabilities,
+        envelope.findings.counts.misconfigurations,
+        envelope.findings.counts.secrets
+    ));
+    if envelope.findings.counts.errors > 0 {
+        lines.push(format!(
+            "  scan errors: {}",
+            envelope.findings.counts.errors
+        ));
+    }
+    lines.append(envelope.findings.lines);
+    if envelope.findings.resources == 0 {
+        lines.push_static("");
+        lines.push_static("No security findings were returned.");
+    }
+
+    let truncated = lines.truncated;
+    ReportView {
+        title: if truncated {
+            format!("trivy — {findings}+ findings")
+        } else {
+            format!("trivy — {findings} findings")
+        },
+        lines: lines.finish(),
+        findings,
+        critical,
+        high,
+        truncated,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_is_scoped_and_resource_conservative() {
+        let mut command = tokio::process::Command::new("trivy");
+        configure_command(&mut command, "prod", "apps");
+        assert_eq!(
+            command.as_std().get_args().collect::<Vec<_>>(),
+            [
+                "kubernetes",
+                "--format",
+                "json",
+                "--report",
+                "summary",
+                "--quiet",
+                "--disable-telemetry",
+                "--skip-version-check",
+                "--no-progress",
+                "--parallel",
+                "1",
+                "--list-all-pkgs=false",
+                "--disable-node-collector",
+                "--timeout",
+                "5m",
+                "--include-namespaces",
+                "apps",
+                "prod",
+            ]
+        );
+
+        let mut command = tokio::process::Command::new("trivy");
+        configure_command(&mut command, "", "");
+        assert!(
+            !command
+                .as_std()
+                .get_args()
+                .any(|arg| arg == "--include-namespaces")
+        );
+    }
+
+    #[test]
+    fn parses_and_formats_kubernetes_json() {
+        let json = r#"{
+            "SchemaVersion": 2,
+            "ClusterName": "prod-cluster",
+            "Findings": [{
+                "Namespace": "apps",
+                "Kind": "Deployment",
+                "Name": "web",
+                "Results": [{
+                    "Target": "nginx:1.20",
+                    "Vulnerabilities": [{
+                        "VulnerabilityID": "CVE-2026-1234",
+                        "PkgName": "openssl",
+                        "InstalledVersion": "1.0",
+                        "FixedVersion": "1.1",
+                        "Title": "Example vulnerability",
+                        "Severity": "CRITICAL"
+                    }],
+                    "Misconfigurations": [{
+                        "ID": "AVD-KSV-0001",
+                        "Title": "Runs as root",
+                        "Severity": "HIGH",
+                        "Status": "FAIL"
+                    }],
+                    "Secrets": [{
+                        "RuleID": "generic-api-key",
+                        "Title": "API key",
+                        "Severity": "MEDIUM"
+                    }]
+                }]
+            }]
+        }"#;
+        let view = parse_reader(json.as_bytes(), "prod", "apps").unwrap();
+        assert_eq!(view.findings, 3);
+        assert_eq!(view.critical, 1);
+        assert_eq!(view.high, 1);
+        assert!(!view.truncated);
+        assert_eq!(view.title, "trivy — 3 findings");
+        assert!(
+            view.lines
+                .iter()
+                .any(|line| line == "apps · Deployment/web")
+        );
+        assert!(view.lines.iter().any(|line| line.contains("CVE-2026-1234")));
+        assert!(view.lines.iter().any(|line| line.contains("AVD-KSV-0001")));
+        assert!(
+            view.lines
+                .iter()
+                .any(|line| line.contains("generic-api-key"))
+        );
+    }
+
+    #[test]
+    fn rendered_output_has_strict_line_and_byte_limits() {
+        let mut lines = BoundedLines::with_limits(3, 64);
+        assert!(lines.push_static("first"));
+        assert!(lines.push_static("second"));
+        assert!(!lines.push_static("third"));
+        let lines = lines.finish();
+        assert_eq!(lines, ["first", "second", TRUNCATION_LINE]);
+        assert!(lines.len() <= 3);
+        assert!(lines.iter().map(String::len).sum::<usize>() <= 64);
+    }
+
+    #[test]
+    fn malformed_json_is_actionable() {
+        let error = parse_reader("not json".as_bytes(), "", "").err().unwrap();
+        assert!(error.starts_with("invalid JSON from Trivy:"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn scan_timeout_stops_a_hung_process() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "sofka-trivy-timeout-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let executable = root.join("trivy");
+        std::fs::write(&executable, "#!/bin/sh\nexec sleep 60\n").unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let error = scan_with_timeout(
+            executable,
+            String::new(),
+            String::new(),
+            Duration::from_millis(25),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.starts_with("Trivy scan timed out"), "{error}");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_detection_requires_an_executable_and_honours_path_order() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "sofka-trivy-path-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let first = root.join("first");
+        let second = root.join("second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        std::fs::write(first.join("trivy"), "not executable").unwrap();
+        let executable = second.join("trivy");
+        std::fs::write(&executable, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = std::env::join_paths([&first, &second]).unwrap();
+        assert_eq!(detect_in_path(&path), Some(executable));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/trivy.rs
+++ b/src/trivy.rs
@@ -94,6 +94,7 @@ fn configure_command(command: &mut tokio::process::Command, context: &str, names
         command.arg("--include-namespaces").arg(namespace);
     }
     if !context.is_empty() {
+        // Trivy defines CONTEXT as the command's sole positional argument.
         command.arg(context);
     }
 }
@@ -848,11 +849,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn command_is_scoped_and_resource_conservative() {
+    fn command_uses_positional_context_and_namespace_flag() {
         let mut command = tokio::process::Command::new("trivy");
         configure_command(&mut command, "prod", "apps");
+        let args = command.as_std().get_args().collect::<Vec<_>>();
         assert_eq!(
-            command.as_std().get_args().collect::<Vec<_>>(),
+            args,
             [
                 "kubernetes",
                 "--format",
@@ -874,6 +876,8 @@ mod tests {
                 "prod",
             ]
         );
+        assert_eq!(args.last(), Some(&std::ffi::OsStr::new("prod")));
+        assert!(!args.contains(&std::ffi::OsStr::new("--context")));
 
         let mut command = tokio::process::Command::new("trivy");
         configure_command(&mut command, "", "");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2135,6 +2135,15 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind(":q / ctrl-c", "quit"),
         bind("?", "global help — close to return to the previous screen"),
     ];
+    if app.trivy_path.is_some() {
+        lines.insert(
+            10,
+            bind(
+                ":trivy",
+                "scan the current context and namespace (optional Trivy CLI)",
+            ),
+        );
+    }
     // Config-defined plugins, with their (possibly modified) key chords.
     if !app.plugins.is_empty() {
         lines.push(Line::from(""));


### PR DESCRIPTION
## Summary

- add `:trivy` only when Trivy is detected, with PATH rescanned by `:reload`
- scope Kubernetes scans to the active context and namespace and stream typed JSON into a searchable report
- minimize resource use with one worker, no node collector, bounded output, and a five-minute timeout

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (612 passed, 1 ignored)