### PR TITLE
feat: add Ctrl+Z pod faults filter

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -44,6 +44,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   inverse match, `-l`/`-f` label and field selectors (evaluated server-side on
   ⏎), and typed column comparisons (`status=CrashLoopBackOff`, `cpu>500m`,
   `memory>1Gi`, `restarts>=5`, `age<2h`). Space-separated terms AND together.
+- **Toggle faults** (`Ctrl+Z`, pods only) shows pending, failed, unknown,
+  terminating, and running pods that are not ready. Completed pods are hidden.
+  The table title shows `[faults]` while the filter is on. It works with the
+  text filter and current namespace or drill scope. Press `Ctrl+Z` again to
+  turn it off. The setting stays on for pod views during the session and does
+  not filter other resource types.
 - **Global fuzzy find** (`:find <text>`) - search object names across the common
   kinds (workloads, pods, services, config, ingresses, jobs, storage, nodes,
   namespaces, Flux objects) in every namespace at once, concurrently. Results

--- a/docs/features.md
+++ b/docs/features.md
@@ -49,7 +49,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   The table title shows `[faults]` while the filter is on. It works with the
   text filter and current namespace or drill scope. Press `Ctrl+Z` again to
   turn it off. The setting stays on for pod views during the session and does
-  not filter other resource types.
+  not filter other resource types. Configured `Ctrl+Z` bookmark, workspace,
+  and matching plugin actions take precedence. Live updates keep the selected
+  pod selected. If it leaves the list or its UID changes, selection is cleared.
 - **Global fuzzy find** (`:find <text>`) - search object names across the common
   kinds (workloads, pods, services, config, ingresses, jobs, storage, nodes,
   namespaces, Flux objects) in every namespace at once, concurrently. Results

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -21,7 +21,7 @@ pickers keep both characters available as input.
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                                                      |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                                              |
 | `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                                                     |
-| `Ctrl+Z`                                      | toggle faults filter in pod views; combine with `/`; press again to turn off                                                                                  |
+| `Ctrl+Z`                                      | toggle faults filter in pod views; configured actions take precedence; combine with `/`; press again to turn off                                              |
 | `n` / `0`                                     | namespace switcher / all namespaces                                                                                                                           |
 | `shift-j`                                     | jump to owner/controller                                                                                                                                      |
 | `o`                                           | show the node the selected row names (pods built in; other kinds via `[views."…"].node`)                                                                      |

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -21,6 +21,7 @@ pickers keep both characters available as input.
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                                                      |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                                              |
 | `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                                                     |
