### PR TITLE
fix: scroll table content without resizing columns

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -18,7 +18,11 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   a NAME/AGE fallback for everything else. STATUS columns use a fixed width of
   26 characters so status changes do not move adjacent columns. A configured
   column width takes priority. Column widths use the full filtered list so
-  scrolling does not move the columns.
+  vertical scrolling does not move the columns.
+- **Horizontal scrolling** - Left and Right move the table by five text positions.
+  NAME and NAMESPACE stay fixed. Other columns keep their widths while you
+  scroll. Arrows in the title show where more content is available. When all
+  columns fit, Left and Right do nothing.
 - **Custom views** - define columns for any resource in the config file. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
   automatically. `w` toggles wide-only columns (kubectl `-o wide`), including

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -58,7 +58,7 @@ pickers keep both characters available as input.
 | `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                                              |
 | `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan)                         |
 | `w`                                           | toggle wide-only columns (kubectl `-o wide`), including node labels                                                                                           |
-| `←` / `→`                                     | scroll columns horizontally (NAMESPACE/NAME stay anchored) — for narrow panes                                                                                 |
+| `←` / `→`                                     | scroll sideways by 5 text positions; NAMESPACE/NAME stay fixed; arrows show more content                                                                      |
 | `:q`, `ctrl-c`                                | quit                                                                                                                                                          |
 | `?`                                           | help                                                                                                                                                          |
 | _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                                                   |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -217,9 +217,7 @@ impl App {
             }
             KeyCode::PageDown => self.move_page(1),
             KeyCode::PageUp => self.move_page(-1),
