### PR TITLE
fix: keep table columns stable during scrolling

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   jobs, cronjobs, PVC/PV, ingresses, endpoints, CustomResourceDefinitions), with
   a NAME/AGE fallback for everything else. STATUS columns use a fixed width of
   26 characters so status changes do not move adjacent columns. A configured
-  column width takes priority.
+  column width takes priority. Column widths use the full filtered list so
+  scrolling does not move the columns.
 - **Custom views** - define columns for any resource in the config file. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
   automatically. `w` toggles wide-only columns (kubectl `-o wide`). See

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1353,6 +1353,7 @@ struct RowsCache {
     dirty: bool,
     keys: Vec<RowKey>,
     cells: crate::store::FastMap<RowKey, CellCacheEntry>,
+    column_widths: Option<TableWidthCache>,
     /// Computed primary sort keys, valid per (sort header, resourceVersion) —
     /// a rebuild touches every object, but only changed rows re-extract.
     sort_keys: crate::store::FastMap<RowKey, SortKeyEntry>,
@@ -1360,6 +1361,11 @@ struct RowsCache {
     /// version it was computed from. A rebuild staled by a filter keystroke or
     /// a sort toggle leaves the store untouched, so the dedup still holds.
     helm_latest: Option<(u64, crate::store::FastSet<RowKey>)>,
+}
+
+struct TableWidthCache {
+    headers: Rc<[String]>,
+    needed: Vec<u16>,
 }
 
 struct CellCacheEntry {
@@ -2065,6 +2071,7 @@ impl App {
                 dirty: true,
                 keys: Vec::new(),
                 cells: crate::store::FastMap::default(),
+                column_widths: None,
                 sort_keys: crate::store::FastMap::default(),
                 helm_latest: None,
             }),

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -11,6 +11,7 @@ impl App {
         cache.dirty = true;
         cache.keys.clear();
         cache.cells.clear();
+        cache.column_widths = None;
         cache.sort_keys.clear();
         cache.helm_latest = None;
     }
@@ -28,6 +29,7 @@ impl App {
     pub(super) fn invalidate_row_contents(&self, key: &str) {
         let mut cache = self.rows_cache.borrow_mut();
         cache.cells.remove(key);
+        cache.column_widths = None;
         cache.sort_keys.remove(key);
         if !self.filter.is_empty()
             || self.sort_column.is_some()
@@ -292,6 +294,7 @@ impl App {
         if !cache.dirty {
             return;
         }
+        cache.column_widths = None;
 
         let headers = self.display_headers();
         let sort_header = self
@@ -498,6 +501,53 @@ impl App {
             .take(n)
             .filter_map(|k| self.store.get(k.as_ref()))
             .collect()
+    }
+
+    /// Measure the full filtered list once per data or view change.
+    /// Scrolling reuses these widths and renders only the rows on screen.
+    pub(crate) fn table_column_widths(&self) -> Vec<u16> {
+        use unicode_width::UnicodeWidthStr;
+
+        self.ensure_rows_cache();
+        let headers = self.display_headers();
+        let mut cache = self.rows_cache.borrow_mut();
+        if let Some(widths) = &cache.column_widths
+            && Rc::ptr_eq(&widths.headers, &headers)
+        {
+            return widths.needed.clone();
+        }
+
+        let width = |s: &str| u16::try_from(s.width()).unwrap_or(u16::MAX);
+        let mut needed: Vec<u16> = headers.iter().map(|h| width(h)).collect();
+        let show_ns = self.show_namespace_column();
+        let ns_off = usize::from(show_ns);
+        let now = crate::columns::now_secs();
+        let RowsCache { keys, cells, .. } = &mut *cache;
+        for key in keys.iter() {
+            let Some(obj) = self.store.get(key.as_ref()) else {
+                continue;
+            };
+            if show_ns {
+                needed[0] =
+                    needed[0].max(width(obj.metadata.namespace.as_deref().unwrap_or_default()));
+            }
+            let entry = self.cell_entry(key, obj, cells, now);
+            for (i, cell) in entry.cells.iter().enumerate() {
+                let cell_width =
+                    if let Some(value) = self.spec.volatile(obj, &self.kind_plural, i, now) {
+                        // Reserve space for elapsed times as the clock advances.
+                        width(&value).max(7)
+                    } else {
+                        width(cell)
+                    };
+                needed[i + ns_off] = needed[i + ns_off].max(cell_width);
+            }
+        }
+        cache.column_widths = Some(TableWidthCache {
+            headers,
+            needed: needed.clone(),
+        });
+        needed
     }
 
     pub(crate) fn ensure_table_cell_cache(&self, rows: &[&DynamicObject]) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1823,6 +1823,113 @@ async fn pod_status_changes_keep_column_positions_stable() {
 }
 
 #[tokio::test]
+async fn scrolling_pods_keeps_column_positions_stable() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    for (width, height) in [(80, 24), (120, 32), (180, 48), (220, 52)] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        app.namespace.clear();
+        for i in 0..90 {
+            let namespace = if i == 0 { "a-long-namespace" } else { "z" };
+            let name = if i == 89 {
+                "pod-89-with-a-much-longer-name-than-the-other-pods".to_string()
+            } else {
+                format!("pod-{i:02}")
+            };
+            apply(
+                &mut app,
+                json!({
+                    "apiVersion": "v1", "kind": "Pod",
+                    "metadata": {"name": name, "namespace": namespace},
+                    "status": {"phase": "Running"}
+                }),
+            );
+        }
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let initial = app.table_hit.borrow().clone().unwrap();
+        let header = |terminal: &Terminal<TestBackend>| -> String {
+            (0..width)
+                .map(|x| terminal.backend().buffer()[(x, initial.header_y)].symbol())
+                .collect()
+        };
+        let initial_header = header(&terminal);
+
+        for key in [KeyCode::Down, KeyCode::Up] {
+            for _ in 0..89 {
+                app.handle_key(press(key)).unwrap();
+                terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+                assert_eq!(
+                    app.table_hit.borrow().as_ref().unwrap().cols,
+                    initial.cols,
+                    "columns moved at {width}x{height}, offset {}",
+                    app.table_state.offset()
+                );
+                assert_eq!(header(&terminal), initial_header);
+            }
+            if key == KeyCode::Down {
+                assert!(app.table_state.offset() > 0);
+                assert_eq!(app.table_state.selected(), Some(89));
+            }
+        }
+        assert_eq!(app.table_state.offset(), 0);
+    }
+}
+
+#[tokio::test]
+async fn table_widths_follow_offscreen_updates_filters_and_view_changes() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let pod = |i: usize, node: &str| {
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": format!("pod-{i:02}"), "namespace": "default"},
+            "spec": {"nodeName": node},
+            "status": {"phase": "Running"}
+        })
+    };
+    for i in 0..40 {
+        apply(&mut app, pod(i, "node"));
+    }
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    let mut terminal = Terminal::new(TestBackend::new(180, 24)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let initial = app.table_hit.borrow().clone().unwrap().cols;
+
+    apply(
+        &mut app,
+        pod(39, "node-with-a-much-longer-name-outside-the-viewport"),
+    );
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let updated = app.table_hit.borrow().clone().unwrap().cols;
+    assert_ne!(updated, initial, "an updated row must change the widths");
+    app.handle_key(press(KeyCode::End)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert_eq!(app.table_hit.borrow().as_ref().unwrap().cols, updated);
+
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "pod-00".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert_eq!(app.row_count(), 1);
+    assert_eq!(app.table_hit.borrow().as_ref().unwrap().cols, initial);
+
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert!(!app.display_headers().iter().any(|h| h == "NODE"));
+    assert_eq!(
+        app.table_hit.borrow().as_ref().unwrap().cols.len(),
+        app.display_headers().len()
+    );
+}
+
+#[tokio::test]
 async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
     use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
     use ratatui::Terminal;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -634,6 +634,10 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let offset = app.table_state.offset();
     let selected = app.table_state.selected();
 
+    let mut needed = app.table_column_widths();
+    if let Some(i) = sort_col {
+        needed[i] = needed[i].max(cell_width(&headers[i]).saturating_add(2));
+    }
     let visible_objects = app.rows_window(offset, visible_rows);
     app.ensure_table_cell_cache(&visible_objects);
     let cell_cache = app.table_cell_cache();
@@ -643,18 +647,6 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // used to call `Timestamp::now()` for itself, so a full table took one
     // reading per volatile cell and could show two rows a second apart.
     let now = crate::columns::now_secs();
-
-    // Widest visible value per display column (headers count too, plus the
-    // sort arrow on the active sort column). Drives the content-aware widths
-    // below so a narrow window trims padding, not data (#166).
-    let mut needed: Vec<u16> = headers
-        .iter()
-        .enumerate()
-        .map(|(i, h)| {
-            let arrow = if Some(i) == sort_col { 2 } else { 0 };
-            cell_width(h) + arrow
-        })
-        .collect();
 
     let rows: Vec<Row> = visible_objects
         .iter()
@@ -707,11 +699,6 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     );
                     cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.0)));
                     cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.1)));
-                }
-            }
-            for (i, c) in cells.iter().enumerate() {
-                if let Some(n) = needed.get_mut(i) {
-                    *n = (*n).max(cell_width(c.as_str()));
                 }
             }
             // Combined colorer: the whole row takes a k9s-style status tint
@@ -796,7 +783,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
 
     // Content-aware column widths (#166): every column asks for its widest
-    // visible value, the rules below bound or weight that ask, and
+    // value in the filtered list, the rules below bound or weight that ask, and
     // `distribute_column_widths` splits the frame. A `Fill`-style layout is
     // deliberately avoided — it hands NAME padding it doesn't need while a
     // long EXTERNAL-IP next to it gets silently trimmed.


### PR DESCRIPTION
Scrolling past the last visible pod moved NAME and other columns because widths were measured from only the rows on screen. Cache widths from the full filtered list so columns stay in place during scrolling. Refresh the widths after data, filter, or view changes.

Regression tests reproduce the original shift and check scrolling at four terminal sizes, from 80 × 24 to 220 × 52. They also check width updates after a row outside the screen changes, filtering, and a wide view change.

Validation: `just check` and all pre-commit checks passed. Tests: 681 passed, 1 ignored.
