### PR TITLE
ci: publish SHA256SUMS in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,8 +126,12 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Generate checksums
+        working-directory: dist
+        run: shasum -a 256 -- *.tar.gz > SHA256SUMS
+
       - name: Upload release assets
-        run: gh release upload "$RELEASE_TAG" dist/*.tar.gz --clobber
+        run: gh release upload "$RELEASE_TAG" dist/*.tar.gz dist/SHA256SUMS --clobber
 
   # Kick the tap's bump workflow so `brew install nklmilojevic/sofka/sofka`
   # picks up the new version immediately instead of waiting for the tap's


### PR DESCRIPTION
Hey there, so I wanted to pin sofka in mise and there's nothing to verify a download against, so this publishes a `SHA256SUMS` asset alongside the tarballs. That should be enough for aqua, mise and brew to verify what they fetched.

Also seems like the cheaper half of Milestone 7 ("Checksums, attestations, and SBOM") from `docs/roadmap.md`. With this file, signing is just a signature over one file instead of one per asset.

Runs inside `dist/` so the sums list bare asset names, not `dist/` paths.

Tested with a real release on my fork: https://github.com/tomvoet/sofka/releases/tag/v0.23.0 
all four tarballs verify against the published SHA256SUMS with `shasum -a 256 -c`