-            // Horizontal column scroll for narrow panes: the NAMESPACE/NAME
-            // prefix stays anchored, → hides the next column after it, ←
-            // brings one back.
+            // Move the viewport; keep NAMESPACE/NAME in place.
             KeyCode::Right => self.scroll_columns(1),
             KeyCode::Left => self.scroll_columns(-1),
             // k9s: SPACE marks/unmarks the current row for bulk actions, then

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1543,11 +1543,10 @@ pub struct App {
     /// `None` for the natural namespace/name order.
     pub sort_column: Option<usize>,
     pub sort_desc: bool,
-    /// Horizontal column scroll: how many columns after the anchored
-    /// NAMESPACE/NAME prefix are hidden off the left edge (←/→ in the
-    /// table). Clamped by `draw_table`, since the header set can change
-    /// underneath it; reset when the view spec is rebuilt.
+    /// Horizontal offset in terminal cells after NAMESPACE/NAME.
+    /// The renderer clamps this when the viewport or columns change.
     pub col_offset: usize,
+    pub col_scroll_max: usize,
     pub filter: String,
     pub faults_only: bool,
     /// Parsed form of `filter`, refreshed lazily when the string changes so
@@ -1920,6 +1919,7 @@ impl App {
             sort_column: None,
             sort_desc: false,
             col_offset: 0,
+            col_scroll_max: 0,
             filter: String::new(),
             faults_only: false,
             filter_cache: RefCell::new(FilterCache {

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -676,6 +676,7 @@ impl App {
         }
         self.clear_rows_cache();
         self.col_offset = 0;
+        self.col_scroll_max = 0;
     }
 
     /// The user-configured view matching the current kind, if any. Synthetic
@@ -719,19 +720,12 @@ impl App {
         self.flash_err = false;
     }
 
-    /// Scroll the table columns horizontally (←/→): the NAMESPACE/NAME
-    /// prefix stays anchored while the columns after it shift. Clamped so
-    /// the last column can always be reached and at least one scrollable
-    /// column stays visible.
+    /// Move the table by five terminal cells. Keep the name columns fixed.
     pub(super) fn scroll_columns(&mut self, delta: isize) {
-        let anchored = usize::from(self.show_namespace_column()) + 1;
-        let scrollable = self.display_headers().len().saturating_sub(anchored);
-        let max = scrollable.saturating_sub(1);
         self.col_offset = self
             .col_offset
-            .min(max)
-            .saturating_add_signed(delta)
-            .min(max);
+            .saturating_add_signed(delta * 5)
+            .min(self.col_scroll_max);
     }
 
     pub fn show_namespace_column(&self) -> bool {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2002,49 +2002,190 @@ async fn mouse_click_selects_row_header_click_sorts_wheel_moves() {
 }
 
 #[tokio::test]
-async fn horizontal_column_scroll_anchors_name_and_clamps() {
-    use ratatui::Terminal;
-    use ratatui::backend::TestBackend;
+async fn horizontal_scroll_keeps_names_and_moves_content_without_resizing() {
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::{Terminal, backend::TestBackend};
+
+    for all_namespaces in [false, true] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        if all_namespaces {
+            app.namespace.clear();
+        }
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": "web", "namespace": "default"},
+                "spec": {"nodeName": "node-abcdefghijklmnopqrstuvwxyz-0123456789-long-value"},
+                "status": {"phase": "Running"}
+            }),
+        );
+        app.handle_key(press(KeyCode::Char('w'))).unwrap();
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert!(app.col_scroll_max > 5);
+        let initial = term.backend().buffer().clone();
+        let hit = app.table_hit.borrow().clone().unwrap();
+        let title = |term: &Terminal<TestBackend>| -> String {
+            (hit.x_min..hit.x_max)
+                .map(|x| term.backend().buffer()[(x, hit.header_y - 1)].symbol())
+                .collect()
+        };
+        assert!(title(&term).contains('→'));
+        assert!(!title(&term).contains('←'));
+        let anchored = usize::from(all_namespaces) + 1;
+        let frozen_end = hit.cols[anchored].0;
+        app.handle_key(press(KeyCode::Left)).unwrap();
+        assert_eq!(app.col_offset, 0);
+        app.handle_key(press(KeyCode::Right)).unwrap();
+        term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert_eq!(app.col_offset, 5);
+        assert!(title(&term).contains('←'));
+        assert!(title(&term).contains('→'));
+        let moved = app.table_hit.borrow().clone().unwrap();
+        assert_eq!(&hit.cols[..anchored], &moved.cols[..anchored]);
+        for y in [hit.header_y, hit.rows_y] {
+            for x in hit.x_min..frozen_end {
+                assert_eq!(
+                    initial[(x, y)].symbol(),
+                    term.backend().buffer()[(x, y)].symbol()
+                );
+            }
+            for x in frozen_end..hit.x_max.saturating_sub(5) {
+                assert_eq!(
+                    initial[(x + 5, y)].symbol(),
+                    term.backend().buffer()[(x, y)].symbol()
+                );
+            }
+        }
+        app.handle_key(press(KeyCode::Left)).unwrap();
+        term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert_eq!(term.backend().buffer(), &initial);
+        app.handle_key(press(KeyCode::Right)).unwrap();
+        term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let &(start, _, index) = moved.cols.last().unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: start,
+            row: moved.header_y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+        assert_eq!(app.sort_column, Some(index));
+        app.handle_key(press(KeyCode::Left)).unwrap();
+        assert_eq!(app.col_offset, 0);
+        for _ in 0..100 {
+            app.handle_key(press(KeyCode::Right)).unwrap();
+        }
+        term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert_eq!(app.col_offset, app.col_scroll_max);
+        assert_eq!(
+            app.table_hit
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .cols
+                .last()
+                .unwrap()
+                .2,
+            app.display_headers().len() - 1
+        );
+        assert!(title(&term).contains('←'));
+        assert!(!title(&term).contains('→'));
+        let at_end = app.col_offset;
+        app.handle_key(press(KeyCode::Right)).unwrap();
+        assert_eq!(app.col_offset, at_end);
+        app.handle_key(press(KeyCode::Char('w'))).unwrap();
+        assert_eq!(app.col_offset, 0);
+    }
+}
+
+#[tokio::test]
+async fn horizontal_scroll_stops_when_columns_fit_and_resets_after_resize() {
+    use ratatui::{Terminal, backend::TestBackend};
 
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");
+    let mut term = Terminal::new(TestBackend::new(180, 24)).unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert_eq!(app.col_scroll_max, 0);
+    let before = term.backend().buffer().clone();
+    app.handle_key(press(KeyCode::Right)).unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert_eq!(app.col_offset, 0);
+    assert_eq!(term.backend().buffer(), &before);
+
+    term.backend_mut().resize(45, 24);
+    term.autoresize().unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    app.handle_key(press(KeyCode::Right)).unwrap();
+    assert!(app.col_offset > 0);
+    term.backend_mut().resize(180, 24);
+    term.autoresize().unwrap();
+    term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert_eq!(app.col_offset, 0);
+    assert_eq!(app.col_scroll_max, 0);
+}
+
+#[tokio::test]
+async fn horizontal_scroll_clips_wide_characters_at_both_edges() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [[views."cert-manager.io/v1/certificates".columns]]
+        name = "VALUE"
+        path = "/spec/value"
+        width = 40
+        align = "right"
+    "#,
+    );
+    app.switch_kind("certificates");
     apply(
         &mut app,
         json!({
-            "apiVersion": "v1", "kind": "Pod",
-            "metadata": {"name": "a", "namespace": "default"},
-            "status": {"phase": "Running"}
+            "apiVersion": "cert-manager.io/v1", "kind": "Certificate",
+            "metadata": {"name": "web", "namespace": "default"},
+            "spec": {"value": "界".repeat(20)}
         }),
     );