+| `Ctrl+Z`                                      | toggle faults filter in pod views; combine with `/`; press again to turn off                                                                                  |
 | `n` / `0`                                     | namespace switcher / all namespaces                                                                                                                           |
 | `shift-j`                                     | jump to owner/controller                                                                                                                                      |
 | `o`                                           | show the node the selected row names (pods built in; other kinds via `[views."…"].node`)                                                                      |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -64,6 +64,12 @@ impl App {
                         && self.kind_plural == "pods"
                         && key.modifiers == KeyModifiers::CONTROL =>
                 {
+                    if self.try_bookmark_key(key)
+                        || self.try_workspace_key(key)
+                        || self.try_plugin_key(key)
+                    {
+                        return Ok(());
+                    }
                     self.faults_only = !self.faults_only;
                     self.invalidate_rows();
                     self.table_state.select(Some(0));

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -59,6 +59,16 @@ impl App {
                     self.start_watch();
                     return Ok(());
                 }
+                KeyCode::Char('z')
+                    if self.mode == Mode::Table
+                        && self.kind_plural == "pods"
+                        && key.modifiers == KeyModifiers::CONTROL =>
+                {
+                    self.faults_only = !self.faults_only;
+                    self.invalidate_rows();
+                    self.table_state.select(Some(0));
+                    return Ok(());
+                }
                 KeyCode::Char('f')
                     if self.mode == Mode::Table && key.modifiers == KeyModifiers::CONTROL =>
                 {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -793,6 +793,21 @@ impl App {
     }
 
     pub fn handle_msg(&mut self, msg: Msg) {
+        let preserve_selection = self.faults_filter_active()
+            && matches!(
+                &msg,
+                Msg::Applied { generation, .. }
+                    | Msg::Deleted { generation, .. }
+                    | Msg::Reset { generation }
+                    | Msg::Synced { generation }
+                    if *generation == self.generation
+            );
+        let selected_pod = if preserve_selection {
+            self.selected_ref()
+                .map(|o| (crate::store::row_key(o), o.metadata.uid.clone()))
+        } else {
+            None
+        };
         match msg {
             Msg::Reset { generation } if generation == self.generation => {
                 // With rows on screen (cached snapshot or established watch)
@@ -1283,6 +1298,20 @@ impl App {
                 }
             },
             _ => {} // stale generation, drop
+        }
+        if preserve_selection {
+            let index = selected_pod.and_then(|(key, uid)| {
+                self.ensure_rows_cache();
+                if self.store.get(&key)?.metadata.uid != uid {
+                    return None;
+                }
+                self.rows_cache
+                    .borrow()
+                    .keys
+                    .iter()
+                    .position(|k| k.as_ref() == key)
+            });
+            self.table_state.select(index);
         }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1549,6 +1549,7 @@ pub struct App {
     /// underneath it; reset when the view spec is rebuilt.
     pub col_offset: usize,
     pub filter: String,
+    pub faults_only: bool,
     /// Parsed form of `filter`, refreshed lazily when the string changes so
     /// neither row matching nor rendering reparses it per frame.
     filter_cache: RefCell<FilterCache>,
@@ -1920,6 +1921,7 @@ impl App {
             sort_desc: false,
             col_offset: 0,
             filter: String::new(),
+            faults_only: false,
             filter_cache: RefCell::new(FilterCache {
                 raw: String::new(),
                 parsed: crate::filter::parse(""),

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -32,6 +32,7 @@ impl App {
         cache.column_widths = None;
         cache.sort_keys.remove(key);
         if !self.filter.is_empty()
+            || self.faults_filter_active()
             || self.sort_column.is_some()
             || self.owner.is_some()
             || self.kind_plural == "helm"
@@ -67,10 +68,17 @@ impl App {
         cells: &mut crate::store::FastMap<RowKey, CellCacheEntry>,
         now: i64,
     ) -> bool {
+        if self.faults_filter_active() && !pod_has_faults(o) {
+            return false;
+        }
         if self.filter.is_empty() {
             return true;
         }
         self.eval_filter(o, key, parsed, cells, now)
+    }
+
+    pub fn faults_filter_active(&self) -> bool {
+        self.faults_only && self.kind_plural == "pods"
     }
 
     fn eval_filter(
@@ -1053,4 +1061,82 @@ impl App {
         let page = self.table_page_rows.max(1) as i32;
         self.move_selection(pages.saturating_mul(page));
     }
+}
+
+fn pod_has_faults(o: &DynamicObject) -> bool {
+    if o.metadata.deletion_timestamp.is_some() {
+        return true;
+    }
+    let d = &o.data;
+    match d.pointer("/status/phase").and_then(Value::as_str) {
+        Some("Succeeded") => return false,
+        Some("Running") => {}
+        _ => return true,
+    }
+    let condition_ready = |kind: &str| {
+        d.pointer("/status/conditions")
+            .and_then(Value::as_array)
+            .is_some_and(|conditions| {
+                conditions.iter().any(|c| {
+                    c.get("type").and_then(Value::as_str) == Some(kind)
+                        && c.get("status").and_then(Value::as_str) == Some("True")
+                })
+            })
+    };
+    if !condition_ready("Ready") {
+        return true;
+    }
+    if d.pointer("/spec/readinessGates")
+        .and_then(Value::as_array)
+        .is_some_and(|gates| {
+            gates.iter().any(|gate| {
+                gate.get("conditionType")
+                    .and_then(Value::as_str)
+                    .is_none_or(|kind| !condition_ready(kind))
+            })
+        })
+    {
+        return true;
+    }
+    let Some(statuses) = d
+        .pointer("/status/containerStatuses")
+        .and_then(Value::as_array)
+    else {
+        return true;
+    };
+    if statuses.is_empty()
+        || statuses.iter().any(|c| {
+            c.get("ready").and_then(Value::as_bool) != Some(true)
+                || c.pointer("/state/running").is_none()
+        })
+        || d.pointer("/spec/containers")
+            .and_then(Value::as_array)
+            .is_some_and(|containers| containers.len() != statuses.len())
+    {
+        return true;
+    }
+    d.pointer("/spec/initContainers")
+        .and_then(Value::as_array)
+        .is_some_and(|containers| {
+            containers.iter().any(|container| {
+                let status = d
+                    .pointer("/status/initContainerStatuses")
+                    .and_then(Value::as_array)
+                    .and_then(|statuses| {
+                        statuses
+                            .iter()
+                            .find(|s| s.get("name") == container.get("name"))
+                    });
+                status.is_none_or(|s| {
+                    if container.get("restartPolicy").and_then(Value::as_str) == Some("Always") {
+                        s.get("ready").and_then(Value::as_bool) != Some(true)
+                            || s.pointer("/state/running").is_none()
+                    } else {
+                        s.pointer("/state/terminated/exitCode")
+                            .and_then(Value::as_i64)
+                            != Some(0)
+                    }
+                })
+            })
+        })
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11308,3 +11308,140 @@ async fn check_unknown_inline_fields(location: &str) {
         std::fs::remove_dir_all(dir).unwrap();
     }
 }
+
+fn faults_test_pod(name: &str) -> Value {
+    json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": name, "namespace": "default", "resourceVersion": "1"},
+        "spec": {"containers": [{"name": "app"}]},
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "containerStatuses": [{"name": "app", "ready": true, "restartCount": 0,
+                                   "state": {"running": {}}}]
+        }
+    })
+}
+
+#[tokio::test]
+async fn ctrl_z_filters_pod_faults() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let healthy = faults_test_pod("healthy");
+    let mut cases = vec![(healthy.clone(), false)];
+    for phase in ["Pending", "Failed", "Unknown", "Succeeded"] {
+        let mut pod = faults_test_pod(phase);
+        pod["status"] = json!({"phase": phase});
+        cases.push((pod, phase != "Succeeded"));
+    }
+    for reason in [
+        "CrashLoopBackOff",
+        "ImagePullBackOff",
+        "ErrImagePull",
+        "ContainerCreating",
+    ] {
+        let mut pod = faults_test_pod(reason);
+        pod["status"]["containerStatuses"][0]["state"] = json!({"waiting": {"reason": reason}});
+        cases.push((pod, true));
+    }
+    let mut unready = faults_test_pod("unready");
+    unready["status"]["conditions"][0]["status"] = json!("False");
+    cases.push((unready, true));
+    let mut container_unready = faults_test_pod("container-unready");
+    container_unready["status"]["containerStatuses"][0]["ready"] = json!(false);
+    cases.push((container_unready, true));
+    let mut missing = faults_test_pod("missing-status");
+    missing["status"]["containerStatuses"] = json!([]);
+    cases.push((missing, true));
+    let mut terminating = faults_test_pod("terminating");
+    terminating["metadata"]["deletionTimestamp"] = json!("2026-09-06T00:00:00Z");
+    cases.push((terminating, true));
+    let mut gate = faults_test_pod("gate");
+    gate["spec"]["readinessGates"] = json!([{"conditionType": "example.com/ready"}]);
+    cases.push((gate, true));
+    for (name, sidecar, ready, faulty) in [
+        ("init-complete", false, true, false),
+        ("init-failed", false, false, true),
+        ("sidecar-ready", true, true, false),
+        ("sidecar-unready", true, false, true),
+    ] {
+        let mut pod = faults_test_pod(name);
+        pod["spec"]["initContainers"] = json!([{"name": "init"}]);
+        let state = if sidecar {
+            pod["spec"]["initContainers"][0]["restartPolicy"] = json!("Always");
+            json!({"running": {}})
+        } else {
+            json!({"terminated": {"exitCode": if ready { 0 } else { 1 }}})
+        };
+        pod["status"]["initContainerStatuses"] =
+            json!([{"name": "init", "ready": ready, "state": state}]);
+        cases.push((pod, faulty));
+    }
+    for (pod, _) in &cases {
+        apply(&mut app, pod.clone());
+    }
+    assert_eq!(app.row_count(), cases.len());
+    app.handle_key(press(KeyCode::End)).unwrap();
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    let names = row_names(&app);
+    for (pod, faulty) in &cases {
+        let name = pod["metadata"]["name"].as_str().unwrap();
+        assert_eq!(names.iter().any(|n| n == name), *faulty, "{name}");
+    }
+    assert_eq!(app.table_state.selected(), Some(0));
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 24)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let screen: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+    assert!(screen.contains("[faults]"));
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert_eq!(app.row_count(), cases.len());
+}
+
+#[tokio::test]
+async fn faults_filter_combines_with_text_and_tracks_watch_updates() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let mut pod = faults_test_pod("api");
+    apply(&mut app, pod.clone());
+    let mut other = faults_test_pod("other");
+    other["status"]["phase"] = json!("Pending");
+    apply(&mut app, other);
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert_eq!(row_names(&app), ["other"]);
+    pod["metadata"]["resourceVersion"] = json!("2");
+    pod["status"]["conditions"][0]["status"] = json!("False");
+    apply(&mut app, pod.clone());
+    assert_eq!(row_names(&app), ["api", "other"]);
+    type_filter(&mut app, "api");
+    assert_eq!(row_names(&app), ["api"]);
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert_eq!(app.filter, "api");
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    pod["metadata"]["resourceVersion"] = json!("3");
+    pod["status"]["conditions"][0]["status"] = json!("True");
+    apply(&mut app, pod);
+    assert!(row_names(&app).is_empty());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(row_names(&app), ["other"]);
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "services".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "services");
+    assert!(!app.faults_filter_active());
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Service",
+        "metadata": {"name": "service", "namespace": "default"}}),
+    );
+    assert_eq!(row_names(&app), ["service"]);
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert!(app.faults_only);
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11445,3 +11445,118 @@ async fn faults_filter_combines_with_text_and_tracks_watch_updates() {
     app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
     assert!(app.faults_only);
 }
