### PR TITLE
fix: keep status column width stable

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -15,7 +15,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Curated columns** for common kinds (pods, deployments, replicasets,
   statefulsets, daemonsets, services, nodes, namespaces, configmaps, secrets,
   jobs, cronjobs, PVC/PV, ingresses, endpoints, CustomResourceDefinitions), with
-  a NAME/AGE fallback for everything else.
+  a NAME/AGE fallback for everything else. STATUS columns use a fixed width of
+  26 characters so status changes do not move adjacent columns. A configured
+  column width takes priority.
 - **Custom views** - define columns for any resource in the config file. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
   automatically. `w` toggles wide-only columns (kubectl `-o wide`). See

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1753,6 +1753,76 @@ fn forward_context_matching_and_validation() {
 }
 
 #[tokio::test]
+async fn pod_status_changes_keep_column_positions_stable() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    for width in [80, 120, 180] {
+        let (mut app, _rx) = test_app();
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for c in "pods".chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.kind_plural, "pods");
+
+        let mut terminal = Terminal::new(TestBackend::new(width, 24)).unwrap();
+        let mut initial_columns = None;
+        for status in [
+            "Pending",
+            "ContainerCreating",
+            "Running",
+            "CrashLoopBackOff",
+            "CreateContainerConfigError",
+            "Running",
+        ] {
+            let state = if status == "Running" {
+                json!({"running": {}})
+            } else {
+                json!({"waiting": {"reason": status}})
+            };
+            apply(
+                &mut app,
+                json!({
+                    "apiVersion": "v1", "kind": "Pod",
+                    "metadata": {"name": "example", "namespace": "default"},
+                    "status": {
+                        "phase": "Running",
+                        "containerStatuses": [{
+                            "ready": status == "Running", "restartCount": 0,
+                            "state": state
+                        }]
+                    }
+                }),
+            );
+            terminal
+                .draw(|frame| crate::ui::draw(frame, &mut app))
+                .unwrap();
+            let hit = app.table_hit.borrow().clone().unwrap();
+            let status_index = app
+                .display_headers()
+                .iter()
+                .position(|header| header == "STATUS")
+                .unwrap();
+            let &(start, end, _) = hit
+                .cols
+                .iter()
+                .find(|(_, _, index)| *index == status_index)
+                .unwrap();
+            assert_eq!(end - start, 26, "status width at terminal width {width}");
+            let status_cell: String = (start..end)
+                .map(|x| terminal.backend().buffer()[(x, hit.rows_y)].symbol())
+                .collect();
+            assert_eq!(status_cell.trim(), status);
+            if let Some(ref columns) = initial_columns {
+                assert_eq!(&hit.cols, columns, "columns moved for {status} at {width}");
+            } else {
+                initial_columns = Some(hit.cols);
+            }
+        }
+    }
+}
+
+#[tokio::test]
 async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
     use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
     use ratatui::Terminal;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -825,10 +825,9 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     "CPU" | "MEM" => ColWidth::Exact(8),
                     "%CPU" | "%MEM" => ColWidth::Exact(5),
                     "PODS" => ColWidth::Exact(5),
-                    // Caps, not fixed: room for the long pod reasons
-                    // (ContainerCreating, CrashLoopBackOff…) when they occur,
-                    // shrink to the visible values when they don't.
-                    "STATUS" => ColWidth::Cap(19),
+                    // Keep status changes from moving the other columns.
+                    // Allow room for CreateContainerConfigError.
+                    "STATUS" => ColWidth::Exact(26),
                     "READY" | "RESTARTS" => ColWidth::Cap(10),
                     // CRD view: group domains run long (e.g.
                     // "kustomize.toolkit.fluxcd.io"), so GROUP/KIND/VERSIONS


### PR DESCRIPTION
Status changes during a live watch resized the STATUS column and moved adjacent columns. Set the default width to 26 characters so transitions such as `ContainerCreating` to `Running` keep the table stable. This also fits `CreateContainerConfigError`. Configured column widths still take priority.

Added a regression test that opens the pods view through keyboard input and checks rendered status text and column positions across six state updates at terminal widths of 80, 120, and 180 characters. Documented the default width.

Validation: `just check` passed, with 679 tests passed and 1 ignored.