-    app.table_state.select(Some(0));
-
-    let headers = app.display_headers().to_vec();
-    assert_eq!(headers[0], "NAME");
-    let scrollable = headers.len() - 1;
-
-    // ← at the left edge is a no-op; → hides the column after NAME.
-    app.handle_key(press(KeyCode::Left)).unwrap();
-    assert_eq!(app.col_offset, 0);
-    app.handle_key(press(KeyCode::Right)).unwrap();
-    assert_eq!(app.col_offset, 1);
-
-    // → clamps so the last scrollable column stays visible.
-    for _ in 0..headers.len() {
-        app.handle_key(press(KeyCode::Right)).unwrap();
-    }
-    assert_eq!(app.col_offset, scrollable - 1);
-
-    // The rendered geometry skips the hidden columns: NAME (0) stays
-    // anchored, then only the last scrollable column follows.
-    let mut term = Terminal::new(TestBackend::new(120, 32)).unwrap();
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    let mut term = Terminal::new(TestBackend::new(30, 24)).unwrap();
     term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
-    let hit = app.table_hit.borrow().clone().expect("geometry recorded");
-    let cols: Vec<usize> = hit.cols.iter().map(|&(_, _, i)| i).collect();
-    assert_eq!(cols, vec![0, headers.len() - 1]);
-
-    // Rebuilding the view spec (view switch, wide toggle) resets the scroll.
-    app.refresh_view_spec();
-    assert_eq!(app.col_offset, 0);
+    for _ in 0..4 {
+        app.handle_key(press(KeyCode::Right)).unwrap();
+        let rendered = term
+            .draw(|f| crate::ui::draw(f, &mut app))
+            .unwrap()
+            .buffer
+            .clone();
+        let hit = app.table_hit.borrow().clone().unwrap();
+        let &(start, end, _) = hit.cols.iter().find(|c| c.2 == 1).unwrap();
+        for x in start..end {
+            let source = app.col_offset + usize::from(x - start);
+            let expected = if source.is_multiple_of(2) && x + 1 < end {
+                "界"
+            } else {
+                " "
+            };
+            assert_eq!(rendered[(x, hit.rows_y)].symbol(), expected);
+            // A terminal does not write the second half of a wide character.
+            if source.is_multiple_of(2) || x == start {
+                assert_eq!(term.backend().buffer()[(x, hit.rows_y)].symbol(), expected);
+            }
+        }
+    }
+    for width in [1, 2, 3, 4, 8] {
+        term.backend_mut().resize(width, 24);
+        term.autoresize().unwrap();
+        term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        app.handle_key(press(KeyCode::Right)).unwrap();
+        term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    }
 }
 
 #[tokio::test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -548,15 +548,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // Offset from a displayed column index back to the view spec's (the spec
     // doesn't know about the prepended NAMESPACE or appended CPU/MEM).
     let ns_off = usize::from(show_ns);
