### PR TITLE
fix: wait for container startup when following logs

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -172,7 +172,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   [Debug containers and pods](debugging.md#debug-containers-and-pods).
 - **Logs** (`l`) - per-container on a pod, or aggregated across all matching
   pods on a workload/service, with filtering, previous-container logs, and
-  configurable tail/buffer/lookback. sofka parses ANSI color from the source app
+  configurable tail/buffer/lookback. If a container is waiting to start, sofka
+  retries until its logs are available. sofka parses ANSI color from the source app
   and maps it onto the active skin instead of printing literal escapes. See
   [Log controls](debugging.md#log-controls).
 - **VictoriaLogs integration** (`L` / `:vlogs`) - log history from a

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -565,16 +565,32 @@ pub(super) async fn forward_log_stream(
     use futures_util::{AsyncBufReadExt, TryStreamExt};
     use tokio::time::MissedTickBehavior;
 
-    let stream = match api.log_stream(&pod, &lp).await {
-        Ok(stream) => stream,
-        Err(e) => {
-            let _ = tx
-                .send(Msg::LogLines {
-                    generation,
-                    lines: vec![format!("[error] {e}")],
-                })
-                .await;
+    let stream = loop {
+        if flag.load(Ordering::SeqCst) != generation || tx.is_closed() {
             return;
+        }
+        match api.log_stream(&pod, &lp).await {
+            Ok(stream) => break stream,
+            Err(kube::Error::Api(e))
+                if lp.follow
+                    && !lp.previous
+                    && e.code == 400
+                    && e.message.contains("is waiting to start") =>
+            {
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    _ = tx.closed() => return,
+                }
+            }
+            Err(e) => {
+                let _ = tx
+                    .send(Msg::LogLines {
+                        generation,
+                        lines: vec![format!("[error] {e}")],
+                    })
+                    .await;
+                return;
+            }
         }
     };
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6139,6 +6139,121 @@ async fn narrow_window_keeps_full_external_ip_visible() {
 }
 
 #[tokio::test]
+async fn logs_wait_for_container_start() {
+    for reason in ["ContainerCreating", "PodInitializing", "ImagePullBackOff"] {
+        let (mut app, mut rx, requests) = waiting_logs_app(400, reason);
+        app.handle_key(press(KeyCode::Char('l'))).unwrap();
+        assert_eq!(app.mode, Mode::Logs);
+        let msg = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let msg = rx.recv().await.unwrap();
+                if matches!(msg, Msg::LogLines { .. }) {
+                    break msg;
+                }
+            }
+        })
+        .await
+        .expect("logs should start after the container starts");
+        app.handle_msg(msg);
+        assert_eq!(requests.load(Ordering::SeqCst), 3);
+        assert_eq!(app.logs.view.lines.iter().collect::<Vec<_>>(), ["started"]);
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn leaving_logs_stops_container_start_retries() {
+    let (mut app, _rx, requests) = waiting_logs_app(400, "ContainerCreating");
+    app.handle_key(press(KeyCode::Char('l'))).unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while requests.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn logs_report_errors_other_than_container_waiting() {
+    for (code, message, key) in [
+        (403, "is waiting to start", 'l'),
+        (400, "invalid container", 'l'),
+        (400, "ContainerCreating", 'p'),
+    ] {
+        let (mut app, mut rx, requests) = waiting_logs_app(code, message);
+        app.handle_key(press(KeyCode::Char(key))).unwrap();
+        let msg = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let msg = rx.recv().await.unwrap();
+                if matches!(msg, Msg::LogLines { .. }) {
+                    break msg;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        app.handle_msg(msg);
+        assert!(app.logs.view.lines[0].starts_with("[error]"));
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+    }
+}
+
+fn waiting_logs_app(code: u16, reason: &str) -> (App, Receiver<Msg>, Arc<AtomicU64>) {
+    let (mut app, rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "pending", "namespace": "default"},
+            "spec": {"containers": [{"name": "app", "image": "test"}]},
+            "status": {"phase": "Pending"}}),
+    );
+    app.table_state.select(Some(0));
+    let requests = Arc::new(AtomicU64::new(0));
+    let seen = requests.clone();
+    let message = if code == 400 && reason != "invalid container" {
+        format!("container \"app\" in pod \"pending\" is waiting to start: {reason}")
+    } else {
+        reason.to_owned()
+    };
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            assert_eq!(
+                request.uri().path(),
+                "/api/v1/namespaces/default/pods/pending/log"
+            );
+            let attempt = seen.fetch_add(1, Ordering::SeqCst);
+            let (status, body) = if attempt < 2 {
+                (
+                    code,
+                    json!({"kind": "Status", "apiVersion": "v1",
+                    "status": "Failure", "message": message,
+                    "reason": "BadRequest", "code": code})
+                    .to_string(),
+                )
+            } else {
+                (200, "started\n".to_owned())
+            };
+            async move {
+                Ok::<_, std::convert::Infallible>(
+                    http::Response::builder()
+                        .status(status)
+                        .body(http_body_util::Full::new(hyper::body::Bytes::from(body)))
+                        .unwrap(),
+                )
+            }
+        }),
+        "default",
+    );
+    (app, rx, requests)
+}
+
+#[tokio::test]
 async fn logs_keep_view_and_restore_selection() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");


### PR DESCRIPTION
Pressing `l` on a pod in `ContainerCreating` stopped the log task after the first API error. The log view now retries once per second while the container waits to start, then shows logs when they become available.

Closing the log view stops retries. Other API errors remain visible, and previous-container logs keep their existing behavior. The shared log task applies the fix to pod, container, and workload log views.

Validation: `just check` passed. Regression tests cover startup retries, cancellation, other API errors, and previous-container logs. The tests use a mock API and require no cluster.

Closes #252
