### PR TITLE
feat: add external plugin packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Rust build artifacts
 /target
-
+.pi*
 # Nix build output symlinks
 /result
 /result-*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,17 @@ network.
 See [why it's faster](vs-k9s.md#why-its-faster) for the performance-relevant
 choices in there.
 
+## Plugin packages
+
+`plugins.rs` loads package manifests and validates input values.
+It also controls adapter processes and reads JSON reports.
+`app/plugins.rs` connects this code to commands, guardrails, and document views.
+
+Adapters receive a resource snapshot through standard input.
+The shared runner serializes that snapshot outside the UI thread.
+Tool arguments and tool result formats belong in the adapter.
+See [Create a plugin package](plugin-authoring.md).
+
 ## Development
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,3 +105,17 @@ A skin in an override sets the colors for that context. A context with no skin
 keeps the session skin (config `skin.name`, the auto-detected default, or your
 last `:skin` choice). Overrides are re-read on every `:ctx` switch, so edits
 apply without a restart.
+
+## Plugin packages
+
+sofka reads packages from the `plugins/` directory next to `config.toml`.
+Each package directory contains a `plugin.toml` manifest.
+Enter `:reload` to read package changes.
+The `:config` view shows invalid packages and absent executables.
+
+Inline `[[plugins]]` entries take priority over packages with the same name or palette command.
+Packages load after cluster and context overrides.
+An empty inline plugin list does not disable installed packages.
+
+The [manifest reference](plugin-authoring.md#manifest) describes the package fields.
+The [authoring guide](plugin-authoring.md) includes an adapter and tests without a cluster.

--- a/docs/features.md
+++ b/docs/features.md
@@ -210,3 +210,19 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   state/snapshot/bundle directories. The connected Kubernetes revision also
   stays visible in the main header.
   Identifiers and counts only, never credentials, tokens, or Secret values.
+
+## External plugin packages
+
+- **Package discovery** reads `plugins/*/plugin.toml` from the sofka configuration directory.
+  Packages reload with `:reload`.
+- **Named commands** and key chords start adapters without changes to sofka's source code.
+- **Validated inputs** supply named arguments with types, defaults, choices, and limits.
+- **JSON reports** show text sections and tables in a searchable document.
+- **Shared execution** limits output and concurrency.
+  It cancels processes on timeout, navigation, or `:plugin-cancel`.
+- **Safety controls** apply read-only mode, confirmation, and guardrails to plugins.
+  Load-test plugins require a network-load declaration.
+- **Managed port-forwards** supply a local endpoint for a selected pod or service.
+- **Local checks** validate package manifests and reports without a cluster.
+
+See [Create a plugin package](plugin-authoring.md).

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -113,3 +113,14 @@ and `ctrl-e` (compact mode) are reserved by built-ins and can't be bound.
 Interactive actions (`e`, `s` for shell, `a`) suspend the TUI and shell out to
 `kubectl`. Delete, scale, restart, set-image, suspend, resume, reconcile, and
 port-forward go through the kube API (or a backgrounded process) directly.
+
+## Plugin commands
+
+| Command                      | Action                                                |
+| ---------------------------- | ----------------------------------------------------- |
+| `:<plugin> [name=value ...]` | Run a plugin with validated inputs.                   |
+| `:plugin-cancel`             | Stop the active plugin run and its temporary forward. |
+
+Installed packages add their commands and key chords to `?` help.
+Use `:reload` after a package change.
+See [Create a plugin package](plugin-authoring.md).

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -63,8 +63,8 @@ It does not run adapters during package discovery.
 It checks package directories in name order.
 An invalid package does not stop other packages.
 The `:config` view shows package errors.
-Package manifests reject unknown fields.
-Inline plugin entries ignore unknown fields to preserve compatibility with existing configurations.
+Package manifests reject unknown fields, including fields in input definitions.
+Inline plugin entries and their input definitions ignore unknown fields to preserve existing configuration.
 
 An inline `[[plugins]]` entry has priority over a package with the same name or command.
 The first package has priority over a later duplicate.

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1,0 +1,415 @@
+# Create a plugin package
+
+A plugin package adds an external tool to sofka.
+The package contains a manifest and, if necessary, an adapter.
+An adapter is a program that changes tool output into a sofka report.
+The adapter can use any programming language.
+
+sofka supplies resource data, process control, output limits, and report display.
+The package supplies tool commands and result interpretation.
+A new package does not require changes to sofka's Rust code.
+
+## Terms
+
+| Term     | Meaning                                                                 |
+| -------- | ----------------------------------------------------------------------- |
+| Package  | A directory that contains `plugin.toml` and related files.              |
+| Manifest | The `plugin.toml` file that describes a plugin.                         |
+| Adapter  | The program that sofka starts for a plugin.                             |
+| Request  | The JSON object that sofka sends to the adapter through standard input. |
+| Report   | The JSON object that the adapter writes to standard output.             |
+| Input    | A named value that the user supplies with a plugin command.             |
+
+## Create your first package
+
+The example requires Python 3.
+It reads the selected object without a cluster request.
+
+1. Copy `examples/plugins/resource-summary/` into your sofka configuration directory.
+
+   ```sh
+   mkdir -p ~/.config/sofka/plugins
+   cp -R examples/plugins/resource-summary ~/.config/sofka/plugins/
+   ```
+
+   If you set `XDG_CONFIG_HOME`, use `$XDG_CONFIG_HOME/sofka/plugins/` instead.
+
+2. Check the package.
+
+   ```sh
+   sofka --validate-plugin ~/.config/sofka/plugins/resource-summary
+   ```
+
+3. In sofka, enter `:reload`.
+4. Select a resource.
+5. Enter `:resource-summary detail=true`.
+
+The report opens in the document view.
+Press `/` to search the report.
+Press `esc` to return to the resource view.
+
+## Package files
+
+```text
+plugins/
+  resource-summary/
+    plugin.toml
+    adapter.py
+    request.json
+```
+
+sofka reads `plugins/*/plugin.toml` at start, on `:reload`, and on a context change.
+It does not run adapters during package discovery.
+It checks package directories in name order.
+An invalid package does not stop other packages.
+The `:config` view shows package errors.
+
+An inline `[[plugins]]` entry has priority over a package with the same name or command.
+The first package has priority over a later duplicate.
+Built-in commands and resource names have priority over plugin commands.
+To remove a package, remove its directory.
+Then enter `:reload`.
+
+## Manifest
+
+```toml
+schema_version = 1
+
+[plugin]
+name = "Resource summary"
+palette = "resource-summary"
+command = "python3"
+args = ["adapter.py"]
+requires = ["python3"]
+install = "Install Python 3 to run this example."
+output = "report"
+mutating = false
+timeout = "10s"
+
+[plugin.inputs.detail]
+type = "boolean"
+default = "false"
+```
+
+| Field            | Function                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| `schema_version` | Required package format version. Use `1`.                                                  |
+| `name`           | Required display name.                                                                     |
+| `palette`        | Optional command name, without `:`. Use lowercase letters, digits, or hyphens.             |
+| `key`            | Optional key chord. Supply `key`, `palette`, or both.                                      |
+| `command`        | Required executable name or path.                                                          |
+| `args`           | Command arguments. Each item is one argument.                                              |
+| `requires`       | Executables that must be available. sofka also checks `command`.                           |
+| `install`        | Instructions that appear when an executable is absent.                                     |
+| `scopes`         | Resource plurals where the plugin can run. An empty list permits all resource kinds.       |
+| `target`         | `selection` by default. Use `context` to run once without a selected object.               |
+| `output`         | Required package output mode: `popup`, `background`, or `report`.                          |
+| `timeout`        | Maximum time for each target. Default: `30s`.                                              |
+| `mutating`       | `true` by default. Use `false` only when the plugin does not change cluster resources.     |
+| `network_load`   | Set to `true` when the plugin generates test traffic. Default: `false`.                    |
+| `confirm`        | Require confirmation before execution. Default: `false`.                                   |
+| `dangerous`      | Require confirmation and identify the action as dangerous. Default: `false`.               |
+| `port_forward`   | Optional remote port for the selected pod or service. See [Port-forwards](#port-forwards). |
+| `inputs`         | Input definitions. See [Inputs](#inputs).                                                  |
+
+The adapter's working directory is the package directory.
+Use `command = "./adapter"` for an executable in that directory.
+The executable must stay within the package directory.
+Arguments can refer to other package files, such as `adapter.py`.
+
+Packages do not permit `shell = true` or `output = "terminal"`.
+Existing inline plugins continue to support these modes.
+A package can contain an executable shell script.
+Use separate arguments when that script starts another program.
+
+If an executable is absent, the command remains in the command palette.
+sofka shows the absent executable and the `install` text when the user selects the command.
+It checks executables again before each run.
+
+## Inputs
+
+Supply inputs as `name=value` arguments.
+Separate arguments with spaces.
+Input values cannot contain spaces in this version.
+
+```text
+:benchmark duration=10s connections=20 port=8080
+```
+
+```toml
+[plugin.inputs.duration]
+type = "duration"
+default = "10s"
+min = 1
+max = 300
+
+[plugin.inputs.connections]
+type = "integer"
+default = "20"
+min = 1
+max = 1000
+
+[plugin.inputs.port]
+type = "integer"
+min = 1
+max = 65535
+```
+
+The `port` input has no default.
+The user must supply it before the adapter can start.
+A key chord uses the default input values.
+
+| Type       | Permitted values                         |
+| ---------- | ---------------------------------------- |
+| `string`   | Text without spaces.                     |
+| `integer`  | An unsigned integer.                     |
+| `boolean`  | `true` or `false`.                       |
+| `duration` | A duration such as `10s`, `2m`, or `1h`. |
+
+Write default values as TOML strings.
+Use `min` and `max` only with integers or durations.
+Duration limits use seconds.
+Use `choices = ["summary", "full"]` to restrict an input to specified values.
+
+sofka rejects unknown inputs, duplicate inputs, invalid values, and absent required inputs before execution.
+The request contains the validated input values as strings.
+
+To pass an input through an argument, use a complete placeholder:
+
+```toml
+args = ["adapter.py", "--duration", "${input.duration}"]
+```
+
+sofka preserves each input as one argument.
+It does not interpret input values as shell commands or other placeholders.
+Existing resource placeholders, such as `$NAME` and `$NAMESPACE`, are also available in `args`.
+Use the JSON request when you need complete resource data.
+
+## Request format
+
+sofka writes one JSON object to standard input.
+It then closes standard input.
+The adapter must read the request before it writes its report.
+
+```json
+{
+  "schema_version": 1,
+  "context": "development",
+  "cluster": "development",
+  "namespace": "default",
+  "resource": "pods",
+  "name": "api",
+  "filter": "",
+  "inputs": { "detail": "true" },
+  "object": {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": { "name": "api", "namespace": "default" }
+  },
+  "forward": null
+}
+```
+
+The adapter inherits sofka's environment, including `KUBECONFIG`.
+The `context` value is `null` when sofka has no explicit kubeconfig context name.
+In that case, let the external tool use its configuration.
+Do not pass a synthetic context name to the tool.
+
+For `target = "selection"`, sofka starts one job for each marked resource.
+If no resources are marked, it uses the selected resource.
+The request contains that resource's namespace and object data.
+
+For `target = "context"`, sofka starts one job.
+The `object` value is `null`, and `name` is empty.
+The `namespace` value is the current namespace.
+An empty namespace means all namespaces.
+The adapter must translate this value into the tool's namespace arguments.
+
+## Report format
+
+With `output = "report"`, the adapter writes one JSON report to standard output.
+Use standard error for diagnostic messages.
+Return exit code `0` for a complete report.
+Return a nonzero exit code for an execution error.
+
+```json
+{
+  "schema_version": 1,
+  "title": "Scan results",
+  "sections": [
+    {
+      "title": "Summary",
+      "lines": ["One resource requires attention."]
+    },
+    {
+      "title": "Findings",
+      "columns": ["Resource", "Severity", "Description"],
+      "rows": [["api", "high", "Example finding"]]
+    }
+  ]
+}
+```
+
+Each section requires a title.
+The `lines`, `columns`, and `rows` fields are optional.
+All text and table cells must be strings.
+Each row must have the same number of cells as the column list.
+
+sofka shows the sections and tables in one searchable document.
+This version does not support row actions or table sorting.
+It replaces control characters in report text with spaces.
+An invalid report produces a visible error.
+
+Some tools return nonzero exit codes when they find problems.
+The adapter must distinguish findings from execution errors.
+For valid findings, write the report and return `0`.
+
+## Execution limits
+
+sofka runs a maximum of eight target jobs at the same time.
+Each job has the configured timeout.
+The timeout includes port-forward setup, request transfer, and output collection.
+Each JSON request has a 1 MiB limit.
+An oversized request stops the job before the adapter starts.
+
+Each job can write a maximum of 1 MiB to standard output and 1 MiB to standard error.
+sofka stops a job that exceeds either limit.
+It limits the combined displayed output to 1 MiB and 5,000 lines, plus a truncation message.
+It releases each job's captured bytes after it processes the result.
+
+The adapter must also limit its own tool output and memory use.
+For large scanner results, read the tool output in parts.
+Do not collect an unlimited result before you write the report.
+
+Only one plugin run can be active.
+A new run cancels the previous run.
+A resource view change, a context change, or program exit cancels the active run.
+Temporary overlays, such as help, do not cancel the run.
+Enter `:plugin-cancel` to cancel a run manually.
+
+On macOS and Linux, sofka starts each adapter in a separate process group.
+Cancellation stops the adapter and child processes in that group.
+Do not detach child processes or move them into another process group.
+
+## Safety controls
+
+Packages execute with the user's permissions.
+They can access the selected object's full data and the inherited environment.
+Install packages only from a source that you trust.
+
+Read-only mode blocks plugins that can change resources or generate test traffic.
+Set `network_load = true` for load-test tools, even if their HTTP requests use `GET`.
+A network-load plugin always requires confirmation.
+Connection count alone does not limit request rate.
+
+Guardrails use the action name `plugin:<palette>`.
+If there is no palette command, they use `plugin:<name>`.
+Use `plugin:*` to match all plugins.
+
+```toml
+[[guardrails]]
+contexts = ["prod-*"]
+actions = ["plugin:benchmark"]
+deny = true
+reason = "Load tests are not permitted in this context."
+```
+
+Guardrails apply before adapter execution or port-forward creation.
+They support denial, confirmation, typed confirmation, and bulk limits.
+For a context plugin across all namespaces, namespace-specific rules also apply.
+Plugin declarations do not create a security sandbox.
+The author is responsible for an accurate `mutating` and `network_load` declaration.
+
+## Port-forwards
+
+A plugin can request a managed forward for a selected pod or service.
+The remote port must be explicit.
+sofka does not select the HTTP port or test the application protocol.
+
+```toml
+[plugin]
+name = "Endpoint benchmark"
+palette = "benchmark"
+command = "python3"
+args = ["adapter.py"]
+scopes = ["pods", "services"]
+output = "report"
+mutating = false
+network_load = true
+port_forward = "${input.port}"
+timeout = "2m"
+
+[plugin.inputs.port]
+type = "integer"
+min = 1
+max = 65535
+```
+
+sofka reuses an existing forward for the same target, namespace, and remote port.
+Otherwise, it starts `kubectl port-forward` on an available local port.
+The new forward binds to `127.0.0.1`.
+sofka waits for the forward to become ready before it starts the adapter.
+
+The request then contains:
+
+```json
+{
+  "forward": {
+    "host": "127.0.0.1",
+    "local_port": 32123,
+    "remote_port": 8080
+  }
+}
+```
+
+The adapter uses these values to construct its URL.
+The adapter supplies the scheme, path, and HTTP options.
+sofka removes a temporary forward when the job finishes or stops.
+It does not remove an existing user forward.
+
+An adapter can use an address from the selected object without a forward.
+For this mode, omit `port_forward`.
+This version does not let an adapter request a forward after execution starts.
+
+## Test an adapter
+
+The example includes a request fixture.
+These checks do not require a Kubernetes cluster.
+
+1. Check the manifest and required executables.
+
+   ```sh
+   sofka --validate-plugin examples/plugins/resource-summary
+   ```
+
+2. Run the adapter with the fixture.
+
+   ```sh
+   python3 examples/plugins/resource-summary/adapter.py \
+     < examples/plugins/resource-summary/request.json > /tmp/sofka-report.json
+   ```
+
+3. Check the report format.
+
+   ```sh
+   sofka --validate-plugin-report /tmp/sofka-report.json
+   ```
+
+4. Install the package in a development configuration directory.
+5. Enter `:reload` in sofka.
+6. Run the plugin through its command or key chord.
+7. Check cancellation, error output, and read-only behavior.
+
+## Convert a built-in integration
+
+For Popeye and Trivy, use `target = "context"` for namespace scans.
+For a selected image scan, use `target = "selection"`.
+Keep executable selection, tool arguments, and tool JSON interpretation in the adapter.
+Write results with the common report format.
+
+For oha, declare its inputs and set `network_load = true`.
+Use the selected object for direct addresses or declare a managed port-forward.
+Keep URL selection, benchmark options, and oha result interpretation in the adapter.
+
+Do not add a tool-specific field to `App` or a tool-specific message to `Msg`.
+If a required function is absent, propose a shared protocol extension.

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -63,6 +63,8 @@ It does not run adapters during package discovery.
 It checks package directories in name order.
 An invalid package does not stop other packages.
 The `:config` view shows package errors.
+Package manifests reject unknown fields.
+Inline plugin entries ignore unknown fields to preserve compatibility with existing configurations.
 
 An inline `[[plugins]]` entry has priority over a package with the same name or command.
 The first package has priority over a later duplicate.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,7 +2,12 @@
 
 ## Plugins
 
-`[[plugins]]` binds a shell-out command to a key. `key` is a **chord**: a single
+Plugins can use inline configuration or separate packages.
+To create a package, see [Create a plugin package](plugin-authoring.md).
+Packages support named commands, validated inputs, JSON reports, and managed port-forwards.
+Enter `:plugin-cancel` to stop the active plugin run.
+
+`[[plugins]]` assigns an external command to a key or palette command. `key` is a **chord**: a single
 character (`"g"`), a modifier combination (`"ctrl-g"`, `"alt-x"`, `"shift-b"`), or
 a function or named key (`"f5"`, `"ctrl-f2"`). A built-in key wins over a plugin
 on the same chord.
@@ -29,10 +34,20 @@ dangerous = true          # confirm (showing the exact command) first
 - **Placeholders** are substituted as whole arguments, never spliced into a shell
   string: `$NAME`, `$NAMESPACE`/`$NS`, `$CONTEXT`, `$CLUSTER`, `$RESOURCE`
   (plural), `$GROUP`, `$VERSION`, `$KIND`, `$FILTER`.
-- **`output`**: `terminal` (default, interactive - suspends the TUI), `popup`
-  (captured off-thread into a scrollable view), or `background` (detached - a
-  notification flashes on completion). `popup` and `background` obey `timeout`
-  (`"30s"` default) and bound the captured output.
+- **`output`** selects `terminal`, `popup`, `background`, or `report`.
+  `terminal` is the default. It suspends the TUI for an interactive command.
+  `popup` shows captured text. `background` shows a completion message.
+  `report` shows a [JSON report](plugin-authoring.md#report-format).
+  Captured modes use `timeout` (`"30s"` by default) and enforce output limits.
+- **`palette`** assigns a command name, such as `palette = "scan"` for `:scan`.
+  The `key` field is optional when `palette` is present.
+- **`target = "context"`** runs once without a selected row.
+  The default, `selection`, uses selected or marked rows.
+- **`requires`** lists required executables. **`install`** supplies instructions when an executable is absent.
+- **`inputs`** defines validated `name=value` arguments.
+  See [Inputs](plugin-authoring.md#inputs).
+- **`network_load = true`** identifies a load test.
+  It requires confirmation and blocks the plugin in read-only mode.
 - **`mutating`** (default `true`): read-only mode blocks a mutating plugin. Set
   it to `false` to allow a known read-only one.
 - **`confirm`** / **`dangerous`**: prompt before running, showing the exact
@@ -42,6 +57,8 @@ dangerous = true          # confirm (showing the exact command) first
 - **Bulk**: with rows marked (`space`), a `popup` or `background` plugin runs over
   every marked row and reports partial failures. An interactive `terminal` plugin
   can't run over a set and refuses a marked run.
+
+Guardrails match plugin actions with `plugin:<palette>`, or `plugin:<name>` when no palette command exists.
 
 On an invalid value (a bad chord, an unknown `output`, a malformed `timeout`)
 sofka disables just that plugin or falls back to the default and shows a warning

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -71,3 +71,13 @@ incomplete rule reviews. The API still enforces access when you open the kind.
 action you took - the action, the target, the context, the time - newest first.
 It records identifiers only, never secret input or decoded values, and never
 writes to disk.
+
+## Plugin actions
+
+Guardrails match plugin actions with `plugin:<palette>`.
+If a plugin has no palette command, use `plugin:<name>`.
+The pattern `plugin:*` matches all plugins.
+
+Read-only mode blocks mutating plugins and plugins with `network_load = true`.
+Network-load plugins require confirmation, even when they do not change Kubernetes resources.
+See [Plugin safety controls](plugin-authoring.md#safety-controls).

--- a/examples/plugins/resource-summary/adapter.py
+++ b/examples/plugins/resource-summary/adapter.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Reference adapter: consumes sofka's request and emits its report protocol."""
+import json
+import sys
+
+request = json.load(sys.stdin)
+if request.get("schema_version") != 1:
+    sys.exit("unsupported request schema_version")
+
+obj = request.get("object") or {}
+metadata = obj.get("metadata", {})
+sections = [{
+    "title": "Selection",
+    "columns": ["Field", "Value"],
+    "rows": [
+        ["Context", request.get("context") or "inferred"],
+        ["Kind", obj.get("kind", "")],
+        ["Namespace", metadata.get("namespace", "")],
+        ["Name", metadata.get("name", "")],
+    ],
+}]
+if request.get("inputs", {}).get("detail") == "true":
+    sections.append({
+        "title": "Labels",
+        "columns": ["Label", "Value"],
+        "rows": [[key, value] for key, value in sorted(metadata.get("labels", {}).items())],
+    })
+json.dump({"schema_version": 1, "title": "Resource summary", "sections": sections}, sys.stdout)

--- a/examples/plugins/resource-summary/plugin.toml
+++ b/examples/plugins/resource-summary/plugin.toml
@@ -1,0 +1,16 @@
+schema_version = 1
+
+[plugin]
+name = "Resource summary"
+palette = "resource-summary"
+command = "python3"
+args = ["adapter.py"]
+requires = ["python3"]
+install = "Install Python 3 to run this example."
+output = "report"
+mutating = false
+timeout = "10s"
+
+[plugin.inputs.detail]
+type = "boolean"
+default = "false"

--- a/examples/plugins/resource-summary/request.json
+++ b/examples/plugins/resource-summary/request.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "context": "development",
+  "cluster": "development",
+  "namespace": "default",
+  "resource": "pods",
+  "name": "api",
+  "filter": "",
+  "inputs": { "detail": "true" },
+  "object": {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "name": "api",
+      "namespace": "default",
+      "labels": { "app": "api" }
+    }
+  },
+  "forward": null
+}

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -6,6 +6,7 @@ impl App {
     /// Remember which view a transient sub-view (logs/detail/diff) was opened
     /// from, so `esc` returns there (e.g. back to the xray tree, not the table).
     pub(super) fn set_return_mode(&mut self) {
+        self.stop_plugins();
         // A transient sub-view (logs/detail/events) opened from a list-style
         // view returns to that view, not the table underneath it.
         self.return_mode = match self.mode {

--- a/src/app/guardrails.rs
+++ b/src/app/guardrails.rs
@@ -27,6 +27,17 @@ impl App {
         targets: &[(String, String)],
         base: ConfirmLevel,
     ) -> Option<ConfirmLevel> {
+        self.guard_scope(action, plural, targets, base, false)
+    }
+
+    pub(super) fn guard_scope(
+        &mut self,
+        action: &str,
+        plural: &str,
+        targets: &[(String, String)],
+        base: ConfirmLevel,
+        all_namespaces: bool,
+    ) -> Option<ConfirmLevel> {
         let ctx = self.cluster.context.clone();
         let mut level = base;
         let mut deny: Option<String> = None;
@@ -40,7 +51,8 @@ impl App {
                 continue;
             }
             // A namespace filter matches if any target is in a listed namespace.
-            if !g.namespaces.is_empty()
+            if !all_namespaces
+                && !g.namespaces.is_empty()
                 && !targets
                     .iter()
                     .any(|(_, ns)| list_matches(&g.namespaces, ns))

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,13 +1,42 @@
 use super::*;
-use futures_util::StreamExt;
 
 impl App {
     // ----- key handling --------------------------------------------------
 
     pub fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
+        let before = match self.mode {
+            Mode::Command => self.palette_return,
+            Mode::Help => self.help_return,
+            Mode::Filter | Mode::Confirm | Mode::Prompt | Mode::SortPicker | Mode::CopyPicker => {
+                Mode::Table
+            }
+            other => other,
+        };
+        let run = self.plugin_run;
+        let result = self.handle_key_inner(key);
+        let overlay = matches!(
+            self.mode,
+            Mode::Command
+                | Mode::Help
+                | Mode::Filter
+                | Mode::DocFilter
+                | Mode::LogFilter
+                | Mode::Confirm
+                | Mode::Prompt
+                | Mode::SortPicker
+                | Mode::CopyPicker
+        );
+        if self.should_quit || (self.plugin_run == run && self.mode != before && !overlay) {
+            self.stop_plugins();
+        }
+        result
+    }
+
+    fn handle_key_inner(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
                 KeyCode::Char('c') => {
+                    self.stop_plugins();
                     self.should_quit = true;
                     return Ok(());
                 }
@@ -288,221 +317,6 @@ impl App {
         }
     }
 
-    /// Run a config-defined plugin bound to `c` if it applies to the current
-    /// kind. Blocked in read-only mode: plugins shell out to arbitrary
-    /// commands, so we can't know they won't mutate the cluster. Returns
-    /// whether a plugin matched (so the caller can stop treating the event as
-    /// an unhandled key).
-    pub(super) fn try_plugin_key(&mut self, key: KeyEvent) -> bool {
-        let Some(plugin) = self
-            .plugins
-            .iter()
-            .find(|p| {
-                crate::keys::KeyChord::parse(&p.key).is_ok_and(|chord| chord.matches(&key))
-                    && (p.scopes.is_empty() || p.scopes.iter().any(|s| s == &self.kind_plural))
-            })
-            .cloned()
-        else {
-            return false;
-        };
-        self.run_plugin(plugin);
-        true
-    }
-
-    /// Resolve placeholders, then run the plugin — after a confirmation prompt
-    /// when it's marked `confirm`/`dangerous`.
-    fn run_plugin(&mut self, plugin: crate::config::Plugin) {
-        // A mutating plugin (the default) is blocked in read-only mode; one
-        // explicitly declared read-only stays available.
-        if plugin.mutating.unwrap_or(true) && self.readonly {
-            self.flash_warn(&format!(
-                "read-only mode — plugin '{}' may mutate (set mutating = false to allow)",
-                plugin.name
-            ));
-            return;
-        }
-        let mode = match plugin.output.as_deref() {
-            Some("popup") => PluginMode::Popup,
-            Some("background") => PluginMode::Background,
-            _ => PluginMode::Terminal,
-        };
-        let timeout = plugin
-            .timeout
-            .as_deref()
-            .and_then(|t| crate::providers::parse_lookback(t).ok())
-            .unwrap_or(30)
-            .max(1) as u64;
-
-        // Marked rows drive a bulk run; otherwise the single selection.
-        let targets = self.action_targets();
-        if targets.is_empty() {
-            self.flash_warn("no selection for plugin");
-            return;
-        }
-        // An interactive terminal command can't compose over a marked set:
-        // refuse rather than surprise the user by running on just one row.
-        if mode == PluginMode::Terminal && targets.len() > 1 {
-            self.flash_warn(&format!(
-                "'{}': a marked set needs output = popup or background",
-                plugin.name
-            ));
-            return;
-        }
-
-        let ctx = self.cluster.context.clone();
-        let cluster = self.cluster.cluster_name.clone();
-        let res = self.kind_plural.clone();
-        let filter = self.filter.clone();
-        let (group, version, kind) = self
-            .kind
-            .as_ref()
-            .map(|k| (k.ar.group.clone(), k.ar.version.clone(), k.ar.kind.clone()))
-            .unwrap_or_default();
-
-        // One (label, argv) job per target. Placeholders are substituted as
-        // whole arguments — never spliced into a shell string. `$NAMESPACE`
-        // before `$NS`/`$NAME` so the longer token wins.
-        let jobs: Vec<(String, Vec<String>)> = targets
-            .iter()
-            .map(|(name, ns)| {
-                let subst = |s: &str| {
-                    s.replace("$NAMESPACE", ns)
-                        .replace("$NS", ns)
-                        .replace("$NAME", name)
-                        .replace("$CONTEXT", &ctx)
-                        .replace("$CLUSTER", &cluster)
-                        .replace("$RESOURCE", &res)
-                        .replace("$GROUP", &group)
-                        .replace("$VERSION", &version)
-                        .replace("$KIND", &kind)
-                        .replace("$FILTER", &filter)
-                };
-                // `shell = true` opts into `sh -c`, still passing the args as
-                // positional parameters ($1, $2, …), not interpolated.
-                let mut argv = if plugin.shell {
-                    vec![
-                        "sh".into(),
-                        "-c".into(),
-                        subst(&plugin.command),
-                        "sofka".into(),
-                    ]
-                } else {
-                    vec![subst(&plugin.command)]
-                };
-                argv.extend(plugin.args.iter().map(|a| subst(a)));
-                (name.clone(), argv)
-            })
-            .collect();
-
-        if plugin.confirm || plugin.dangerous {
-            let cmd = truncate_cmd(&jobs[0].1);
-            let head = if jobs.len() > 1 {
-                format!("Run plugin '{}' on {} resources?", plugin.name, jobs.len())
-            } else {
-                format!("Run plugin '{}'?", plugin.name)
-            };
-            self.confirm_label = if plugin.dangerous {
-                format!("⚠ {head} (dangerous)  {cmd}")
-            } else {
-                format!("{head}  {cmd}")
-            };
-            self.confirm_action = Some(ConfirmAction::Plugin {
-                jobs,
-                name: plugin.name.clone(),
-                mode,
-                timeout,
-            });
-            self.mode = Mode::Confirm;
-            return;
-        }
-        self.launch_plugin(jobs, plugin.name.clone(), mode, timeout);
-    }
-
-    /// Dispatch resolved plugin jobs (one per target) by output mode.
-    pub(super) fn launch_plugin(
-        &mut self,
-        jobs: Vec<(String, Vec<String>)>,
-        name: String,
-        mode: PluginMode,
-        timeout: u64,
-    ) {
-        if jobs.is_empty() {
-            return;
-        }
-        let n = jobs.len();
-        self.note_action(
-            format!("plugin: {name}"),
-            if n == 1 {
-                "1 target".to_string()
-            } else {
-                format!("{n} targets")
-            },
-        );
-        match mode {
-            PluginMode::Terminal => {
-                // Terminal runs are single (enforced in run_plugin).
-                let argv = jobs.into_iter().next().map(|(_, a)| a).unwrap_or_default();
-                if argv.is_empty() {
-                    return;
-                }
-                self.flash = format!("plugin: {name}");
-                self.flash_err = false;
-                self.pending = Some(Suspend::Shell(argv));
-            }
-            PluginMode::Popup => {
-                // Mirror describe: stay put, swap to the doc view when output
-                // lands, so a view switch mid-run cleanly drops the result.
-                self.set_return_mode();
-                let claim = self.claim_status(plugin_flash(&name, n, ""));
-                self.spawn_plugin(jobs, format!("{name} — output"), mode, timeout, claim);
-            }
-            PluginMode::Background => {
-                let claim = self.claim_status(plugin_flash(&name, n, " (background)"));
-                self.spawn_plugin(jobs, name, mode, timeout, claim);
-            }
-        }
-    }
-
-    /// Run every job off-thread with a per-job timeout, bounded output capture,
-    /// and bounded concurrency, then report back via [`Msg`]. A hung command
-    /// can't freeze the UI — the timeout aborts it — and the aggregated result
-    /// is generation-gated like every other stream. For a bulk run this is
-    /// where partial failures are counted.
-    fn spawn_plugin(
-        &mut self,
-        jobs: Vec<(String, Vec<String>)>,
-        title: String,
-        mode: PluginMode,
-        timeout: u64,
-        claim: StatusClaim,
-    ) {
-        let tx = self.tx.clone();
-        let genr = self.generation;
-        tokio::spawn(async move {
-            let dur = Duration::from_secs(timeout);
-            // Bounded concurrency, results in the marked order.
-            let results: Vec<(String, SpawnOutcome)> =
-                futures_util::stream::iter(jobs.into_iter().map(|(label, argv)| async move {
-                    let out = tokio::time::timeout(
-                        dur,
-                        tokio::process::Command::new(&argv[0])
-                            .args(&argv[1..])
-                            .output(),
-                    )
-                    .await;
-                    (label, out)
-                }))
-                .buffered(8)
-                .collect()
-                .await;
-            let msg = match mode {
-                PluginMode::Popup => plugin_popup_msg(genr, claim, title, timeout, results),
-                _ => plugin_bulk_msg(genr, claim, title, timeout, results),
-            };
-            let _ = tx.send(msg).await;
-        });
-    }
-
     pub(super) fn key_command(&mut self, key: KeyEvent) {
         // Configured completion chords win over everything else (including
         // the shared line-editing chords), so a `[keys]` rebind like ctrl-w
@@ -611,7 +425,19 @@ impl App {
                 } else if let Some(s) = picked {
                     match s.kind {
                         SuggestKind::Command => {
-                            self.run_palette_command(&s.label);
+                            if self
+                                .plugins
+                                .iter()
+                                .any(|p| p.palette.as_deref() == Some(&s.label))
+                            {
+                                let args = typed
+                                    .split_once(char::is_whitespace)
+                                    .map(|(_, args)| args)
+                                    .unwrap_or("");
+                                self.run_palette_command(&format!("{} {args}", s.label));
+                            } else {
+                                self.run_palette_command(&s.label);
+                            }
                         }
                         SuggestKind::Resource => self.switch_kind_ns(&s.label, ns_arg),
                         // Handled by the outer match arms above.
@@ -640,6 +466,7 @@ impl App {
 
     /// Run a built-in palette action.
     pub(super) fn run_action(&mut self, action: PaletteAction) {
+        self.stop_plugins();
         match action {
             PaletteAction::Quit => self.should_quit = true,
             PaletteAction::Ctx => self.open_contexts(),
@@ -743,7 +570,33 @@ impl App {
                 self.run_action(a);
                 true
             }
-            None => false,
+            None => {
+                let (name, args) = cmd.split_once(char::is_whitespace).unwrap_or((cmd, ""));
+                if name == "plugin-cancel" {
+                    self.stop_plugins();
+                    self.flash_warn("plugin cancelled");
+                    return true;
+                }
+                if self.cluster.resolve(name).is_some() || crate::app::plugin_command_reserved(name)
+                {
+                    return false;
+                }
+                let plugin = self
+                    .plugins
+                    .iter()
+                    .find(|p| p.palette.as_deref() == Some(name))
+                    .cloned();
+                if let Some(plugin) = plugin {
+                    if !plugin.scopes.is_empty() && !plugin.scopes.contains(&self.kind_plural) {
+                        self.flash_warn("plugin does not apply to this resource kind");
+                    } else {
+                        self.run_plugin(plugin, args);
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
         }
     }
 
@@ -790,6 +643,31 @@ impl App {
                         score,
                         Suggestion {
                             label: c.names[0].to_string(),
+                            kind: SuggestKind::Command,
+                        },
+                    ));
+                }
+            }
+        }
+
+        if !q.is_empty() {
+            for name in self
+                .plugins
+                .iter()
+                .filter(|p| p.scopes.is_empty() || p.scopes.contains(&self.kind_plural))
+                .filter_map(|p| p.palette.as_deref())
+                .chain(std::iter::once("plugin-cancel"))
+            {
+                if PALETTE_COMMANDS.iter().any(|c| c.names.contains(&name))
+                    || self.cluster.resolve(name).is_some()
+                {
+                    continue;
+                }
+                if let Some(score) = self.matcher.fuzzy_match(name, q) {
+                    scored.push((
+                        score,
+                        Suggestion {
+                            label: name.into(),
                             kind: SuggestKind::Command,
                         },
                     ));
@@ -1306,166 +1184,6 @@ fn is_ctx_command(head: &str) -> bool {
     PALETTE_COMMANDS
         .iter()
         .any(|c| matches!(c.action, PaletteAction::Ctx) && c.names.contains(&head))
-}
-
-/// Bound the number of captured output lines and total bytes from a
-/// popup/background plugin, so a chatty command can't balloon memory or the
-/// redraw. Mirrors the log view's tail-buffer discipline.
-const PLUGIN_MAX_LINES: usize = 5_000;
-const PLUGIN_MAX_BYTES: usize = 1 << 20; // 1 MiB
-
-/// A short, single-line preview of an argv for the confirmation dialog.
-fn truncate_cmd(argv: &[String]) -> String {
-    let joined = argv.join(" ");
-    if joined.chars().count() > 120 {
-        let mut s: String = joined.chars().take(119).collect();
-        s.push('…');
-        s
-    } else {
-        joined
-    }
-}
-
-type SpawnOutcome = Result<std::io::Result<std::process::Output>, tokio::time::error::Elapsed>;
-
-/// Split captured bytes into bounded display lines.
-fn bounded_lines(bytes: &[u8]) -> Vec<String> {
-    let text = String::from_utf8_lossy(&bytes[..bytes.len().min(PLUGIN_MAX_BYTES)]);
-    let mut lines: Vec<String> = text
-        .lines()
-        .take(PLUGIN_MAX_LINES)
-        .map(str::to_string)
-        .collect();
-    if text.lines().count() > PLUGIN_MAX_LINES {
-        lines.push(format!("… output truncated at {PLUGIN_MAX_LINES} lines"));
-    }
-    lines
-}
-
-/// First non-empty line of stderr, for a compact failure summary.
-fn stderr_summary(stderr: &[u8]) -> String {
-    String::from_utf8_lossy(stderr)
-        .lines()
-        .map(str::trim)
-        .find(|l| !l.is_empty())
-        .unwrap_or("failed")
-        .chars()
-        .take(160)
-        .collect()
-}
-
-/// Reduce one job's outcome to `(ok, stdout lines, short failure reason)`.
-fn reduce_outcome(timeout: u64, outcome: SpawnOutcome) -> (bool, Vec<String>, String) {
-    match outcome {
-        Err(_) => {
-            let r = format!("timed out after {timeout}s");
-            (false, vec![r.clone()], r)
-        }
-        Ok(Err(e)) => {
-            let r = format!("failed to start: {e}");
-            (false, vec![format!("failed to run: {e}")], r)
-        }
-        Ok(Ok(out)) => {
-            let mut lines = bounded_lines(&out.stdout);
-            if out.status.success() {
-                if lines.is_empty() {
-                    lines.push("(no output)".into());
-                }
-                (true, lines, String::new())
-            } else {
-                let err = stderr_summary(&out.stderr);
-                let reason = if err.is_empty() {
-                    format!("exited {}", exit_label(&out.status))
-                } else {
-                    lines.push(String::new());
-                    lines.push(format!("[stderr] {err}"));
-                    format!("exited {} — {err}", exit_label(&out.status))
-                };
-                (false, lines, reason)
-            }
-        }
-    }
-}
-
-/// Build [`Msg::PluginOutput`] for a finished popup run, aggregating one block
-/// per job (with a `== label ==` header when there's more than one).
-fn plugin_popup_msg(
-    generation: u64,
-    claim: StatusClaim,
-    title: String,
-    timeout: u64,
-    results: Vec<(String, SpawnOutcome)>,
-) -> Msg {
-    let total = results.len();
-    let multi = total > 1;
-    let mut lines = Vec::new();
-    let mut failed = 0;
-    for (i, (label, outcome)) in results.into_iter().enumerate() {
-        let (ok, block, _) = reduce_outcome(timeout, outcome);
-        if !ok {
-            failed += 1;
-        }
-        if multi {
-            if i > 0 {
-                lines.push(String::new());
-            }
-            lines.push(format!("== {label} =="));
-        }
-        lines.extend(block);
-    }
-    let warn = (failed > 0).then(|| format!("{failed} of {total} failed"));
-    Msg::PluginOutput {
-        generation,
-        claim,
-        title,
-        lines,
-        warn,
-    }
-}
-
-/// Build [`Msg::PluginBulkDone`] for a finished background run, counting
-/// successes and listing the failures (target label + reason).
-fn plugin_bulk_msg(
-    generation: u64,
-    claim: StatusClaim,
-    name: String,
-    timeout: u64,
-    results: Vec<(String, SpawnOutcome)>,
-) -> Msg {
-    let mut ok = 0;
-    let mut failed = Vec::new();
-    for (label, outcome) in results {
-        let (success, _, reason) = reduce_outcome(timeout, outcome);
-        if success {
-            ok += 1;
-        } else {
-            failed.push(format!("{label}: {reason}"));
-        }
-    }
-    Msg::PluginBulkDone {
-        generation,
-        claim,
-        name,
-        ok,
-        failed,
-    }
-}
-
-fn exit_label(status: &std::process::ExitStatus) -> String {
-    match status.code() {
-        Some(c) => format!("code {c}"),
-        None => "by signal".into(),
-    }
-}
-
-/// Flash text for a launched popup/background run, noting the count on a bulk
-/// run.
-fn plugin_flash(name: &str, n: usize, suffix: &str) -> String {
-    if n > 1 {
-        format!("plugin: {name} ×{n}{suffix}…")
-    } else {
-        format!("plugin: {name}{suffix}…")
-    }
 }
 
 /// Order scored palette completions: score descending, then label length,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -267,6 +267,7 @@ impl App {
         self.applied_filter_labels = filter_labels;
         self.applied_filter_fields = filter_fields;
         self.clear_progress_flash();
+        self.stop_plugins();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -783,6 +784,7 @@ impl App {
     pub(super) fn bump_generation(&mut self) {
         self.stop_event_stream();
         self.clear_progress_flash();
+        self.stop_plugins();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -1022,12 +1024,15 @@ impl App {
                 self.clear_claimed_status(claim);
             }
             Msg::PluginOutput {
+                run,
                 generation,
                 claim,
                 title,
                 lines,
                 warn,
-            } if generation == self.generation => {
+            } if generation == self.generation && run == self.plugin_run => {
+                self.plugin_task = None;
+                self.plugin_claim = None;
                 self.detail = Scrollable {
                     title,
                     lines: lines.into(),
@@ -1040,12 +1045,15 @@ impl App {
                 }
             }
             Msg::PluginBulkDone {
+                run,
                 generation,
                 claim,
                 name,
                 ok,
                 failed,
-            } if generation == self.generation => {
+            } if generation == self.generation && run == self.plugin_run => {
+                self.plugin_task = None;
+                self.plugin_claim = None;
                 if failed.is_empty() {
                     self.set_claimed_status(claim, format!("plugin {name}: {ok} ok"), false);
                 } else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -310,7 +310,7 @@ enum ConfirmAction {
     /// Run a confirmed plugin (`confirm`/`dangerous`) once accepted — one job
     /// (label, argv) per target, so a bulk run confirms once.
     Plugin {
-        jobs: Vec<(String, Vec<String>)>,
+        jobs: Vec<crate::plugins::Job>,
         name: String,
         mode: PluginMode,
         timeout: u64,
@@ -331,6 +331,8 @@ pub enum PluginMode {
     Terminal,
     /// Captured off-thread into a scrollable document view.
     Popup,
+    /// Versioned JSON report rendered as a searchable document.
+    Report,
     /// Detached; a notification flashes on completion.
     Background,
 }
@@ -1537,6 +1539,9 @@ pub struct App {
     pub user_aliases: HashMap<String, String>,
     /// User-defined shell-out plugins.
     pub plugins: Vec<crate::config::Plugin>,
+    pub(super) plugin_task: Option<crate::plugins::Task>,
+    pub(super) plugin_run: u64,
+    pub(super) plugin_claim: Option<StatusClaim>,
     /// Saved navigation commands (`[[bookmarks]]`), re-applied on context
     /// switch and `:reload`.
     pub bookmarks: Vec<crate::config::Bookmark>,
@@ -1847,6 +1852,9 @@ impl App {
             all_contexts: Vec::new(),
             user_aliases: HashMap::new(),
             plugins: Vec::new(),
+            plugin_task: None,
+            plugin_run: 0,
+            plugin_claim: None,
             bookmarks: Vec::new(),
             pending_bookmark: None,
             workspaces: Vec::new(),
@@ -2007,6 +2015,7 @@ mod navigation;
 mod notify;
 mod overlays;
 mod pickers;
+mod plugins;
 mod rightsize;
 mod rows;
 mod snapshot;
@@ -2019,3 +2028,8 @@ pub use pickers::DEFAULT_SORT_LABEL;
 
 #[cfg(test)]
 mod tests;
+
+/// Built-ins retain ownership of their command names when loading packages.
+pub(crate) fn plugin_command_reserved(name: &str) -> bool {
+    name == "plugin-cancel" || PALETTE_COMMANDS.iter().any(|c| c.names.contains(&name))
+}

--- a/src/app/plugins.rs
+++ b/src/app/plugins.rs
@@ -1,0 +1,499 @@
+use super::*;
+
+impl App {
+    /// Run a config-defined plugin bound to `c` if it applies to the current
+    /// kind. Blocked in read-only mode: plugins shell out to arbitrary
+    /// commands, so we can't know they won't mutate the cluster. Returns
+    /// whether a plugin matched (so the caller can stop treating the event as
+    /// an unhandled key).
+    pub(super) fn try_plugin_key(&mut self, key: KeyEvent) -> bool {
+        let Some(plugin) = self
+            .plugins
+            .iter()
+            .find(|p| {
+                crate::keys::KeyChord::parse(&p.key).is_ok_and(|chord| chord.matches(&key))
+                    && (p.scopes.is_empty() || p.scopes.iter().any(|s| s == &self.kind_plural))
+            })
+            .cloned()
+        else {
+            return false;
+        };
+        self.run_plugin(plugin, "");
+        true
+    }
+
+    /// Resolve placeholders, then run the plugin — after a confirmation prompt
+    /// when it's marked `confirm`/`dangerous`.
+    pub(super) fn run_plugin(&mut self, plugin: crate::config::Plugin, arguments: &str) {
+        if let Err(e) = crate::plugins::available(&plugin) {
+            self.flash_warn(&e);
+            return;
+        }
+        let inputs = match crate::plugins::inputs(&plugin, arguments) {
+            Ok(inputs) => inputs,
+            Err(e) => {
+                self.flash_warn(&e);
+                return;
+            }
+        };
+        // A mutating plugin (the default) is blocked in read-only mode; one
+        // explicitly declared read-only stays available.
+        if (plugin.mutating.unwrap_or(true) || plugin.network_load) && self.readonly {
+            let reason = if plugin.network_load {
+                "generates network load"
+            } else {
+                "may mutate (set mutating = false to allow)"
+            };
+            self.flash_warn(&format!(
+                "read-only mode — plugin '{}' {reason}",
+                plugin.name
+            ));
+            return;
+        }
+        let mode = match plugin.output.as_deref() {
+            Some("popup") => PluginMode::Popup,
+            Some("report") => PluginMode::Report,
+            Some("background") => PluginMode::Background,
+            _ => PluginMode::Terminal,
+        };
+        let timeout = plugin
+            .timeout
+            .as_deref()
+            .and_then(|t| crate::providers::parse_lookback(t).ok())
+            .unwrap_or(30)
+            .max(1) as u64;
+
+        // Marked rows drive a bulk run; otherwise the single selection.
+        let targets = if plugin.target.as_deref() == Some("context") {
+            vec![(String::new(), self.namespace.clone())]
+        } else {
+            self.action_targets()
+        };
+        if targets.is_empty() {
+            self.flash_warn("no selection for plugin");
+            return;
+        }
+        // An interactive terminal command can't compose over a marked set:
+        // refuse rather than surprise the user by running on just one row.
+        if mode == PluginMode::Terminal && targets.len() > 1 {
+            self.flash_warn(&format!(
+                "'{}': a marked set needs output = popup or background",
+                plugin.name
+            ));
+            return;
+        }
+
+        let ctx = self.cluster.context.clone();
+        let cluster = self.cluster.cluster_name.clone();
+        let res = self.kind_plural.clone();
+        let filter = self.filter.clone();
+        let (group, version, kind) = self
+            .kind
+            .as_ref()
+            .map(|k| (k.ar.group.clone(), k.ar.version.clone(), k.ar.kind.clone()))
+            .unwrap_or_default();
+
+        // One (label, argv) job per target. Placeholders are substituted as
+        // whole arguments — never spliced into a shell string. `$NAMESPACE`
+        // before `$NS`/`$NAME` so the longer token wins.
+        let remote = if let Some(port) = &plugin.port_forward {
+            match crate::plugins::input_arg(port, &inputs).parse::<u16>() {
+                Ok(n) if n > 0 => Some(n),
+                _ => {
+                    self.flash_warn("port_forward must resolve to a port from 1 to 65535");
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+        if remote.is_some() && !matches!(res.as_str(), "pods" | "services") {
+            self.flash_warn("plugin port-forward requires a pod or service");
+            return;
+        }
+        let jobs: Vec<crate::plugins::Job> = targets
+            .iter()
+            .map(|(name, ns)| {
+                let subst = |s: &str| {
+                    // Inputs are literal argv values, never re-expanded as context placeholders.
+                    if s.starts_with("${input.") {
+                        return crate::plugins::input_arg(s, &inputs);
+                    }
+                    s.replace("$NAMESPACE", ns)
+                        .replace("$NS", ns)
+                        .replace("$NAME", name)
+                        .replace("$CONTEXT", &ctx)
+                        .replace("$CLUSTER", &cluster)
+                        .replace("$RESOURCE", &res)
+                        .replace("$GROUP", &group)
+                        .replace("$VERSION", &version)
+                        .replace("$KIND", &kind)
+                        .replace("$FILTER", &filter)
+                };
+                let mut argv = if plugin.shell {
+                    vec![
+                        "sh".into(),
+                        "-c".into(),
+                        subst(&plugin.command),
+                        "sofka".into(),
+                    ]
+                } else {
+                    vec![if plugin.package_dir.is_some() {
+                        plugin.command.clone()
+                    } else {
+                        subst(&plugin.command)
+                    }]
+                };
+                argv.extend(plugin.args.iter().map(|a| subst(a)));
+                let object = if plugin.package_dir.is_some()
+                    && plugin.target.as_deref() != Some("context")
+                {
+                    let key = if ns.is_empty() {
+                        name.clone()
+                    } else {
+                        format!("{ns}/{name}")
+                    };
+                    self.store.shared(&key)
+                } else {
+                    None
+                };
+                let request = plugin.package_dir.as_ref().map(|_| {
+                    let mut request = serde_json::json!({
+                        "schema_version": 1, "context": self.cluster.kubectl_context(),
+                        "cluster": cluster, "namespace": ns, "resource": res,
+                        "name": name, "filter": filter, "inputs": inputs, "forward": null
+                    });
+                    if object.is_none() {
+                        request["object"] = Value::Null;
+                    }
+                    request
+                });
+                let forward = remote.map(|remote| {
+                    let target = format!("{}/{name}", if res == "pods" { "pod" } else { "svc" });
+                    let local = self.port_forwards.iter().find_map(|pf| {
+                        let same = pf.target == target || (res == "pods" && pf.target == *name);
+                        if pf.ns != *ns || !same {
+                            return None;
+                        }
+                        let (l, r) = pf.ports.split_once(':').unwrap_or((&pf.ports, &pf.ports));
+                        (r.parse::<u16>().ok() == Some(remote))
+                            .then(|| l.parse::<u16>().ok())
+                            .flatten()
+                            .filter(|p| *p > 0)
+                    });
+                    let mut argv = self.kubectl_base();
+                    argv.extend(["port-forward".into(), "-n".into(), ns.clone(), target]);
+                    crate::plugins::Forward {
+                        argv,
+                        remote,
+                        local,
+                    }
+                });
+                crate::plugins::Job {
+                    label: name.clone(),
+                    argv,
+                    directory: plugin.package_dir.clone(),
+                    request,
+                    object,
+                    forward,
+                }
+            })
+            .collect();
+
+        let base = if plugin.confirm || plugin.dangerous || plugin.network_load {
+            guardrails::ConfirmLevel::Plain
+        } else {
+            guardrails::ConfirmLevel::None
+        };
+        let action_name = format!(
+            "plugin:{}",
+            plugin.palette.as_deref().unwrap_or(&plugin.name)
+        );
+        let all_namespaces =
+            plugin.target.as_deref() == Some("context") && self.namespace.is_empty();
+        let Some(level) = self.guard_scope(&action_name, &res, &targets, base, all_namespaces)
+        else {
+            return;
+        };
+        let cmd = truncate_cmd(&jobs[0].argv);
+        let input_preview = inputs
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let scope = format!(
+            "context={ctx} namespace={}",
+            if self.namespace.is_empty() {
+                "all"
+            } else {
+                &self.namespace
+            }
+        );
+        let forward_preview = remote
+            .map(|port| format!(" port-forward={res}/{}:{port}", targets[0].0))
+            .unwrap_or_default();
+        let cmd = format!("{scope}{forward_preview} {cmd} {input_preview}");
+        let head = format!("Run plugin '{}' on {} target(s)?", plugin.name, jobs.len());
+        let label = if plugin.dangerous || plugin.network_load {
+            format!("⚠ {head} (dangerous)  {cmd}")
+        } else {
+            format!("{head}  {cmd}")
+        };
+        let hint = if plugin.target.as_deref() == Some("context") {
+            ctx.clone()
+        } else if targets.len() == 1 {
+            targets[0].0.clone()
+        } else {
+            targets.len().to_string()
+        };
+        self.stop_plugins();
+        self.begin_guarded(
+            ConfirmAction::Plugin {
+                jobs,
+                name: plugin.name,
+                mode,
+                timeout,
+            },
+            label,
+            level,
+            hint,
+        );
+    }
+
+    /// Dispatch resolved plugin jobs (one per target) by output mode.
+    pub(super) fn launch_plugin(
+        &mut self,
+        jobs: Vec<crate::plugins::Job>,
+        name: String,
+        mode: PluginMode,
+        timeout: u64,
+    ) {
+        if jobs.is_empty() {
+            return;
+        }
+        let n = jobs.len();
+        self.note_action(
+            format!("plugin: {name}"),
+            if n == 1 {
+                "1 target".to_string()
+            } else {
+                format!("{n} targets")
+            },
+        );
+        match mode {
+            PluginMode::Terminal => {
+                // Terminal runs are single (enforced in run_plugin).
+                let argv = jobs
+                    .into_iter()
+                    .next()
+                    .map(|job| job.argv)
+                    .unwrap_or_default();
+                if argv.is_empty() {
+                    return;
+                }
+                self.flash = format!("plugin: {name}");
+                self.flash_err = false;
+                self.pending = Some(Suspend::Shell(argv));
+            }
+            PluginMode::Popup | PluginMode::Report => {
+                // Mirror describe: stay put, swap to the doc view when output
+                // lands, so a view switch mid-run cleanly drops the result.
+                self.set_return_mode();
+                let claim = self.claim_status(plugin_flash(&name, n, ""));
+                self.spawn_plugin(jobs, format!("{name} — output"), mode, timeout, claim);
+            }
+            PluginMode::Background => {
+                let claim = self.claim_status(plugin_flash(&name, n, " (background)"));
+                self.spawn_plugin(jobs, name, mode, timeout, claim);
+            }
+        }
+    }
+
+    /// Run every job off-thread with a per-job timeout, bounded output capture,
+    /// and bounded concurrency, then report back via [`Msg`]. A hung command
+    /// can't freeze the UI — the timeout aborts it — and the aggregated result
+    /// is generation-gated like every other stream. For a bulk run this is
+    /// where partial failures are counted.
+    fn spawn_plugin(
+        &mut self,
+        jobs: Vec<crate::plugins::Job>,
+        title: String,
+        mode: PluginMode,
+        timeout: u64,
+        claim: StatusClaim,
+    ) {
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        self.stop_plugins();
+        let run = self.plugin_run;
+        self.plugin_claim = Some(claim);
+        self.plugin_task = Some(crate::plugins::Task(tokio::spawn(async move {
+            let dur = Duration::from_secs(timeout);
+            // Bounded concurrency, results in the marked order.
+            let total = jobs.len();
+            let mut results = futures_util::stream::iter(jobs.into_iter().map(|job| async move {
+                let label = job.label.clone();
+                let out = tokio::time::timeout(dur, crate::plugins::execute(job)).await;
+                (label, out)
+            }))
+            .buffered(8);
+            let mut lines = crate::plugins::Lines::default();
+            let mut failures = crate::plugins::Lines::default();
+            let mut failed = 0;
+            while let Some((label, outcome)) = results.next().await {
+                let (ok, block, reason) =
+                    reduce_plugin_outcome(timeout, outcome, mode == PluginMode::Report);
+                if !ok {
+                    failed += 1;
+                    failures.push(format!("{label}: {reason}"));
+                }
+                if total > 1 {
+                    lines.push(format!("== {label} =="));
+                }
+                lines.extend(block);
+            }
+            let msg = match mode {
+                PluginMode::Popup | PluginMode::Report => Msg::PluginOutput {
+                    run,
+                    generation: genr,
+                    claim,
+                    title,
+                    lines: lines.finish(),
+                    warn: (failed > 0).then(|| format!("{failed} of {total} failed")),
+                },
+                _ => Msg::PluginBulkDone {
+                    run,
+                    generation: genr,
+                    claim,
+                    name: title,
+                    ok: total - failed,
+                    failed: failures.finish(),
+                },
+            };
+            let _ = tx.send(msg).await;
+        })));
+    }
+
+    pub(super) fn stop_plugins(&mut self) {
+        self.plugin_task = None;
+        if let Some(claim) = self.plugin_claim.take() {
+            self.clear_claimed_status(claim);
+        }
+        self.plugin_run = self.plugin_run.wrapping_add(1);
+    }
+}
+
+/// Bound the number of captured output lines and total bytes from a
+/// popup/background plugin, so a chatty command can't balloon memory or the
+/// redraw. Mirrors the log view's tail-buffer discipline.
+const PLUGIN_MAX_LINES: usize = 5_000;
+const PLUGIN_MAX_BYTES: usize = 1 << 20; // 1 MiB
+
+/// A short, single-line preview of an argv for the confirmation dialog.
+fn truncate_cmd(argv: &[String]) -> String {
+    let joined = argv.join(" ");
+    if joined.chars().count() > 120 {
+        let mut s: String = joined.chars().take(119).collect();
+        s.push('…');
+        s
+    } else {
+        joined
+    }
+}
+
+type SpawnOutcome = Result<std::io::Result<std::process::Output>, tokio::time::error::Elapsed>;
+
+/// Split captured bytes into bounded display lines.
+fn bounded_lines(bytes: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(&bytes[..bytes.len().min(PLUGIN_MAX_BYTES)]);
+    let mut lines: Vec<String> = text
+        .lines()
+        .take(PLUGIN_MAX_LINES)
+        .map(str::to_string)
+        .collect();
+    if text.lines().count() > PLUGIN_MAX_LINES {
+        lines.push(format!("… output truncated at {PLUGIN_MAX_LINES} lines"));
+    }
+    lines
+}
+
+/// First non-empty line of stderr, for a compact failure summary.
+fn stderr_summary(stderr: &[u8]) -> String {
+    String::from_utf8_lossy(stderr)
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("failed")
+        .chars()
+        .take(160)
+        .collect()
+}
+
+/// Reduce one job's outcome to `(ok, stdout lines, short failure reason)`.
+fn reduce_outcome(timeout: u64, outcome: SpawnOutcome) -> (bool, Vec<String>, String) {
+    match outcome {
+        Err(_) => {
+            let r = format!("timed out after {timeout}s");
+            (false, vec![r.clone()], r)
+        }
+        Ok(Err(e)) => {
+            let r = format!("failed to start: {e}");
+            (false, vec![format!("failed to run: {e}")], r)
+        }
+        Ok(Ok(out)) => {
+            let mut lines = bounded_lines(&out.stdout);
+            if out.status.success() {
+                if lines.is_empty() {
+                    lines.push("(no output)".into());
+                }
+                (true, lines, String::new())
+            } else {
+                let err = stderr_summary(&out.stderr);
+                let reason = if err.is_empty() {
+                    format!("exited {}", exit_label(&out.status))
+                } else {
+                    lines.push(String::new());
+                    lines.push(format!("[stderr] {err}"));
+                    format!("exited {} — {err}", exit_label(&out.status))
+                };
+                (false, lines, reason)
+            }
+        }
+    }
+}
+
+fn reduce_plugin_outcome(
+    timeout: u64,
+    outcome: SpawnOutcome,
+    report: bool,
+) -> (bool, Vec<String>, String) {
+    if report {
+        match outcome {
+            Ok(Ok(out)) if out.status.success() => match crate::plugins::render_report(&out.stdout)
+            {
+                Ok(lines) => (true, lines, String::new()),
+                Err(e) => (false, vec![e.clone()], e),
+            },
+            other => reduce_outcome(timeout, other),
+        }
+    } else {
+        reduce_outcome(timeout, outcome)
+    }
+}
+
+fn exit_label(status: &std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(c) => format!("code {c}"),
+        None => "by signal".into(),
+    }
+}
+
+/// Flash text for a launched popup/background run, noting the count on a bulk
+/// run.
+fn plugin_flash(name: &str, n: usize, suffix: &str) -> String {
+    if n > 1 {
+        format!("plugin: {name} ×{n}{suffix}…")
+    } else {
+        format!("plugin: {name}{suffix}…")
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10319,3 +10319,66 @@ async fn plugin_timeout_is_visible_through_the_command_path() {
     );
     assert!(app.plugin_task.is_none());
 }
+
+#[tokio::test]
+async fn unknown_inline_plugin_fields_preserve_base_and_override_settings() {
+    for layer in ["base", "cluster", "context"] {
+        let dir = std::env::temp_dir().join(format!(
+            "sofka-inline-plugin-compat-{}-{layer}",
+            std::process::id()
+        ));
+        write_config(&dir, "readonly = false\n");
+        let config_dir = match layer {
+            "cluster" => dir.join("clusters/test-cluster"),
+            "context" => dir.join("clusters/test-cluster/test-context"),
+            _ => dir.clone(),
+        };
+        write_config(
+            &config_dir,
+            r#"
+            readonly = true
+            favorite_namespaces = ["safe"]
+            [aliases]
+            pluginpods = "pods"
+            [[plugins]]
+            name = "Compatible plugin"
+            palette = "compatible-plugin"
+            command = "echo"
+            mutating = false
+            obsolete_option = true
+            [[plugins]]
+            name = "Other plugin"
+            key = "ctrl-g"
+            command = "echo"
+            mutating = false
+        "#,
+        );
+        let (mut app, _rx) = app_with_pod();
+        app.cluster.cluster_name = "test-cluster".into();
+        app.cluster.context = "test-context".into();
+        app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+        plugin_command(&mut app, "reload");
+        assert!(
+            app.readonly,
+            "{layer}: read-only setting was lost: {}",
+            app.flash
+        );
+        assert_eq!(app.namespace_favorites, ["safe"]);
+        assert_eq!(
+            app.user_aliases.get("pluginpods").map(String::as_str),
+            Some("pods")
+        );
+        assert_eq!(app.plugins.len(), 2, "{layer}: plugins were lost");
+        assert!(
+            app.config_warnings.is_empty(),
+            "{layer}: {:?}",
+            app.config_warnings
+        );
+        plugin_command(&mut app, "compatible-plugin");
+        assert!(
+            matches!(app.pending, Some(Suspend::Shell(_))),
+            "{layer}: inline plugin did not run"
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10322,9 +10322,18 @@ async fn plugin_timeout_is_visible_through_the_command_path() {
 
 #[tokio::test]
 async fn unknown_inline_plugin_fields_preserve_base_and_override_settings() {
+    check_unknown_inline_fields("plugin").await;
+}
+
+#[tokio::test]
+async fn unknown_inline_input_fields_preserve_base_and_override_settings() {
+    check_unknown_inline_fields("input").await;
+}
+
+async fn check_unknown_inline_fields(location: &str) {
     for layer in ["base", "cluster", "context"] {
         let dir = std::env::temp_dir().join(format!(
-            "sofka-inline-plugin-compat-{}-{layer}",
+            "sofka-inline-plugin-compat-{}-{layer}-{location}",
             std::process::id()
         ));
         write_config(&dir, "readonly = false\n");
@@ -10335,7 +10344,7 @@ async fn unknown_inline_plugin_fields_preserve_base_and_override_settings() {
         };
         write_config(
             &config_dir,
-            r#"
+            &r#"
             readonly = true
             favorite_namespaces = ["safe"]
             [aliases]
@@ -10344,14 +10353,37 @@ async fn unknown_inline_plugin_fields_preserve_base_and_override_settings() {
             name = "Compatible plugin"
             palette = "compatible-plugin"
             command = "echo"
+            args = ["${input.count}"]
             mutating = false
-            obsolete_option = true
+            PLUGIN_EXTRA
+            [plugins.inputs.count]
+            type = "integer"
+            default = "2"
+            min = 1
+            max = 5
+            INPUT_EXTRA
             [[plugins]]
             name = "Other plugin"
             key = "ctrl-g"
             command = "echo"
             mutating = false
-        "#,
+        "#
+            .replace(
+                "PLUGIN_EXTRA",
+                if location == "plugin" {
+                    "obsolete_option = true"
+                } else {
+                    ""
+                },
+            )
+            .replace(
+                "INPUT_EXTRA",
+                if location == "input" {
+                    "obsolete_option = true"
+                } else {
+                    ""
+                },
+            ),
         );
         let (mut app, _rx) = app_with_pod();
         app.cluster.cluster_name = "test-cluster".into();
@@ -10375,10 +10407,16 @@ async fn unknown_inline_plugin_fields_preserve_base_and_override_settings() {
             app.config_warnings
         );
         plugin_command(&mut app, "compatible-plugin");
+        let Some(Suspend::Shell(argv)) = app.pending.take() else {
+            panic!("{layer}: inline plugin did not run");
+        };
+        assert_eq!(argv, ["echo", "2"]);
+        plugin_command(&mut app, "compatible-plugin count=6");
         assert!(
-            matches!(app.pending, Some(Suspend::Shell(_))),
-            "{layer}: inline plugin did not run"
+            app.pending.is_none(),
+            "{layer}: input limits must still apply"
         );
+        assert!(app.flash.contains("outside range"));
         std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3334,6 +3334,7 @@ async fn every_async_result_is_scoped_to_its_own_operation() {
     assert_eq!(app.flash, "deleting 3 pods…");
 
     app.handle_msg(Msg::PluginBulkDone {
+        run: app.plugin_run,
         generation: app.generation,
         claim: find,
         name: "sync".into(),
@@ -9939,4 +9940,382 @@ async fn filtering_matches_a_naive_fuzzy_pass() {
 
         assert_eq!(got, want, "filter {pat:?} diverged from a naive fuzzy pass");
     }
+}
+
+// Plugin packages exercise the same palette/key path as installed adapters.
+fn plugin_command(app: &mut App, command: &str) {
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in command.chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+}
+
+fn named_plugin(command: &str, args: &[&str]) -> crate::config::Plugin {
+    crate::config::Plugin {
+        name: "Example".into(),
+        palette: Some("example-plugin".into()),
+        command: command.into(),
+        args: args.iter().map(|s| (*s).into()).collect(),
+        mutating: Some(false),
+        ..Default::default()
+    }
+}
+
+async fn plugin_result(rx: &mut Receiver<Msg>) -> Msg {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let msg = rx.recv().await.expect("plugin channel closed");
+            if matches!(msg, Msg::PluginOutput { .. } | Msg::PluginBulkDone { .. }) {
+                return msg;
+            }
+        }
+    })
+    .await
+    .expect("plugin did not finish")
+}
+
+#[tokio::test]
+async fn plugin_palette_validates_inputs_and_preserves_literal_arguments() {
+    let (mut app, _rx) = app_with_pod();
+    let mut plugin = named_plugin("echo", &["${input.count}", "${input.value}"]);
+    plugin.inputs = toml::from_str(
+        r#"
+        [count]
+        type = "integer"
+        default = "20"
+        min = 1
+        max = 100
+        [value]
+        type = "string"
+        default = "$NAME"
+    "#,
+    )
+    .unwrap();
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin count=101");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("outside range"), "{}", app.flash);
+    plugin_command(&mut app, "example-plugin typo=1");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("unknown input"));
+    plugin_command(&mut app, "exampl-plug count=3 value=literal");
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("completion dropped plugin input");
+    };
+    assert_eq!(argv, ["echo", "3", "literal"]);
+    plugin_command(&mut app, "example-plugin count=4 value=$(false)");
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("plugin not invoked");
+    };
+    assert_eq!(argv, ["echo", "4", "$(false)"]);
+    plugin_command(&mut app, "example-plugin");
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("plugin not invoked");
+    };
+    assert_eq!(argv, ["echo", "20", "$NAME"]);
+}
+
+#[tokio::test]
+async fn plugin_commands_respect_scope_dependencies_and_builtin_precedence() {
+    let (mut app, _rx) = app_with_pod();
+    let mut plugin = named_plugin("echo", &[]);
+    plugin.requires = vec!["sofka-missing-dependency-test-7941".into()];
+    plugin.install = Some("Install the example tool".into());
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("Install the example tool"));
+    app.plugins[0].requires.clear();
+    app.plugins[0].scopes = vec!["services".into()];
+    plugin_command(&mut app, "example-plugin");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("does not apply"));
+    app.plugins[0].scopes.clear();
+    app.plugins[0].palette = Some("pods".into());
+    plugin_command(&mut app, "pods");
+    assert!(app.pending.is_none(), "resource names win");
+    app.plugins[0].palette = Some("q".into());
+    plugin_command(&mut app, "q");
+    assert!(app.should_quit);
+    assert!(app.pending.is_none(), "built-ins win");
+}
+
+#[tokio::test]
+async fn network_load_plugins_confirm_and_obey_readonly_and_guardrails() {
+    let (mut app, _rx) = app_with_pod();
+    let mut plugin = named_plugin("echo", &[]);
+    plugin.network_load = true;
+    app.plugins = vec![plugin];
+    app.readonly = true;
+    plugin_command(&mut app, "example-plugin");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("generates network load"));
+    app.readonly = false;
+    plugin_command(&mut app, "example-plugin");
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(app.pending.is_none());
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert!(app.pending.take().is_some());
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["plugin:*".into()],
+        deny: true,
+        ..Default::default()
+    }];
+    plugin_command(&mut app, "example-plugin");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("blocked by guardrail"));
+    app.guardrails[0].deny = false;
+    app.guardrails[0].confirmation = Some("type-resource-name".into());
+    plugin_command(&mut app, "example-plugin");
+    assert_eq!(app.mode, Mode::Prompt);
+    app.handle_key(press(KeyCode::Char('a'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.pending.is_some());
+}
+
+#[tokio::test]
+async fn context_plugin_runs_without_selection_and_receives_request() {
+    let (mut app, mut rx) = test_app();
+    let mut plugin = named_plugin("/bin/cat", &[]);
+    plugin.target = Some("context".into());
+    plugin.output = Some("popup".into());
+    plugin.package_dir = Some(std::env::temp_dir());
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    let Msg::PluginOutput { lines, .. } = plugin_result(&mut rx).await else {
+        panic!("missing output");
+    };
+    let request: Value = serde_json::from_str(&lines.join("\n")).unwrap();
+    assert_eq!(request["schema_version"], 1);
+    assert!(request["object"].is_null());
+    assert_eq!(request["namespace"], app.namespace);
+}
+
+#[tokio::test]
+async fn package_report_renders_tables_and_remains_searchable() {
+    let (mut app, mut rx) = app_with_pod();
+    let report = r#"{"schema_version":1,"title":"Scan","sections":[{"title":"Findings","columns":["Resource","Severity"],"rows":[["api","high"]]}]}"#;
+    let mut plugin = named_plugin("/bin/echo", &[report]);
+    plugin.output = Some("report".into());
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    app.handle_msg(plugin_result(&mut rx).await);
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.detail.lines.iter().any(|s| s == "api | high"));
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    app.handle_key(press(KeyCode::Char('h'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.detail.filter, "h");
+}
+
+#[tokio::test]
+async fn invalid_report_is_a_visible_failure() {
+    let (mut app, mut rx) = app_with_pod();
+    let mut plugin = named_plugin("/bin/echo", &[r#"{"schema_version":8,"title":"Future"}"#]);
+    plugin.output = Some("report".into());
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    app.handle_msg(plugin_result(&mut rx).await);
+    assert!(app.flash_err);
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|s| s.contains("unsupported report"))
+    );
+}
+
+#[tokio::test]
+async fn cancelling_and_replacing_plugins_rejects_stale_results() {
+    let (mut app, _rx) = app_with_pod();
+    let mut plugin = named_plugin("/bin/sleep", &["20"]);
+    plugin.output = Some("popup".into());
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    let run = app.plugin_run;
+    let claim = current_claim(&app);
+    assert!(app.plugin_task.is_some());
+    plugin_command(&mut app, "plugin-cancel");
+    assert!(app.plugin_task.is_none());
+    app.handle_msg(Msg::PluginOutput {
+        run,
+        generation: app.generation,
+        claim,
+        title: "stale".into(),
+        lines: vec!["old result".into()],
+        warn: None,
+    });
+    assert_eq!(app.mode, Mode::Table);
+    plugin_command(&mut app, "example-plugin");
+    let first = app.plugin_run;
+    plugin_command(&mut app, "example-plugin");
+    assert!(app.plugin_run > first);
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.plugin_task.is_none(), "opening YAML cancels work");
+}
+
+#[tokio::test]
+async fn context_switch_and_quit_cancel_plugin_tasks() {
+    let (mut app, _rx) = app_with_pod();
+    let mut plugin = named_plugin("/bin/sleep", &["20"]);
+    plugin.output = Some("popup".into());
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    plugin_command(&mut app, "services");
+    assert!(app.plugin_task.is_none());
+    app.plugins[0].target = Some("context".into());
+    plugin_command(&mut app, "example-plugin");
+    app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
+    assert!(app.should_quit);
+    assert!(app.plugin_task.is_none());
+}
+
+#[tokio::test]
+async fn plugin_package_reload_loads_valid_packages_and_isolates_invalid_ones() {
+    let dir = std::env::temp_dir().join(format!("sofka-plugin-reload-{}", std::process::id()));
+    let package = dir.join("plugins/example");
+    let broken = dir.join("plugins/broken");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::create_dir_all(&broken).unwrap();
+    std::fs::write(
+        package.join("plugin.toml"),
+        r#"
+        schema_version = 1
+        [plugin]
+        name = "Example"
+        palette = "example-plugin"
+        command = "/bin/cat"
+        output = "popup"
+        target = "context"
+        mutating = false
+    "#,
+    )
+    .unwrap();
+    std::fs::write(broken.join("plugin.toml"), "not valid TOML").unwrap();
+    let (mut app, mut rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    plugin_command(&mut app, "reload");
+    assert_eq!(app.plugins.len(), 1);
+    assert!(app.config_warnings.iter().any(|w| w.contains("broken")));
+    plugin_command(&mut app, "example-plugin");
+    app.handle_msg(plugin_result(&mut rx).await);
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|s| s.contains("schema_version"))
+    );
+    std::fs::remove_file(package.join("plugin.toml")).unwrap();
+    plugin_command(&mut app, "reload");
+    assert!(app.plugins.is_empty());
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[tokio::test]
+async fn plugin_forward_uses_selected_target_and_requires_valid_port_before_launch() {
+    let (mut app, _rx) = app_with_pod();
+    let mut plugin = named_plugin("/bin/cat", &[]);
+    plugin.output = Some("report".into());
+    plugin.package_dir = Some(std::env::temp_dir());
+    plugin.port_forward = Some("8080".into());
+    plugin.confirm = true;
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    assert_eq!(app.mode, Mode::Confirm);
+    let Some(ConfirmAction::Plugin { jobs, .. }) = &app.confirm_action else {
+        panic!("missing preview");
+    };
+    let forward = jobs[0].forward.as_ref().unwrap();
+    assert_eq!(forward.remote, 8080);
+    assert!(forward.argv.ends_with(&[
+        "port-forward".into(),
+        "-n".into(),
+        "default".into(),
+        "pod/a".into()
+    ]));
+    assert_eq!(
+        jobs[0].object.as_ref().unwrap().metadata.name.as_deref(),
+        Some("a")
+    );
+    assert!(app.confirm_label.contains("port-forward=pods/a:8080"));
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    app.plugins[0].port_forward = Some("0".into());
+    plugin_command(&mut app, "example-plugin");
+    assert!(app.plugin_task.is_none());
+    assert!(app.flash.contains("1 to 65535"));
+}
+
+#[tokio::test]
+async fn context_plugin_cannot_bypass_namespace_guardrails_in_all_namespaces_mode() {
+    let (mut app, _rx) = test_app();
+    let mut plugin = named_plugin("echo", &[]);
+    plugin.target = Some("context".into());
+    app.plugins = vec![plugin];
+    app.namespace.clear();
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["plugin:*".into()],
+        namespaces: vec!["restricted".into()],
+        deny: true,
+        ..Default::default()
+    }];
+    plugin_command(&mut app, "example-plugin");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("blocked by guardrail"));
+}
+
+#[tokio::test]
+async fn package_request_uses_the_selected_snapshot_and_limits_large_objects() {
+    let (mut app, mut rx) = app_with_pod();
+    let mut plugin = named_plugin("/bin/cat", &[]);
+    plugin.package_dir = Some(std::env::temp_dir());
+    plugin.output = Some("popup".into());
+    app.plugins = vec![plugin];
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","labels":{"revision":"old"}}}),
+    );
+    plugin_command(&mut app, "example-plugin");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default","labels":{"revision":"new"}}}),
+    );
+    let Msg::PluginOutput { lines, .. } = plugin_result(&mut rx).await else {
+        panic!("missing request");
+    };
+    let request: Value = serde_json::from_str(&lines.join("\n")).unwrap();
+    assert_eq!(request["object"]["metadata"]["labels"]["revision"], "old");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1","kind":"Pod","metadata":{"name":"a","namespace":"default"},"spec":{"large":"x".repeat(crate::plugins::MAX_BYTES)}}),
+    );
+    plugin_command(&mut app, "example-plugin");
+    app.handle_msg(plugin_result(&mut rx).await);
+    assert!(app.flash_err);
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|s| s.contains("request exceeds 1 MiB"))
+    );
+}
+
+#[tokio::test]
+async fn plugin_timeout_is_visible_through_the_command_path() {
+    let (mut app, mut rx) = app_with_pod();
+    let mut plugin = named_plugin("/bin/sleep", &["30"]);
+    plugin.output = Some("popup".into());
+    plugin.timeout = Some("1s".into());
+    app.plugins = vec![plugin];
+    plugin_command(&mut app, "example-plugin");
+    app.handle_msg(plugin_result(&mut rx).await);
+    assert!(app.flash_err);
+    assert!(
+        app.detail
+            .lines
+            .iter()
+            .any(|s| s.contains("timed out after 1s"))
+    );
+    assert!(app.plugin_task.is_none());
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -784,9 +784,27 @@ pub struct Skin {
 /// output = "popup"          # capture into a scrollable view (not the terminal)
 /// ```
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Plugin {
     /// Key chord that triggers the plugin (see [`crate::keys::KeyChord`]).
+    #[serde(default)]
     pub key: String,
+    /// Optional command-palette name, independent of the executable.
+    pub palette: Option<String>,
+    #[serde(default)]
+    pub requires: Vec<String>,
+    pub install: Option<String>,
+    #[serde(default)]
+    pub inputs: std::collections::BTreeMap<String, crate::plugins::Input>,
+    /// `context` runs once without requiring a selected row; default `selection`.
+    pub target: Option<String>,
+    /// Declare traffic generation even when no Kubernetes objects are mutated.
+    #[serde(default)]
+    pub network_load: bool,
+    /// Remote port (or an input placeholder) to forward for the selected pod/service.
+    pub port_forward: Option<String>,
+    #[serde(skip)]
+    pub package_dir: Option<PathBuf>,
     pub name: String,
     pub command: String,
     #[serde(default)]
@@ -1059,14 +1077,16 @@ pub fn bookmark_warnings(bookmarks: &[Bookmark]) -> Vec<String> {
 pub fn plugin_warnings(plugins: &[Plugin]) -> Vec<String> {
     let mut warns = Vec::new();
     for p in plugins {
-        if let Err(e) = crate::keys::KeyChord::parse(&p.key) {
+        if !(p.key.is_empty() && p.palette.is_some())
+            && let Err(e) = crate::keys::KeyChord::parse(&p.key)
+        {
             warns.push(format!("plugin {:?}: invalid key — {e}", p.name));
         }
         if let Some(o) = &p.output
-            && !matches!(o.as_str(), "terminal" | "popup" | "background")
+            && !matches!(o.as_str(), "terminal" | "popup" | "background" | "report")
         {
             warns.push(format!(
-                "plugin {:?}: unknown output {o:?} (expected terminal/popup/background) — using terminal",
+                "plugin {:?}: unknown output {o:?} (expected terminal/popup/background/report) — using terminal",
                 p.name
             ));
         }
@@ -1206,13 +1226,16 @@ impl ConfigLoader {
 
         // A type mismatch introduced by an override drops back to the base
         // config (validated at load time) rather than losing everything.
-        let config = merged.try_into().unwrap_or_else(|e| {
+        let mut config: Config = merged.try_into().unwrap_or_else(|e| {
             warnings.push(format!("ignoring cluster overrides: {e}"));
             self.base
                 .clone()
                 .and_then(|b| b.try_into().ok())
                 .unwrap_or_default()
         });
+        if let Some(dir) = &self.dir {
+            crate::plugins::load_packages(&dir.join("plugins"), &mut config.plugins, &mut warnings);
+        }
         let skin_override = overlay
             .get("skin")
             .and_then(|s| s.get("name"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -784,8 +784,10 @@ pub struct Skin {
 /// output = "popup"          # capture into a scrollable view (not the terminal)
 /// ```
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Plugin {
+    /// Inline configuration ignores unknown fields. Package validation rejects them.
+    #[serde(flatten)]
+    pub(crate) unknown_fields: std::collections::BTreeMap<String, toml::Value>,
     /// Key chord that triggers the plugin (see [`crate::keys::KeyChord`]).
     #[serde(default)]
     pub key: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod k8s;
 pub mod keys;
 pub mod logfilter;
 pub mod nsmem;
+pub mod plugins;
 pub mod providers;
 pub mod rightsize;
 pub mod snapshot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,14 @@ struct Args {
     #[arg(long)]
     snapshot: bool,
 
+    /// Validate a plugin package without executing it or connecting to a cluster.
+    #[arg(long, value_name = "DIR", conflicts_with_all = ["check", "snapshot", "info", "validate_plugin_report"])]
+    validate_plugin: Option<PathBuf>,
+
+    /// Validate and render a versioned plugin JSON report without a cluster.
+    #[arg(long, value_name = "FILE", conflicts_with_all = ["check", "snapshot", "info"])]
+    validate_plugin_report: Option<PathBuf>,
+
     /// Print version/build, config sources, directories, and the current
     /// kubeconfig context, then exit (no cluster connection). For live
     /// discovery/metrics/watch status, use `:info` inside the TUI.
@@ -102,6 +110,24 @@ fn main() -> Result<()> {
 }
 
 async fn run_main(args: Args) -> Result<()> {
+    if let Some(dir) = &args.validate_plugin {
+        let plugin = sofka::plugins::read_package(dir).map_err(anyhow::Error::msg)?;
+        sofka::plugins::available(&plugin).map_err(anyhow::Error::msg)?;
+        println!("valid plugin: {}", plugin.name);
+        return Ok(());
+    }
+    if let Some(path) = &args.validate_plugin_report {
+        use std::io::Read;
+        let mut bytes = Vec::new();
+        std::fs::File::open(path)?
+            .take((sofka::plugins::MAX_BYTES + 1) as u64)
+            .read_to_end(&mut bytes)?;
+        for line in sofka::plugins::render_report(&bytes).map_err(anyhow::Error::msg)? {
+            println!("{line}");
+        }
+        return Ok(());
+    }
+
     let (loader, mut config_warnings) = config::ConfigLoader::load();
 
     // `--info`: print static diagnostics (no cluster connection) and exit.

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -14,8 +14,10 @@ pub const MAX_BYTES: usize = 1 << 20;
 pub const MAX_LINES: usize = 5_000;
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Input {
+    /// Inline configuration ignores unknown fields. Package validation rejects them.
+    #[serde(flatten)]
+    unknown_fields: BTreeMap<String, toml::Value>,
     #[serde(rename = "type")]
     pub kind: String,
     pub default: Option<String>,
@@ -236,6 +238,9 @@ pub fn validate_plugin(plugin: &Plugin) -> Result<(), String> {
         return Err("packages must use an executable adapter, not shell = true".into());
     }
     for (name, spec) in &plugin.inputs {
+        if let Some(field) = spec.unknown_fields.keys().next() {
+            return Err(format!("unknown field {field:?} in plugin input {name:?}"));
+        }
         if name.is_empty()
             || !name
                 .bytes()
@@ -653,6 +658,12 @@ mod tests {
                 .unwrap_err()
                 .contains("unknown field")
         );
+        let nested_error = package(&format!(
+            "{valid}[plugin.inputs.count]\ntype = 'integer'\ndefault = '2'\nobsolete_option = true\n"
+        ))
+        .unwrap_err();
+        assert!(nested_error.contains("unknown field \"obsolete_option\""));
+        assert!(nested_error.contains("plugin input \"count\""));
         assert!(
             package(&valid.replace("palette = 'demo'", "palette = 'ctx'"))
                 .unwrap_err()

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -189,6 +189,9 @@ pub fn read_package(dir: &Path) -> Result<Plugin, String> {
 }
 
 pub fn validate_plugin(plugin: &Plugin) -> Result<(), String> {
+    if let Some(field) = plugin.unknown_fields.keys().next() {
+        return Err(format!("unknown field {field:?} in plugin manifest"));
+    }
     if plugin.name.trim().is_empty() || plugin.command.trim().is_empty() {
         return Err("name and command must not be empty".into());
     }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,0 +1,793 @@
+//! Versioned external plugin packages and their bounded process/report protocol.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+
+use crate::config::Plugin;
+
+pub const MAX_BYTES: usize = 1 << 20;
+pub const MAX_LINES: usize = 5_000;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Input {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub default: Option<String>,
+    pub min: Option<u64>,
+    pub max: Option<u64>,
+    #[serde(default)]
+    pub choices: Vec<String>,
+}
+
+impl Input {
+    fn validate(&self, value: &str) -> Result<(), String> {
+        let number = match self.kind.as_str() {
+            "string" => None,
+            "boolean" if matches!(value, "true" | "false") => None,
+            "integer" => Some(
+                value
+                    .parse::<u64>()
+                    .map_err(|_| "expected unsigned integer")?,
+            ),
+            "duration" => Some(crate::providers::parse_lookback(value)? as u64),
+            _ => return Err(format!("invalid {} value {value:?}", self.kind)),
+        };
+        if let Some(n) = number
+            && (self.min.is_some_and(|m| n < m) || self.max.is_some_and(|m| n > m))
+        {
+            return Err(format!(
+                "value outside range {:?}..{:?}",
+                self.min, self.max
+            ));
+        }
+        if !self.choices.is_empty() && !self.choices.iter().any(|c| c == value) {
+            return Err(format!("expected one of {}", self.choices.join(", ")));
+        }
+        Ok(())
+    }
+}
+
+pub fn inputs(plugin: &Plugin, arguments: &str) -> Result<BTreeMap<String, String>, String> {
+    let mut supplied = BTreeMap::new();
+    for word in arguments.split_whitespace() {
+        let (name, value) = word
+            .split_once('=')
+            .ok_or("use name=value plugin arguments")?;
+        if !plugin.inputs.contains_key(name) {
+            return Err(format!("unknown input {name:?}"));
+        }
+        if supplied
+            .insert(name.to_string(), value.to_string())
+            .is_some()
+        {
+            return Err(format!("duplicate input {name:?}"));
+        }
+    }
+    for (name, spec) in &plugin.inputs {
+        let value = supplied
+            .get(name)
+            .or(spec.default.as_ref())
+            .ok_or_else(|| format!("missing input {name}=…"))?
+            .clone();
+        spec.validate(&value).map_err(|e| format!("{name}: {e}"))?;
+        supplied.insert(name.clone(), value);
+    }
+    Ok(supplied)
+}
+
+pub fn input_arg(value: &str, inputs: &BTreeMap<String, String>) -> String {
+    value
+        .strip_prefix("${input.")
+        .and_then(|s| s.strip_suffix('}'))
+        .and_then(|key| inputs.get(key))
+        .cloned()
+        .unwrap_or_else(|| value.into())
+}
+
+pub fn available(plugin: &Plugin) -> Result<(), String> {
+    let missing: Vec<_> = plugin
+        .requires
+        .iter()
+        .filter(|name| executable(name).is_none())
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "missing executables: {}{}",
+            missing
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+            plugin
+                .install
+                .as_ref()
+                .map(|s| format!(" — {s}"))
+                .unwrap_or_default()
+        ))
+    }
+}
+
+pub fn executable(name: &str) -> Option<PathBuf> {
+    let candidates = if name.contains(std::path::MAIN_SEPARATOR) {
+        vec![PathBuf::from(name)]
+    } else {
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+            .map(|p| p.join(name))
+            .collect()
+    };
+    candidates.into_iter().find(|p| {
+        p.metadata().is_ok_and(|m| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                m.is_file() && m.permissions().mode() & 0o111 != 0
+            }
+            #[cfg(not(unix))]
+            {
+                m.is_file()
+            }
+        })
+    })
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    schema_version: u32,
+    plugin: Plugin,
+}
+
+pub fn read_package(dir: &Path) -> Result<Plugin, String> {
+    let dir = dir.canonicalize().map_err(|e| e.to_string())?;
+    let path = dir.join("plugin.toml");
+    use std::io::Read;
+    let mut bytes = Vec::new();
+    std::fs::File::open(&path)
+        .map_err(|e| e.to_string())?
+        .take((MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|e| e.to_string())?;
+    if bytes.len() > MAX_BYTES {
+        return Err("manifest exceeds 1 MiB".into());
+    }
+    let manifest: Manifest =
+        toml::from_str(std::str::from_utf8(&bytes).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+    if manifest.schema_version != 1 {
+        return Err("unsupported schema_version (expected 1)".into());
+    }
+    let mut plugin = manifest.plugin;
+    validate_plugin(&plugin)?;
+    if plugin.command.starts_with("./") {
+        let command = dir
+            .join(&plugin.command)
+            .canonicalize()
+            .map_err(|e| e.to_string())?;
+        if !command.starts_with(&dir) {
+            return Err("relative command escapes package directory".into());
+        }
+        plugin.command = command.to_string_lossy().into_owned();
+    }
+    for requirement in &mut plugin.requires {
+        if requirement.starts_with("./") {
+            *requirement = dir.join(&*requirement).to_string_lossy().into_owned();
+        }
+    }
+    if !plugin.requires.contains(&plugin.command) {
+        plugin.requires.push(plugin.command.clone());
+    }
+    plugin.package_dir = Some(dir);
+    Ok(plugin)
+}
+
+pub fn validate_plugin(plugin: &Plugin) -> Result<(), String> {
+    if plugin.name.trim().is_empty() || plugin.command.trim().is_empty() {
+        return Err("name and command must not be empty".into());
+    }
+    if let Some(name) = &plugin.palette
+        && (name.is_empty()
+            || !name
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'))
+    {
+        return Err("palette must contain lowercase letters, digits or hyphens".into());
+    }
+    if plugin
+        .palette
+        .as_deref()
+        .is_some_and(crate::app::plugin_command_reserved)
+    {
+        return Err("palette command is reserved by sofka".into());
+    }
+    let warnings = crate::config::plugin_warnings(std::slice::from_ref(plugin));
+    if !warnings.is_empty() {
+        return Err(warnings.join("; "));
+    }
+    if !matches!(
+        plugin.target.as_deref(),
+        None | Some("selection" | "context")
+    ) {
+        return Err("target must be selection or context".into());
+    }
+    if plugin.port_forward.is_some()
+        && (plugin.target.as_deref() == Some("context")
+            || plugin.output.as_deref() != Some("report"))
+    {
+        return Err("port_forward requires target = selection and output = report".into());
+    }
+    if !matches!(
+        plugin.output.as_deref(),
+        Some("popup" | "background" | "report")
+    ) {
+        return Err("packages require captured output: popup, background or report".into());
+    }
+    if plugin.shell {
+        return Err("packages must use an executable adapter, not shell = true".into());
+    }
+    for (name, spec) in &plugin.inputs {
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
+        {
+            return Err(format!("invalid input name {name:?}"));
+        }
+        if !matches!(
+            spec.kind.as_str(),
+            "string" | "integer" | "boolean" | "duration"
+        ) {
+            return Err(format!("{name}: unsupported input type"));
+        }
+        if spec.min.zip(spec.max).is_some_and(|(min, max)| min > max) {
+            return Err(format!("{name}: min exceeds max"));
+        }
+        if (spec.min.is_some() || spec.max.is_some())
+            && !matches!(spec.kind.as_str(), "integer" | "duration")
+        {
+            return Err(format!("{name}: min/max require integer or duration"));
+        }
+        if let Some(value) = &spec.default {
+            spec.validate(value).map_err(|e| format!("{name}: {e}"))?;
+        }
+    }
+    for argument in plugin.args.iter().chain(plugin.port_forward.iter()) {
+        if argument.contains("${input.") {
+            let name = argument.strip_prefix("${input.").and_then(|a| a.strip_suffix('}'))
+                .filter(|name| plugin.inputs.contains_key(*name))
+                .ok_or_else(|| format!("invalid input placeholder {argument:?}; use a declared input as a whole argument"))?;
+            if name.is_empty() {
+                return Err("empty input placeholder".into());
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn load_packages(dir: &Path, plugins: &mut Vec<Plugin>, warnings: &mut Vec<String>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            warnings.push(format!("{}: {e}", dir.display()));
+            return;
+        }
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(e) if e.path().is_dir() => paths.push(e.path()),
+            Ok(_) => {}
+            Err(e) => warnings.push(format!("{}: {e}", dir.display())),
+        }
+    }
+    paths.sort();
+    for path in paths {
+        match read_package(&path) {
+            Ok(p) => {
+                if plugins.iter().any(|old| {
+                    old.name == p.name || (p.palette.is_some() && old.palette == p.palette)
+                }) {
+                    warnings.push(format!(
+                        "{}: duplicate plugin name/command; earlier configuration wins",
+                        path.display()
+                    ));
+                } else {
+                    if let Err(e) = available(&p) {
+                        warnings.push(format!("plugin {}: {e}", p.name));
+                    }
+                    plugins.push(p);
+                }
+            }
+            Err(e) => warnings.push(format!("ignoring {}: {e}", path.display())),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Report {
+    schema_version: u32,
+    title: String,
+    #[serde(default)]
+    sections: Vec<Section>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Section {
+    title: String,
+    #[serde(default)]
+    lines: Vec<String>,
+    #[serde(default)]
+    columns: Vec<String>,
+    #[serde(default)]
+    rows: Vec<Vec<String>>,
+}
+
+pub fn render_report(bytes: &[u8]) -> Result<Vec<String>, String> {
+    if bytes.len() > MAX_BYTES {
+        return Err("report exceeds 1 MiB".into());
+    }
+    let report: Report =
+        serde_json::from_slice(bytes).map_err(|e| format!("invalid plugin report: {e}"))?;
+    if report.schema_version != 1 {
+        return Err("unsupported report schema_version (expected 1)".into());
+    }
+    let mut lines = vec![clean(&report.title)];
+    for section in report.sections {
+        lines.push(String::new());
+        lines.push(clean(&section.title));
+        lines.extend(section.lines.iter().map(|s| clean(s)));
+        if !section.columns.is_empty() {
+            lines.push(
+                section
+                    .columns
+                    .iter()
+                    .map(|s| clean(s))
+                    .collect::<Vec<_>>()
+                    .join(" | "),
+            );
+        }
+        for row in section.rows {
+            if row.len() != section.columns.len() {
+                return Err("report row length does not match columns".into());
+            }
+            lines.push(row.iter().map(|s| clean(s)).collect::<Vec<_>>().join(" | "));
+        }
+    }
+    Ok(bound_lines(lines))
+}
+
+fn clean(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect()
+}
+
+#[derive(Default)]
+pub struct Lines {
+    lines: Vec<String>,
+    bytes: usize,
+    truncated: bool,
+}
+
+impl Lines {
+    pub fn push(&mut self, line: String) {
+        if self.truncated {
+            return;
+        }
+        if self.lines.len() >= MAX_LINES || self.bytes + line.len() > MAX_BYTES {
+            self.truncated = true;
+        } else {
+            self.bytes += line.len();
+            self.lines.push(line);
+        }
+    }
+
+    pub fn extend(&mut self, lines: impl IntoIterator<Item = String>) {
+        for line in lines {
+            self.push(line);
+        }
+    }
+
+    pub fn finish(mut self) -> Vec<String> {
+        if self.truncated {
+            self.lines.push("… output truncated".into());
+        }
+        self.lines
+    }
+}
+
+pub fn bound_lines(lines: Vec<String>) -> Vec<String> {
+    let mut output = Lines::default();
+    output.extend(lines);
+    output.finish()
+}
+
+pub struct Job {
+    pub label: String,
+    pub argv: Vec<String>,
+    pub directory: Option<PathBuf>,
+    pub request: Option<Value>,
+    pub object: Option<std::sync::Arc<kube::core::DynamicObject>>,
+    pub forward: Option<Forward>,
+}
+
+pub struct Forward {
+    pub argv: Vec<String>,
+    pub remote: u16,
+    pub local: Option<u16>,
+}
+
+/// Dropping an owner cancels its task instead of detaching it.
+pub struct Task(pub tokio::task::JoinHandle<()>);
+impl Drop for Task {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+struct Process {
+    child: tokio::process::Child,
+    #[cfg(unix)]
+    group: u32,
+}
+impl Process {
+    fn spawn(command: &mut tokio::process::Command) -> std::io::Result<Self> {
+        command.kill_on_drop(true);
+        #[cfg(unix)]
+        command.process_group(0);
+        let child = command.spawn()?;
+        Ok(Self {
+            #[cfg(unix)]
+            group: child.id().unwrap_or_default(),
+            child,
+        })
+    }
+}
+impl Drop for Process {
+    fn drop(&mut self) {
+        // Adapters may launch scanners; cancel the whole private process group.
+        #[cfg(unix)]
+        if self.group > 0 {
+            let _ = std::process::Command::new("/bin/kill")
+                .args(["-KILL", "--", &format!("-{}", self.group)])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+        let _ = self.child.start_kill();
+    }
+}
+
+async fn read_limited(mut stream: impl AsyncRead + Unpin) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    (&mut stream)
+        .take((MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .await?;
+    if bytes.len() > MAX_BYTES {
+        return Err(std::io::Error::other("plugin output exceeds 1 MiB"));
+    }
+    Ok(bytes)
+}
+
+async fn forward(spec: &Forward) -> std::io::Result<(u16, Option<(Process, Task)>)> {
+    if let Some(port) = spec.local {
+        return Ok((port, None));
+    }
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    let mut cmd = tokio::process::Command::new(&spec.argv[0]);
+    cmd.args(&spec.argv[1..])
+        .arg(format!(":{}", spec.remote))
+        .arg("--address=127.0.0.1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let mut child = Process::spawn(&mut cmd)?;
+    let mut stdout = BufReader::new(child.child.stdout.take().unwrap());
+    let mut line = Vec::new();
+    loop {
+        let n = (&mut stdout)
+            .take(4096)
+            .read_until(b'\n', &mut line)
+            .await?;
+        if n == 0 || line.len() >= 4096 {
+            return Err(std::io::Error::other(
+                "port-forward failed before becoming ready",
+            ));
+        }
+        let text = String::from_utf8_lossy(&line);
+        if let Some(port) = text
+            .strip_prefix("Forwarding from 127.0.0.1:")
+            .and_then(|s| s.split_whitespace().next())
+            .and_then(|p| p.parse().ok())
+        {
+            let drain = Task(tokio::spawn(async move {
+                let _ = tokio::io::copy(&mut stdout, &mut tokio::io::sink()).await;
+            }));
+            return Ok((port, Some((child, drain))));
+        }
+        line.clear();
+    }
+}
+
+struct RequestBuffer(Vec<u8>);
+
+impl std::io::Write for RequestBuffer {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if self.0.len() + bytes.len() > MAX_BYTES {
+            return Err(std::io::Error::other("plugin request exceeds 1 MiB"));
+        }
+        self.0.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+pub async fn execute(mut job: Job) -> std::io::Result<std::process::Output> {
+    let mut forward_owner = None;
+    if let Some(spec) = &job.forward {
+        let (port, owner) = forward(spec).await?;
+        forward_owner = owner;
+        if let Some(request) = &mut job.request {
+            request["forward"] = serde_json::json!({"host": "127.0.0.1", "local_port": port, "remote_port": spec.remote});
+        }
+    }
+    let input = job
+        .request
+        .as_ref()
+        .map(|request| {
+            let mut writer = RequestBuffer(Vec::new());
+            if let Some(object) = &job.object {
+                #[derive(serde::Serialize)]
+                struct Request<'a> {
+                    #[serde(flatten)]
+                    fields: &'a Value,
+                    object: &'a kube::core::DynamicObject,
+                }
+                serde_json::to_writer(
+                    &mut writer,
+                    &Request {
+                        fields: request,
+                        object,
+                    },
+                )?;
+            } else {
+                serde_json::to_writer(&mut writer, request)?;
+            }
+            Ok::<_, std::io::Error>(writer.0)
+        })
+        .transpose()?;
+    let mut command = tokio::process::Command::new(&job.argv[0]);
+    command
+        .args(&job.argv[1..])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(dir) = &job.directory {
+        command.current_dir(dir);
+    }
+    let mut process = Process::spawn(&mut command)?;
+    let mut stdin = process.child.stdin.take().unwrap();
+    let stdout = process.child.stdout.take().unwrap();
+    let stderr = process.child.stderr.take().unwrap();
+
+    let write = async {
+        if let Some(input) = input {
+            stdin.write_all(&input).await?;
+        }
+        drop(stdin);
+        Ok::<_, std::io::Error>(())
+    };
+    let (_, stdout, stderr, status) = tokio::try_join!(
+        write,
+        read_limited(stdout),
+        read_limited(stderr),
+        process.child.wait()
+    )?;
+    drop(forward_owner);
+    Ok(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(command: &str, args: &[&str]) -> Job {
+        Job {
+            label: "test".into(),
+            argv: std::iter::once(command)
+                .chain(args.iter().copied())
+                .map(str::to_string)
+                .collect(),
+            directory: None,
+            request: None,
+            object: None,
+            forward: None,
+        }
+    }
+
+    fn package(text: &str) -> Result<Plugin, String> {
+        let dir = std::env::temp_dir().join(format!(
+            "sofka-package-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("plugin.toml"), text).unwrap();
+        let result = read_package(&dir);
+        std::fs::remove_dir_all(dir).unwrap();
+        result
+    }
+
+    #[test]
+    fn manifests_reject_unknown_versions_fields_commands_and_invalid_inputs() {
+        let valid = "schema_version = 1\n[plugin]\nname = 'Demo'\npalette = 'demo'\ncommand = '/bin/cat'\noutput = 'report'\n";
+        assert!(package(valid).is_ok());
+        assert!(
+            package(&valid.replace("schema_version = 1", "schema_version = 2"))
+                .unwrap_err()
+                .contains("unsupported")
+        );
+        assert!(
+            package(&format!("{valid}typo = true\n"))
+                .unwrap_err()
+                .contains("unknown field")
+        );
+        assert!(
+            package(&valid.replace("palette = 'demo'", "palette = 'ctx'"))
+                .unwrap_err()
+                .contains("reserved")
+        );
+        assert!(
+            package(&valid.replace("output = 'report'", "output = 'terminal'"))
+                .unwrap_err()
+                .contains("captured output")
+        );
+        assert!(
+            package(&format!(
+                "{valid}[plugin.inputs.count]\ntype = 'integer'\ndefault = '99'\nmax = 5\n"
+            ))
+            .unwrap_err()
+            .contains("outside range")
+        );
+        assert!(
+            package(&format!("{valid}args = ['${{input.missing}}']\n"))
+                .unwrap_err()
+                .contains("invalid input placeholder")
+        );
+    }
+
+    #[test]
+    fn report_rejects_wrong_row_shapes_and_bounds_rendered_lines() {
+        let bad = br#"{"schema_version":1,"title":"Scan","sections":[{"title":"Rows","columns":["One"],"rows":[["a","b"]]}]}"#;
+        assert!(render_report(bad).unwrap_err().contains("row length"));
+        let report = serde_json::json!({"schema_version": 1, "title": "Scan", "sections": [{"title": "Rows", "lines": vec!["test"; MAX_LINES + 1]}]});
+        let lines = render_report(&serde_json::to_vec(&report).unwrap()).unwrap();
+        assert!(lines.len() <= MAX_LINES + 1);
+        assert!(lines.last().unwrap().contains("truncated"));
+        assert!(
+            render_report(&vec![b' '; MAX_BYTES + 1])
+                .unwrap_err()
+                .contains("exceeds")
+        );
+    }
+
+    #[test]
+    fn aggregate_output_budget_applies_across_jobs() {
+        let mut lines = Lines::default();
+        for _ in 0..100 {
+            lines.push("x".repeat(50_000));
+        }
+        let output = lines.finish();
+        assert!(output.iter().map(String::len).sum::<usize>() <= MAX_BYTES + 32);
+        assert!(output.last().unwrap().contains("truncated"));
+    }
+
+    #[tokio::test]
+    async fn capture_stops_chatty_processes_before_unbounded_allocation() {
+        let error = execute(job("/bin/sh", &["-c", "head -c 1100000 /dev/zero"]))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("exceeds 1 MiB"));
+    }
+
+    #[tokio::test]
+    async fn adapters_receive_stdin_and_run_in_their_package_directory() {
+        let mut command = job("/bin/sh", &["-c", "pwd; cat"]);
+        let dir = std::env::temp_dir().canonicalize().unwrap();
+        command.directory = Some(dir.clone());
+        command.request =
+            Some(serde_json::json!({"schema_version":1,"object":{"metadata":{"name":"pod"}}}));
+        let output = execute(command).await.unwrap();
+        assert!(output.status.success());
+        let text = String::from_utf8(output.stdout).unwrap();
+        let (cwd, json) = text.split_once('\n').unwrap();
+        assert_eq!(Path::new(cwd), dir);
+        assert_eq!(
+            serde_json::from_str::<Value>(json).unwrap()["object"]["metadata"]["name"],
+            "pod"
+        );
+    }
+
+    #[tokio::test]
+    async fn managed_forward_waits_for_readiness_and_supplies_local_port() {
+        let mut command = job("/bin/cat", &[]);
+        command.request = Some(serde_json::json!({"schema_version":1}));
+        command.forward = Some(Forward {
+            argv: vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "printf 'Forwarding from 127.0.0.1:32123 -> 80\\n'; sleep 30".into(),
+                "forward".into(),
+            ],
+            remote: 80,
+            local: None,
+        });
+        let output = tokio::time::timeout(std::time::Duration::from_secs(3), execute(command))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(output.status.success());
+        let request: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(request["forward"]["local_port"], 32123);
+        assert_eq!(request["forward"]["remote_port"], 80);
+    }
+
+    #[tokio::test]
+    async fn existing_forward_does_not_spawn_another_process() {
+        let mut command = job("/bin/cat", &[]);
+        command.request = Some(serde_json::json!({}));
+        command.forward = Some(Forward {
+            argv: vec!["does-not-exist".into()],
+            remote: 443,
+            local: Some(32124),
+        });
+        let output = execute(command).await.unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output.stdout).unwrap()["forward"]["local_port"],
+            32124
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timeout_kills_adapter_descendants() {
+        let dir = std::env::temp_dir().join(format!("sofka-plugin-cancel-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join("orphan");
+        let command = job(
+            "/bin/sh",
+            &[
+                "-c",
+                "(sleep 1; printf orphan > \"$1\") & wait",
+                "test",
+                marker.to_str().unwrap(),
+            ],
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(150), execute(command))
+                .await
+                .is_err()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        assert!(!marker.exists(), "a descendant survived cancellation");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -88,6 +88,7 @@ pub enum Msg {
     },
     /// Captured output of an `output = "popup"` plugin run.
     PluginOutput {
+        run: u64,
         generation: u64,
         claim: StatusClaim,
         title: String,
@@ -98,6 +99,7 @@ pub enum Msg {
     /// Completion notice for an `output = "background"` plugin run (single or
     /// bulk): how many jobs succeeded and the failures (label + reason).
     PluginBulkDone {
+        run: u64,
         generation: u64,
         claim: StatusClaim,
         name: String,
@@ -453,6 +455,10 @@ impl Store {
 
     pub fn get(&self, key: &str) -> Option<&DynamicObject> {
         self.items.get(key).map(AsRef::as_ref)
+    }
+
+    pub(crate) fn shared(&self, key: &str) -> Option<Arc<DynamicObject>> {
+        self.items.get(key).cloned()
     }
 
     pub fn key(&self, key: &str) -> Option<&RowKey> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2132,6 +2132,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "provider logs: change lookback period (30m, 4h, 2d)",
         ),
         Line::from(""),
+        bind(
+            ":plugin-cancel",
+            "cancel the active plugin and its temporary forward",
+        ),
         bind(":q / ctrl-c", "quit"),
         bind("?", "global help — close to return to the previous screen"),
     ];
@@ -2140,9 +2144,18 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled("  Plugins", theme::title())));
         for p in &app.plugins {
-            let key = crate::keys::KeyChord::parse(&p.key)
-                .map(|c| c.label())
-                .unwrap_or_else(|_| format!("{}?", p.key));
+            let mut bindings = Vec::new();
+            if !p.key.is_empty() {
+                bindings.push(
+                    crate::keys::KeyChord::parse(&p.key)
+                        .map(|c| c.label())
+                        .unwrap_or_else(|_| format!("{}?", p.key)),
+                );
+            }
+            if let Some(command) = &p.palette {
+                bindings.push(format!(":{command}"));
+            }
+            let key = bindings.join(" / ");
             let scope = if p.scopes.is_empty() {
                 "all resources".to_string()
             } else {


### PR DESCRIPTION
External tool integrations need common process control and report output. Separate implementations would duplicate application state and task control.

This change lets authors add tools as plugin packages without changes to sofka's Rust code. It supplies the shared system for #231, #232, and #234. The authors can then move tool commands and result interpretation into adapters.

- Load versioned packages from the configuration directory.
- Add named commands, executable checks, and validated inputs.
- Send resource snapshots through standard input and display JSON reports.
- Apply output limits, cancellation, read-only mode, confirmation, and guardrails.
- Supply managed port-forwards for selected pods and services.
- Include an author guide, a reference adapter, and local validation commands.
- Ignore local `.pi` files.

Existing inline plugins remain available. Report tables support search but do not support sorting. Port-forward requests require an explicit remote port before the adapter starts.

Validation: `just check` passes on current `main` with this change. Tests: 626 passed; 1 ignored. The reference adapter and both local validation commands also pass.