-    // Horizontal column scroll: everything after the anchored NAMESPACE/NAME
-    // prefix can be shifted off the left edge with ←/→. Clamped here (not
-    // only in the key handler) because the header set can change underneath
-    // the offset (wide toggle, printer columns arriving).
-    let name_col = if show_ns { 1 } else { 0 };
-    let scrollable_cols = headers.len().saturating_sub(name_col + 1);
-    app.col_offset = app.col_offset.min(scrollable_cols.saturating_sub(1));
-    let col_offset = app.col_offset;
-    let col_visible = move |i: usize| i <= name_col || i >= name_col + 1 + col_offset;
+    let name_col = usize::from(show_ns);
     // Per-column custom alignment, precomputed so cells don't re-borrow app.
     let aligns: Vec<Option<Alignment>> = (0..headers.len())
         .map(|i| {
@@ -567,38 +559,34 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     let align_of = |i: usize| aligns.get(i).copied().flatten();
 
-    let header_row = Row::new(
-        headers
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| col_visible(*i))
-            .map(|(i, h)| {
-                // Active sort column gets a direction arrow in the sorter color
-                // (sky, bold), matching k9s; the label inherits the header color.
-                if Some(i) == sort_col {
-                    let mut line = Line::from(vec![
-                        Span::raw(h.clone()),
-                        Span::styled(
-                            sort_arrow,
-                            Style::default()
-                                .fg(theme::sorter())
-                                .add_modifier(Modifier::BOLD),
-                        ),
-                    ]);
-                    if let Some(a) = align_of(i) {
-                        line = line.alignment(a);
-                    }
-                    Cell::from(line)
-                } else {
-                    match align_of(i) {
-                        Some(a) => Cell::from(Text::from(h.clone()).alignment(a)),
-                        None => Cell::from(h.clone()),
-                    }
+    let header_cells = headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| {
+            // Active sort column gets a direction arrow in the sorter color
+            // (sky, bold), matching k9s; the label inherits the header color.
+            if Some(i) == sort_col {
+                let mut line = Line::from(vec![
+                    Span::raw(h.clone()),
+                    Span::styled(
+                        sort_arrow,
+                        Style::default()
+                            .fg(theme::sorter())
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ]);
+                if let Some(a) = align_of(i) {
+                    line = line.alignment(a);
                 }
-            })
-            .collect::<Vec<_>>(),
-    )
-    .style(theme::header_row());
+                Cell::from(line)
+            } else {
+                match align_of(i) {
+                    Some(a) => Cell::from(Text::from(h.clone()).alignment(a)),
+                    None => Cell::from(h.clone()),
+                }
+            }
+        })
+        .collect::<Vec<_>>();
 
     // Column indices (fixed for the whole table) for the columns that get
     // their own visibility treatment below, computed once rather than
@@ -638,6 +626,78 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(i) = sort_col {
         needed[i] = needed[i].max(cell_width(&headers[i]).saturating_add(2));
     }
+    // Compute widths from all columns before applying the viewport offset.
+    let col_rules: Vec<(ColWidth, u16)> = headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| {
+            // A custom column's configured width wins over the curated rules.
+            let rule = if let Some(w) = i
+                .checked_sub(ns_off)
+                .and_then(|si| app.view_spec().width_at(si))
+            {
+                ColWidth::Exact(w)
+            } else {
+                match h.as_str() {
+                    // NAME is the column you actually read — its weight takes
+                    // most of a wide window's surplus, and most of the shared
+                    // space when the window can't fit everything.
+                    "NAME" => ColWidth::Flex(6),
+                    "NAMESPACE" => ColWidth::Flex(2),
+                    "NODE" | "CLAIM" | "VOLUME" | "HOSTS" => ColWidth::Flex(1),
+                    "AGE" => ColWidth::Cap(7),
+                    // Volatile numerics keep a fixed width so a metrics tick
+                    // never reflows the whole table.
+                    "CPU" | "MEM" => ColWidth::Exact(8),
+                    "%CPU" | "%MEM" => ColWidth::Exact(5),
+                    "PODS" => ColWidth::Exact(5),
+                    // Keep status changes from moving the other columns.
+                    // Allow room for CreateContainerConfigError.
+                    "STATUS" => ColWidth::Exact(26),
+                    "READY" | "RESTARTS" => ColWidth::Cap(10),
+                    // CRD view: group domains run long (e.g.
+                    // "kustomize.toolkit.fluxcd.io"), so GROUP/KIND/VERSIONS
+                    // get generous ceilings NAME's weight can't crush.
+                    "GROUP" => ColWidth::Cap(30),
+                    "KIND" | "VERSIONS" => ColWidth::Cap(20),
+                    "SCOPE" => ColWidth::Cap(12),
+                    // Flux views: the Ready condition message and git/chart
+                    // revision are the columns you read — they split the
+                    // leftover space with NAME.
+                    "MESSAGE" => ColWidth::Flex(4),
+                    "REVISION" => ColWidth::Flex(2),
+                    "SUSPENDED" => ColWidth::Cap(9),
+                    _ => ColWidth::Flex(1),
+                }
+            };
+            (rule, needed[i])
+        })
+        .collect();
+    // Mirror the Table widget's fixed overhead: borders, the always-reserved
+    // 2-cell highlight symbol, and the 2-cell spacing between columns.
+    let ncols = col_rules.len() as u16;
+    let content_budget = area
+        .width
+        .saturating_sub(2)
+        .saturating_sub(2)
+        .saturating_sub(2 * ncols.saturating_sub(1));
+    let mut widths = distribute_column_widths(content_budget, &col_rules);
+    for (i, (rule, needed)) in col_rules.iter().enumerate() {
+        if matches!(rule, ColWidth::Flex(_)) {
+            let minimum = if i <= name_col {
+                (*needed).min(area.width.saturating_sub(4) / (2 * (name_col + 1) as u16))
+            } else {
+                *needed
+            };
+            widths[i] = widths[i].max(minimum);
+        }
+    }
+    let inner = area.inner(ratatui::layout::Margin::new(1, 1));
+    let viewport = TableViewport::new(&widths, name_col + 1, inner.width);
+    app.col_scroll_max = viewport.max_offset;
+    app.col_offset = app.col_offset.min(app.col_scroll_max);
+    let col_offset = app.col_offset;
+
     let visible_objects = app.rows_window(offset, visible_rows);
     app.ensure_table_cell_cache(&visible_objects);
     let cell_cache = app.table_cell_cache();
@@ -648,7 +708,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // reading per volatile cell and could show two rows a second apart.
     let now = crate::columns::now_secs();
 
-    let rows: Vec<Row> = visible_objects
+    let rows: Vec<Vec<Cell>> = visible_objects
         .iter()
         .map(|obj| {
             let row_key = crate::store::row_key(obj);
@@ -728,7 +788,6 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             let render_cells: Vec<Cell> = cells
                 .into_iter()
                 .enumerate()
-                .filter(|(i, _)| col_visible(*i))
                 .map(|(i, c)| {
                     let align = align_of(i);
                     if marked_row {
@@ -778,73 +837,8 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     }
                 })
                 .collect();
-            Row::new(render_cells)
+            render_cells
         })
-        .collect();
-
-    // Content-aware column widths (#166): every column asks for its widest
-    // value in the filtered list, the rules below bound or weight that ask, and
-    // `distribute_column_widths` splits the frame. A `Fill`-style layout is
-    // deliberately avoided — it hands NAME padding it doesn't need while a
-    // long EXTERNAL-IP next to it gets silently trimmed.
-    let col_rules: Vec<(ColWidth, u16)> = headers
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| col_visible(*i))
-        .map(|(i, h)| {
-            // A custom column's configured width wins over the curated rules.
-            let rule = if let Some(w) = i
-                .checked_sub(ns_off)
-                .and_then(|si| app.view_spec().width_at(si))
-            {
-                ColWidth::Exact(w)
-            } else {
-                match h.as_str() {
-                    // NAME is the column you actually read — its weight takes
-                    // most of a wide window's surplus, and most of the shared
-                    // space when the window can't fit everything.
-                    "NAME" => ColWidth::Flex(6),
-                    "NAMESPACE" => ColWidth::Flex(2),
-                    "NODE" | "CLAIM" | "VOLUME" | "HOSTS" => ColWidth::Flex(1),
-                    "AGE" => ColWidth::Cap(7),
-                    // Volatile numerics keep a fixed width so a metrics tick
-                    // never reflows the whole table.
-                    "CPU" | "MEM" => ColWidth::Exact(8),
-                    "%CPU" | "%MEM" => ColWidth::Exact(5),
-                    "PODS" => ColWidth::Exact(5),
-                    // Keep status changes from moving the other columns.
-                    // Allow room for CreateContainerConfigError.
-                    "STATUS" => ColWidth::Exact(26),
-                    "READY" | "RESTARTS" => ColWidth::Cap(10),
-                    // CRD view: group domains run long (e.g.
-                    // "kustomize.toolkit.fluxcd.io"), so GROUP/KIND/VERSIONS
-                    // get generous ceilings NAME's weight can't crush.
-                    "GROUP" => ColWidth::Cap(30),
-                    "KIND" | "VERSIONS" => ColWidth::Cap(20),
-                    "SCOPE" => ColWidth::Cap(12),
-                    // Flux views: the Ready condition message and git/chart
-                    // revision are the columns you read — they split the
-                    // leftover space with NAME.
-                    "MESSAGE" => ColWidth::Flex(4),
-                    "REVISION" => ColWidth::Flex(2),
-                    "SUSPENDED" => ColWidth::Cap(9),
-                    _ => ColWidth::Flex(1),
-                }
-            };
-            (rule, needed[i])
-        })
-        .collect();
-    // Mirror the Table widget's fixed overhead: borders, the always-reserved
-    // 2-cell highlight symbol, and the 2-cell spacing between columns.
-    let ncols = col_rules.len() as u16;
-    let content_budget = area
-        .width
-        .saturating_sub(2)
-        .saturating_sub(2)
-        .saturating_sub(2 * ncols.saturating_sub(1));
-    let widths: Vec<Constraint> = distribute_column_widths(content_budget, &col_rules)
-        .into_iter()
-        .map(Constraint::Length)
         .collect();
 
     let kind_label = app.list_title();
