### PR TITLE
fix: disable gzip compression for watch requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ dependencies = [
  "terminal-colorsaurus",
  "tokio",
  "toml",
+ "tower",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ similar = "3.1.1"
 terminal-colorsaurus = "1.0.3"
 tokio = { version = "1.52.3", features = ["full"] }
 toml = "1.1.2"
+tower = { version = "0.5.3", features = ["util"] }
 unicode-width = "0.2.2"
 
 [profile.release]

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   aliases (`po`, `dp`, `svc`, `no`, `cm`, `sts`, `ds`, `ks`, `hr`, …) and correct
   precedence - core `pods` wins over `pods.metrics.k8s.io`.
 - **Live watch** of any kind through `kube::runtime::watcher`, streamed into an
-  in-memory store.
+  in-memory store. Watch requests use uncompressed responses to avoid gzip
+  stream errors. List requests retain gzip compression.
 - **Curated columns** for common kinds (pods, deployments, replicasets,
   statefulsets, daemonsets, services, nodes, namespaces, configmaps, secrets,
   jobs, cronjobs, PVC/PV, ingresses, endpoints, CustomResourceDefinitions), with

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -272,13 +272,12 @@ async fn await_counts(rx: &mut Receiver<Msg>, want: &[(&str, usize)]) {
     assert!(seen.is_ok(), "never saw counts {want:?}");
 }
 
-/// A stand-in API server that gzip-encodes its list response and records the
-/// request headers it was asked with. Enabling the `gzip` cargo feature is the
-/// entire change: kube installs its decompression layer inside
-/// `Client::try_from`, which is what `Cluster::from_config` calls — so nothing
-/// in this repo constructs the middleware. That makes it worth pinning from the
-/// outside rather than trusting the feature flag.
-async fn mock_gzip_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+/// Serve compressed lists and one watch, with one gzip member per event when requested.
+async fn mock_gzip_api() -> (
+    String,
+    Arc<std::sync::Mutex<Vec<String>>>,
+    mpsc::Sender<String>,
+) {
     use std::io::Write;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
@@ -295,12 +294,15 @@ async fn mock_gzip_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
     let addr = listener.local_addr().expect("local addr");
     let headers = Arc::new(std::sync::Mutex::new(Vec::new()));
     let seen = Arc::clone(&headers);
+    let (frame_tx, frame_rx) = mpsc::channel::<String>(16);
+    let frames = Arc::new(tokio::sync::Mutex::new(Some(frame_rx)));
     tokio::spawn(async move {
         loop {
             let Ok((mut sock, _)) = listener.accept().await else {
                 return;
             };
             let seen = Arc::clone(&seen);
+            let frames = Arc::clone(&frames);
             tokio::spawn(async move {
                 let (r, mut w) = sock.split();
                 let mut reader = BufReader::new(r);
@@ -308,19 +310,53 @@ async fn mock_gzip_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
                 if reader.read_line(&mut request_line).await.unwrap_or(0) == 0 {
                     return;
                 }
+                let mut gzip = false;
                 loop {
                     let mut header = String::new();
                     if reader.read_line(&mut header).await.unwrap_or(0) == 0 || header == "\r\n" {
                         break;
                     }
+                    gzip |= header.trim().eq_ignore_ascii_case("accept-encoding: gzip");
                     seen.lock()
                         .unwrap()
                         .push(header.trim().to_ascii_lowercase());
                 }
-                // A watch would be answered uncompressed by a real apiserver;
-                // this mock only has to serve the list the watcher opens with.
                 if request_line.contains("watch=true") {
-                    std::future::pending::<()>().await;
+                    let encoding = if gzip {
+                        "content-encoding: gzip\r\n"
+                    } else {
+                        ""
+                    };
+                    let head = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ntransfer-encoding: chunked\r\n{encoding}\r\n"
+                    );
+                    w.write_all(head.as_bytes()).await.unwrap();
+                    let Some(mut rx) = frames.lock().await.take() else {
+                        std::future::pending::<()>().await;
+                        return;
+                    };
+                    while let Some(frame) = rx.recv().await {
+                        let mut body = format!("{frame}\n").into_bytes();
+                        if gzip {
+                            let mut enc = flate2::write::GzEncoder::new(
+                                Vec::new(),
+                                flate2::Compression::fast(),
+                            );
+                            enc.write_all(&body).unwrap();
+                            body = enc.finish().unwrap();
+                        }
+                        if w.write_all(format!("{:x}\r\n", body.len()).as_bytes())
+                            .await
+                            .is_err()
+                            || w.write_all(&body).await.is_err()
+                            || w.write_all(b"\r\n").await.is_err()
+                        {
+                            return;
+                        }
+                        w.flush().await.unwrap();
+                    }
+                    let _ = w.write_all(b"0\r\n\r\n").await;
+                    return;
                 }
                 let mut enc =
                     flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
@@ -335,7 +371,7 @@ async fn mock_gzip_api() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
             });
         }
     });
-    (format!("http://{addr}"), headers)
+    (format!("http://{addr}"), headers, frame_tx)
 }
 
 /// A `Cluster` whose client talks to `url` instead of a real API server.
@@ -345,7 +381,7 @@ fn mock_cluster(url: &str) -> Cluster {
     // this test is about the app's fallback, not the client's retries.
     config.default_retry = false;
     let mut cluster = Cluster::fake();
-    cluster.client = Client::try_from(config).expect("mock client");
+    cluster.client = crate::k8s::build_client(config).expect("mock client");
     cluster.cluster_url = url.into();
     cluster
 }