+
+#[tokio::test]
+async fn configured_ctrl_z_actions_take_precedence_over_faults() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.bookmarks = vec![crate::config::Bookmark {
+        key: Some("ctrl-z".into()),
+        name: "services".into(),
+        resource: "services".into(),
+        ..Default::default()
+    }];
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert_eq!(app.kind_plural, "services");
+    assert!(!app.faults_only);
+
+    app.bookmarks.clear();
+    app.switch_kind("pods");
+    app.workspaces = vec![crate::config::Workspace {
+        key: Some("ctrl-z".into()),
+        name: "ops".into(),
+        context: None,
+        views: vec![crate::config::WorkspaceView {
+            name: "services".into(),
+            resource: "services".into(),
+            ..Default::default()
+        }],
+    }];
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert_eq!(app.kind_plural, "services");
+    assert!(!app.faults_only);
+
+    app.workspaces.clear();
+    app.switch_kind("pods");
+    app.readonly = true;
+    app.plugins = vec![crate::config::Plugin {
+        key: "ctrl-z".into(),
+        name: "custom".into(),
+        command: "true".into(),
+        scopes: vec!["pods".into()],
+        ..Default::default()
+    }];
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert!(app.flash.contains("read-only"));
+    assert!(!app.faults_only);
+    app.plugins[0].scopes = vec!["services".into()];
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert!(app.faults_only);
+}
+
+#[tokio::test]
+async fn faults_watch_changes_preserve_pod_identity_or_clear_selection() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for name in ["b", "c", "d"] {
+        let mut pod = faults_test_pod(name);
+        pod["metadata"]["uid"] = json!(name);
+        pod["status"]["phase"] = json!("Pending");
+        apply(&mut app, pod);
+    }
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    assert_eq!(
+        app.selected_ref().unwrap().metadata.name.as_deref(),
+        Some("c")
+    );
+
+    let mut earlier = faults_test_pod("a");
+    earlier["status"]["phase"] = json!("Pending");
+    apply(&mut app, earlier);
+    assert_eq!(app.table_state.selected(), Some(2));
+    assert_eq!(
+        app.selected_ref().unwrap().metadata.name.as_deref(),
+        Some("c")
+    );
+
+    let mut recovered = faults_test_pod("b");
+    recovered["metadata"]["uid"] = json!("b");
+    recovered["metadata"]["resourceVersion"] = json!("2");
+    apply(&mut app, recovered);
+    assert_eq!(app.table_state.selected(), Some(1));
+    assert_eq!(
+        app.selected_ref().unwrap().metadata.name.as_deref(),
+        Some("c")
+    );
+
+    let mut recovered = faults_test_pod("c");
+    recovered["metadata"]["uid"] = json!("c");
+    recovered["metadata"]["resourceVersion"] = json!("2");
+    apply(&mut app, recovered);
+    assert!(app.selected_ref().is_none());
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 24)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert_eq!(app.table_state.selected(), None);
+    app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+    assert_ne!(app.mode, Mode::Confirm);
+
+    app.handle_key(press(KeyCode::End)).unwrap();
+    assert_eq!(
+        app.selected_ref().unwrap().metadata.name.as_deref(),
+        Some("d")
+    );
+    let mut replacement = faults_test_pod("d");
+    replacement["metadata"]["uid"] = json!("replacement");
+    replacement["metadata"]["resourceVersion"] = json!("2");
+    replacement["status"]["phase"] = json!("Pending");
+    apply(&mut app, replacement);
+    assert_eq!(app.table_state.selected(), None);
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    let key = row_key(app.selected_ref().unwrap());
+    app.handle_msg(Msg::Deleted {
+        generation: app.generation,
+        key,
+    });
+    assert_eq!(app.table_state.selected(), None);
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -853,6 +853,9 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         Span::styled(format!(" {kind_label} "), theme::title()),
         Span::styled(format!("[{count}]"), Style::default().fg(theme::counter())),
     ];