@@ -856,9 +850,11 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     if app.faults_filter_active() {
         title.push(Span::styled(" [faults]", Style::default().fg(theme::red())));
     }
-    // Horizontal scroll indicator: how many columns are hidden off the left.
     if col_offset > 0 {
-        title.push(Span::styled(format!(" ‹{col_offset}"), theme::dim()));
+        title.push(Span::styled(" ←", theme::dim()));
+    }
+    if col_offset < app.col_scroll_max {
+        title.push(Span::styled(" →", theme::dim()));
     }
     if !app.marked.is_empty() {
         title.push(Span::styled(
@@ -887,66 +883,172 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     }
     title.push(Span::raw(" "));
 
-    let mut render_state = ratatui::widgets::TableState::default();
-    let render_selected = if count > 0 {
-        selected.map(|i| i.saturating_sub(offset))
-    } else {
-        None
-    };
-    render_state.select(render_selected);
-    // Record the geometry for mouse hit-testing (click-to-select, header-click
-    // sort). Mirrors the Table widget's own column layout: the area inside the
-    // borders, the always-reserved 2-cell highlight symbol, then a horizontal
-    // layout with the same widths, spacing, and default Start flex. Each range
-    // carries the display-header index it shows, since columns can be
-    // scrolled out of view.
-    {
-        use ratatui::layout::{Flex, Margin};
-        let inner = area.inner(Margin::new(1, 1));
-        let sel_w = 2u16; // "▌ " with HighlightSpacing::Always
-        let cols_area = Rect {
-            x: inner.x.saturating_add(sel_w),
-            y: inner.y,
-            width: inner.width.saturating_sub(sel_w),
-            height: inner.height,
+    let render_selected = selected
+        .filter(|_| count > 0)
+        .map(|i| i.saturating_sub(offset));
+    app.record_table_hit(
+        inner.y,
+        inner.y.saturating_add(1),
+        inner.height.saturating_sub(1),
+        inner.x,
+        inner.x.saturating_add(inner.width),
+        viewport
+            .ranges(col_offset)
+            .iter()
+            .map(|&(start, end, i, _)| (inner.x + start, inner.x + end, i))
+            .collect(),
+    );
+    frame.render_widget(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(theme::border_focused())
+            .title(Line::from(title)),
+        area,
+    );
+    frame.render_widget(
+        ScrollingTable {
+            header: header_cells,
+            rows,
+            widths,
+            viewport,
+            offset: col_offset,
+            selected: render_selected,
+        },
+        inner,
+    );
+}
+
+/// Positions in the full table, measured from the selection marker.
+struct TableViewport {
+    columns: Vec<(usize, usize)>,
+    anchored: usize,
+    frozen_width: usize,
+    width: usize,
+    max_offset: usize,
+}
+
+impl TableViewport {
+    fn new(widths: &[u16], anchored: usize, width: u16) -> Self {
+        let mut end = 2usize;
+        let columns: Vec<_> = widths
+            .iter()
+            .map(|&width| {
+                let start = end;
+                end += usize::from(width);
+                let range = (start, end);
+                end += 2;
+                range
+            })
+            .collect();
+        let frozen_width = columns.get(anchored).map_or(end.saturating_sub(2), |c| c.0);
+        let width = usize::from(width);
+        let max_offset = if frozen_width < width {
+            end.saturating_sub(2).saturating_sub(width)
+        } else {
+            0
         };
-        let rects = Layout::horizontal(widths.clone())
-            .flex(Flex::Start)
-            .spacing(2)
-            .split(cols_area);
-        app.record_table_hit(
-            inner.y,
-            inner.y.saturating_add(1),
-            inner.height.saturating_sub(1),
-            inner.x,
-            inner.x.saturating_add(inner.width),
-            rects
-                .iter()
-                .zip((0..headers.len()).filter(|&i| col_visible(i)))
-                .map(|(r, i)| (r.x, r.x + r.width, i))
-                .collect(),
-        );
+        Self {
+            columns,
+            anchored,
+            frozen_width,
+            width,
+            max_offset,
+        }
     }
 
-    let table = Table::new(rows, widths)
-        .header(header_row)
-        .row_highlight_style(theme::selected_row())
-        .highlight_symbol("▌ ")
-        // Always reserve the highlight-symbol column so rows never shift right
-        // when a selection appears.
-        .highlight_spacing(HighlightSpacing::Always)
-        // A little breathing room between columns (default is a single space,
-        // easy to lose track of where one column ends and the next starts).
-        .column_spacing(2)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Line::from(title)),
-        );
+    /// Visible ranges plus the source offset within each cell.
+    fn ranges(&self, offset: usize) -> Vec<(u16, u16, usize, u16)> {
+        self.columns
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &(start, end))| {
+                let (left, right, shift) = if i < self.anchored {
+                    (0, self.width, 0)
+                } else {
+                    (self.frozen_width + offset, self.width + offset, offset)
+                };
+                let visible_start = start.max(left);
+                let visible_end = end.min(right);
+                (visible_start < visible_end).then_some((
+                    visible_start.saturating_sub(shift) as u16,
+                    visible_end.saturating_sub(shift) as u16,
+                    i,
+                    visible_start.saturating_sub(start) as u16,
+                ))
+            })
+            .collect()
+    }
+}
 
