### PR TITLE
feat: cycle common resources with Tab by default

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -22,6 +22,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Drill-down navigation** with a breadcrumb stack: workload/service → pods,
   cronjob → its jobs, node → its pods, pod → containers, namespace → re-scope,
   CRD → its custom resources. `esc` goes back.
+- **Resource cycling** (`Tab` / `Shift-Tab`) - browse pods → services →
+  deployments → statefulsets → daemonsets → secrets → configmaps → ingresses →
+  PVCs, wrapping in either direction without configuration. Keeps the current
+  namespace (including all namespaces), skips kinds absent from API discovery,
+  and follows the active workspace's views when one is open. `[` / `]` remain
+  view history.
 - **Command palette** (`:`) - fuzzy search over the full resource catalog, your
   saved bookmarks and workspaces, and the built-in commands (`ctx`, `helm`,
   `pulse`, `xray`, `explain`, `timeline`, `gitops`, `can-i`, `journal`, `debug`,

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -12,7 +12,7 @@ pickers keep both characters available as input.
 | `:<resource>`                                 | command palette - fuzzy over kinds and built-in commands                                                                                                      |
 | `:<resource> <ns>`                            | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                                                 |
 | `[` / `]`                                     | view history - back / forward through visited kind+namespace views                                                                                            |
-| `Tab` / `shift-Tab`                           | cycle views of the active workspace (when one is open)                                                                                                        |
+| `Tab` / `shift-Tab`                           | next / previous common resource in the current namespace; cycle workspace views when one is open                                                              |
 | `enter`                                       | drill down (workload/svc → pods, cronjob → jobs, node → pods, pod → containers, ns → re-scope, CRD → resources, or [views](views.md))                         |
 | `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                                                     |
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                                                      |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -85,6 +85,14 @@ view = "xray"                            # optional: xray | pulse
 
 ## Workspaces
 
+Without an active workspace, `Tab` / `Shift-Tab` cycle pods → services →
+deployments → statefulsets → daemonsets → secrets → configmaps → ingresses →
+PVCs in the current namespace, including all namespaces. The cycle wraps and
+skips kinds absent from API discovery. From a resource outside this set, `Tab`
+starts at pods and `Shift-Tab` starts at PVCs (or the next available kind in
+that direction). Switching resources clears filters and drill-down scope, as
+with `:resource`; `[` / `]` still navigate view history.
+
 `[[workspaces]]` group several views into a named set for one task - checkout
 ops, a cluster upgrade, cert renewal. Open one with a chord or the palette (`▦`).
 sofka switches the optional context once and shows the first view. `Tab` /

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -258,12 +258,12 @@ impl App {
             // Browser-style view history: [ back, ] forward.
             KeyCode::Char('[') => self.history_back(),
             KeyCode::Char(']') => self.history_forward(),
-            // Cycle the active workspace's views (no-op when none is open).
+            // Cycle workspace views, or the default resources in this namespace.
             KeyCode::Tab => {
-                self.cycle_workspace(true);
+                self.cycle_views(true);
             }
             KeyCode::BackTab => {
-                self.cycle_workspace(false);
+                self.cycle_views(false);
             }
             // k9s: 0 = all namespaces.
             KeyCode::Char('0') => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7548,7 +7548,7 @@ async fn workspace_opens_first_view_and_tab_cycles() {
             },
         ],
     }];
-    assert!(app.open_workspace_named("ops"));
+    app.handle_key(ctrl(KeyCode::Char('w'))).unwrap();
     assert_eq!(app.kind_plural, "pods");
     assert_eq!(app.namespace, "checkout");
     assert!(app.flash.contains("[1/2]"));
@@ -7556,6 +7556,7 @@ async fn workspace_opens_first_view_and_tab_cycles() {
     // Tab advances to the second view; wraps back on the third press.
     app.handle_key(press(KeyCode::Tab)).unwrap();
     assert_eq!(app.kind_plural, "deployments");
+    assert_eq!(app.namespace, "checkout");
     assert!(app.flash.contains("[2/2]"));
     app.handle_key(press(KeyCode::Tab)).unwrap();
     assert_eq!(app.kind_plural, "pods");
@@ -7564,13 +7565,175 @@ async fn workspace_opens_first_view_and_tab_cycles() {
     // Shift-Tab goes back.
     app.handle_key(press(KeyCode::BackTab)).unwrap();
     assert_eq!(app.kind_plural, "deployments");
+    assert_eq!(app.namespace, "checkout");
+}
+
+fn resource_cycle_app() -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    for (group, kind, plural) in [
+        ("apps", "StatefulSet", "statefulsets"),
+        ("apps", "DaemonSet", "daemonsets"),
+        ("", "ConfigMap", "configmaps"),
+        ("networking.k8s.io", "Ingress", "ingresses"),
+        ("", "PersistentVolumeClaim", "persistentvolumeclaims"),
+    ] {
+        app.cluster.register_kind(group, kind, plural, true);
+    }
+    (app, rx)
 }
 
 #[tokio::test]
-async fn tab_is_a_noop_without_an_active_workspace() {
+async fn tab_cycles_common_resources_in_both_directions_and_keeps_namespace() {
+    let resources = [
+        "pods",
+        "services",
+        "deployments",
+        "statefulsets",
+        "daemonsets",
+        "secrets",
+        "configmaps",
+        "ingresses",
+        "persistentvolumeclaims",
+        "pods",
+    ];
+    for namespace in ["checkout", ""] {
+        let (mut app, _rx) = resource_cycle_app();
+        app.switch_kind_ns("pods", Some(namespace));
+        for expected in &resources[1..] {
+            app.handle_key(press(KeyCode::Tab)).unwrap();
+            assert_eq!(app.kind_plural, *expected);
+            assert_eq!(app.namespace, namespace);
+            assert!(app.active_workspace.is_none());
+        }
+        for expected in resources[..resources.len() - 1].iter().rev() {
+            app.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT))
+                .unwrap();
+            assert_eq!(app.kind_plural, *expected);
+            assert_eq!(app.namespace, namespace);
+        }
+    }
+}
+
+#[tokio::test]
+async fn tab_cycle_tracks_palette_navigation_namespace_changes_and_history() {
+    let (mut app, _rx) = resource_cycle_app();
+    app.switch_kind_ns("pods", Some("checkout"));
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for ch in "deployments payments".chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.kind_plural, "statefulsets");
+    assert_eq!(app.namespace, "payments");
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    assert_eq!(app.kind_plural, "statefulsets");
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.kind_plural, "daemonsets");
+    assert_eq!(app.namespace, "");
+}
+
+#[tokio::test]
+async fn tab_cycle_enters_from_resources_outside_the_default_set() {
+    for (key, expected) in [
+        (KeyCode::Tab, "pods"),
+        (KeyCode::BackTab, "persistentvolumeclaims"),
+    ] {
+        let (mut app, _rx) = resource_cycle_app();
+        app.switch_kind_ns("jobs", Some("checkout"));
+        app.handle_key(press(key)).unwrap();
+        assert_eq!(app.kind_plural, expected);
+        assert_eq!(app.namespace, "checkout");
+    }
+}
+
+#[tokio::test]
+async fn tab_cycle_clears_drill_scope_and_filter() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind_ns("deployments", Some("checkout"));
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "apps/v1", "kind": "Deployment",
+            "metadata": {"name": "web", "namespace": "checkout"},
+            "spec": {"selector": {"matchLabels": {"app": "web"}}}
+        }),
+    );
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.labels.as_deref(), Some("app=web"));
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.filter, "w");
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.kind_plural, "services");
+    assert_eq!(app.namespace, "checkout");
+    assert!(app.filter.is_empty());
+    assert!(app.labels.is_none());
+    assert!(app.fields.is_none());
+    assert!(app.owner.is_none());
+    assert!(app.scope_label.is_none());
+    assert!(app.stack.is_empty());
+}
+
+#[tokio::test]
+async fn resource_cycle_hint_is_visible_and_changes_for_a_workspace() {
+    use ratatui::{Terminal, backend::TestBackend};
+
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");
-    assert!(!app.cycle_workspace(true));
+    app.workspaces = vec![crate::config::Workspace {
+        key: Some("ctrl-w".into()),
+        name: "ops".into(),
+        views: vec![crate::config::WorkspaceView {
+            name: "Pods".into(),
+            resource: "pods".into(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }];
+    for (key, expected) in [
+        (press(KeyCode::Tab), "Tab/⇧Tab: resources"),
+        (ctrl(KeyCode::Char('w')), "Tab/⇧Tab: workspace"),
+    ] {
+        app.handle_key(key).unwrap();
+        for width in [60, 160] {
+            let mut terminal = Terminal::new(TestBackend::new(width, 24)).unwrap();
+            terminal
+                .draw(|frame| crate::ui::draw(frame, &mut app))
+                .unwrap();
+            let screen: String = terminal
+                .backend()
+                .buffer()
+                .content
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect();
+            assert!(
+                screen.contains(expected),
+                "missing {expected} at width {width}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn tab_cycle_skips_undiscovered_kinds() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.kind_plural, "secrets");
+    app.handle_key(press(KeyCode::BackTab)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    app.switch_kind("pods");
+    app.handle_key(press(KeyCode::BackTab)).unwrap();
+    assert_eq!(app.kind_plural, "secrets");
+    app.handle_key(press(KeyCode::Tab)).unwrap();
     assert_eq!(app.kind_plural, "pods");
 }
 

--- a/src/app/workspaces.rs
+++ b/src/app/workspaces.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+const DEFAULT_RESOURCES: [&str; 9] = [
+    "pods",
+    "services",
+    "deployments",
+    "statefulsets",
+    "daemonsets",
+    "secrets",
+    "configmaps",
+    "ingresses",
+    "persistentvolumeclaims",
+];
+
 impl App {
     /// Trigger a workspace bound to `key`. Returns whether one matched.
     pub(super) fn try_workspace_key(&mut self, key: KeyEvent) -> bool {
@@ -63,11 +75,11 @@ impl App {
         }
     }
 
-    /// `Tab`/`Shift-Tab`: move to the next/previous view of the active
-    /// workspace (wrapping). No-op when no workspace is active.
-    pub(super) fn cycle_workspace(&mut self, forward: bool) -> bool {
+    /// `Tab`/`Shift-Tab`: cycle the active workspace, or common resources in
+    /// the current namespace when no workspace is open.
+    pub(super) fn cycle_views(&mut self, forward: bool) -> bool {
         let Some(ws) = &self.active_workspace else {
-            return false;
+            return self.cycle_default_resources(forward);
         };
         let len = ws.views.len();
         if len == 0 {
@@ -83,6 +95,27 @@ impl App {
         }
         self.apply_active_view();
         true
+    }
+
+    fn cycle_default_resources(&mut self, forward: bool) -> bool {
+        let len = DEFAULT_RESOURCES.len();
+        let current = DEFAULT_RESOURCES
+            .iter()
+            .position(|resource| *resource == self.kind_plural)
+            .unwrap_or(if forward { len - 1 } else { 0 });
+        for offset in 1..=len {
+            let index = if forward {
+                (current + offset) % len
+            } else {
+                (current + len - offset) % len
+            };
+            let resource = DEFAULT_RESOURCES[index];
+            if self.cluster.resolve(resource).is_some() {
+                self.switch_kind(resource);
+                return true;
+            }
+        }
+        false
     }
 
     /// Apply the active workspace's current view and set the status line.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1979,6 +1979,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "switch kind and namespace at once (all/* = all namespaces)",
         ),
         bind("[ · ]", "view history — back · forward"),
+        bind(
+            "Tab · ⇧Tab",
+            "next · previous resource in this namespace (workspace views when open)",
+        ),
         bind(":ctx · :pulse", "switch context · cluster-health dashboard"),
         bind(
             ":fleet",
@@ -3443,10 +3447,21 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
         _ => {
             // Per-resource verbs live in the header hint column when it
             // fits; only repeat the full line when the header dropped it.
-            let hint = if header_hints_fit(frame.area().width) {
-                "  :resource  /filter  S:sort I:invert  w:wide  space:mark  [ ]:history  0:all-ns  ?:help"
+            let cycle = if app.mode != Mode::Table {
+                ""
+            } else if app.active_workspace.is_some() {
+                "Tab/⇧Tab: workspace  "
             } else {
-                "  :resource  /filter  S:sort I:invert  w:wide  ⏎drill  y:yaml d:describe l:logs e:edit s:shell/scale i:image r:restart f:fwd ^d:del  ?:help"
+                "Tab/⇧Tab: resources  "
+            };
+            let hint = if header_hints_fit(frame.area().width) {
+                format!(
+                    "  {cycle}:resource  /filter  S:sort I:invert  w:wide  space:mark  [ ]:history  0:all-ns  ?:help"
+                )
+            } else {
+                format!(
+                    "  {cycle}:resource  /filter  S:sort I:invert  w:wide  ⏎drill  y:yaml d:describe l:logs e:edit s:shell/scale i:image r:restart f:fwd ^d:del  ?:help"
+                )
             };
             Line::from(Span::styled(hint, theme::dim()))
         }


### PR DESCRIPTION
Tab previously did nothing unless a workspace was opened. It now cycles common resources in the current namespace without configuration: pods → services → deployments → statefulsets → daemonsets → secrets → configmaps → ingresses → PVCs. Shift-Tab reverses the cycle, and both directions wrap and skip kinds absent from API discovery.

Cycling starts relative to the current resource, preserves all-namespaces mode, and clears filters and drill-down scope like a resource command. Active workspaces retain their configured views and namespace behavior; `[` / `]` remain history. Help, documentation, and a table footer hint explain the shortcut. `<` / `>` remain available for custom bindings.

Validation: `just check` (formatting, clippy with warnings denied, and tests). Key-driven tests cover both directions, wrapping, namespace changes, palette navigation, history, workspace precedence, undiscovered kinds, drill-down cleanup, and footer hints at 60 and 160 columns.

Closes #201
