### PR TITLE
fix: reject stale lockfiles in dependency checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked

--- a/.just/rust.just
+++ b/.just/rust.just
@@ -17,11 +17,11 @@ fmt-check:
 
 # Run clippy with the same policy as CI.
 clippy:
-    cd "{{ root }}" && cargo clippy --all-targets -- -D warnings
+    cd "{{ root }}" && cargo clippy --locked --all-targets -- -D warnings
 
 # Run the unit test suite.
 test:
-    cd "{{ root }}" && cargo test
+    cd "{{ root }}" && cargo test --locked
 
 # Build the debug binary.
 build:

--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -13,13 +13,13 @@ stage_fixed = true
 priority = 1
 
 [pre-commit.commands.clippy]
-glob = ["*.rs"]
-run = "cargo clippy --all-targets -- -D warnings"
+glob = ["*.rs", "Cargo.toml", "Cargo.lock"]
+run = "cargo clippy --locked --all-targets -- -D warnings"
 priority = 2
 
 [pre-commit.commands.test]
-glob = ["*.rs"]
-run = "cargo test --quiet"
+glob = ["*.rs", "Cargo.toml", "Cargo.lock"]
+run = "cargo test --locked --quiet"
 priority = 3
 
 [pre-commit.commands.format-nix]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,14 +22,16 @@ Use the `Justfile`; it matches CI exactly.
 ```sh
 just check          # fmt-check + clippy (-D warnings) + cargo test
 just fmt            # cargo fmt --all
-just clippy         # cargo clippy --all-targets -- -D warnings
-just test           # cargo test
+just clippy         # cargo clippy --locked --all-targets -- -D warnings
+just test           # cargo test --locked
 just run <resource> # cargo run -- <resource> against the current kube context
 just smoke          # headless connectivity check (cargo run -- --check)
 ```
 
-CI runs `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
-and `cargo test`. All three must pass before a PR is ready.
+CI runs `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`,
+and `cargo test --locked`. All three must pass before a PR is ready.
+The locked checks reject dependency changes without a matching `Cargo.lock`
+update. Regenerate the lockfile with Cargo and commit it with the manifest change.
 
 ## Code
 


### PR DESCRIPTION
Dependency changes could pass CI without updating Cargo.lock because Clippy and tests silently regenerated it. Release builds use `--locked`, so the same commit could then fail at release time, as found in #190.

Require `--locked` for Clippy and tests in CI, the shared Just recipes, and pre-commit hooks. Also run the pre-commit checks for Cargo.toml and Cargo.lock changes, and document the lockfile requirement.

Validation:
- `just check`: formatting and Clippy passed; 601 tests passed, 1 ignored.
- Confirmed `cargo clippy --locked --offline --all-targets -- -D warnings` rejects PR #190's unchanged lockfile at commit 526ce4f.
- Pre-commit formatters and zizmor passed.