-    frame.render_stateful_widget(table, area, &mut render_state);
+struct ScrollingTable<'a> {
+    header: Vec<Cell<'a>>,
+    rows: Vec<Vec<Cell<'a>>>,
+    widths: Vec<u16>,
+    viewport: TableViewport,
+    offset: usize,
+    selected: Option<usize>,
+}
+
+impl ratatui::widgets::Widget for ScrollingTable<'_> {
+    fn render(self, area: Rect, buf: &mut ratatui::buffer::Buffer) {
+        use ratatui::widgets::StatefulWidget;
+
+        let ranges = self.viewport.ranges(self.offset);
+        let max_width = ranges
+            .iter()
+            .map(|&(_, _, i, _)| self.widths[i])
+            .max()
+            .unwrap_or(0);
+        // Reuse one row of storage. Long values do not allocate a full table.
+        let mut source = ratatui::buffer::Buffer::empty(Rect::new(0, 0, max_width, 1));
+        for (y, cells) in std::iter::once(self.header)
+            .chain(self.rows)
+            .take(usize::from(area.height))
+            .enumerate()
+        {
+            let y_pos = area.y + y as u16;
+            let selected = y > 0 && self.selected == Some(y - 1);
+            let style = if y == 0 {
+                theme::header_row()
+            } else if selected {
+                theme::selected_row()
+            } else {
+                Style::default()
+            };
+            buf.set_style(Rect::new(area.x, y_pos, area.width, 1), style);
+            if selected {
+                buf.set_stringn(area.x, y_pos, "▌ ", usize::from(area.width), style);
+            }
+            for &(start, end, index, source_start) in &ranges {
+                source.reset();
+                if let Some(bg) = theme::background() {
+                    source.set_style(source.area, Style::default().bg(bg));
+                }
+                let cell_area = Rect::new(0, 0, self.widths[index], 1);
+                let mut state = ratatui::widgets::TableState::default();
+                state.select(selected.then_some(0));
+                let table = Table::new(
+                    [Row::new([cells[index].clone()]).style(style)],
+                    [Constraint::Length(self.widths[index])],
+                )
+                .row_highlight_style(theme::selected_row());
+                StatefulWidget::render(table, cell_area, &mut source, &mut state);
+                let source_end = source_start + (end - start);
+                let mut x = 0;
+                while x < source_end {
+                    let cell = &source[(x, 0)];
+                    let symbol_width = cell.symbol().width().max(1) as u16;
+                    if x >= source_start && x.saturating_add(symbol_width) <= source_end {
+                        let target = &mut buf[(area.x + start + (x - source_start), y_pos)];
+                        target.set_symbol(cell.symbol());
+                        target.set_style(cell.style());
+                    }
+                    x = x.saturating_add(symbol_width);
+                }
+            }
+        }
+    }
 }
 
 /// How a table column's width is decided when splitting the frame (#166).
@@ -2005,7 +2107,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind("shift-j", "jump to owner (controller)"),
         bind("o", "show node hosting the pod"),
-        bind("←/→", "scroll columns (NAMESPACE/NAME stay anchored)"),
+        bind(
+            "←/→",
+            "scroll sideways (5 cells; NAMESPACE/NAME stay fixed)",
+        ),
         bind("esc", "go back / pop view / clear filter"),
         bind("j/k g/G", "move · top/bottom"),
         bind(


### PR DESCRIPTION
Left and Right previously hid whole columns and expanded the remaining columns. They now move the table content by five terminal cells without changing column widths. NAME and NAMESPACE stay fixed. Direction markers show where more content is available, and scrolling stops when all columns fit.

The change preserves header-click sorting after scrolling, handles wide characters at both edges, and updates the help text and documentation.

Validation: `just check` and the commit hooks passed. The test suite passed with 688 tests and 1 ignored test. Tests cover fixed name columns, content movement, scroll limits, window resizing, header clicks, direction markers, wide characters, and narrow windows.
