### PR TITLE
feat: show node labels in wide mode

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -21,7 +21,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   scrolling does not move the columns.
 - **Custom views** - define columns for any resource in the config file. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
-  automatically. `w` toggles wide-only columns (kubectl `-o wide`). See
+  automatically. `w` toggles wide-only columns (kubectl `-o wide`), including
+  node labels. See
   [Views and thresholds](views.md).
 - **Drill-down navigation** with a breadcrumb stack: workload/service → pods,
   cronjob → its jobs, node → its pods, pod → containers, namespace → re-scope,

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -56,7 +56,7 @@ pickers keep both characters available as input.
 | `t`                                           | Flux: suspend/resume/reconcile menu · ArgoCD App/AppSet: suspend/resume (App: + sync) · CronJobs: trigger/suspend/resume · pods: file transfer (`kubectl cp`) |
 | `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                                              |
 | `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan)                         |
-| `w`                                           | toggle wide-only columns (kubectl `-o wide`)                                                                                                                  |
+| `w`                                           | toggle wide-only columns (kubectl `-o wide`), including node labels                                                                                           |
 | `←` / `→`                                     | scroll columns horizontally (NAMESPACE/NAME stay anchored) — for narrow panes                                                                                 |
 | `:q`, `ctrl-c`                                | quit                                                                                                                                                          |
 | `?`                                           | help                                                                                                                                                          |

--- a/docs/views.md
+++ b/docs/views.md
@@ -51,7 +51,14 @@ a warning in the app - they never take down the TUI.
 
 Custom columns also overlay sofka's curated core-resource views. Pods already
 show `IP` and `NODE` after toggling wide mode with `w`, and nodes always show
-`VERSION`. Extra node topology and provisioning details can come from labels:
+`VERSION`. Press `w` in the nodes view to show `LABELS` as comma-separated
+`key=value` pairs in key order. Nodes without labels show `<none>`.
+Use `/` to find text in the visible labels. To filter by an exact label, press
+`/`, enter `-l karpenter.sh/nodepool=default`, then press Enter. Label selectors
+also work with wide mode off. Use the label key and value for your cluster.
+
+Custom columns can show individual labels or annotations. Extra node topology
+and provisioning details can come from labels:
 
 ```toml
 # Karpenter example; adjust provider-specific NODEPOOL and TYPE label names.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8741,6 +8741,73 @@ async fn user_view_adds_provider_label_columns_to_curated_nodes() {
 }
 
 #[tokio::test]
+async fn node_wide_labels_render_filter_and_refresh() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("nodes");
+    let narrow_headers = app.display_headers().to_vec();
+    assert!(!narrow_headers.iter().any(|header| header == "LABELS"));
+    for (name, labels) in [
+        (
+            "worker-1",
+            json!({"zone": "west", "karpenter.sh/nodepool": "general", "empty": ""}),
+        ),
+        ("worker-2", json!({})),
+        ("worker-3", Value::Null),
+    ] {
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Node",
+                "metadata": {"name": name, "resourceVersion": "1", "labels": labels}
+            }),
+        );
+    }
+
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    let labels_index = app
+        .display_headers()
+        .iter()
+        .position(|h| *h == "LABELS")
+        .unwrap();
+    {
+        let rows = app.rows();
+        app.ensure_table_cell_cache(&rows);
+        let cache = app.table_cell_cache();
+        for row in rows {
+            let (cells, _) = cache.get(&row_key(row)).unwrap();
+            let expected = if row.metadata.name.as_deref() == Some("worker-1") {
+                "empty=,karpenter.sh/nodepool=general,zone=west"
+            } else {
+                "<none>"
+            };
+            assert_eq!(cells[labels_index], expected);
+        }
+    }
+
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "general".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.rows().len(), 1);
+    assert_eq!(app.rows()[0].metadata.name.as_deref(), Some("worker-1"));
+
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Node",
+            "metadata": {"name": "worker-1", "resourceVersion": "2",
+                         "labels": {"karpenter.sh/nodepool": "batch"}}
+        }),
+    );
+    assert!(app.rows().is_empty());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.rows().len(), 3);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.display_headers().to_vec(), narrow_headers);
+}
+
+#[tokio::test]
 async fn user_view_replace_swaps_out_curated_columns() {
     let (mut app, _rx) = test_app();
     install_views(

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -167,6 +167,7 @@ const NODE_COLUMNS: &[Column] = &[
     column("ROLES", col_node_roles),
     column("TAINTS", col_node_taints),
     column("VERSION", col_node_version),
+    wide_column("LABELS", col_node_labels),
     column("AGE", col_age),
 ];
 
@@ -899,6 +900,25 @@ fn col_node_taints<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 
 fn col_node_version<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     Cow::Borrowed(sget(ctx.data, &["status", "nodeInfo", "kubeletVersion"]).unwrap_or_default())
+}
+
+fn col_node_labels<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    let Some(labels) = ctx
+        .obj
+        .metadata
+        .labels
+        .as_ref()
+        .filter(|labels| !labels.is_empty())
+    else {
+        return Cow::Borrowed("<none>");
+    };
+    Cow::Owned(
+        labels
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join(","),
+    )
 }
 
 fn col_namespace_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2010,7 +2010,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "page tables and documents forward/back (also PgDn/PgUp)",
         ),
         bind("S · I", "sort by column (fuzzy picker) · invert direction"),
-        bind("w", "toggle wide columns (kubectl -o wide)"),
+        bind(
+            "w",
+            "toggle wide columns (kubectl -o wide), including node labels",
+        ),
         bind(
             "ctrl-e",
             "compact mode: collapse header + footer (for tiled panes)",


### PR DESCRIPTION
The default node view had no wide columns, so users needed custom configuration to see and search node pool labels. Pressing `w` now shows a `LABELS` column with comma-separated `key=value` pairs in key order. Nodes without labels show `<none>`.

The column uses the existing text filter and wide mode. Help and docs describe the new column and label selector syntax. A keyboard test covers the wide toggle, label display, empty labels, filtering, and watch updates.

Validation: `just check` and all pre-commit checks passed. 682 tests passed; 1 ignored.

Closes #244