@@ -506,14 +542,10 @@ async fn node_pods_backs_off_when_the_initial_list_keeps_failing() {
     );
 }
 
-/// Compression is transparent: the `gzip` cargo feature is the only change, and
-/// it has to survive a dependency bump that reshuffles kube's client stack.
-/// Both halves are checked — the request advertises gzip, and a gzip-encoded
-/// body is inflated before deserialization. Without the feature the second
-/// assertion fails first, because serde is handed the raw deflate stream.
+/// List requests still negotiate and decode gzip through the production client.
 #[tokio::test]
 async fn the_client_negotiates_and_inflates_gzip() {
-    let (url, headers) = mock_gzip_api().await;
+    let (url, headers, _frames) = mock_gzip_api().await;
     let (tx, mut rx) = mpsc::channel(1024);
     let mut app = App::new(mock_cluster(&url), tx);
 
@@ -526,6 +558,78 @@ async fn the_client_negotiates_and_inflates_gzip() {
     assert!(
         seen.iter().any(|h| h == "accept-encoding: gzip"),
         "client did not ask for gzip; headers: {seen:?}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_keeps_pod_updates_and_deletes_working_with_gzip_available() {
+    let (url, headers, frames) = mock_gzip_api().await;
+    let (tx, mut rx) = mpsc::channel(1024);
+    let mut app = App::new(mock_cluster(&url), tx);
+    app.kind = app.cluster.resolve("pods");
+    app.kind_plural = "pods".into();
+    app.namespace = "default".into();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+
+    let mut pod = json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "a", "namespace": "default", "resourceVersion": "1"},
+        "status": {"phase": "Pending"}
+    });
+    let bookmark = json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"resourceVersion": "1", "annotations": {"k8s.io/initial-events-end": "true"}}
+    });
+    for (event, object) in [
+        ("ADDED", pod.clone()),
+        ("BOOKMARK", bookmark),
+        ("MODIFIED", {
+            pod["metadata"]["resourceVersion"] = json!("2");
+            pod["status"]["phase"] = json!("Running");
+            pod.clone()
+        }),
+        ("DELETED", pod),
+    ] {
+        frames
+            .send(json!({"type": event, "object": object}).to_string())
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            loop {
+                let msg = rx.recv().await.expect("watch channel closed");
+                if let Msg::Error { error, .. } = &msg {
+                    panic!("watch failed: {error}");
+                }
+                let received = matches!(
+                    (&msg, event),
+                    (Msg::Applied { .. }, "ADDED" | "MODIFIED")
+                        | (Msg::Synced { .. }, "BOOKMARK")
+                        | (Msg::Deleted { .. }, "DELETED")
+                );
+                app.handle_msg(msg);
+                if received {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("watch event timeout");
+        match event {
+            "ADDED" => assert!(app.store.get("default/a").is_some()),
+            "MODIFIED" => assert_eq!(
+                app.store.get("default/a").unwrap().data["status"]["phase"],
+                "Running"
+            ),
+            "DELETED" => assert!(app.store.get("default/a").is_none()),
+            _ => {}
+        }
+    }
+    assert!(
+        headers
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|h| h == "accept-encoding: identity")
     );
 }
 

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -19,6 +19,27 @@ use tokio::task::JoinHandle;
 
 use crate::store::{Msg, row_key};
 
+pub(crate) fn build_client(config: Config) -> Result<Client, kube::Error> {
+    let layer =
+        tower::util::MapRequestLayer::new(|mut request: http::Request<kube::client::Body>| {
+            let watch = request.uri().query().is_some_and(|query| {
+                form_urlencoded::parse(query.as_bytes())
+                    .any(|(key, value)| key == "watch" && value == "true")
+            });
+            if watch {
+                // Watch responses can contain multiple gzip members, which the client cannot decode.
+                request.headers_mut().insert(
+                    http::header::ACCEPT_ENCODING,
+                    http::HeaderValue::from_static("identity"),
+                );
+            }
+            request
+        });
+    Ok(kube::client::ClientBuilder::try_from(config)?
+        .with_layer(&layer)
+        .build())
+}
+
 /// A resolvable Kubernetes resource type.
 #[derive(Clone)]
 pub struct Kind {
@@ -131,7 +152,7 @@ impl Cluster {
     ) -> Result<Self> {
         let cluster_url = config.cluster_url.to_string();
         let default_namespace = config.default_namespace.clone();
-        let client = Client::try_from(config).context("building kube client")?;
+        let client = build_client(config).context("building kube client")?;
         let version_client = client.clone();
 
         let cluster_name = cluster_name_for(&context).unwrap_or_default();


### PR DESCRIPTION
Pod watches can fail with `there are extra bytes after body has been decompressed` when the API server sends multiple gzip members. This was reproduced on Kubernetes v1.37.0 after gzip support was added in #194.

Watch requests now use `Accept-Encoding: identity`. List requests retain gzip compression. The client keeps its existing authentication, proxy, retry, and TLS configuration.

Validation:

- `just check`: formatting, Clippy, and all tests passed.
- The new test starts a pod watch through the refresh key and checks initial pods, bookmarks, updates, and deletion. It fails with the exact reported error when the fix is removed.
- The existing gzip list test passes.
- The fixed production client completed a direct pod watch on the same cluster: 194 events and a clean end of stream.
