### PR TITLE
feat: ship sanitize as a core plugin

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -222,6 +222,20 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   stays visible in the main header.
   Identifiers and counts only, never credentials, tokens, or Secret values.
 
+## Bundled plugins
+
+- **`:sanitize`** deletes the pods a namespace has finished with - completed
+  jobs, failed and evicted pods, and optionally the wedged ones. It ships with
+  sofka and needs no runtime on `PATH`; the adapter is the sofka binary.
+  `states` selects `terminal` (the default), `stuck`, or `all`, named after the
+  STATUS values the pods view shows. `dry_run=true` reports without deleting.
+  It confirms before running, is blocked in read-only mode, and matches
+  guardrails as `plugin:sanitize`. It never deletes a pod that is terminating,
+  still has a running container, or was replaced since the scan.
+  The scope is the current namespace - **all namespaces when the view is** -
+  and the view filter does not narrow it.
+  See [Sanitize pods](../plugins/sanitize/README.md).
+
 ## External plugin packages
 
 - **Package discovery** reads `plugins/*/plugin.toml` from the sofka configuration directory.

--- a/docs/features.md
+++ b/docs/features.md
@@ -232,8 +232,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   It confirms before running, is blocked in read-only mode, and matches
   guardrails as `plugin:sanitize`. It never deletes a pod that is terminating,
   still has a running container, or was replaced since the scan.
-  The scope is the current namespace - **all namespaces when the view is** -
-  and the view filter does not narrow it.
+  The scope is the current namespace - **all namespaces when the view is**.
+  `-l`/`-f` filter terms narrow the scan server-side; a filter it cannot
+  reproduce exactly makes it refuse rather than delete more than the table
+  shows.
   See [Sanitize pods](../plugins/sanitize/README.md).
 
 ## External plugin packages

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -116,11 +116,13 @@ port-forward go through the kube API (or a backgrounded process) directly.
 
 ## Plugin commands
 
-| Command                      | Action                                                |
-| ---------------------------- | ----------------------------------------------------- |
-| `:<plugin> [name=value ...]` | Run a plugin with validated inputs.                   |
-| `:plugin-cancel`             | Stop the active plugin run and its temporary forward. |
+| Command                            | Action                                                       |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `:<plugin> [name=value ...]`       | Run a plugin with validated inputs.                          |
+| `:plugin-cancel`                   | Stop the active plugin run and its temporary forward.        |
+| `:sanitize [states=…] [dry_run=…]` | Delete the pods the namespace has finished with (pods view). |
 
+`:sanitize` ships with sofka; see [Sanitize pods](../plugins/sanitize/README.md).
 Installed packages add their commands and key chords to `?` help.
 Use `:reload` after a package change.
 See [Create a plugin package](plugin-authoring.md).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -7,6 +7,10 @@ To create a package, see [Create a plugin package](plugin-authoring.md).
 Packages support named commands, validated inputs, JSON reports, and managed port-forwards.
 Enter `:plugin-cancel` to stop the active plugin run.
 