+    if app.faults_filter_active() {
+        title.push(Span::styled(" [faults]", Style::default().fg(theme::red())));
+    }
     // Horizontal scroll indicator: how many columns are hidden off the left.
     if col_offset > 0 {
         title.push(Span::styled(format!(" ‹{col_offset}"), theme::dim()));
@@ -2028,6 +2031,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind("n · 0", "namespace switcher · 0 = all namespaces"),
         bind("ctrl-r", "refresh watch"),
+        bind("ctrl-z", "toggle faults filter (pods only)"),
         Line::from(""),
         Line::from(Span::styled("  Inspect", theme::title())),
         bind("y · d", "view YAML · describe (kubectl)"),


### PR DESCRIPTION
Pod lists had no direct way to show only pods with faults. A status text filter could miss a pod that was running but not ready.

Add `Ctrl+Z` in pod views to turn the faults filter on or off. It shows pending, failed, unknown, terminating, and unready pods, and hides completed pods. Readiness checks include regular containers, init containers, sidecars, and readiness gates.

The filter works with existing text filters and the current scope, updates with watch events, and shows `[faults]` in the table title. Its setting stays active for pod views during the session without filtering other resource types. Configured `Ctrl+Z` bookmark, workspace, and matching plugin actions take precedence. Watch updates keep selection by pod key and UID, and clear it if the pod leaves the list or is replaced. Help and key documentation are included.

Validation: `just check` and the pre-commit checks passed. The test suite reports 686 passed and 1 ignored. New tests use `handle_key` to check pod states, readiness, the title indicator, text filters, watch updates, resource changes, configured key precedence, and selection identity. The selection test also checks that a delete key press after selection is cleared cannot target another pod.