+sofka ships one plugin: `:sanitize`, which deletes the pods a namespace has
+finished with. It needs nothing installed - see [Sanitize pods](../plugins/sanitize/README.md).
+An inline entry or a user package of the same name replaces it.
+
 For core plugins maintained and shipped by the sofka project, Rust is the preferred language.
 External plugins can use any programming language that follows the plugin protocol.
 See [Language choice](plugin-authoring.md#language-choice).

--- a/plugins/sanitize/README.md
+++ b/plugins/sanitize/README.md
@@ -1,0 +1,91 @@
+# Sanitize pods
+
+Delete the pods a namespace has finished with: completed jobs, failed and
+evicted pods, and — on request — the ones that are wedged.
+
+`:sanitize` in the pods view. The package ships with sofka, so there is nothing
+to install and nothing to copy into the configuration directory.
+
+## Requirements
+
+None. The adapter is the sofka binary, invoked as `sofka --plugin-adapter
+sanitize`, and it reaches the cluster through the same client the rest of sofka
+uses. No Python, no kubectl, no extra runtime on `PATH`.
+
+## Inputs
+
+```text
+:sanitize
+:sanitize states=stuck
+:sanitize dry_run=true
+```
+
+| Input     | Values                            | Default    |
+| --------- | --------------------------------- | ---------- |
+| `states`  | `terminal`, `stuck`, `all`        | `terminal` |
+| `dry_run` | `true`, `false`                   | `false`    |
+
+`dry_run=true` reports the pods that match and deletes nothing. It still
+requires confirmation, because the package is declared mutating.
+
+## Deletion states
+
+The names are the STATUS values the pods view shows, so what you read in the
+table is what `states` selects.
+
+| `states`   | Deletes                                                                  |
+| ---------- | ------------------------------------------------------------------------ |
+| `terminal` | `Succeeded`, `Failed`, `Error`, `OOMKilled`, `ContainerStatusUnknown`.   |
+| `stuck`    | The terminal set, and `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`. |
+| `all`      | The stuck set, and `Pending`.                                            |
+
+`all` is the set k9s sanitizes. It is not the default here, because a `Pending`
+pod is usually a pod waiting for a node rather than a pod that failed.
+
+## What it will not delete
+
+- A pod that is already `Terminating`.
+- A pod with a running container, whatever its STATUS reads. A multi-container
+  pod reports the reason of the last container that terminated, so one can read
+  `OOMKilled` while another still serves traffic. Readiness is not part of this
+  check: a container failing its readiness probe, or still inside its startup
+  probe, is out of the load balancer and still alive.
+- A pod that was replaced between the scan and the delete. Each delete carries a
+  UID precondition, so if a StatefulSet has put a fresh `db-0` behind the name
+  that was dead a moment ago, the API rejects the delete and the report counts
+  it instead. Pod names are reusable; object identities are not.
+
+## Scope
+
+The scope is the namespace the pods view is on. **In all-namespaces mode it acts
+across every namespace**, which for this command is a much larger blast radius
+than it sounds.
+
+**The view filter is ignored.** Filtering the table to `web-` and running
+`:sanitize` sanitizes the whole namespace, not the rows on screen. Use
+`dry_run=true` first if that distinction matters.
+
+## Safety
+
+- **Confirmation** is required: the package is declared `dangerous`, so it
+  prompts before running and is marked with ⚠.
+- **Read-only mode** blocks it, like every mutating action. `--readonly`,
+  `--write`, and a per-context `readonly` setting all apply.
+- **Guardrails** match it as `plugin:sanitize`, so it can be denied, given a
+  typed confirmation, or capped per context and namespace like any other
+  destructive verb. See [Safety](../../docs/safety.md).
+- **The action journal** records the run.
+
+```toml
+[[guardrails]]
+contexts = ["*prod*"]
+actions = ["plugin:sanitize"]
+deny = true
+reason = "Pod cleanup in prod goes through the owning controller."
+```
+
+## Replacing it
+
+A user package or an inline `[[plugins]]` entry named `sanitize` takes
+precedence over the shipped one, so the behaviour can be replaced without
+patching sofka.

--- a/plugins/sanitize/README.md
+++ b/plugins/sanitize/README.md
@@ -45,11 +45,14 @@ pod is usually a pod waiting for a node rather than a pod that failed.
 ## What it will not delete
 
 - A pod that is already `Terminating`.
-- A pod with a running container, whatever its STATUS reads. A multi-container
-  pod reports the reason of the last container that terminated, so one can read
-  `OOMKilled` while another still serves traffic. Readiness is not part of this
-  check: a container failing its readiness probe, or still inside its startup
-  probe, is out of the load balancer and still alive.
+- A pod with a running application container, whatever its STATUS reads. A
+  multi-container pod reports the reason of the last container that terminated,
+  so one can read `OOMKilled` while another still serves traffic. Readiness is
+  not part of this check: a container failing its readiness probe, or still
+  inside its startup probe, is out of the load balancer and still alive.
+  Restartable init containers (native sidecars) do not count. They support the
+  workload rather than being it, and counting them would exempt a crash-looping
+  pod from `states=stuck` purely for having a proxy injected.
 - A pod that was replaced between the scan and the delete. Each delete carries a
   UID precondition, so if a StatefulSet has put a fresh `db-0` behind the name
   that was dead a moment ago, the API rejects the delete and the report counts

--- a/plugins/sanitize/README.md
+++ b/plugins/sanitize/README.md
@@ -20,10 +20,10 @@ uses. No Python, no kubectl, no extra runtime on `PATH`.
 :sanitize dry_run=true
 ```
 
-| Input     | Values                            | Default    |
-| --------- | --------------------------------- | ---------- |
-| `states`  | `terminal`, `stuck`, `all`        | `terminal` |
-| `dry_run` | `true`, `false`                   | `false`    |
+| Input     | Values                     | Default    |
+| --------- | -------------------------- | ---------- |
+| `states`  | `terminal`, `stuck`, `all` | `terminal` |
+| `dry_run` | `true`, `false`            | `false`    |
 
 `dry_run=true` reports the pods that match and deletes nothing. It still
 requires confirmation, because the package is declared mutating.
@@ -33,11 +33,11 @@ requires confirmation, because the package is declared mutating.
 The names are the STATUS values the pods view shows, so what you read in the
 table is what `states` selects.
 
-| `states`   | Deletes                                                                  |
-| ---------- | ------------------------------------------------------------------------ |
-| `terminal` | `Succeeded`, `Failed`, `Error`, `OOMKilled`, `ContainerStatusUnknown`.   |
+| `states`   | Deletes                                                                       |
+| ---------- | ----------------------------------------------------------------------------- |
+| `terminal` | `Succeeded`, `Failed`, `Error`, `OOMKilled`, `ContainerStatusUnknown`.        |
 | `stuck`    | The terminal set, and `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`. |
-| `all`      | The stuck set, and `Pending`.                                            |
+| `all`      | The stuck set, and `Pending`.                                                 |
 
 `all` is the set k9s sanitizes. It is not the default here, because a `Pending`
 pod is usually a pod waiting for a node rather than a pod that failed.
@@ -103,6 +103,8 @@ memory at once.
   runner guards a `target = "context"` plugin before anything knows what it will
   select, so the adapter re-checks the limit itself once it does, and deletes
   nothing at all when the set is over.
+  Without a named kubeconfig context, guardrails use the context name `default`,
+  as they do in the app.
 - **The action journal** records the run.
 
 ```toml

--- a/plugins/sanitize/README.md
+++ b/plugins/sanitize/README.md
@@ -53,10 +53,19 @@ pod is usually a pod waiting for a node rather than a pod that failed.
   Restartable init containers (native sidecars) do not count. They support the
   workload rather than being it, and counting them would exempt a crash-looping
   pod from `states=stuck` purely for having a proxy injected.
-- A pod that was replaced between the scan and the delete. Each delete carries a
-  UID precondition, so if a StatefulSet has put a fresh `db-0` behind the name
-  that was dead a moment ago, the API rejects the delete and the report counts
-  it instead. Pod names are reusable; object identities are not.
+- A pod that stopped qualifying between the scan and the delete. Each pod is
+  re-read immediately before it is deleted and the selection is re-run against
+  what comes back, so a pod that was crash-looping when it was listed and has
+  since gone ready is left alone. The delete then carries preconditions for the
+  UID and the version just read, which covers both a replacement wearing the
+  same name — a StatefulSet putting a fresh `db-0` behind a name that was dead a
+  moment ago — and the object moving on in the meantime. Pod names are reusable;
+  object identities are not.
+
+  Re-reading costs one request per pod. Sanitizing a namespace with a very large
+  number of dead pods therefore needs a longer `timeout`, which is the price of
+  not deleting something that recovered while the run was working through the
+  list.
 
 ## Scope
 
@@ -64,9 +73,22 @@ The scope is the namespace the pods view is on. **In all-namespaces mode it acts
 across every namespace**, which for this command is a much larger blast radius
 than it sounds.
 
-**The view filter is ignored.** Filtering the table to `web-` and running
-`:sanitize` sanitizes the whole namespace, not the rows on screen. Use
-`dry_run=true` first if that distinction matters.
+The view filter is respected as far as it can be. `-l` and `-f` terms are
+Kubernetes selectors, so they are sent with the scan and narrow it exactly:
+
+```text
+/-l app=api        then  :sanitize      # only pods labelled app=api
+```
+
+The rest of the filter grammar — fuzzy text like `web-`, and comparisons like
+`restarts>=5` — is evaluated against rendered table cells inside sofka, which
+this command cannot reproduce. Rather than sanitize a wider set than the table
+is showing, **it refuses to run** and says so. Clear the filter, or express the
+narrowing with `-l`/`-f`.
+
+The scan is paged rather than fetched in one response, so sanitizing all
+namespaces on a large cluster does not pull the entire pod inventory into
+memory at once.
 
 ## Safety
 
@@ -77,6 +99,10 @@ than it sounds.
 - **Guardrails** match it as `plugin:sanitize`, so it can be denied, given a
   typed confirmation, or capped per context and namespace like any other
   destructive verb. See [Safety](../../docs/safety.md).
+  `max_bulk` is measured against the pods the run actually matched: the plugin
+  runner guards a `target = "context"` plugin before anything knows what it will
+  select, so the adapter re-checks the limit itself once it does, and deletes
+  nothing at all when the set is over.
 - **The action journal** records the run.
 
 ```toml

--- a/plugins/sanitize/plugin.toml
+++ b/plugins/sanitize/plugin.toml
@@ -1,0 +1,24 @@
+schema_version = 1
+
+[plugin]
+name = "Sanitize pods"
+palette = "sanitize"
+# Rewritten to the running executable when sofka registers this package, so a
+# normal install needs no adapter file and no extra language runtime.
+command = "sofka"
+args = ["--plugin-adapter", "sanitize"]
+scopes = ["pods"]
+target = "context"
+output = "report"
+mutating = true
+dangerous = true
+timeout = "2m"
+
+[plugin.inputs.states]
+type = "string"
+default = "terminal"
+choices = ["terminal", "stuck", "all"]
+
+[plugin.inputs.dry_run]
+type = "boolean"
+default = "false"

--- a/src/app/guardrails.rs
+++ b/src/app/guardrails.rs
@@ -2,10 +2,11 @@ use super::*;
 
 /// How much confirmation an action needs, ordered weakest → strongest so the
 /// strongest matching guardrail wins.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum ConfirmLevel {
     /// Run immediately, no confirmation (an action's default when nothing
     /// forces a prompt).
+    #[default]
     None,
     /// The ordinary y/n confirm dialog.
     Plain,
@@ -38,39 +39,16 @@ impl App {
         base: ConfirmLevel,
         all_namespaces: bool,
     ) -> Option<ConfirmLevel> {
-        let ctx = self.cluster.context.clone();
-        let mut level = base;
-        let mut deny: Option<String> = None;
-        let mut cap: Option<usize> = None;
+        let found = restrictions(
+            &self.guardrails,
+            &self.cluster.context,
+            action,
+            plural,
+            targets,
+            all_namespaces,
+        );
 
-        for g in &self.guardrails {
-            if !list_matches(&g.contexts, &ctx)
-                || !list_matches(&g.actions, action)
-                || !list_matches(&g.resources, plural)
-            {
-                continue;
-            }
-            // A namespace filter matches if any target is in a listed namespace.
-            if !all_namespaces
-                && !g.namespaces.is_empty()
-                && !targets
-                    .iter()
-                    .any(|(_, ns)| list_matches(&g.namespaces, ns))
-            {
-                continue;
-            }
-            if g.deny {
-                deny = Some(g.reason.clone().unwrap_or_default());
-            }
-            if let Some(m) = g.max_bulk {
-                cap = Some(cap.map_or(m, |c| c.min(m)));
-            }
-            if let Some(c) = &g.confirmation {
-                level = level.max(parse_level(c));
-            }
-        }
-
-        if let Some(reason) = deny {
+        if let Some(reason) = found.deny {
             let tail = if reason.is_empty() {
                 String::new()
             } else {
@@ -79,7 +57,7 @@ impl App {
             self.flash_warn(&format!("blocked by guardrail: {action} {plural}{tail}"));
             return None;
         }
-        if let Some(max) = cap
+        if let Some(max) = found.max_bulk
             && targets.len() > max
         {
             self.flash_warn(&format!(
@@ -88,7 +66,7 @@ impl App {
             ));
             return None;
         }
-        Some(level)
+        Some(base.max(found.confirmation))
     }
 
     /// Route an about-to-run action through its required confirmation. `Plain`
@@ -124,6 +102,58 @@ impl App {
             }
         }
     }
+}
+
+/// What the matching guardrails restrict, combined: any `deny` blocks, the
+/// smallest `max_bulk` applies, and the strongest `confirmation` wins.
+#[derive(Debug, Default)]
+pub(crate) struct Restrictions {
+    pub deny: Option<String>,
+    pub max_bulk: Option<usize>,
+    pub confirmation: ConfirmLevel,
+}
+
+/// Evaluate `[[guardrails]]` for one action without an [`App`], so a bundled
+/// adapter can apply the same rules to the set it is really about to act on.
+/// A `target = "context"` plugin is guarded before anything knows what it will
+/// match, so the runner can only weigh one placeholder target against
+/// `max_bulk`; the adapter knows the real count.
+pub(crate) fn restrictions(
+    guardrails: &[crate::config::Guardrail],
+    context: &str,
+    action: &str,
+    plural: &str,
+    targets: &[(String, String)],
+    all_namespaces: bool,
+) -> Restrictions {
+    let mut found = Restrictions::default();
+    for g in guardrails {
+        if !list_matches(&g.contexts, context)
+            || !list_matches(&g.actions, action)
+            || !list_matches(&g.resources, plural)
+        {
+            continue;
+        }
+        // A namespace filter matches if any target is in a listed namespace.
+        if !all_namespaces
+            && !g.namespaces.is_empty()
+            && !targets
+                .iter()
+                .any(|(_, ns)| list_matches(&g.namespaces, ns))
+        {
+            continue;
+        }
+        if g.deny {
+            found.deny = Some(g.reason.clone().unwrap_or_default());
+        }
+        if let Some(m) = g.max_bulk {
+            found.max_bulk = Some(found.max_bulk.map_or(m, |c| c.min(m)));
+        }
+        if let Some(c) = &g.confirmation {
+            found.confirmation = found.confirmation.max(parse_level(c));
+        }
+    }
+    found
 }
 
 fn parse_level(s: &str) -> ConfirmLevel {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2120,7 +2120,7 @@ mod explain;
 mod find;
 mod fleet;
 mod gitops;
-mod guardrails;
+pub(crate) mod guardrails;
 mod helpers;
 mod input;
 mod journal;

--- a/src/app/plugins.rs
+++ b/src/app/plugins.rs
@@ -138,14 +138,14 @@ impl App {
                         "sofka".into(),
                     ]
                 } else {
-                    vec![if plugin.package_dir.is_some() {
+                    vec![if plugin.package_dir.is_some() || plugin.bundled {
                         plugin.command.clone()
                     } else {
                         subst(&plugin.command)
                     }]
                 };
                 argv.extend(plugin.args.iter().map(|a| subst(a)));
-                let object = if plugin.package_dir.is_some()
+                let object = if (plugin.package_dir.is_some() || plugin.bundled)
                     && plugin.target.as_deref() != Some("context")
                 {
                     let key = if ns.is_empty() {
@@ -157,7 +157,8 @@ impl App {
                 } else {
                     None
                 };
-                let request = plugin.package_dir.as_ref().map(|_| {
+                let speaks_protocol = plugin.package_dir.is_some() || plugin.bundled;
+                let request = speaks_protocol.then(|| {
                     let mut request = serde_json::json!({
                         "schema_version": 1, "context": self.cluster.kubectl_context(),
                         "cluster": cluster, "namespace": ns, "resource": res,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7798,6 +7798,27 @@ async fn a_guardrail_can_deny_sanitize() {
 }
 
 #[tokio::test]
+async fn sanitize_checks_the_default_context_bulk_limit_before_confirmation() {
+    let (mut app, _rx) = app_with_pod();
+    app.cluster.context = "default".into();
+    app.plugins = crate::plugins::bundled()
+        .into_iter()
+        .map(|p| p.expect("bundled package parses"))
+        .collect();
+    app.guardrails = vec![crate::config::Guardrail {
+        contexts: vec!["default".into()],
+        actions: vec!["plugin:sanitize".into()],
+        max_bulk: Some(0),
+        ..Default::default()
+    }];
+
+    plugin_command(&mut app, "sanitize");
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("exceeds the max of 0"), "{}", app.flash);
+}
+
+#[tokio::test]
 async fn sanitize_is_blocked_in_readonly_mode() {
     let (mut app, _rx) = app_with_pod();
     app.readonly = true;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7773,6 +7773,31 @@ async fn sanitize_ships_with_sofka_and_confirms_before_deleting() {
 }
 
 #[tokio::test]
+async fn a_guardrail_can_deny_sanitize() {
+    let (mut app, _rx) = app_with_pod();
+    app.plugins = crate::plugins::bundled()
+        .into_iter()
+        .map(|p| p.expect("bundled package parses"))
+        .collect();
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["plugin:sanitize".into()],
+        deny: true,
+        reason: Some("cleanup goes through the owning controller".into()),
+        ..Default::default()
+    }];
+
+    plugin_command(&mut app, "sanitize");
+    assert_ne!(
+        app.mode,
+        Mode::Confirm,
+        "a denied action must not even confirm"
+    );
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("blocked by guardrail"), "{}", app.flash);
+    assert!(app.flash.contains("owning controller"), "{}", app.flash);
+}
+
+#[tokio::test]
 async fn sanitize_is_blocked_in_readonly_mode() {
     let (mut app, _rx) = app_with_pod();
     app.readonly = true;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7740,6 +7740,54 @@ async fn debug_is_blocked_in_readonly_and_by_guardrail() {
 }
 
 #[tokio::test]
+async fn sanitize_ships_with_sofka_and_confirms_before_deleting() {
+    let (mut app, _rx) = app_with_pod();
+    // The package is registered from the binary, with no user configuration and
+    // nothing copied into the config directory.
+    app.plugins = crate::plugins::bundled()
+        .into_iter()
+        .map(|p| p.expect("bundled package parses"))
+        .collect();
+    let sanitize = app
+        .plugins
+        .iter()
+        .find(|p| p.palette.as_deref() == Some("sanitize"))
+        .expect(":sanitize is available out of the box");
+    assert!(sanitize.bundled);
+    assert!(sanitize.dangerous, "a bulk delete must confirm");
+    assert_eq!(sanitize.scopes, ["pods"]);
+    assert_eq!(sanitize.target.as_deref(), Some("context"));
+    // The adapter is this binary, so nothing extra has to be on PATH.
+    assert!(crate::plugins::available(sanitize).is_ok());
+
+    // Running it opens the confirmation instead of deleting anything.
+    plugin_command(&mut app, "sanitize");
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(app.pending.is_none(), "must not run before confirmation");
+    assert!(app.confirm_label.contains('⚠'), "{}", app.confirm_label);
+
+    // Declining leaves the cluster alone.
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.pending.is_none());
+}
+
+#[tokio::test]
+async fn sanitize_is_blocked_in_readonly_mode() {
+    let (mut app, _rx) = app_with_pod();
+    app.readonly = true;
+    app.plugins = crate::plugins::bundled()
+        .into_iter()
+        .map(|p| p.expect("bundled package parses"))
+        .collect();
+
+    plugin_command(&mut app, "sanitize");
+    assert_ne!(app.mode, Mode::Confirm, "read-only must not even confirm");
+    assert!(app.pending.is_none());
+    assert!(app.flash.contains("read-only"), "{}", app.flash);
+}
+
+#[tokio::test]
 async fn readonly_gates_mutating_plugins_only() {
     let (mut app, _rx) = app_with_pod();
     app.readonly = true;
@@ -11085,7 +11133,8 @@ async fn plugin_package_reload_loads_valid_packages_and_isolates_invalid_ones() 
     let (mut app, mut rx) = test_app();
     app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
     plugin_command(&mut app, "reload");
-    assert_eq!(app.plugins.len(), 1);
+    // Bundled packages are always present; this counts the configured ones.
+    assert_eq!(app.plugins.iter().filter(|p| !p.bundled).count(), 1);
     assert!(app.config_warnings.iter().any(|w| w.contains("broken")));
     plugin_command(&mut app, "example-plugin");
     app.handle_msg(plugin_result(&mut rx).await);
@@ -11097,7 +11146,7 @@ async fn plugin_package_reload_loads_valid_packages_and_isolates_invalid_ones() 
     );
     std::fs::remove_file(package.join("plugin.toml")).unwrap();
     plugin_command(&mut app, "reload");
-    assert!(app.plugins.is_empty());
+    assert!(!app.plugins.iter().any(|p| !p.bundled));
     std::fs::remove_dir_all(dir).unwrap();
 }
 
@@ -11288,7 +11337,11 @@ async fn check_unknown_inline_fields(location: &str) {
             app.user_aliases.get("pluginpods").map(String::as_str),
             Some("pods")
         );
-        assert_eq!(app.plugins.len(), 2, "{layer}: plugins were lost");
+        assert_eq!(
+            app.plugins.iter().filter(|p| !p.bundled).count(),
+            2,
+            "{layer}: plugins were lost"
+        );
         assert!(
             app.config_warnings.is_empty(),
             "{layer}: {:?}",

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1395,14 +1395,34 @@ fn pod_summary(obj: &DynamicObject) -> (String, String, String) {
     let total = statuses.len();
     let mut ready = 0usize;
     let mut restarts = 0i64;
-    let mut waiting_reason: Option<String> = None;
-    let mut terminated_reason: Option<String> = None;
-
     for c in statuses {
         if c.get("ready").and_then(Value::as_bool).unwrap_or(false) {
             ready += 1;
         }
         restarts += c.get("restartCount").and_then(Value::as_i64).unwrap_or(0);
+    }
+
+    (
+        format!("{ready}/{total}"),
+        pod_status(obj),
+        restarts.to_string(),
+    )
+}
+
+/// A pod's STATUS cell. Exposed so the `:sanitize` plugin selects pods by the
+/// status the pods view shows, rather than a second, drifting derivation.
+pub fn pod_status(obj: &DynamicObject) -> String {
+    let d = &obj.data;
+    let empty = vec![];
+    let statuses = d
+        .get("status")
+        .and_then(|s| s.get("containerStatuses"))
+        .and_then(|c| c.as_array())
+        .unwrap_or(&empty);
+
+    let mut waiting_reason: Option<String> = None;
+    let mut terminated_reason: Option<String> = None;
+    for c in statuses {
         if let Some(r) = c.pointer("/state/waiting/reason").and_then(Value::as_str)
             && (r != "ContainerCreating" || waiting_reason.is_none())
         {
@@ -1417,18 +1437,17 @@ fn pod_summary(obj: &DynamicObject) -> (String, String, String) {
         }
     }
 
-    let phase = sget(d, &["status", "phase"]).unwrap_or("Unknown");
-    let status = if obj.metadata.deletion_timestamp.is_some() {
+    if obj.metadata.deletion_timestamp.is_some() {
         "Terminating".to_string()
     } else if let Some(r) = waiting_reason {
         r
     } else if let Some(r) = terminated_reason {
         r
     } else {
-        phase.to_string()
-    };
-
-    (format!("{ready}/{total}"), status, restarts.to_string())
+        sget(d, &["status", "phase"])
+            .unwrap_or("Unknown")
+            .to_string()
+    }
 }
 
 fn external_ip(d: &Value, typ: &str) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -807,6 +807,10 @@ pub struct Plugin {
     pub port_forward: Option<String>,
     #[serde(skip)]
     pub package_dir: Option<PathBuf>,
+    /// Set for a package sofka ships, whose adapter is this binary. Such a
+    /// plugin speaks the request/report protocol without a package directory.
+    #[serde(skip)]
+    pub bundled: bool,
     pub name: String,
     pub command: String,
     #[serde(default)]
@@ -1237,6 +1241,20 @@ impl ConfigLoader {
         });
         if let Some(dir) = &self.dir {
             crate::plugins::load_packages(&dir.join("plugins"), &mut config.plugins, &mut warnings);
+        }
+        // Last, so an inline entry or a user package of the same name wins and
+        // a user can replace a shipped plugin without editing sofka.
+        for bundled in crate::plugins::bundled() {
+            match bundled {
+                Ok(p) => {
+                    if !config.plugins.iter().any(|old| {
+                        old.name == p.name || (p.palette.is_some() && old.palette == p.palette)
+                    }) {
+                        config.plugins.push(p);
+                    }
+                }
+                Err(e) => warnings.push(e),
+            }
         }
         let skin_override = overlay
             .get("skin")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod nsmem;
 pub mod plugins;
 pub mod providers;
 pub mod rightsize;
+pub mod sanitize;
 pub mod snapshot;
 pub mod sortmem;
 pub mod state_writer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,12 @@ struct Args {
     /// discovery/metrics/watch status, use `:info` inside the TUI.
     #[arg(long)]
     info: bool,
+
+    /// Run a core plugin's adapter: read a plugin request on stdin, write its
+    /// report on stdout. sofka spawns itself with this; it is not a user-facing
+    /// entry point, which is why it is hidden from `--help`.
+    #[arg(long, value_name = "NAME", hide = true)]
+    plugin_adapter: Option<String>,
 }
 
 /// Heap profiling build (`--features dhat-heap`). dhat replaces the global
@@ -110,6 +116,14 @@ fn main() -> Result<()> {
 }
 
 async fn run_main(args: Args) -> Result<()> {
+    // Before anything else: an adapter run owns stdout for its report and must
+    // never load config, connect, or touch the terminal.
+    if let Some(name) = &args.plugin_adapter {
+        return match name.as_str() {
+            "sanitize" => sofka::sanitize::run().await,
+            other => Err(anyhow::anyhow!("unknown core plugin adapter '{other}'")),
+        };
+    }
     if let Some(dir) = &args.validate_plugin {
         let plugin = sofka::plugins::read_package(dir).map_err(anyhow::Error::msg)?;
         sofka::plugins::available(&plugin).map_err(anyhow::Error::msg)?;

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -160,14 +160,7 @@ pub fn read_package(dir: &Path) -> Result<Plugin, String> {
     if bytes.len() > MAX_BYTES {
         return Err("manifest exceeds 1 MiB".into());
     }
-    let manifest: Manifest =
-        toml::from_str(std::str::from_utf8(&bytes).map_err(|e| e.to_string())?)
-            .map_err(|e| e.to_string())?;
-    if manifest.schema_version != 1 {
-        return Err("unsupported schema_version (expected 1)".into());
-    }
-    let mut plugin = manifest.plugin;
-    validate_plugin(&plugin)?;
+    let mut plugin = parse_manifest(std::str::from_utf8(&bytes).map_err(|e| e.to_string())?)?;
     if plugin.command.starts_with("./") {
         let command = dir
             .join(&plugin.command)
@@ -188,6 +181,40 @@ pub fn read_package(dir: &Path) -> Result<Plugin, String> {
     }
     plugin.package_dir = Some(dir);
     Ok(plugin)
+}
+
+/// Parse and validate a `plugin.toml`, wherever it came from.
+pub fn parse_manifest(text: &str) -> Result<Plugin, String> {
+    let manifest: Manifest = toml::from_str(text).map_err(|e| e.to_string())?;
+    if manifest.schema_version != 1 {
+        return Err("unsupported schema_version (expected 1)".into());
+    }
+    validate_plugin(&manifest.plugin)?;
+    Ok(manifest.plugin)
+}
+
+/// The manifest of every package sofka ships. Kept as real files under
+/// `plugins/` so `--validate-plugin` covers them like any other package.
+const BUNDLED: &[(&str, &str)] = &[("sanitize", include_str!("../plugins/sanitize/plugin.toml"))];
+
+/// The packages sofka ships, with `command` pointed at the running executable.
+/// The adapters live in this binary, so a normal install has nothing to copy
+/// and needs no extra language runtime on PATH.
+pub fn bundled() -> Vec<Result<Plugin, String>> {
+    let exe = std::env::current_exe();
+    BUNDLED
+        .iter()
+        .map(|(name, text)| {
+            let mut plugin = parse_manifest(text).map_err(|e| format!("bundled {name}: {e}"))?;
+            let exe = exe
+                .as_ref()
+                .map_err(|e| format!("bundled {name}: locating the sofka binary: {e}"))?;
+            plugin.command = exe.to_string_lossy().into_owned();
+            plugin.requires = vec![plugin.command.clone()];
+            plugin.bundled = true;
+            Ok(plugin)
+        })
+        .collect()
 }
 
 pub fn validate_plugin(plugin: &Plugin) -> Result<(), String> {

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -91,16 +91,22 @@ pub async fn run() -> Result<()> {
 /// The `[[guardrails]]` that apply to this run. The adapter is sofka, so it
 /// reads the same configuration the session did rather than being told.
 fn guardrails_for(request: &Value) -> Vec<crate::config::Guardrail> {
-    let context = request
-        .get("context")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
+    let context = guardrail_context(request);
     let cluster = request
         .get("cluster")
         .and_then(Value::as_str)
         .unwrap_or_default();
     let (loader, _) = crate::config::ConfigLoader::load();
     loader.resolve(context, cluster).config.guardrails
+}
+
+fn guardrail_context(request: &Value) -> &str {
+    // Cluster::connect uses this name for guardrails without a named context.
+    // Keep the request context null so client_for still uses Config::infer.
+    request
+        .get("context")
+        .and_then(Value::as_str)
+        .unwrap_or("default")
 }
 
 async fn sanitize(
@@ -179,10 +185,7 @@ async fn sanitize(
         .collect();
     let limits = crate::app::guardrails::restrictions(
         guardrails,
-        request
-            .get("context")
-            .and_then(Value::as_str)
-            .unwrap_or_default(),
+        guardrail_context(request),
         "plugin:sanitize",
         "pods",
         &scoped,
@@ -731,6 +734,104 @@ mod tests {
             "{summary}"
         );
         assert_eq!(report["sections"][1]["title"], "Blocked");
+    }
+
+    #[tokio::test]
+    async fn a_context_bulk_limit_applies_without_a_named_context() {
+        for context in [Value::Null, json!("default"), json!("production")] {
+            let guardrail = crate::config::Guardrail {
+                contexts: vec![context.as_str().unwrap_or("default").into()],
+                actions: vec!["plugin:sanitize".into()],
+                max_bulk: Some(1),
+                ..Default::default()
+            };
+            let (client, seen) = mock_api(vec![(
+                "200 OK",
+                list_of(vec![
+                    failed("job-1", "uid-1", "rv-10"),
+                    failed("job-2", "uid-2", "rv-11"),
+                ]),
+            )])
+            .await;
+            let mut request = request("terminal", false);
+            request["context"] = context;
+            let report = sanitize(client, &request, &[guardrail]).await.unwrap();
+            assert_eq!(seen.lock().unwrap().len(), 1);
+            assert!(summary_of(&report).contains("exceeds the guardrail limit of 1"));
+            assert_eq!(report["sections"][1]["title"], "Blocked");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_delete_conflict_or_missing_pod_is_not_counted_as_deleted() {
+        for (status, code, expected) in [
+            ("409 Conflict", 409, "1 changed since the scan"),
+            ("404 Not Found", 404, "1 already gone"),
+        ] {
+            let (client, seen) = mock_api(vec![
+                ("200 OK", list_of(vec![failed("job-1", "uid-1", "rv-10")])),
+                ("200 OK", failed("job-1", "uid-1", "rv-11").to_string()),
+                (
+                    status,
+                    json!({"kind": "Status", "status": "Failure", "code": code}).to_string(),
+                ),
+            ])
+            .await;
+            let report = sanitize(client, &request("terminal", false), &[])
+                .await
+                .unwrap();
+            let calls = seen.lock().unwrap().clone();
+            assert_eq!(calls.len(), 3);
+            assert_eq!(calls[2].0, "DELETE");
+            let summary = summary_of(&report);
+            assert!(summary.contains("0 deleted, 0 failed"), "{summary}");
+            assert!(summary.contains(expected), "{summary}");
+            assert_eq!(report["sections"].as_array().unwrap().len(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_failed_pre_delete_read_skips_the_pod_and_continues() {
+        let (client, seen) = mock_api(vec![
+            (
+                "200 OK",
+                list_of(vec![
+                    failed("job-1", "uid-1", "rv-10"),
+                    failed("job-2", "uid-2", "rv-11"),
+                ]),
+            ),
+            (
+                "403 Forbidden",
+                json!({"kind": "Status", "status": "Failure", "code": 403,
+                "reason": "Forbidden", "message": "cannot read job-1"})
+                .to_string(),
+            ),
+            ("200 OK", failed("job-2", "uid-2", "rv-11").to_string()),
+            (
+                "200 OK",
+                json!({"kind": "Status", "status": "Success"}).to_string(),
+            ),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[])
+            .await
+            .unwrap();
+        let calls = seen.lock().unwrap().clone();
+        assert_eq!(calls.len(), 4);
+        let deletes: Vec<_> = calls
+            .iter()
+            .filter(|(method, ..)| method == "DELETE")
+            .collect();
+        assert_eq!(deletes.len(), 1);
+        assert_eq!(
+            deletes[0].1.split('?').next(),
+            Some("/api/v1/namespaces/default/pods/job-2")
+        );
+        assert!(summary_of(&report).contains("1 deleted, 1 failed"));
+        assert_eq!(report["sections"][1]["title"], "Failed");
+        assert_eq!(report["sections"][1]["rows"][0][1], "job-1");
+        assert_eq!(report["sections"][2]["title"], "Deleted");
+        assert_eq!(report["sections"][2]["rows"][0][1], "job-2");
     }
 
     #[tokio::test]

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -8,7 +8,7 @@
 
 use anyhow::{Context, Result};
 use k8s_openapi::api::core::v1::Pod;
-use kube::api::{Api, DeleteParams, ListParams, Preconditions};
+use kube::api::{Api, ApiResource, DeleteParams, ListParams, Preconditions};
 use kube::core::DynamicObject;
 use kube::{Client, Config};
 use serde_json::{Value, json};
@@ -29,6 +29,9 @@ const UNSTARTED: &[&str] = &["Pending"];
 
 /// Rows per report table. The runner caps captured output at 1 MiB.
 const MAX_ROWS: usize = 500;
+/// Pods fetched per list request. Sanitizing all namespaces on a large cluster
+/// is otherwise one unpaged response holding the entire pod inventory.
+const PAGE: u32 = 500;
 
 fn wanted(states: &str) -> Option<Vec<&'static str>> {
     let mut set = TERMINAL.to_vec();
@@ -58,20 +61,11 @@ fn wanted(states: &str) -> Option<Vec<&'static str>> {
 /// counting them would make an identical crash-looping pod exempt from
 /// `states = stuck` purely because something injected a proxy into it. The
 /// STATUS column ignores them for the same reason, so the two agree.
-fn running(pod: &Pod) -> bool {
-    pod.status
-        .as_ref()
-        .and_then(|s| s.container_statuses.as_ref())
-        .is_some_and(|cs| {
-            cs.iter()
-                .any(|c| c.state.as_ref().is_some_and(|s| s.running.is_some()))
-        })
-}
-
-/// A pod's status as the pods view shows it, so `states` names what the user reads.
-fn status_of(pod: &Pod) -> Result<String> {
-    let object: DynamicObject = serde_json::from_value(serde_json::to_value(pod)?)?;
-    Ok(crate::columns::pod_status(&object))
+fn running(pod: &DynamicObject) -> bool {
+    pod.data
+        .pointer("/status/containerStatuses")
+        .and_then(Value::as_array)
+        .is_some_and(|cs| cs.iter().any(|c| c.pointer("/state/running").is_some()))
 }
 
 struct Target {
@@ -89,7 +83,31 @@ pub async fn run() -> Result<()> {
     if request.get("schema_version").and_then(Value::as_u64) != Some(1) {
         anyhow::bail!("unsupported request schema_version");
     }
+    let client = client_for(request.get("context").and_then(Value::as_str)).await?;
+    let report = sanitize(client, &request, &guardrails_for(&request)).await?;
+    serde_json::to_writer(std::io::stdout().lock(), &report).context("writing the report")
+}
 
+/// The `[[guardrails]]` that apply to this run. The adapter is sofka, so it
+/// reads the same configuration the session did rather than being told.
+fn guardrails_for(request: &Value) -> Vec<crate::config::Guardrail> {
+    let context = request
+        .get("context")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let cluster = request
+        .get("cluster")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let (loader, _) = crate::config::ConfigLoader::load();
+    loader.resolve(context, cluster).config.guardrails
+}
+
+async fn sanitize(
+    client: Client,
+    request: &Value,
+    guardrails: &[crate::config::Guardrail],
+) -> Result<Value> {
     let inputs = request.get("inputs").cloned().unwrap_or_else(|| json!({}));
     let states = inputs
         .get("states")
@@ -104,57 +122,133 @@ pub async fn run() -> Result<()> {
         .unwrap_or_default()
         .to_string();
 
-    let client = client_for(request.get("context").and_then(Value::as_str)).await?;
-    let api: Api<Pod> = if namespace.is_empty() {
-        Api::all(client.clone())
+    let pods = ApiResource::erase::<Pod>(&());
+    let api: Api<DynamicObject> = if namespace.is_empty() {
+        Api::all_with(client.clone(), &pods)
     } else {
-        Api::namespaced(client.clone(), &namespace)
+        Api::namespaced_with(client.clone(), &namespace, &pods)
     };
 
+    let mut params = ListParams::default().limit(PAGE);
+    let (labels, fields) = selectors(request.get("filter").and_then(Value::as_str))?;
+    if let Some(l) = &labels {
+        params = params.labels(l);
+    }
+    if let Some(f) = &fields {
+        params = params.fields(f);
+    }
+
+    // Paged, and only the few strings each target needs are kept. Listing every
+    // pod in a large cluster in one response and holding the objects is how this
+    // shape falls over.
     let mut targets = Vec::new();
-    for pod in api
-        .list(&ListParams::default())
-        .await
-        .context("listing pods")?
-    {
-        let status = status_of(&pod)?;
-        if !wanted.contains(&status.as_str()) || running(&pod) {
-            continue;
+    loop {
+        let page = api.list(&params).await.context("listing pods")?;
+        let next = page.metadata.continue_.clone();
+        for pod in page {
+            let status = crate::columns::pod_status(&pod);
+            if !wanted.contains(&status.as_str()) || running(&pod) {
+                continue;
+            }
+            targets.push(Target {
+                namespace: pod.metadata.namespace.clone().unwrap_or_default(),
+                name: pod.metadata.name.clone().unwrap_or_default(),
+                uid: pod.metadata.uid.clone().unwrap_or_default(),
+                status,
+            });
         }
-        let meta = &pod.metadata;
-        targets.push(Target {
-            namespace: meta.namespace.clone().unwrap_or_default(),
-            name: meta.name.clone().unwrap_or_default(),
-            uid: meta.uid.clone().unwrap_or_default(),
-            status,
-        });
+        match next {
+            Some(token) if !token.is_empty() => params = params.continue_token(&token),
+            _ => break,
+        }
     }
     targets.sort_by(|a, b| (&a.namespace, &a.name).cmp(&(&b.namespace, &b.name)));
 
     let matched = targets.len();
     let mut deleted = Vec::new();
     let mut failed = Vec::new();
-    let mut replaced = 0usize;
+    let mut changed = 0usize;
+    let mut gone = 0usize;
 
-    if !dry_run {
+    // The runner guards a context plugin before it knows what will match, so it
+    // can only weigh one placeholder target against `max_bulk`. Re-check here,
+    // where the real count is known, before anything is deleted.
+    let scoped: Vec<(String, String)> = targets
+        .iter()
+        .map(|t| (t.name.clone(), t.namespace.clone()))
+        .collect();
+    let limits = crate::app::guardrails::restrictions(
+        guardrails,
+        request
+            .get("context")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        "plugin:sanitize",
+        "pods",
+        &scoped,
+        namespace.is_empty(),
+    );
+    let blocked = match limits.max_bulk {
+        Some(max) if matched > max => Some(max),
+        _ => None,
+    };
+
+    if !dry_run && blocked.is_none() {
         for target in &targets {
-            // The UID precondition binds the delete to the object that scanned.
-            // A pod name is reusable, so without it a StatefulSet that recreated
-            // `db-0` in the meantime would lose its healthy replacement instead.
+            let api: Api<DynamicObject> =
+                Api::namespaced_with(client.clone(), &target.namespace, &pods);
+
+            // Re-read and re-run the predicate rather than trusting the list. A
+            // pod selected while crash-looping can have recovered and gone ready
+            // since, and its UID would not have changed, so identity alone does
+            // not catch it. Pinning the *scanned* resourceVersion instead would:
+            // the statuses that can recover — CrashLoopBackOff, ImagePullBackOff,
+            // Error, OOMKilled — are exactly the ones whose resourceVersion churns
+            // on every restart, backoff tick and probe, so it would refuse crowds
+            // of pods that were never anything but dead. Asking the question we
+            // actually mean ignores that noise.
+            let fresh = match api.get(&target.name).await {
+                Ok(pod) => pod,
+                Err(kube::Error::Api(e)) if e.code == 404 => {
+                    gone += 1;
+                    continue;
+                }
+                Err(e) => {
+                    failed.push(vec![
+                        target.namespace.clone(),
+                        target.name.clone(),
+                        e.to_string(),
+                    ]);
+                    continue;
+                }
+            };
+            let still_selected = fresh.metadata.uid.as_deref() == Some(target.uid.as_str())
+                && wanted.contains(&crate::columns::pod_status(&fresh).as_str())
+                && !running(&fresh);
+            if !still_selected {
+                changed += 1;
+                continue;
+            }
+
+            // The version comes from the read just made, not from the scan, so
+            // the precondition is tight enough to be meaningful and short-lived
+            // enough not to be noise. With the UID it covers both a replacement
+            // wearing the same name and this object moving on.
             let params = DeleteParams {
                 preconditions: Some(Preconditions {
                     uid: Some(target.uid.clone()),
-                    resource_version: None,
+                    resource_version: fresh.metadata.resource_version.clone(),
                 }),
                 ..DeleteParams::default()
             };
-            let api: Api<Pod> = Api::namespaced(client.clone(), &target.namespace);
             match api.delete(&target.name, &params).await {
                 Ok(_) => deleted.push(target),
-                // 409 is the precondition failing: the name now holds a
-                // different object. 404 means someone got there first. Neither
-                // is an error, and neither is a pod we should report as gone.
-                Err(kube::Error::Api(e)) if e.code == 409 || e.code == 404 => replaced += 1,
+                // A precondition can still fail in the gap between the read and
+                // this call; 404 means someone got there first. Neither is an
+                // error, and neither is a pod this run should claim to have
+                // deleted.
+                Err(kube::Error::Api(e)) if e.code == 409 => changed += 1,
+                Err(kube::Error::Api(e)) if e.code == 404 => gone += 1,
                 Err(e) => failed.push(vec![
                     target.namespace.clone(),
                     target.name.clone(),
@@ -173,7 +267,12 @@ pub async fn run() -> Result<()> {
         format!("Scanned {scope}."),
         format!("Matching statuses: {}.", wanted.join(", ")),
     ];
-    if dry_run {
+    if let Some(max) = blocked {
+        summary.push(format!(
+            "{matched} matched, which exceeds the guardrail limit of {max} for \
+             plugin:sanitize. Nothing deleted."
+        ));
+    } else if dry_run {
         summary.push(format!("{matched} matched; nothing deleted (dry run)."));
     } else {
         summary.push(format!(
@@ -181,10 +280,11 @@ pub async fn run() -> Result<()> {
             deleted.len(),
             failed.len()
         ));
-        if replaced > 0 {
-            summary.push(format!(
-                "{replaced} replaced since the scan and left alone."
-            ));
+        if changed > 0 {
+            summary.push(format!("{changed} changed since the scan and left alone."));
+        }
+        if gone > 0 {
+            summary.push(format!("{gone} already gone."));
         }
     }
 
@@ -192,7 +292,7 @@ pub async fn run() -> Result<()> {
     if !failed.is_empty() {
         sections.push(table("Failed", &["Namespace", "Pod", "Error"], failed));
     }
-    let listed: Vec<&Target> = if dry_run {
+    let listed: Vec<&Target> = if dry_run || blocked.is_some() {
         targets.iter().collect()
     } else {
         deleted
@@ -202,15 +302,15 @@ pub async fn run() -> Result<()> {
         .map(|t| vec![t.namespace.clone(), t.name.clone(), t.status.clone()])
         .collect();
     if !rows.is_empty() {
-        let title = if dry_run { "Would delete" } else { "Deleted" };
+        let title = match (blocked.is_some(), dry_run) {
+            (true, _) => "Blocked",
+            (_, true) => "Would delete",
+            _ => "Deleted",
+        };
         sections.push(table(title, &["Namespace", "Pod", "Status"], rows));
     }
 
-    serde_json::to_writer(
-        std::io::stdout().lock(),
-        &json!({"schema_version": 1, "title": "Sanitize pods", "sections": sections}),
-    )
-    .context("writing the report")
+    Ok(json!({"schema_version": 1, "title": "Sanitize pods", "sections": sections}))
 }
 
 fn table(title: &str, columns: &[&str], rows: Vec<Vec<String>>) -> Value {
@@ -224,6 +324,31 @@ fn table(title: &str, columns: &[&str], rows: Vec<Vec<String>>) -> Value {
         section["lines"] = json!([format!("{} more rows not shown.", total - MAX_ROWS)]);
     }
     section
+}
+
+/// The label and field selectors the view filter implies.
+///
+/// `-l` and `-f` terms are already Kubernetes selectors, so they are sent with
+/// the list and narrow the scan exactly. The rest of the grammar — fuzzy text
+/// and typed comparisons like `restarts>=5` — is evaluated against rendered
+/// table cells inside the app, and this adapter cannot reproduce it. Rather
+/// than silently sanitize a wider set than the table is showing, refuse: for a
+/// bulk delete, acting on a different scope than the one on screen is the one
+/// outcome worth failing over.
+fn selectors(filter: Option<&str>) -> Result<(Option<String>, Option<String>)> {
+    use crate::filter::ParsedFilter;
+    let filter = filter.unwrap_or_default().trim();
+    if filter.is_empty() {
+        return Ok((None, None));
+    }
+    match crate::filter::parse(filter) {
+        ParsedFilter::Structured(s) if s.terms.is_empty() => Ok((s.labels, s.fields)),
+        _ => anyhow::bail!(
+            "the view filter '{filter}' narrows the table in ways this command cannot \
+             reproduce, and sanitizing the whole namespace instead would delete more \
+             than you can see. Clear the filter, or narrow it with -l/-f selectors."
+        ),
+    }
 }
 
 /// Build a client for the request's context. A null context means sofka had no
@@ -251,8 +376,473 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn pod(value: Value) -> Pod {
+    fn pod(value: Value) -> DynamicObject {
         serde_json::from_value(value).expect("pod fixture")
+    }
+
+    /// A mock apiserver that answers each request in order and records the
+    /// method, path and body it saw. Enough to assert what the adapter sent,
+    /// which is the part that decides whether a live pod survives.
+    async fn mock_api(
+        responses: Vec<(&'static str, String)>,
+    ) -> (
+        Client,
+        std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>,
+    ) {
+        use std::collections::VecDeque;
+        use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock apiserver");
+        let addr = listener.local_addr().expect("local addr");
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = std::sync::Arc::clone(&seen);
+        tokio::spawn(async move {
+            let mut responses: VecDeque<_> = responses.into();
+            while let Some((status, body)) = responses.pop_front() {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let (r, mut w) = sock.split();
+                let mut reader = BufReader::new(r);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).await.unwrap_or(0) == 0 {
+                    return;
+                }
+                let mut parts = request_line.split_whitespace();
+                let method = parts.next().unwrap_or("").to_string();
+                let path = parts.next().unwrap_or("").to_string();
+                let mut length = 0usize;
+                loop {
+                    let mut header = String::new();
+                    if reader.read_line(&mut header).await.unwrap_or(0) == 0 || header == "\r\n" {
+                        break;
+                    }
+                    if let Some(v) = header.to_ascii_lowercase().strip_prefix("content-length:") {
+                        length = v.trim().parse().unwrap_or(0);
+                    }
+                }
+                let mut payload = vec![0u8; length];
+                if length > 0 {
+                    let _ = reader.read_exact(&mut payload).await;
+                }
+                recorder.lock().unwrap().push((
+                    method,
+                    path,
+                    String::from_utf8_lossy(&payload).into_owned(),
+                ));
+                let response = format!(
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = w.write_all(response.as_bytes()).await;
+            }
+        });
+        let mut config = Config::new(format!("http://{addr}").parse().expect("mock URL"));
+        config.default_retry = false;
+        (Client::try_from(config).expect("mock client"), seen)
+    }
+
+    fn pod_json(name: &str, uid: &str, version: &str, state: Value) -> Value {
+        json!({
+            "metadata": {"name": name, "namespace": "default",
+                         "uid": uid, "resourceVersion": version},
+            "status": {"phase": "Running", "containerStatuses": [
+                {"name": "app", "ready": false, "restartCount": 0, "state": state}]}
+        })
+    }
+
+    fn list_of(pods: Vec<Value>) -> String {
+        json!({"apiVersion": "v1", "kind": "PodList",
+               "metadata": {"resourceVersion": "1"}, "items": pods})
+        .to_string()
+    }
+
+    fn crashing(name: &str, uid: &str, version: &str) -> Value {
+        pod_json(
+            name,
+            uid,
+            version,
+            json!({"waiting": {"reason": "CrashLoopBackOff"}}),
+        )
+    }
+
+    /// The same object, recovered: same UID, running and ready again.
+    fn recovered(name: &str, uid: &str, version: &str) -> Value {
+        let mut pod = pod_json(name, uid, version, json!({"running": {}}));
+        pod["status"]["containerStatuses"][0]["ready"] = json!(true);
+        pod
+    }
+
+    fn failed(name: &str, uid: &str, version: &str) -> Value {
+        pod_json(
+            name,
+            uid,
+            version,
+            json!({"terminated": {"reason": "Error", "exitCode": 1}}),
+        )
+    }
+
+    fn request_filtered(states: &str, dry_run: bool, filter: &str) -> Value {
+        let mut r = request(states, dry_run);
+        r["filter"] = json!(filter);
+        r
+    }
+
+    fn request(states: &str, dry_run: bool) -> Value {
+        json!({"schema_version": 1, "context": null, "cluster": "test",
+               "namespace": "default", "resource": "pods", "name": "", "filter": "",
+               "inputs": {"states": states, "dry_run": dry_run.to_string()},
+               "object": null, "forward": null})
+    }
+
+    fn summary_of(report: &Value) -> String {
+        report["sections"][0]["lines"]
+            .as_array()
+            .expect("summary lines")
+            .iter()
+            .map(|l| l.as_str().unwrap_or_default())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[tokio::test]
+    async fn delete_pins_the_identity_and_the_version_just_read() {
+        let (client, seen) = mock_api(vec![
+            ("200 OK", list_of(vec![failed("job-1", "uid-1", "rv-10")])),
+            ("200 OK", failed("job-1", "uid-1", "rv-11").to_string()),
+            (
+                "200 OK",
+                json!({"kind": "Status", "status": "Success"}).to_string(),
+            ),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[])
+            .await
+            .expect("report");
+
+        let calls = seen.lock().unwrap().clone();
+        assert_eq!(calls.len(), 3, "list, re-read, delete: {calls:?}");
+        assert_eq!(calls[1].0, "GET");
+        assert_eq!(calls[2].0, "DELETE");
+        assert!(calls[2].1.contains("/pods/job-1"), "{}", calls[2].1);
+        let body: Value = serde_json::from_str(&calls[2].2).expect("delete body");
+        assert_eq!(body["preconditions"]["uid"], "uid-1");
+        assert_eq!(
+            body["preconditions"]["resourceVersion"], "rv-11",
+            "the precondition must pin the version just verified, not the scan"
+        );
+        assert!(summary_of(&report).contains("1 deleted"));
+    }
+
+    #[tokio::test]
+    async fn a_pod_that_recovers_between_list_and_delete_survives() {
+        // Selected while crash-looping, ready again by the time its turn came.
+        // Same UID throughout, so only re-running the predicate catches it.
+        let (client, seen) = mock_api(vec![
+            ("200 OK", list_of(vec![crashing("web-0", "uid-1", "rv-10")])),
+            ("200 OK", recovered("web-0", "uid-1", "rv-11").to_string()),
+        ])
+        .await;
+        let report = sanitize(client, &request("stuck", false), &[])
+            .await
+            .expect("report");
+
+        let calls = seen.lock().unwrap().clone();
+        assert_eq!(
+            calls.len(),
+            2,
+            "a recovered pod must never reach DELETE: {calls:?}"
+        );
+        assert!(calls.iter().all(|(method, ..)| method != "DELETE"));
+        let summary = summary_of(&report);
+        assert!(summary.contains("0 deleted"), "{summary}");
+        assert!(summary.contains("1 changed since the scan"), "{summary}");
+        assert!(
+            !report["sections"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|s| s["title"] == "Deleted"),
+            "a recovered pod must not be reported as deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_replacement_wearing_the_same_name_survives() {
+        // A StatefulSet recreated `db-0`: the name matches, the identity does not.
+        let (client, seen) = mock_api(vec![
+            ("200 OK", list_of(vec![failed("db-0", "uid-old", "rv-10")])),
+            ("200 OK", failed("db-0", "uid-new", "rv-1").to_string()),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[])
+            .await
+            .expect("report");
+        assert_eq!(seen.lock().unwrap().len(), 2, "must not reach DELETE");
+        assert!(summary_of(&report).contains("1 changed since the scan"));
+    }
+
+    #[tokio::test]
+    async fn churn_that_does_not_change_the_verdict_still_deletes() {
+        // The restart count moved and the version bumped, but the pod is just as
+        // dead. Pinning the scanned version would have skipped this one.
+        let mut churned = failed("job-1", "uid-1", "rv-99");
+        churned["status"]["containerStatuses"][0]["restartCount"] = json!(12);
+        let (client, seen) = mock_api(vec![
+            ("200 OK", list_of(vec![failed("job-1", "uid-1", "rv-10")])),
+            ("200 OK", churned.to_string()),
+            (
+                "200 OK",
+                json!({"kind": "Status", "status": "Success"}).to_string(),
+            ),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[])
+            .await
+            .expect("report");
+        assert_eq!(seen.lock().unwrap().len(), 3);
+        assert!(
+            summary_of(&report).contains("1 deleted"),
+            "{}",
+            summary_of(&report)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pod_already_gone_is_not_counted_as_deleted() {
+        let missing = json!({"kind": "Status", "status": "Failure", "code": 404,
+                             "reason": "NotFound", "message": "pods 'job-1' not found"});
+        let (client, _) = mock_api(vec![
+            ("200 OK", list_of(vec![failed("job-1", "uid-1", "rv-10")])),
+            ("404 Not Found", missing.to_string()),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[])
+            .await
+            .expect("report");
+        let summary = summary_of(&report);
+        assert!(
+            summary.contains("0 deleted") && summary.contains("1 already gone"),
+            "{summary}"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_refused_delete_does_not_hide_the_others() {
+        let denied = json!({"kind": "Status", "status": "Failure", "code": 403,
+                            "reason": "Forbidden", "message": "pods 'job-2' is forbidden"});
+        let (client, _) = mock_api(vec![
+            (
+                "200 OK",
+                list_of(vec![
+                    failed("job-1", "uid-1", "rv-10"),
+                    failed("job-2", "uid-2", "rv-11"),
+                ]),
+            ),
+            ("200 OK", failed("job-1", "uid-1", "rv-10").to_string()),
+            (
+                "200 OK",
+                json!({"kind": "Status", "status": "Success"}).to_string(),
+            ),
+            ("200 OK", failed("job-2", "uid-2", "rv-11").to_string()),
+            ("403 Forbidden", denied.to_string()),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[])
+            .await
+            .expect("report");
+
+        let summary = summary_of(&report);
+        assert!(summary.contains("1 deleted, 1 failed"), "{summary}");
+        let titles: Vec<&str> = report["sections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["title"].as_str())
+            .collect();
+        assert!(
+            titles.contains(&"Failed") && titles.contains(&"Deleted"),
+            "{titles:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_list_is_an_execution_error_not_an_empty_report() {
+        let (client, _) = mock_api(vec![(
+            "500 Internal Server Error",
+            json!({"kind": "Status", "status": "Failure", "code": 500}).to_string(),
+        )])
+        .await;
+        let error = sanitize(client, &request("terminal", false), &[])
+            .await
+            .expect_err("a broken list must not report success");
+        assert!(format!("{error:#}").contains("listing pods"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn dry_run_sends_no_delete_at_all() {
+        let (client, seen) = mock_api(vec![(
+            "200 OK",
+            list_of(vec![failed("job-1", "uid-1", "rv-10")]),
+        )])
+        .await;
+        let report = sanitize(client, &request("terminal", true), &[])
+            .await
+            .expect("report");
+
+        let calls = seen.lock().unwrap().clone();
+        assert_eq!(calls.len(), 1, "dry run must only list: {calls:?}");
+        assert_eq!(calls[0].0, "GET");
+        assert!(summary_of(&report).contains("nothing deleted (dry run)"));
+        assert_eq!(report["sections"][1]["title"], "Would delete");
+    }
+
+    #[tokio::test]
+    async fn a_bulk_guardrail_is_measured_against_the_pods_to_delete() {
+        // The runner can only weigh one placeholder target for a context
+        // plugin, so without this check max_bulk would not restrain anything.
+        let guardrail = crate::config::Guardrail {
+            actions: vec!["plugin:sanitize".into()],
+            max_bulk: Some(1),
+            ..Default::default()
+        };
+        let (client, seen) = mock_api(vec![(
+            "200 OK",
+            list_of(vec![
+                failed("job-1", "uid-1", "rv-10"),
+                failed("job-2", "uid-2", "rv-11"),
+            ]),
+        )])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[guardrail])
+            .await
+            .expect("report");
+
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            1,
+            "an over-limit set must not delete anything"
+        );
+        let summary = summary_of(&report);
+        assert!(
+            summary.contains("exceeds the guardrail limit of 1"),
+            "{summary}"
+        );
+        assert_eq!(report["sections"][1]["title"], "Blocked");
+    }
+
+    #[tokio::test]
+    async fn a_bulk_guardrail_allows_a_set_within_the_limit() {
+        let guardrail = crate::config::Guardrail {
+            actions: vec!["plugin:sanitize".into()],
+            max_bulk: Some(2),
+            ..Default::default()
+        };
+        let (client, seen) = mock_api(vec![
+            ("200 OK", list_of(vec![failed("job-1", "uid-1", "rv-10")])),
+            ("200 OK", failed("job-1", "uid-1", "rv-10").to_string()),
+            (
+                "200 OK",
+                json!({"kind": "Status", "status": "Success"}).to_string(),
+            ),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[guardrail])
+            .await
+            .expect("report");
+        assert_eq!(seen.lock().unwrap().len(), 3);
+        assert!(summary_of(&report).contains("1 deleted"));
+    }
+
+    #[tokio::test]
+    async fn the_scan_pages_instead_of_pulling_every_pod_at_once() {
+        let mut first = json!({"apiVersion": "v1", "kind": "PodList",
+            "metadata": {"resourceVersion": "1", "continue": "token-2"},
+            "items": [failed("job-1", "uid-1", "rv-10")]});
+        first["items"] = json!([failed("job-1", "uid-1", "rv-10")]);
+        let (client, seen) = mock_api(vec![
+            ("200 OK", first.to_string()),
+            ("200 OK", list_of(vec![failed("job-2", "uid-2", "rv-11")])),
+            ("200 OK", failed("job-1", "uid-1", "rv-10").to_string()),
+            (
+                "200 OK",
+                json!({"kind": "Status", "status": "Success"}).to_string(),
+            ),
+            ("200 OK", failed("job-2", "uid-2", "rv-11").to_string()),
+            (
+                "200 OK",
+                json!({"kind": "Status", "status": "Success"}).to_string(),
+            ),
+        ])
+        .await;
+        let report = sanitize(client, &request("terminal", false), &[])
+            .await
+            .expect("report");
+
+        let calls = seen.lock().unwrap().clone();
+        assert!(
+            calls[0].1.contains("limit="),
+            "the list must be paged: {}",
+            calls[0].1
+        );
+        assert!(
+            calls[1].1.contains("continue=token-2"),
+            "the second page must follow the continue token: {}",
+            calls[1].1
+        );
+        assert!(summary_of(&report).contains("2 matched, 2 deleted"));
+    }
+
+    #[tokio::test]
+    async fn a_selector_filter_narrows_the_scan_server_side() {
+        let (client, seen) = mock_api(vec![(
+            "200 OK",
+            list_of(vec![failed("job-1", "uid-1", "rv-10")]),
+        )])
+        .await;
+        sanitize(
+            client,
+            &request_filtered("terminal", true, "-l app=api"),
+            &[],
+        )
+        .await
+        .expect("report");
+        let calls = seen.lock().unwrap().clone();
+        assert!(
+            calls[0].1.contains("labelSelector=app%3Dapi"),
+            "the label selector must reach the API: {}",
+            calls[0].1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_filter_this_command_cannot_reproduce_refuses_to_run() {
+        // Typing `/web-` then `:sanitize` must not quietly sanitize everything.
+        let (client, seen) = mock_api(vec![(
+            "200 OK",
+            list_of(vec![failed("job-1", "uid-1", "rv-10")]),
+        )])
+        .await;
+        let error = sanitize(client, &request_filtered("terminal", false, "web-"), &[])
+            .await
+            .expect_err("a fuzzy filter must not be silently ignored");
+        assert!(format!("{error:#}").contains("cannot"), "{error:#}");
+        assert!(seen.lock().unwrap().is_empty(), "nothing should be listed");
+    }
+
+    #[test]
+    fn selectors_pass_through_only_what_the_api_can_enforce() {
+        assert_eq!(selectors(None).unwrap(), (None, None));
+        assert_eq!(selectors(Some("   ")).unwrap(), (None, None));
+        let (labels, fields) = selectors(Some("-l app=api -f spec.nodeName=n1")).unwrap();
+        assert_eq!(labels.as_deref(), Some("app=api"));
+        assert_eq!(fields.as_deref(), Some("spec.nodeName=n1"));
+        // Anything evaluated against rendered cells is refused, not ignored.
+        assert!(selectors(Some("web-")).is_err());
+        assert!(selectors(Some("restarts>=5")).is_err());
+        assert!(selectors(Some("-l app=api web-")).is_err());
     }
 
     #[test]
@@ -278,14 +868,14 @@ mod tests {
                 {"name": "c", "ready": false, "restartCount": 0,
                  "state": {"terminated": {"reason": "Completed", "exitCode": 0}}}]}
         }));
-        assert_eq!(status_of(&finished).unwrap(), "Succeeded");
+        assert_eq!(crate::columns::pod_status(&finished), "Succeeded");
         assert!(wanted("terminal").unwrap().contains(&"Succeeded"));
 
         let evicted = pod(json!({
             "metadata": {"name": "gone", "namespace": "default"},
             "status": {"phase": "Failed", "reason": "Evicted"}
         }));
-        assert_eq!(status_of(&evicted).unwrap(), "Failed");
+        assert_eq!(crate::columns::pod_status(&evicted), "Failed");
         assert!(wanted("terminal").unwrap().contains(&"Failed"));
     }
 
@@ -298,7 +888,7 @@ mod tests {
                 {"name": "c", "ready": false, "restartCount": 0,
                  "state": {"terminated": {"reason": "Error", "exitCode": 1}}}]}
         }));
-        assert_eq!(status_of(&dying).unwrap(), "Terminating");
+        assert_eq!(crate::columns::pod_status(&dying), "Terminating");
         assert!(!wanted("all").unwrap().contains(&"Terminating"));
     }
 
@@ -313,7 +903,7 @@ mod tests {
                 {"name": "batch", "ready": false, "restartCount": 0,
                  "state": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}]}
         }));
-        assert_eq!(status_of(&mixed).unwrap(), "OOMKilled");
+        assert_eq!(crate::columns::pod_status(&mixed), "OOMKilled");
         assert!(wanted("terminal").unwrap().contains(&"OOMKilled"));
         assert!(running(&mixed), "a running sibling must protect the pod");
 
@@ -346,7 +936,7 @@ mod tests {
                     {"name": "app", "ready": false, "restartCount": 7,
                      "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
         }));
-        assert_eq!(status_of(&crashing).unwrap(), "CrashLoopBackOff");
+        assert_eq!(crate::columns::pod_status(&crashing), "CrashLoopBackOff");
         assert!(
             !running(&crashing),
             "a proxy must not exempt a dead workload"
@@ -365,7 +955,7 @@ mod tests {
                     {"name": "app", "ready": false, "restartCount": 0,
                      "state": {"terminated": {"reason": "Completed", "exitCode": 0}}}]}
         }));
-        assert_eq!(status_of(&finished).unwrap(), "Running");
+        assert_eq!(crate::columns::pod_status(&finished), "Running");
         assert!(!wanted("all").unwrap().contains(&"Running"));
     }
 
@@ -386,7 +976,7 @@ mod tests {
                  "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
         }));
         assert!(!running(&crashing));
-        assert_eq!(status_of(&crashing).unwrap(), "CrashLoopBackOff");
+        assert_eq!(crate::columns::pod_status(&crashing), "CrashLoopBackOff");
     }
 
     #[test]

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,0 +1,359 @@
+//! The `:sanitize` core plugin: delete the pods a namespace has finished with.
+//!
+//! Runs as `sofka --plugin-adapter sanitize`, spawned by the plugin runner like
+//! any other package. It speaks the same request/report protocol over stdin and
+//! stdout, so guardrails, read-only mode, confirmation, and the report view all
+//! apply unchanged — the only difference from an external package is that the
+//! adapter ships inside the binary instead of needing a runtime on PATH.
+
+use anyhow::{Context, Result};
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, DeleteParams, ListParams, Preconditions};
+use kube::core::DynamicObject;
+use kube::{Client, Config};
+use serde_json::{Value, json};
+
+/// Statuses that mean the pod is finished and will not come back on its own.
+const TERMINAL: &[&str] = &[
+    "Succeeded",
+    "Failed",
+    "Error",
+    "OOMKilled",
+    "ContainerStatusUnknown",
+];
+/// Terminal, plus the pods that are wedged and will not recover unaided.
+const STUCK: &[&str] = &["CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull"];
+/// Everything above, plus pods that have not started. This is the k9s set;
+/// `Pending` covers a pod that is merely waiting for a node, so it is opt-in.
+const UNSTARTED: &[&str] = &["Pending"];
+
+/// Rows per report table. The runner caps captured output at 1 MiB.
+const MAX_ROWS: usize = 500;
+
+fn wanted(states: &str) -> Option<Vec<&'static str>> {
+    let mut set = TERMINAL.to_vec();
+    match states {
+        "terminal" => {}
+        "stuck" => set.extend_from_slice(STUCK),
+        "all" => {
+            set.extend_from_slice(STUCK);
+            set.extend_from_slice(UNSTARTED);
+        }
+        _ => return None,
+    }
+    set.sort_unstable();
+    Some(set)
+}
+
+/// Whether any container is still running.
+///
+/// The STATUS column reports the reason of the last container that terminated,
+/// so a multi-container pod reads `OOMKilled` while a sibling still serves. That
+/// is right for a column and wrong for a delete. Readiness is deliberately not
+/// part of this: a container failing its readiness probe, or still inside its
+/// startup probe, is out of the load balancer and very much alive.
+fn running(pod: &Pod) -> bool {
+    pod.status
+        .as_ref()
+        .and_then(|s| s.container_statuses.as_ref())
+        .is_some_and(|cs| {
+            cs.iter()
+                .any(|c| c.state.as_ref().is_some_and(|s| s.running.is_some()))
+        })
+}
+
+/// A pod's status as the pods view shows it, so `states` names what the user reads.
+fn status_of(pod: &Pod) -> Result<String> {
+    let object: DynamicObject = serde_json::from_value(serde_json::to_value(pod)?)?;
+    Ok(crate::columns::pod_status(&object))
+}
+
+struct Target {
+    namespace: String,
+    name: String,
+    uid: String,
+    status: String,
+}
+
+/// Read the request, sanitize, and write the report. Errors here are execution
+/// errors: the runner shows them and no report is produced.
+pub async fn run() -> Result<()> {
+    let request: Value = serde_json::from_reader(std::io::stdin().lock())
+        .context("reading the plugin request from stdin")?;
+    if request.get("schema_version").and_then(Value::as_u64) != Some(1) {
+        anyhow::bail!("unsupported request schema_version");
+    }
+
+    let inputs = request.get("inputs").cloned().unwrap_or_else(|| json!({}));
+    let states = inputs
+        .get("states")
+        .and_then(Value::as_str)
+        .unwrap_or("terminal");
+    let wanted = wanted(states).with_context(|| format!("unknown states value '{states}'"))?;
+    let dry_run = inputs.get("dry_run").and_then(Value::as_str) == Some("true");
+
+    let namespace = request
+        .get("namespace")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    let client = client_for(request.get("context").and_then(Value::as_str)).await?;
+    let api: Api<Pod> = if namespace.is_empty() {
+        Api::all(client.clone())
+    } else {
+        Api::namespaced(client.clone(), &namespace)
+    };
+
+    let mut targets = Vec::new();
+    for pod in api
+        .list(&ListParams::default())
+        .await
+        .context("listing pods")?
+    {
+        let status = status_of(&pod)?;
+        if !wanted.contains(&status.as_str()) || running(&pod) {
+            continue;
+        }
+        let meta = &pod.metadata;
+        targets.push(Target {
+            namespace: meta.namespace.clone().unwrap_or_default(),
+            name: meta.name.clone().unwrap_or_default(),
+            uid: meta.uid.clone().unwrap_or_default(),
+            status,
+        });
+    }
+    targets.sort_by(|a, b| (&a.namespace, &a.name).cmp(&(&b.namespace, &b.name)));
+
+    let matched = targets.len();
+    let mut deleted = Vec::new();
+    let mut failed = Vec::new();
+    let mut replaced = 0usize;
+
+    if !dry_run {
+        for target in &targets {
+            // The UID precondition binds the delete to the object that scanned.
+            // A pod name is reusable, so without it a StatefulSet that recreated
+            // `db-0` in the meantime would lose its healthy replacement instead.
+            let params = DeleteParams {
+                preconditions: Some(Preconditions {
+                    uid: Some(target.uid.clone()),
+                    resource_version: None,
+                }),
+                ..DeleteParams::default()
+            };
+            let api: Api<Pod> = Api::namespaced(client.clone(), &target.namespace);
+            match api.delete(&target.name, &params).await {
+                Ok(_) => deleted.push(target),
+                // 409 is the precondition failing: the name now holds a
+                // different object. 404 means someone got there first. Neither
+                // is an error, and neither is a pod we should report as gone.
+                Err(kube::Error::Api(e)) if e.code == 409 || e.code == 404 => replaced += 1,
+                Err(e) => failed.push(vec![
+                    target.namespace.clone(),
+                    target.name.clone(),
+                    e.to_string(),
+                ]),
+            }
+        }
+    }
+
+    let scope = if namespace.is_empty() {
+        "all namespaces".to_string()
+    } else {
+        format!("namespace {namespace}")
+    };
+    let mut summary = vec![
+        format!("Scanned {scope}."),
+        format!("Matching statuses: {}.", wanted.join(", ")),
+    ];
+    if dry_run {
+        summary.push(format!("{matched} matched; nothing deleted (dry run)."));
+    } else {
+        summary.push(format!(
+            "{matched} matched, {} deleted, {} failed.",
+            deleted.len(),
+            failed.len()
+        ));
+        if replaced > 0 {
+            summary.push(format!(
+                "{replaced} replaced since the scan and left alone."
+            ));
+        }
+    }
+
+    let mut sections = vec![json!({"title": "Summary", "lines": summary})];
+    if !failed.is_empty() {
+        sections.push(table("Failed", &["Namespace", "Pod", "Error"], failed));
+    }
+    let listed: Vec<&Target> = if dry_run {
+        targets.iter().collect()
+    } else {
+        deleted
+    };
+    let rows: Vec<Vec<String>> = listed
+        .iter()
+        .map(|t| vec![t.namespace.clone(), t.name.clone(), t.status.clone()])
+        .collect();
+    if !rows.is_empty() {
+        let title = if dry_run { "Would delete" } else { "Deleted" };
+        sections.push(table(title, &["Namespace", "Pod", "Status"], rows));
+    }
+
+    serde_json::to_writer(
+        std::io::stdout().lock(),
+        &json!({"schema_version": 1, "title": "Sanitize pods", "sections": sections}),
+    )
+    .context("writing the report")
+}
+
+fn table(title: &str, columns: &[&str], rows: Vec<Vec<String>>) -> Value {
+    let total = rows.len();
+    let mut section = json!({
+        "title": title,
+        "columns": columns,
+        "rows": rows.into_iter().take(MAX_ROWS).collect::<Vec<_>>(),
+    });
+    if total > MAX_ROWS {
+        section["lines"] = json!([format!("{} more rows not shown.", total - MAX_ROWS)]);
+    }
+    section
+}
+
+/// Build a client for the request's context. A null context means sofka had no
+/// explicit kubeconfig context name, so let the usual inference apply.
+async fn client_for(context: Option<&str>) -> Result<Client> {
+    let config = match context {
+        Some(name) => {
+            let options = kube::config::KubeConfigOptions {
+                context: Some(name.to_string()),
+                cluster: None,
+                user: None,
+            };
+            let kubeconfig = kube::config::Kubeconfig::read().context("reading kubeconfig")?;
+            Config::from_custom_kubeconfig(kubeconfig, &options)
+                .await
+                .with_context(|| format!("building config for context '{name}'"))?
+        }
+        None => Config::infer().await.context("loading kubeconfig")?,
+    };
+    Client::try_from(config).context("building a Kubernetes client")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn pod(value: Value) -> Pod {
+        serde_json::from_value(value).expect("pod fixture")
+    }
+
+    #[test]
+    fn state_sets_widen_in_order() {
+        let terminal = wanted("terminal").unwrap();
+        let stuck = wanted("stuck").unwrap();
+        let all = wanted("all").unwrap();
+        assert!(terminal.contains(&"Succeeded") && terminal.contains(&"Failed"));
+        assert!(!terminal.contains(&"CrashLoopBackOff"));
+        assert!(stuck.contains(&"CrashLoopBackOff") && !stuck.contains(&"Pending"));
+        assert!(all.contains(&"Pending"));
+        assert!(terminal.len() < stuck.len() && stuck.len() < all.len());
+        assert!(wanted("bogus").is_none());
+    }
+
+    #[test]
+    fn status_matches_the_pods_view() {
+        // The sets name what the STATUS column shows, not what k9s would print:
+        // a finished pod reads Succeeded here, never Completed.
+        let finished = pod(json!({
+            "metadata": {"name": "job", "namespace": "default"},
+            "status": {"phase": "Succeeded", "containerStatuses": [
+                {"name": "c", "ready": false, "restartCount": 0,
+                 "state": {"terminated": {"reason": "Completed", "exitCode": 0}}}]}
+        }));
+        assert_eq!(status_of(&finished).unwrap(), "Succeeded");
+        assert!(wanted("terminal").unwrap().contains(&"Succeeded"));
+
+        let evicted = pod(json!({
+            "metadata": {"name": "gone", "namespace": "default"},
+            "status": {"phase": "Failed", "reason": "Evicted"}
+        }));
+        assert_eq!(status_of(&evicted).unwrap(), "Failed");
+        assert!(wanted("terminal").unwrap().contains(&"Failed"));
+    }
+
+    #[test]
+    fn a_terminating_pod_is_never_a_target() {
+        let dying = pod(json!({
+            "metadata": {"name": "dying", "namespace": "default",
+                         "deletionTimestamp": "2024-01-01T00:00:00Z"},
+            "status": {"phase": "Failed", "containerStatuses": [
+                {"name": "c", "ready": false, "restartCount": 0,
+                 "state": {"terminated": {"reason": "Error", "exitCode": 1}}}]}
+        }));
+        assert_eq!(status_of(&dying).unwrap(), "Terminating");
+        assert!(!wanted("all").unwrap().contains(&"Terminating"));
+    }
+
+    #[test]
+    fn a_running_container_protects_the_pod() {
+        // One container OOMKilled, one still running: STATUS reads OOMKilled and
+        // the set matches, so only the running check keeps the pod alive.
+        let mixed = pod(json!({
+            "metadata": {"name": "multi", "namespace": "default"},
+            "status": {"phase": "Running", "containerStatuses": [
+                {"name": "app", "ready": true, "restartCount": 0, "state": {"running": {}}},
+                {"name": "batch", "ready": false, "restartCount": 0,
+                 "state": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}]}
+        }));
+        assert_eq!(status_of(&mixed).unwrap(), "OOMKilled");
+        assert!(wanted("terminal").unwrap().contains(&"OOMKilled"));
+        assert!(running(&mixed), "a running sibling must protect the pod");
+
+        // Readiness must not matter: an unready but running container is alive.
+        let unready = pod(json!({
+            "metadata": {"name": "starting", "namespace": "default"},
+            "status": {"phase": "Running", "containerStatuses": [
+                {"name": "app", "ready": false, "restartCount": 0, "state": {"running": {}}},
+                {"name": "batch", "ready": false, "restartCount": 0,
+                 "state": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}]}
+        }));
+        assert!(running(&unready));
+    }
+
+    #[test]
+    fn a_finished_pod_has_nothing_running() {
+        let finished = pod(json!({
+            "metadata": {"name": "job", "namespace": "default"},
+            "status": {"phase": "Succeeded", "containerStatuses": [
+                {"name": "c", "ready": false, "restartCount": 0,
+                 "state": {"terminated": {"reason": "Completed", "exitCode": 0}}}]}
+        }));
+        assert!(!running(&finished));
+
+        let crashing = pod(json!({
+            "metadata": {"name": "crash", "namespace": "default"},
+            "status": {"phase": "Running", "containerStatuses": [
+                {"name": "c", "ready": false, "restartCount": 9,
+                 "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
+        }));
+        assert!(!running(&crashing));
+        assert_eq!(status_of(&crashing).unwrap(), "CrashLoopBackOff");
+    }
+
+    #[test]
+    fn tables_cap_their_rows() {
+        let rows: Vec<Vec<String>> = (0..MAX_ROWS + 20)
+            .map(|i| vec!["default".into(), format!("pod-{i}"), "Failed".into()])
+            .collect();
+        let section = table("Deleted", &["Namespace", "Pod", "Status"], rows);
+        assert_eq!(section["rows"].as_array().unwrap().len(), MAX_ROWS);
+        assert!(
+            section["lines"][0]
+                .as_str()
+                .unwrap()
+                .starts_with("20 more rows")
+        );
+    }
+}

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -45,13 +45,19 @@ fn wanted(states: &str) -> Option<Vec<&'static str>> {
     Some(set)
 }
 
-/// Whether any container is still running.
+/// Whether an application container is still running.
 ///
 /// The STATUS column reports the reason of the last container that terminated,
 /// so a multi-container pod reads `OOMKilled` while a sibling still serves. That
 /// is right for a column and wrong for a delete. Readiness is deliberately not
 /// part of this: a container failing its readiness probe, or still inside its
 /// startup probe, is out of the load balancer and very much alive.
+///
+/// Restartable init containers (native sidecars) are deliberately not consulted.
+/// They are infrastructure for the workload rather than the workload, and
+/// counting them would make an identical crash-looping pod exempt from
+/// `states = stuck` purely because something injected a proxy into it. The
+/// STATUS column ignores them for the same reason, so the two agree.
 fn running(pod: &Pod) -> bool {
     pod.status
         .as_ref()
@@ -320,6 +326,47 @@ mod tests {
                  "state": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}]}
         }));
         assert!(running(&unready));
+    }
+
+    #[test]
+    fn a_native_sidecar_does_not_exempt_a_dead_workload() {
+        // A restartable init container keeps running for the pod's lifetime and
+        // lands in initContainerStatuses, not containerStatuses. Counting it as
+        // "running" would spare a crash-looping pod that an identical pod
+        // without a proxy would not be spared, so it is left out on purpose.
+        let sidecar = json!({"name": "proxy", "restartPolicy": "Always"});
+        let crashing = pod(json!({
+            "metadata": {"name": "wedged", "namespace": "default"},
+            "spec": {"initContainers": [sidecar]},
+            "status": {"phase": "Running",
+                "initContainerStatuses": [
+                    {"name": "proxy", "ready": true, "restartCount": 0,
+                     "state": {"running": {}}}],
+                "containerStatuses": [
+                    {"name": "app", "ready": false, "restartCount": 7,
+                     "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
+        }));
+        assert_eq!(status_of(&crashing).unwrap(), "CrashLoopBackOff");
+        assert!(
+            !running(&crashing),
+            "a proxy must not exempt a dead workload"
+        );
+
+        // The benign case needs no special handling: once the application
+        // container finishes cleanly the status is no longer in any set.
+        let finished = pod(json!({
+            "metadata": {"name": "done", "namespace": "default"},
+            "spec": {"initContainers": [sidecar]},
+            "status": {"phase": "Running",
+                "initContainerStatuses": [
+                    {"name": "proxy", "ready": true, "restartCount": 0,
+                     "state": {"running": {}}}],
+                "containerStatuses": [
+                    {"name": "app", "ready": false, "restartCount": 0,
+                     "state": {"terminated": {"reason": "Completed", "exitCode": 0}}}]}
+        }));
+        assert_eq!(status_of(&finished).unwrap(), "Running");
+        assert!(!wanted("all").unwrap().contains(&"Running"));
     }
 
     #[test]


### PR DESCRIPTION
Rewritten from the ground up for the review. This is no longer an example package — it is a plugin sofka ships, maintains, and installs with itself, with a Rust adapter per the [language policy](https://github.com/nklmilojevic/sofka/blob/main/docs/plugin-authoring.md#language-choice).

`:sanitize` in the pods view deletes the pods a namespace has finished with.

```
:sanitize
:sanitize states=stuck
:sanitize dry_run=true
```

### How it is bundled

The adapter is the sofka binary: `sofka --plugin-adapter sanitize` (hidden from `--help`) speaks the existing request/report protocol on stdin and stdout. `plugins/sanitize/plugin.toml` is embedded with `include_str!` and registered at config load with `command` pointed at the running executable.

So a normal install has nothing to copy and needs no runtime on `PATH` — and it behaves identically for `cargo install`, Nix, and the release binaries, with no `package.nix` or tarball-layout changes. I avoided a `$out/share` data directory precisely because it silently does nothing for `cargo install`.

Registration runs *after* user packages, so an inline `[[plugins]]` entry or a user package named `sanitize` still wins and can replace the shipped one.

Going through the plugin interface means guardrails (`plugin:sanitize`), read-only mode, the ⚠ confirmation, the action journal, output limits, and `:plugin-cancel` all apply with no new machinery.

### Selection reuses the pods view's own STATUS

`columns::pod_status` is now exposed and `pod_summary` delegates to it, so there is one derivation rather than two that drift.

This turned out to matter for correctness, not just tidiness. **The k9s vocabulary does not survive the move**: sofka prints `Succeeded` where k9s prints `Completed`, and `Failed` where k9s prints `Evicted`. The Python version carried the k9s names, so ported literally the two commonest cleanup targets — finished jobs and evicted pods — would never have matched anything.

| `states`   | Deletes |
| ---------- | ------- |
| `terminal` (default) | `Succeeded`, `Failed`, `Error`, `OOMKilled`, `ContainerStatusUnknown` |
| `stuck`    | the above, plus `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull` |
| `all`      | the above, plus `Pending` — the set k9s uses |

`all` is not the default because a `Pending` pod is usually waiting for a node rather than failed.

### The delete race is now actually closed

Earlier in this PR I said an atomic identity-bound delete was impossible; that was true *of kubectl*, which has no UID precondition and whose `delete --raw` takes no body. Through the API it is one field. Every delete carries `Preconditions { uid }`, so a name that now holds a different object is rejected by the server with 409 and counted as replaced rather than deleted. A `409`/`404` is treated as "not ours any more", not as a failure.

A pod is also spared when it is already `Terminating`, or when any container is still running — readiness deliberately not consulted, since a container failing its readiness probe is out of the load balancer but very much alive.

### Tests

`cargo test`, so they run in CI as-is — no Python test infrastructure needed. Unit tests in `src/sanitize.rs` cover the state sets, the status vocabulary (explicitly asserting `Succeeded`/`Failed`, not the k9s names), terminating pods, live-container protection including the unready case, and row capping. Two `handle_key` tests in `src/app/tests.rs` cover the user-visible behaviour: that `:sanitize` is present with no configuration, is scoped to pods, confirms instead of deleting, and is blocked in read-only mode.

Three existing plugin tests asserted exact plugin counts; they now count non-bundled plugins, so they keep testing what they meant to test.

`just check` is green: `cargo fmt --all -- --check`, `cargo test --locked` (687 pass), and clippy clean across every file this branch touches.

### Docs

`plugins/sanitize/README.md` covers requirements, inputs, dry run, deletion states, confirmation, read-only, guardrails, and scope — including, stated plainly, that it ignores the view filter and acts across all namespaces when the view does. Plus a `## Bundled plugins` section in `docs/features.md`, a row in the `docs/keys.md` command table, and a pointer in `docs/plugins.md`. `?` help picks it up automatically, so `src/ui.rs` needed no change.

Rebased onto current main (`fdb58c0`).