### PR TITLE
feat: browse and transfer PVC contents (x on a PVC)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,9 @@ explain.rs   Deterministic "why is this unhealthy?" analysis — pure, turns
              an object + its pods + events into ranked findings, unit-tested.
 timeline.rs  Session-local per-object state-change history diffed from the
              watch stream (pure transition logic, unit-tested).
+pvcexplore.rs PVC browsing: which pod already mounts a claim, the helper pod
+             for one nothing mounts, and the `ls` parser, all pure and
+             unit-tested. `app/pvcexplore.rs` drives it.
 ui.rs        All ratatui rendering: header, table, scrollable views, popups,
              status bar.
 theme.rs     Palette + semantic styles, skin resolution.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,7 @@ Each of these is documented where the feature itself is:
 | `[keys]`              | palette completion key rebinds              | [Key reference](keys.md#palette-completion-keys)           |
 | `[debug]`             | ephemeral and node debug images             | [Debug containers](debugging.md#debug-containers-and-pods) |
 | `[bundle]`            | redaction and size caps for `:bundle`       | [Diagnostic bundles](debugging.md#diagnostic-bundles)      |
+| `[pvc_explore]`       | helper pod image and TTL for PVC explore    | [PVC explore](features.md#pvc-explore)                     |
 | `[providers.metrics]` | Prometheus/VictoriaMetrics for `:rightsize` | [Providers](providers.md#right-sizing-metrics-provider)    |
 | `[providers.logs]`    | VictoriaLogs backend for `L`                | [Providers](providers.md#log-provider-victorialogs)        |
 | `[fleet]`             | contexts in the cross-cluster dashboard     | [Providers](providers.md#fleet-dashboard)                  |

--- a/docs/features.md
+++ b/docs/features.md
@@ -222,9 +222,13 @@ right - so a download or an upload is one keystroke rather than a hand-written
   it expires on its own even if sofka never gets to delete it, and closing the
   browser - or quitting sofka - deletes it immediately. `:pvc-clean` removes
   any a crashed session left behind: it sweeps the current namespace, or every
-  namespace when the view is across all of them, matching on both the name
-  prefix and the label sofka sets, and skipping the pod your own open browser
-  is using. It cannot tell a leftover from a pod *another* session is browsing
+  namespace when the view is across all of them, requiring the name prefix,
+  both of the labels sofka sets, and the annotation naming the claim, and
+  skipping the pod your own open browser is using. None of that evidence is
+  unforgeable - anything sofka writes on creation, anything else can write too
+  - so it is there to make an accidental match essentially impossible, not as
+  a permission check; the confirmation, the guardrail and read-only mode are
+  what bound a deliberate one. It cannot tell a leftover from a pod *another* session is browsing
   through right now, so the confirmation says so. Deleting pods is a mutation
   like any other: blocked in read-only mode, matched by the `pvc-explore`
   guardrail, recorded in `:journal`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -168,6 +168,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   container) - download from or upload to a pod via `kubectl cp`, off-thread
   with a completion flash. Uploads are gated by the `transfer` guardrail and
   read-only mode.
+- **PVC explore** (`x` on a PVC, or `:pvc-explore`) - a two-pane browser over a
+  volume's contents, with `s` for a shell inside it. See
+  [PVC explore](#pvc-explore).
 - **Ephemeral debug containers** and **node debug pods** (`:debug`). See
   [Debug containers and pods](debugging.md#debug-containers-and-pods).
 - **Logs** (`l`) - per-container on a pod, or aggregated across all matching
@@ -196,6 +199,89 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `kubectl apply`s - sofka diffs against the previous revision this session's
   watch saw, so "what just changed?" has an answer. The last revision of up to
   256 changed objects is kept in memory.
+
+## PVC explore
+
+A PersistentVolumeClaim has no API that returns its contents: the only way to
+see what is on a volume is from inside a pod that mounts it. `x` on a PVC row
+(or `:pvc-explore`) does that for you and puts the result on screen as a
+two-pane file browser - your local filesystem on the left, the volume on the
+right - so a download or an upload is one keystroke rather than a hand-written
+`kubectl cp` path.
+
+- **It uses a pod that is already there.** sofka looks for a running pod in the
+  claim's namespace that mounts it, preferring one with a writable mount, and
+  execs into that container at its `mountPath`. Nothing is created, so this
+  works in read-only mode.
+- **Otherwise it offers a helper pod.** When nothing mounts the claim - the
+  common case for a volume you are trying to inspect *because* its workload is
+  scaled to zero - sofka asks before creating a short-lived pod that mounts it
+  at `/pvc`. That is a write: it is blocked in read-only mode, matches the
+  `pvc-explore` guardrail action, and always confirms, naming the image and the
+  namespace. The helper carries both a `sleep` and `activeDeadlineSeconds`, so
+  it expires on its own even if sofka never gets to delete it, and closing the
+  browser - or quitting sofka - deletes it immediately. `:pvc-clean` removes
+  any a crashed session left behind: it sweeps the current namespace, or every
+  namespace when the view is across all of them, matching on both the name
+  prefix and the label sofka sets, and skipping the pod your own open browser
+  is using. It cannot tell a leftover from a pod *another* session is browsing
+  through right now, so the confirmation says so. Deleting pods is a mutation
+  like any other: blocked in read-only mode, matched by the `pvc-explore`
+  guardrail, recorded in `:journal`.
+- **Navigation is confined to the mount.** `⌫` stops at the mount point, and
+  every listing verifies with `pwd -P` that it actually landed inside the
+  volume - so a symlink on the volume pointing at `/` is refused rather than
+  quietly dropping you into the serving pod's root. sofka also treats the
+  volume's contents as untrusted: GNU `ls` writes file names into a pipe
+  unescaped, so a file whose name contains a newline can inject what looks
+  like an extra row, and a symlink target can carry an absolute path. Such a
+  row may still appear as a phantom entry - there is no way to tell it from a
+  real one - but it is contained: entries naming `.`, `..`, or anything
+  containing `/` are discarded, so a forged row can reach neither outside the
+  mount nor outside the directory a download lands in. busybox `ls` - the
+  default helper image - substitutes `?` for control characters instead, so
+  there is nothing to forge; such a name lists looking ordinary and fails when
+  you open or copy it.
+- **`c` copies from the focused pane into the other one** - out of the volume
+  when the right pane has the cursor, into it when the left one does. Uploads go
+  through `kubectl cp`, are blocked in read-only mode, match the `pvc-upload`
+  guardrail action, and are refused up front when the mount is `readOnly`. A
+  download that would overwrite a local file confirms first. `kubectl cp`
+  splits its arguments on the first `:`, so a name containing one is refused
+  with an explanation rather than a `filespec must match the canonical format`
+  from kubectl.
+- **`s` opens a shell** at the directory the remote pane is showing (or at the
+  mount point, from the PVC row directly). The exec lands in a real pod, so it
+  passes the same `shell` guardrail as `s` on that pod's row - a rule that
+  denies shells in prod is not defeated by reaching the pod through a claim it
+  mounts, and a denied shell is refused before a helper pod is created rather
+  than after.
+
+Listings are read with `ls -A -l` over `kubectl exec`, so the pod's image needs
+a shell and `ls`; transfers additionally need `tar`, as `kubectl cp` always
+does. An entry `ls` cannot stat still appears, with an unknown size and a
+warning, rather than blanking the whole directory. The helper-pod image and
+lifetime are configurable:
+
+```toml
+[pvc_explore]
+image = "busybox:1.37"   # helper-pod image
+ttl = "30m"              # how long it lives before deleting itself
+```
+
+Only a `Bound` filesystem claim can be browsed: an unbound one has no volume
+behind it, and a `volumeMode: Block` one has no filesystem. A listing is a
+point-in-time read, not a watch: `r` re-reads both panes. Both panes cap one
+directory at 5,000 entries - on the volume side by `head` inside the pod, so a
+spool directory is never streamed out in full. An entry nothing could stat
+still lists, with `?` for its size.
+
+The helper pod runs as whatever user its image defaults to, because reading a
+volume's contents generally needs root. It drops all capabilities and sets
+`allowPrivilegeEscalation: false` and `seccompProfile: RuntimeDefault`, which
+satisfies the `baseline` Pod Security Standard - but not `restricted`, which
+also requires `runAsNonRoot`. In a namespace enforcing `restricted` the helper
+pod is rejected; browse through a pod that already mounts the claim instead.
 
 ## Safety
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -27,7 +27,7 @@ pickers keep both characters available as input.
 | `o`                                           | show the node the selected row names (pods built in; other kinds via `[views."…"].node`)                                                                      |
 | `ctrl-r`                                      | refresh the watch                                                                                                                                             |
 | `y` / `d` / `E`                               | view YAML / describe (`kubectl`) / live events                                                                                                                |
-| `x`                                           | secrets: show `data` base64-decoded (as `stringData`)                                                                                                         |
+| `x`                                           | secrets: show `data` base64-decoded (as `stringData`) · PVCs: browse the volume                                                                               |
 | `X` / `T`                                     | explain why the selection is unhealthy / session-local state-change timeline                                                                                  |
 | `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                                          |
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                                                      |
@@ -43,10 +43,11 @@ pickers keep both characters available as input.
 | `c`                                           | copy resource name to clipboard                                                                                                                               |
 | `Y`                                           | copy any cell of the selected row: picker over the displayed columns (type to match a column name or value), `⏎` copies                                       |
 | `e`                                           | edit in `$EDITOR` (`kubectl edit`)                                                                                                                            |
-| `s`                                           | shell into pod / scale a workload (context-dependent)                                                                                                         |
+| `s`                                           | shell into pod / shell into a PVC's volume / scale a workload (context-dependent)                                                                             |
 | `a`                                           | attach to pod                                                                                                                                                 |
 | `:debug`                                      | pod: ephemeral debug container (`d` in the picker targets one) · node: privileged debug pod (previewed + confirmed)                                           |
 | `:debug-clean`                                | delete the node debugger pods launched this session                                                                                                           |
+| `:pvc-explore` / `:pvc-clean`                 | browse the selected PVC (also `:pvc-browse`; see below) · delete helper pods a previous session left behind (also `:pvc-cleanup`)                             |
 | `:bundle` / `:bundle-save`                    | assemble a redacted diagnostic bundle for the selection · write the previewed bundle to a file                                                                |
 | `:snapshot [text\|json\|yaml]` / `:snapshots` | capture the current view to a file · browse, open, and delete saved snapshots                                                                                 |
 | `:notify`                                     | toggle watch notifications on the selected object                                                                                                             |
@@ -62,6 +63,23 @@ pickers keep both characters available as input.
 | `:q`, `ctrl-c`                                | quit                                                                                                                                                          |
 | `?`                                           | help                                                                                                                                                          |
 | _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                                                   |
+
+## PVC explore (`x` on a PVC)
+
+A two-pane file browser over a PersistentVolumeClaim: your local filesystem on
+the left, the volume on the right. `s` on a PVC row opens a shell at the mount
+point instead. See [PVC explore](features.md#pvc-explore).
+
+| Key              | Action                                                                      |
+| ---------------- | --------------------------------------------------------------------------- |
+| `tab`, `←` / `→` | switch pane (the focused pane has the bright border)                        |
+| `j`/`k`, `g`/`G` | move within the focused pane                                                |
+| `enter`          | open the selected directory                                                 |
+| `⌫` or `-`       | go up one directory - stops at the mount point, never above it              |
+| `c`              | copy the selection into the other pane: download from the volume, or upload |
+| `s`              | shell into the volume at the directory the remote pane is showing           |
+| `r`              | re-read both panes                                                          |
+| `esc` / `q`      | close (and delete the helper pod, if one was created)                       |
 
 ## Logs view
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -24,7 +24,14 @@ Each rule matches on `contexts`, `namespaces`, `resources`, and `actions` globs
 (block the action), `confirmation` (require confirmation), and `max_bulk`
 (a row limit for one action). The gated `actions` are the destructive verbs sofka
 performs directly: `delete`, `force-delete`, `drain`, `restart`, `shell` (exec),
-`debug`, `node-debug`, and `transfer` (a file upload into a pod).
+`debug`, `node-debug`, `transfer` (a file upload into a pod), `pvc-explore`
+(creating a helper pod to mount an unmounted PVC, and the `:pvc-clean` sweep
+that deletes them - both matched against `persistentvolumeclaims`), and
+`pvc-upload` (a file upload into a volume, matched the same way). The PVC
+shell and the PVC upload also pass the `shell` and `transfer` rules for the
+pod they reach the volume through, exactly like `s` and `t` on that pod's row -
+a rule that already blocks shells or uploads in prod is not defeated by
+reaching the same pod through a claim it mounts.
 
 sofka combines the restrictions from all matching rules:
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// Interactive-shell entrypoint for `exec`/`debug`: prefer bash when the image
 /// ships it, otherwise fall back to sh, in a single `sh -c` invocation.
-const SHELL_FALLBACK: &str = "command -v bash >/dev/null 2>&1 && exec bash || exec sh";
+pub(super) const SHELL_FALLBACK: &str = "command -v bash >/dev/null 2>&1 && exec bash || exec sh";
 
 impl App {
     // ----- actions -------------------------------------------------------
@@ -1431,6 +1431,7 @@ impl App {
         self.guardrails = resolved.config.guardrails;
         self.debug = resolved.config.debug;
         self.bundle_cfg = resolved.config.bundle;
+        self.pvc_cfg = resolved.config.pvc_explore;
         self.logs_cfg = resolved.config.logs;
         self.fleet_cfg = resolved.config.fleet;
         // Running forwards keep running; :reload only refreshes what's saved.
@@ -1442,6 +1443,7 @@ impl App {
         warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
         warnings.extend(crate::config::forward_warnings(&self.forwards_cfg));
         warnings.extend(crate::config::notify_warnings(&self.notify_cfg));
+        warnings.extend(crate::config::pvc_explore_warnings(&self.pvc_cfg));
         let (palette_keys, key_warnings) =
             crate::config::compile_palette_keys(&resolved.config.keys);
         self.palette_keys = palette_keys;
@@ -1719,6 +1721,7 @@ impl App {
                 ns,
                 pod,
                 container,
+                upload: true,
                 src,
                 dest,
             },

--- a/src/app/guardrails.rs
+++ b/src/app/guardrails.rs
@@ -69,6 +69,29 @@ impl App {
         Some(base.max(found.confirmation))
     }
 
+    /// Whether a guardrail denies `action` outright, without flashing or
+    /// otherwise touching the app. For looking ahead: a caller that is about
+    /// to do expensive setup for an action can find out it will be refused
+    /// before paying for it. [`Self::guard`] is still the gate — this only
+    /// avoids the wasted work.
+    pub(super) fn guard_denies(
+        &self,
+        action: &str,
+        plural: &str,
+        targets: &[(String, String)],
+    ) -> bool {
+        restrictions(
+            &self.guardrails,
+            &self.cluster.context,
+            action,
+            plural,
+            targets,
+            false,
+        )
+        .deny
+        .is_some()
+    }
+
     /// Route an about-to-run action through its required confirmation. `Plain`
     /// uses the y/n dialog; the typed levels use a prompt that must match a
     /// resource name (`name_hint`) or the context; `None` runs immediately.
@@ -79,6 +102,14 @@ impl App {
         level: ConfirmLevel,
         name_hint: String,
     ) {
+        // The PVC browser is the only full-screen view that launches guarded
+        // actions, so it is the only one the dialog has to return to; every
+        // other guarded action starts (and belongs) at the table.
+        self.confirm_return = if self.mode == Mode::PvcExplore {
+            Mode::PvcExplore
+        } else {
+            Mode::Table
+        };
         match level {
             ConfirmLevel::None => self.run_confirm_action(action),
             ConfirmLevel::Plain => {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -7,9 +7,11 @@ impl App {
         let before = match self.mode {
             Mode::Command => self.palette_return,
             Mode::Help => self.help_return,
-            Mode::Filter | Mode::Confirm | Mode::Prompt | Mode::SortPicker | Mode::CopyPicker => {
-                Mode::Table
-            }
+            // Where the overlay will return to: the table, except for a
+            // dialog raised from the PVC browser, which returns there. Getting
+            // this wrong reads as "left the view" and stops a running plugin.
+            Mode::Confirm | Mode::Prompt => self.overlay_return(),
+            Mode::Filter | Mode::SortPicker | Mode::CopyPicker => Mode::Table,
             other => other,
         };
         let run = self.plugin_run;
@@ -28,6 +30,23 @@ impl App {
         );
         if self.should_quit || (self.plugin_run == run && self.mode != before && !overlay) {
             self.stop_plugins();
+        }
+        // Anything that navigated out of the PVC browser — a palette jump, a
+        // bookmark, a workspace — would otherwise leave it holding a helper
+        // pod and two stale panes. `leave_pvc_explore` is idempotent, so the
+        // `esc` path having already run it costs nothing.
+        if self.pvc.active && self.mode != Mode::PvcExplore && !overlay {
+            self.leave_pvc_explore();
+        }
+        // A PVC shell waiting on a dialog can also be walked away from — `:`
+        // is accepted from `Mode::Confirm` and simply abandons the action.
+        // Nothing else will ever run the suspend, so release what it holds.
+        let awaiting = matches!(self.mode, Mode::Confirm | Mode::Prompt) || self.pending.is_some();
+        if self.pvc.shell_pending && !self.pvc.active && !awaiting {
+            if matches!(self.confirm_action, Some(ConfirmAction::PvcShell { .. })) {
+                self.confirm_action = None;
+            }
+            self.after_suspend();
         }
         result
     }
@@ -153,6 +172,7 @@ impl App {
             Mode::Snapshots => self.key_snapshots(key),
             Mode::Fleet => self.key_fleet(key),
             Mode::Find => self.key_find(key),
+            Mode::PvcExplore => self.key_pvc_explore(key),
         }
         Ok(())
     }
@@ -180,6 +200,7 @@ impl App {
                 | Mode::Snapshots
                 | Mode::Fleet
                 | Mode::Find
+                | Mode::PvcExplore
         )
     }
 
@@ -232,6 +253,10 @@ impl App {
             // k9s: `x` shows a secret's data base64-decoded. Elsewhere `x`
             // stays free for user plugins (the fallthrough arm below).
             KeyCode::Char('x') if self.kind_plural == "secrets" => self.open_decoded_secret(),
+            // `x` on a PVC opens the split-pane volume browser.
+            KeyCode::Char('x') if self.kind_plural == "persistentvolumeclaims" => {
+                self.open_pvc_explore()
+            }
             KeyCode::Char('E') => self.open_events(),
             KeyCode::Char('l') => self.open_logs(),
             // Logs from the configured external provider ([providers.logs]).
@@ -242,6 +267,10 @@ impl App {
             KeyCode::Char('s') => {
                 if self.kind_plural == "pods" {
                     self.request_exec();
+                } else if self.kind_plural == "persistentvolumeclaims" {
+                    // A PVC can't scale; `s` shells into the volume instead,
+                    // through whatever pod mounts it.
+                    self.request_pvc_shell();
                 } else {
                     self.request_scale();
                 }
@@ -500,6 +529,8 @@ impl App {
             PaletteAction::Info => self.open_info(),
             PaletteAction::Fleet => self.open_fleet(),
             PaletteAction::Rightsize => self.open_rightsize(),
+            PaletteAction::PvcExplore => self.open_pvc_explore(),
+            PaletteAction::PvcClean => self.request_pvc_clean(),
             PaletteAction::Find => self.flash_warn("usage: :find <text>"),
             PaletteAction::Diff => self.open_diff(),
             PaletteAction::Events => self.switch_kind("events.events.k8s.io"),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -792,7 +792,28 @@ impl App {
         }
     }
 
+    /// Fold one background message into the app, then tidy up after any view
+    /// it displaced. The key path has the same sweep in `handle_key`; a
+    /// message that opens a document view (a finished describe, a plugin
+    /// report, a bundle) can displace the PVC browser without a keystroke
+    /// being involved at all.
     pub fn handle_msg(&mut self, msg: Msg) {
+        self.handle_msg_inner(msg);
+        let overlay = matches!(
+            self.mode,
+            Mode::PvcExplore
+                | Mode::Command
+                | Mode::Help
+                | Mode::Filter
+                | Mode::Confirm
+                | Mode::Prompt
+        );
+        if self.pvc.active && !overlay {
+            self.leave_pvc_explore();
+        }
+    }
+
+    fn handle_msg_inner(&mut self, msg: Msg) {
         let preserve_selection = self.faults_filter_active()
             && matches!(
                 &msg,
@@ -1205,9 +1226,72 @@ impl App {
                 claim,
                 result,
             } if generation == self.generation => match result {
-                Ok(summary) => self.set_claimed_status(claim, summary, false),
+                Ok(summary) => {
+                    self.set_claimed_status(claim, summary, false);
+                    // A copy made in the PVC browser changed one of the two
+                    // panes; show the file where it landed.
+                    self.refresh_pvc_panes();
+                }
                 Err(e) => self.set_claimed_status(claim, format!("cp failed: {e}"), true),
             },
+            // Deliberately not generation-guarded: a helper pod may already
+            // exist by the time this lands, and the stale branch is the only
+            // thing that can clean it up.
+            Msg::PvcTarget {
+                generation,
+                run,
+                namespace,
+                context,
+                claim,
+                result,
+            } => {
+                if generation == self.generation {
+                    self.handle_pvc_target(run, namespace, claim, result);
+                } else {
+                    self.discard_pvc_target(namespace, context, result);
+                }
+            }
+            Msg::PvcListing {
+                generation,
+                run,
+                path,
+                result,
+            } => {
+                if generation == self.generation {
+                    self.handle_pvc_listing(run, path, result);
+                } else if run == self.pvc.run {
+                    // A watch restart under an in-flight listing. The result
+                    // belongs to a generation that is over, but the pane is
+                    // still waiting on it — without this it says "loading…"
+                    // until the user presses `r`.
+                    self.pvc.loading = false;
+                }
+            }
+            Msg::PvcHelpersCleaned {
+                generation,
+                claim,
+                deleted,
+                failed,
+            } if generation == self.generation => {
+                if failed.is_empty() {
+                    self.set_claimed_status(
+                        claim,
+                        format!("removed {deleted} PVC helper pod(s)"),
+                        false,
+                    );
+                } else {
+                    let shown: Vec<&str> = failed.iter().take(3).map(String::as_str).collect();
+                    self.set_claimed_status(
+                        claim,
+                        format!(
+                            "pvc-clean: removed {deleted}, {} failed — {}",
+                            failed.len(),
+                            shown.join("; ")
+                        ),
+                        true,
+                    );
+                }
+            }
             Msg::LogsSaved {
                 generation,
                 claim,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,6 +33,7 @@ use crate::k8s::{Cluster, Kind};
 use crate::store::{Msg, Pulse, RowKey, StatusClaim, Store, StoreMutation, XrayItem, row_key};
 
 pub(crate) use guardrails::ConfirmLevel;
+pub use pvcexplore::{Pane, PvcExplore, PvcIntent};
 
 impl App {
     /// Mark the row ordering stale without touching the store — the shape of a
@@ -187,6 +188,9 @@ pub enum Mode {
     Fleet,
     /// Global fuzzy-find results picker (`:find <text>`).
     Find,
+    /// Split-pane PVC browser (`x` on a PVC): local files on the left, the
+    /// volume's contents on the right.
+    PvcExplore,
 }
 
 /// A request for the run loop to suspend the TUI and run an interactive
@@ -264,13 +268,17 @@ enum ConfirmAction {
     Edit { argv: Vec<String> },
     /// Shell into a pod, once a guardrail confirmation is satisfied.
     Exec { ns: String, name: String },
-    /// Upload a local file into a pod (`kubectl cp`), once a guardrail
-    /// confirmation is satisfied. Upload only — a download doesn't mutate
-    /// the pod, so it never needs confirming.
+    /// Copy a file between a pod and the local filesystem (`kubectl cp`),
+    /// once its confirmation is satisfied. An upload is confirmed because a
+    /// guardrail asked; a download because it would overwrite a local file.
+    /// The direction has to travel with the action — running a download as an
+    /// upload would write into the cluster, past every check the upload path
+    /// makes.
     Transfer {
         ns: String,
         pod: String,
         container: Option<String>,
+        upload: bool,
         src: String,
         dest: String,
     },
@@ -305,6 +313,25 @@ enum ConfirmAction {
     },
     /// Delete the node debugger pods sofka launched this session (`:debug-clean`).
     CleanupDebuggers,
+    /// Create a temporary pod that mounts a PVC nothing else mounts, so it can
+    /// be browsed or shelled into.
+    PvcHelper {
+        ns: String,
+        claim: String,
+        intent: PvcIntent,
+    },
+    /// Shell into the pod a PVC is reachable through, once the `shell`
+    /// guardrail is satisfied.
+    PvcShell {
+        ns: String,
+        pod: String,
+        container: String,
+        path: String,
+        claim: String,
+    },
+    /// Delete the PVC-explore helper pods left behind by earlier sessions.
+    /// `None` sweeps every namespace, matching an all-namespaces view.
+    PvcClean { scope: Option<String> },
     /// Run a confirmed plugin (`confirm`/`dangerous`) once accepted — one job
     /// (label, argv) per target, so a bulk run confirms once.
     Plugin {
@@ -534,6 +561,8 @@ enum PaletteAction {
     Info,
     Fleet,
     Rightsize,
+    PvcExplore,
+    PvcClean,
     Find,
     Diff,
     Events,
@@ -654,6 +683,19 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     PaletteCommand {
         action: PaletteAction::Rightsize,
         names: &["rightsize", "sizing", "vpa"],
+    },
+    PaletteCommand {
+        action: PaletteAction::PvcExplore,
+        // Both names stay prefixed. A bare "pvc" is the kubectl alias for
+        // the PVC list, and a palette command outranks a kind, so claiming it
+        // would stop `:pvc` navigating; bare "explore"/"browse" are words a
+        // user plugin may already have taken, and the palette reserves what
+        // it names.
+        names: &["pvc-explore", "pvc-browse"],
+    },
+    PaletteCommand {
+        action: PaletteAction::PvcClean,
+        names: &["pvc-clean", "pvc-cleanup"],
     },
     PaletteCommand {
         action: PaletteAction::Quit,
@@ -1743,6 +1785,16 @@ pub struct App {
     pub transfer_menu_state: ListState,
     pub transfer_target: Option<(String, String, Option<String>)>,
 
+    /// Split-pane PVC browser state (`x` on a PVC row, `:pvc-explore`).
+    pub pvc: PvcExplore,
+    /// `[pvc_explore]` helper-pod defaults.
+    pub pvc_cfg: crate::config::PvcExploreConfig,
+
+    /// Where a confirm/guardrail overlay returns to once it is answered. Only
+    /// the PVC browser sets it away from the table: every other guarded action
+    /// is launched from the table and returns there.
+    pub(super) confirm_return: Mode,
+
     /// Background `kubectl port-forward` processes started with `f`/`F`.
     /// Viewed/stopped via `:pf`; killed automatically on drop.
     pub port_forwards: Vec<PortForward>,
@@ -2010,6 +2062,9 @@ impl App {
             flux_menu_state: ListState::default(),
             transfer_menu_state: ListState::default(),
             transfer_target: None,
+            pvc: PvcExplore::default(),
+            pvc_cfg: crate::config::PvcExploreConfig::default(),
+            confirm_return: Mode::Table,
             port_forwards: Vec::new(),
             forwards_cfg: Vec::new(),
             notify_cfg: crate::config::NotifyConfig::default(),
@@ -2104,6 +2159,31 @@ impl App {
         matches!(self.prompt_kind, Some(PromptKind::RenameContext { .. }))
     }
 
+    /// Where a confirm dialog returns to. Not every `Mode::Confirm` goes
+    /// through `begin_guarded` (`:debug-clean` sets it directly), so a stale
+    /// `confirm_return` must never send us to a browser that isn't open.
+    pub(super) fn overlay_return(&self) -> Mode {
+        if self.confirm_return == Mode::PvcExplore && self.pvc.active {
+            Mode::PvcExplore
+        } else {
+            Mode::Table
+        }
+    }
+
+    /// Whether the open dialog belongs to the PVC browser, so the renderer
+    /// keeps the two panes underneath it.
+    pub fn over_pvc_browser(&self) -> bool {
+        self.pvc.active && self.confirm_return == Mode::PvcExplore
+    }
+
+    /// Whether the active prompt is a guardrail confirmation raised from the
+    /// PVC browser, so esc/enter return to the browser instead of the table.
+    pub(super) fn prompt_over_pvc(&self) -> bool {
+        self.pvc.active
+            && self.confirm_return == Mode::PvcExplore
+            && matches!(self.prompt_kind, Some(PromptKind::GuardConfirm { .. }))
+    }
+
     /// Whether the logs view is showing the external log provider (enables
     /// provider-only keys like `T`).
     pub fn provider_logs_active(&self) -> bool {
@@ -2134,6 +2214,7 @@ mod notify;
 mod overlays;
 mod pickers;
 mod plugins;
+mod pvcexplore;
 mod rightsize;
 mod rows;
 mod snapshot;

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -117,10 +117,11 @@ impl App {
                 ns,
                 pod,
                 container,
+                upload,
                 src,
                 dest,
             } => {
-                self.start_transfer(ns, pod, container, true, src, dest);
+                self.start_transfer(ns, pod, container, upload, src, dest);
             }
             ConfirmAction::Drain { targets } => {
                 self.do_drain_nodes(targets);
@@ -155,16 +156,34 @@ impl App {
             } => {
                 self.launch_plugin(jobs, name, mode, timeout);
             }
+            ConfirmAction::PvcHelper { ns, claim, intent } => {
+                self.create_pvc_helper(ns, claim, intent);
+            }
+            ConfirmAction::PvcShell {
+                ns,
+                pod,
+                container,
+                path,
+                claim,
+            } => self.do_pvc_shell(ns, pod, container, path, claim),
+            ConfirmAction::PvcClean { scope } => self.cleanup_pvc_helpers(scope),
         }
     }
 
     pub(super) fn key_confirm(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                let back = self.overlay_return();
                 if let Some(action) = self.confirm_action.take() {
                     self.run_confirm_action(action);
                 }
-                self.mode = Mode::Table;
+                // An action that opened a view of its own (a shell suspend, a
+                // fresh browser) has already set the mode; only fall back to
+                // where the dialog came from if it didn't.
+                if self.mode == Mode::Confirm {
+                    self.mode = back;
+                }
+                self.confirm_return = Mode::Table;
             }
             KeyCode::Char('f') | KeyCode::Char('F') => {
                 let update = match self.confirm_action.as_mut() {
@@ -213,8 +232,14 @@ impl App {
                 }
             }
             _ => {
-                self.confirm_action = None;
-                self.mode = Mode::Table;
+                // A cancelled PVC shell leaves state (possibly a helper pod)
+                // that only the suspend-and-return path would have cleaned up.
+                let cancelled = self.confirm_action.take();
+                if matches!(cancelled, Some(ConfirmAction::PvcShell { .. })) {
+                    self.pvc_shell_cancelled();
+                }
+                self.mode = self.overlay_return();
+                self.confirm_return = Mode::Table;
             }
         }
     }
@@ -232,10 +257,20 @@ impl App {
                     Mode::Logs
                 } else if self.prompt_over_contexts() {
                     Mode::Contexts
+                } else if self.prompt_over_pvc() {
+                    Mode::PvcExplore
                 } else {
                     Mode::Table
                 };
-                self.prompt_kind = None;
+                let cancelled = self.prompt_kind.take();
+                if matches!(
+                    cancelled,
+                    Some(PromptKind::GuardConfirm { ref action, .. })
+                        if matches!(**action, ConfirmAction::PvcShell { .. })
+                ) {
+                    self.pvc_shell_cancelled();
+                }
+                self.confirm_return = Mode::Table;
             }
             KeyCode::Enter => {
                 let input = self.prompt_input.trim().to_string();
@@ -243,6 +278,8 @@ impl App {
                     Mode::Logs
                 } else if self.prompt_over_contexts() {
                     Mode::Contexts
+                } else if self.prompt_over_pvc() {
+                    Mode::PvcExplore
                 } else {
                     Mode::Table
                 };
@@ -338,6 +375,12 @@ impl App {
                             self.run_confirm_action(*action);
                         } else {
                             self.flash_warn("guardrail: input did not match — cancelled");
+                            // Same teardown as an Esc: the action is dropped
+                            // here too, so anything it was holding — a helper
+                            // pod, a pending suspend — has to be released.
+                            if matches!(*action, ConfirmAction::PvcShell { .. }) {
+                                self.pvc_shell_cancelled();
+                            }
                         }
                     }
                     // Empty input = cancel, keep the old name.
@@ -347,6 +390,10 @@ impl App {
                     Some(PromptKind::RenameContext { .. }) => {}
                     None => {}
                 }
+                // The prompt is done with, whichever way it went; leaving the
+                // marker set would aim the next confirm dialog at a view that
+                // has nothing to do with it.
+                self.confirm_return = Mode::Table;
             }
             KeyCode::Backspace => {
                 self.prompt_input.pop();

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -762,6 +762,9 @@ impl App {
         // where they're still valid (a successful switch drops the cache).
         // Bump first: this switch's own progress flash belongs to the new
         // generation, and the bump clears any left over from the old one.
+        // The browser (and any helper pod it created) belongs to the context
+        // being left: nothing in the new one can serve it.
+        self.leave_pvc_explore();
         self.bump_generation();
         self.set_flash(format!("switching to {name}…"));
         self.stash_view_snapshot();
@@ -797,6 +800,7 @@ impl App {
         self.guardrails = resolved.config.guardrails;
         self.debug = resolved.config.debug;
         self.bundle_cfg = resolved.config.bundle;
+        self.pvc_cfg = resolved.config.pvc_explore;
         self.logs_cfg = resolved.config.logs;
         self.fleet_cfg = resolved.config.fleet;
         // Tracked debuggers belong to the previous cluster/context.
@@ -805,6 +809,7 @@ impl App {
         plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         plugin_warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
+        plugin_warnings.extend(crate::config::pvc_explore_warnings(&self.pvc_cfg));
         let (palette_keys, key_warnings) =
             crate::config::compile_palette_keys(&resolved.config.keys);
         self.palette_keys = palette_keys;

--- a/src/app/pvcexplore.rs
+++ b/src/app/pvcexplore.rs
@@ -3,7 +3,9 @@ use super::*;
 use std::path::PathBuf;
 
 use crate::app::actions::SHELL_FALLBACK;
-use crate::pvcexplore::{self as pvc, Entry, HELPER_LABEL, HELPER_MOUNT, HELPER_PREFIX, Mount};
+use crate::pvcexplore::{
+    self as pvc, Entry, HELPER_ANNOTATION, HELPER_MOUNT, HELPER_PREFIX, Mount,
+};
 
 /// Ceiling on one `kubectl exec … ls`. A directory on an unresponsive NFS
 /// backend can hang the exec indefinitely; without this the pane would sit on
@@ -990,7 +992,7 @@ impl App {
                 Some(ns) => Api::namespaced(client, ns),
                 None => Api::all(client),
             };
-            let selector = format!("{}={}", HELPER_LABEL.0, HELPER_LABEL.1);
+            let selector = pvc::helper_selector();
             let mut deleted = 0usize;
             let mut failed = Vec::new();
             match pods.list(&ListParams::default().labels(&selector)).await {
@@ -999,9 +1001,20 @@ impl App {
                         let Some(name) = pod.metadata.name.clone() else {
                             continue;
                         };
-                        // Name prefix as well as the label: a pod that only
-                        // happens to carry the label is not ours to delete.
+                        // The labels got it into this list; the name prefix
+                        // and the claim annotation are the rest of the
+                        // evidence. None of it is unforgeable — nothing sofka
+                        // writes on creation is — but all four together make
+                        // an accidental match essentially impossible, and a
+                        // deliberate one still has to get past the
+                        // confirmation and the `pvc-explore` guardrail.
+                        let names_a_claim = pod
+                            .metadata
+                            .annotations
+                            .as_ref()
+                            .is_some_and(|a| a.contains_key(HELPER_ANNOTATION));
                         if !name.starts_with(HELPER_PREFIX)
+                            || !names_a_claim
                             || keep.as_deref() == Some(name.as_str())
                         {
                             continue;

--- a/src/app/pvcexplore.rs
+++ b/src/app/pvcexplore.rs
@@ -1,0 +1,1271 @@
+use super::*;
+
+use std::path::PathBuf;
+
+use crate::app::actions::SHELL_FALLBACK;
+use crate::pvcexplore::{self as pvc, Entry, HELPER_LABEL, HELPER_MOUNT, HELPER_PREFIX, Mount};
+
+/// Ceiling on one `kubectl exec … ls`. A directory on an unresponsive NFS
+/// backend can hang the exec indefinitely; without this the pane would sit on
+/// "loading…" with nothing to cancel.
+const LIST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long to wait for a helper pod to reach `Running` before giving up. An
+/// image pull on a cold node is the slow case.
+const HELPER_READY_TIMEOUT: Duration = Duration::from_secs(90);
+const HELPER_POLL: Duration = Duration::from_millis(500);
+
+/// What the user asked for before sofka knew which pod could serve it.
+/// Resolving a claim is asynchronous (and may need a helper pod), so the
+/// intent has to survive the round trip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PvcIntent {
+    /// Open the split-pane browser.
+    Browse,
+    /// Suspend the TUI and drop into a shell at the mount point.
+    Shell,
+}
+
+/// Which pane has the cursor. The local side is on the left and the volume on
+/// the right, so "copy" always means "into the other one".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Pane {
+    Local,
+    Remote,
+}
+
+/// State for the PVC browser (`x` on a PVC row).
+pub struct PvcExplore {
+    /// The browser owns the screen. Also what tells the confirm/transfer
+    /// overlays to draw over it rather than over the table.
+    pub active: bool,
+    pub claim: String,
+    pub namespace: String,
+    /// The pod and path the volume is reachable through. `None` until the
+    /// resolve round trip lands.
+    pub mount: Option<Mount>,
+    /// What the user asked for, kept until the target resolves.
+    pub intent: PvcIntent,
+    /// Directory the remote pane is showing, and the mount point it may not
+    /// walk above.
+    pub remote_path: String,
+    pub remote: Vec<Entry>,
+    pub remote_state: ListState,
+    /// Why the remote pane is empty, when it is empty for a reason.
+    pub remote_error: Option<String>,
+    /// A listing is in flight — the pane shows the last one until it lands.
+    pub loading: bool,
+    /// The local pane hit [`crate::pvcexplore::MAX_ENTRIES`] too.
+    pub local_truncated: bool,
+    /// The current listing hit [`crate::pvcexplore::MAX_ENTRIES`] and there is
+    /// more behind it.
+    /// A count would be a lie — the cap is applied inside the container, so
+    /// nothing ever counted the rest.
+    pub truncated: bool,
+    /// Directory whose entries are actually on screen. A failed navigation
+    /// returns the title to it — tracking "the path before the last request"
+    /// would name a directory that was itself never successfully listed once
+    /// two navigations are in flight.
+    displayed_path: String,
+    pub local_path: PathBuf,
+    pub local: Vec<Entry>,
+    pub local_state: ListState,
+    pub local_error: Option<String>,
+    pub focus: Pane,
+    /// A shell was queued straight from a PVC row (not from inside the
+    /// browser), so its state — including any helper pod — is torn down once
+    /// the suspended shell returns, not before it has started.
+    pub(super) shell_pending: bool,
+    /// Entry to put the cursor on when the next listing lands — the directory
+    /// just stepped out of, so `⌫` returns you to where you were rather than
+    /// to the top of the parent.
+    want_select: Option<String>,
+    /// Bumped on every navigation so a slow listing for a directory the user
+    /// has already left is discarded instead of replacing the current one.
+    pub run: u64,
+}
+
+impl Default for PvcExplore {
+    fn default() -> Self {
+        Self {
+            active: false,
+            claim: String::new(),
+            namespace: String::new(),
+            mount: None,
+            intent: PvcIntent::Browse,
+            remote_path: String::new(),
+            remote: Vec::new(),
+            remote_state: ListState::default(),
+            remote_error: None,
+            loading: false,
+            truncated: false,
+            local_truncated: false,
+            displayed_path: String::new(),
+            want_select: None,
+            local_path: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")),
+            local: Vec::new(),
+            local_state: ListState::default(),
+            local_error: None,
+            focus: Pane::Remote,
+            shell_pending: false,
+            run: 0,
+        }
+    }
+}
+
+impl PvcExplore {
+    /// The mount point, which is also the floor for `..`.
+    pub fn root(&self) -> &str {
+        self.mount.as_ref().map(|m| m.path.as_str()).unwrap_or("/")
+    }
+
+    /// The directory whose entries are on screen — which is not
+    /// [`Self::remote_path`] while a listing is in flight, because the pane
+    /// deliberately keeps showing the old one until the new one arrives.
+    /// Every action builds its path from here, so what you are looking at is
+    /// what `c`, `s` and `⏎` act on even when a slow exec is still running.
+    pub fn current_dir(&self) -> &str {
+        if self.displayed_path.is_empty() {
+            &self.remote_path
+        } else {
+            &self.displayed_path
+        }
+    }
+
+    pub fn selected_remote(&self) -> Option<&Entry> {
+        self.remote.get(self.remote_state.selected()?)
+    }
+
+    pub fn selected_local(&self) -> Option<&Entry> {
+        self.local.get(self.local_state.selected()?)
+    }
+
+    /// Put the cursor back on `previous` if that entry is still there, else on
+    /// the first row. A refresh — or the pane reload after a copy — otherwise
+    /// resets both cursors, which in a directory of any size means re-finding
+    /// your place after every single file.
+    fn reselect(state: &mut ListState, entries: &[Entry], previous: Option<&str>) {
+        // The current index first, then the name: with two rows of the same
+        // name (which a forged `ls` row can produce) this keeps the cursor
+        // where it is instead of jumping to the other one.
+        let at = state.selected().filter(|i| {
+            entries
+                .get(*i)
+                .is_some_and(|e| Some(e.name.as_str()) == previous)
+        });
+        let index = at
+            .or_else(|| previous.and_then(|name| entries.iter().position(|e| e.name == name)))
+            .or(if entries.is_empty() { None } else { Some(0) });
+        state.select(index);
+    }
+}
+
+impl App {
+    /// `x` on a PVC row, or `:pvc-explore`: open the split-pane browser for
+    /// the selected claim. Read-only until you ask for a transfer, so it is
+    /// available in read-only mode.
+    pub(super) fn open_pvc_explore(&mut self) {
+        self.start_pvc(PvcIntent::Browse);
+    }
+
+    /// `s` on a PVC row: a shell at the mount point instead of the browser.
+    /// The same target resolution, a different thing done with it.
+    pub(super) fn request_pvc_shell(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
+        self.start_pvc(PvcIntent::Shell);
+    }
+
+    fn start_pvc(&mut self, intent: PvcIntent) {
+        if self.kind_plural != "persistentvolumeclaims" {
+            self.flash_warn("PVC explore only works on persistentvolumeclaims");
+            return;
+        }
+        let Some(obj) = self.selected_ref() else {
+            self.flash_warn("no PVC selected");
+            return;
+        };
+        let claim = obj.metadata.name.clone().unwrap_or_default();
+        let ns = obj.metadata.namespace.clone().unwrap_or_default();
+        if ns.is_empty() {
+            self.flash_warn("PVC has no namespace");
+            return;
+        }
+        // An unbound claim has no volume behind it yet — there is nothing to
+        // mount, and a helper pod would sit Pending until it timed out.
+        let phase = obj
+            .data
+            .get("status")
+            .and_then(|s| s.get("phase"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if !phase.is_empty() && phase != "Bound" {
+            self.flash_warn(&format!(
+                "{claim} is {phase}, not Bound — nothing to browse"
+            ));
+            return;
+        }
+        // A block claim is a raw device, not a filesystem: no pod mounts it at
+        // a path, and a helper pod asking for one would sit in
+        // ContainerCreating until it timed out.
+        if obj
+            .data
+            .get("spec")
+            .and_then(|s| s.get("volumeMode"))
+            .and_then(Value::as_str)
+            == Some("Block")
+        {
+            self.flash_warn(&format!(
+                "{claim} is a block volume — it has no filesystem to browse"
+            ));
+            return;
+        }
+        // Opening a second claim abandons the first. Tear it down here, or its
+        // helper pod is orphaned for the rest of its TTL.
+        self.leave_pvc_explore();
+        self.pvc.claim = claim.clone();
+        self.pvc.namespace = ns.clone();
+        self.pvc.intent = intent;
+        self.pvc.mount = None;
+        self.spawn_pvc_resolve(ns, claim);
+    }
+
+    /// Find a running pod that already mounts the claim. Nothing is created
+    /// here: a `None` result comes back to the UI, which then asks before
+    /// creating a helper pod.
+    fn spawn_pvc_resolve(&mut self, ns: String, claim: String) {
+        self.pvc.run += 1;
+        let run = self.pvc.run;
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        let status = self.claim_status(format!("finding a pod that mounts {claim}…"));
+        let context = self.cluster.context.clone();
+        tokio::spawn(async move {
+            let pods: Api<DynamicObject> = Api::namespaced_with(client, &ns, &pod_resource());
+            let result = match pods.list(&ListParams::default()).await {
+                Ok(list) => Ok(pvc::find_mount(&list.items, &claim)),
+                Err(e) => Err(format!("listing pods in {ns}: {e}")),
+            };
+            let _ = tx
+                .send(Msg::PvcTarget {
+                    generation: genr,
+                    run,
+                    namespace: ns,
+                    context,
+                    claim: status,
+                    result,
+                })
+                .await;
+        });
+    }
+
+    /// The resolve round trip landed: open what was asked for, or offer a
+    /// helper pod when nothing mounts the claim.
+    pub(super) fn handle_pvc_target(
+        &mut self,
+        run: u64,
+        namespace: String,
+        status: StatusClaim,
+        result: Result<Option<Mount>, String>,
+    ) {
+        // Superseded — the user asked for another claim, or gave up, while a
+        // helper pod was still coming up. Creating it already succeeded, so
+        // dropping the message here would leak it for its whole TTL.
+        if run != self.pvc.run {
+            if let Ok(Some(mount)) = result {
+                self.delete_helper(namespace, mount);
+            }
+            // The dropped operation still owns the status bar, and a message
+            // ending in "…" is never expired by the tick.
+            self.clear_claimed_status(status);
+            return;
+        }
+        match result {
+            Err(e) => self.set_claimed_status(status, e, true),
+            Ok(Some(mount)) => {
+                self.clear_claimed_status(status);
+                self.enter_pvc_target(namespace, mount);
+            }
+            Ok(None) => {
+                self.clear_claimed_status(status);
+                self.offer_pvc_helper();
+            }
+        }
+    }
+
+    fn enter_pvc_target(&mut self, namespace: String, mount: Mount) {
+        let intent = self.pvc.intent;
+        // The resolve is slow enough (a helper pod can take a minute to pull)
+        // that the user may have moved on — to a document view, or to another
+        // kind entirely. Opening the browser on top of that would be a view
+        // they didn't ask for, so hand the pod back and say why.
+        // An overlay over the table — the palette, help, a filter — is not
+        // moving on: it closes back to the same view. A dialog is different:
+        // opening the browser over it would discard a decision the user has
+        // not made yet, so treat it as moved on and hand the pod back.
+        let over_table = matches!(
+            self.mode,
+            Mode::Table | Mode::Command | Mode::Help | Mode::Filter
+        );
+        let moved_on =
+            !self.pvc.active && (!over_table || self.kind_plural != "persistentvolumeclaims");
+        if moved_on {
+            self.delete_helper(namespace, mount);
+            self.pvc.shell_pending = false;
+            self.flash_warn(&format!(
+                "{} is ready, but you've moved on — press x on it again",
+                self.pvc.claim
+            ));
+            return;
+        }
+        let path = mount.path.clone();
+        self.pvc.mount = Some(mount);
+        match intent {
+            PvcIntent::Shell => {
+                // A shell needs no browser state — resolve, suspend, done. The
+                // teardown waits for `after_suspend`: deleting a helper pod
+                // here would pull the volume out from under a shell the run
+                // loop has not started yet. A guardrail that refuses the
+                // shell means nothing will suspend, so tear down immediately.
+                self.pvc.shell_pending = true;
+                if !self.pvc_shell_at(&path) {
+                    self.after_suspend();
+                }
+            }
+            PvcIntent::Browse => {
+                self.set_return_mode();
+                self.pvc.active = true;
+                self.pvc.focus = Pane::Remote;
+                // Seeded, not left empty: a first listing that fails restores
+                // the title from here, and an empty path would blank it and
+                // make `⌫` and `r` both misbehave.
+                self.pvc.displayed_path = path.clone();
+                self.pvc.remote.clear();
+                self.pvc.remote_error = None;
+                self.pvc.truncated = false;
+                self.mode = Mode::PvcExplore;
+                self.reload_local();
+                self.open_remote_dir(path, None);
+            }
+        }
+    }
+
+    /// Nothing mounts the claim, so browsing it means creating a pod that
+    /// does. That writes to the cluster: refused in read-only mode, gated by
+    /// the `pvc-explore` guardrail, and always confirmed — the dialog names
+    /// the image and the claim.
+    fn offer_pvc_helper(&mut self) {
+        if self.readonly {
+            self.flash_warn(&format!(
+                "nothing mounts {} — browsing it needs a helper pod, which read-only mode blocks",
+                self.pvc.claim
+            ));
+            return;
+        }
+        let ns = self.pvc.namespace.clone();
+        let claim = self.pvc.claim.clone();
+        // A shell that a `shell` guardrail will refuse would otherwise create
+        // a pod, wait for it to pull, and delete it again — all to reach a
+        // refusal. The check is namespace-wide because the pod that would
+        // serve the shell does not exist yet.
+        if self.pvc.intent == PvcIntent::Shell
+            && self.guard_denies("shell", "pods", &[(String::from("*"), ns.clone())])
+        {
+            self.flash_warn(&format!(
+                "blocked by guardrail: shell pods — not creating a helper pod for {claim}"
+            ));
+            return;
+        }
+        let targets = [(claim.clone(), ns.clone())];
+        let Some(level) = self.guard(
+            "pvc-explore",
+            "persistentvolumeclaims",
+            &targets,
+            ConfirmLevel::Plain,
+        ) else {
+            return;
+        };
+        let image = self.pvc_cfg.image.clone();
+        let label =
+            format!("Nothing mounts {claim}. Create a temporary {image} pod in {ns} to mount it?");
+        self.begin_guarded(
+            ConfirmAction::PvcHelper {
+                ns,
+                claim: claim.clone(),
+                intent: self.pvc.intent,
+            },
+            label,
+            level,
+            claim,
+        );
+    }
+
+    /// Create the helper pod and wait for it to run. `generateName` means two
+    /// sessions browsing the same claim never collide on a name.
+    pub(super) fn create_pvc_helper(&mut self, ns: String, claim: String, intent: PvcIntent) {
+        self.pvc.intent = intent;
+        self.pvc.run += 1;
+        let run = self.pvc.run;
+        let ttl = self.pvc_ttl_secs();
+        let manifest = pvc::helper_pod(&claim, &self.pvc_cfg.image, ttl);
+        self.note_action("pvc-explore helper pod", format!("{claim} in {ns}"));
+        let status = self.claim_status(format!("starting a helper pod for {claim}…"));
+        let context = self.cluster.context.clone();
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let result = start_helper(client, &ns, manifest).await;
+            let _ = tx
+                .send(Msg::PvcTarget {
+                    generation: genr,
+                    run,
+                    namespace: ns,
+                    context,
+                    claim: status,
+                    result: result.map(Some),
+                })
+                .await;
+        });
+    }
+
+    /// `[pvc_explore] ttl`, already validated at load; a value that slipped
+    /// through falls back to the default rather than creating a pod that never
+    /// expires.
+    fn pvc_ttl_secs(&self) -> u64 {
+        crate::providers::parse_lookback(&self.pvc_cfg.ttl)
+            .ok()
+            .and_then(|s| u64::try_from(s).ok())
+            .filter(|s| *s > 0)
+            .unwrap_or(crate::config::PVC_DEFAULT_TTL_SECS)
+    }
+
+    // ----- browsing ------------------------------------------------------
+
+    /// Show `path` in the remote pane. The listing runs off-thread; the pane
+    /// keeps showing the previous directory until it arrives, so navigation
+    /// never blanks the screen.
+    fn open_remote_dir(&mut self, path: String, select: Option<String>) {
+        self.pvc.run += 1;
+        let run = self.pvc.run;
+        // Per request, so a listing that fails cannot leave a wanted selection
+        // behind to steer an unrelated later one.
+        self.pvc.want_select = select;
+        self.pvc.remote_path = path.clone();
+        self.pvc.loading = true;
+        let Some((argv, nonce)) = self.pvc_list_argv(&path) else {
+            self.pvc.loading = false;
+            return;
+        };
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        tokio::spawn(async move {
+            let result = run_listing(&argv, &nonce).await;
+            let _ = tx
+                .send(Msg::PvcListing {
+                    generation: genr,
+                    run,
+                    path,
+                    result,
+                })
+                .await;
+        });
+    }
+
+    pub(super) fn handle_pvc_listing(
+        &mut self,
+        run: u64,
+        path: String,
+        result: crate::store::PvcListingResult,
+    ) {
+        if run != self.pvc.run || !self.pvc.active {
+            return;
+        }
+        self.pvc.loading = false;
+        self.pvc.remote_path = path.clone();
+        match result {
+            Ok((listing, warn)) => {
+                self.pvc.truncated = listing.truncated;
+                // Re-listing the same directory keeps the cursor; stepping
+                // into a new one starts at the top, unless we stepped *out* of
+                // one, in which case it starts on the one we left.
+                let keep = self.pvc.want_select.take().or_else(|| {
+                    (self.pvc.displayed_path == self.pvc.remote_path)
+                        .then(|| self.pvc.selected_remote().map(|e| e.name.clone()))
+                        .flatten()
+                });
+                self.pvc.remote = listing.entries;
+                self.pvc.remote_error = None;
+                self.pvc.displayed_path = self.pvc.remote_path.clone();
+                PvcExplore::reselect(
+                    &mut self.pvc.remote_state,
+                    &self.pvc.remote,
+                    keep.as_deref(),
+                );
+                // Entries `ls` could not stat are still listed; say so rather
+                // than let the pane quietly under-report what is there.
+                if let Some(w) = warn {
+                    self.flash_warn(&w);
+                }
+            }
+            // Step back to where the pane was, the way the local side does on
+            // a failed `cd` — the entries on screen still belong to that
+            // directory, so leaving the title pointing somewhere else would
+            // mislabel them.
+            Err(e) => {
+                self.pvc.remote_path = self.pvc.displayed_path.clone();
+                self.pvc.want_select = None;
+                // Only when the failure is about the directory still on
+                // screen: with nothing to step back to, the pane would
+                // otherwise read "empty" — the one thing an unreadable volume
+                // must never say, and the flash expires after eight seconds.
+                // A failed step-out from an *empty* directory is a different
+                // thing, and must not label that directory unreadable.
+                if self.pvc.remote.is_empty() && self.pvc.displayed_path == path {
+                    self.pvc.remote_error = Some(e.clone());
+                }
+                self.flash_warn(&e);
+            }
+        }
+    }
+
+    /// Re-read the local pane. Local directories are read on the UI thread:
+    /// unlike a cluster call this is a syscall against the page cache, and the
+    /// asynchrony would only buy a frame of staleness.
+    fn reload_local(&mut self) {
+        let keep = self.pvc.selected_local().map(|e| e.name.clone());
+        self.reload_local_selecting(keep);
+    }
+
+    /// [`Self::reload_local`], choosing what the cursor lands on. Stepping
+    /// *into* a directory passes `None`: the current selection names the
+    /// directory being entered, and reselecting that name inside it would be a
+    /// coincidence rather than a place the user has been.
+    fn reload_local_selecting(&mut self, keep: Option<String>) {
+        match pvc::read_local(&self.pvc.local_path) {
+            Ok((entries, truncated)) => {
+                self.pvc.local = entries;
+                self.pvc.local_truncated = truncated;
+                self.pvc.local_error = None;
+                PvcExplore::reselect(&mut self.pvc.local_state, &self.pvc.local, keep.as_deref());
+            }
+            Err(e) => {
+                self.pvc.local.clear();
+                self.pvc.local_state.select(None);
+                self.pvc.local_error = Some(e);
+            }
+        }
+    }
+
+    /// The listing argv, and the nonce its output has to carry back.
+    fn pvc_list_argv(&self, path: &str) -> Option<(Vec<String>, String)> {
+        let mount = self.pvc.mount.as_ref()?;
+        let probe = pvc::list_probe(&mount.path);
+        let mut argv = self.kubectl_base();
+        argv.extend([
+            "exec".into(),
+            "-n".into(),
+            self.pvc.namespace.clone(),
+            mount.pod.clone(),
+            "-c".into(),
+            mount.container.clone(),
+            "--".into(),
+            "sh".into(),
+            "-c".into(),
+            probe.script,
+            // `$0`, then the path as `$1`: never spliced into the script.
+            "sh".into(),
+            path.to_string(),
+            probe.root,
+        ]);
+        Some((argv, probe.nonce))
+    }
+
+    /// Ask for a shell rooted at `path` inside the mount. Returns whether
+    /// anything is still going to happen — `false` means a guardrail refused
+    /// it and nothing will suspend.
+    ///
+    /// The exec lands in a real pod, so it passes the same `shell` guardrail
+    /// as `s` on that pod's row. Without this, a rule denying shells in prod
+    /// is defeated by shelling into a claim a prod pod mounts.
+    fn pvc_shell_at(&mut self, path: &str) -> bool {
+        let Some(mount) = self.pvc.mount.clone() else {
+            return false;
+        };
+        let ns = self.pvc.namespace.clone();
+        let targets = [(mount.pod.clone(), ns.clone())];
+        let Some(level) = self.guard("shell", "pods", &targets, ConfirmLevel::None) else {
+            return false;
+        };
+        let label = format!("Shell into {} via {}?", self.pvc.claim, mount.pod);
+        let hint = mount.pod.clone();
+        self.begin_guarded(
+            ConfirmAction::PvcShell {
+                ns,
+                pod: mount.pod,
+                container: mount.container,
+                path: path.to_string(),
+                claim: self.pvc.claim.clone(),
+            },
+            label,
+            level,
+            hint,
+        );
+        true
+    }
+
+    /// Queue the shell, once any guardrail confirmation is satisfied.
+    pub(super) fn do_pvc_shell(
+        &mut self,
+        ns: String,
+        pod: String,
+        container: String,
+        path: String,
+        claim: String,
+    ) {
+        self.note_action("pvc shell", format!("{claim} in {ns}"));
+        let mut argv = self.kubectl_base();
+        argv.extend([
+            "exec".into(),
+            "-it".into(),
+            "-n".into(),
+            ns,
+            pod,
+            "-c".into(),
+            container,
+            "--".into(),
+            "sh".into(),
+            "-c".into(),
+            // A path that has gone away silently drops the shell at the
+            // container's WORKDIR, which is not where the user asked to be.
+            // The message names no path: after the suspend this goes to a
+            // real terminal, and both the path and `$PWD` are volume-derived
+            // text that has not been through any escaping.
+            format!(
+                "cd -- \"$1\" 2>/dev/null || \
+                 echo 'sofka: that directory is gone; starting where the container does' >&2\n\
+                 {SHELL_FALLBACK}"
+            ),
+            "sh".into(),
+            path,
+        ]);
+        self.pending = Some(Suspend::Shell(argv));
+    }
+
+    /// A guarded PVC shell was cancelled at the dialog: nothing will suspend,
+    /// so run the teardown the suspend would have triggered.
+    pub(super) fn pvc_shell_cancelled(&mut self) {
+        self.after_suspend();
+    }
+
+    // ----- transfers -----------------------------------------------------
+
+    /// `c`: copy the focused pane's selection into the other pane's directory.
+    /// The direction is the focus, so one key does both and there is never a
+    /// question about which way it went.
+    fn copy_across(&mut self) {
+        match self.pvc.focus {
+            Pane::Remote => self.pvc_download(),
+            Pane::Local => self.pvc_upload(),
+        }
+    }
+
+    fn pvc_download(&mut self) {
+        let Some(entry) = self.pvc.selected_remote().cloned() else {
+            self.flash_warn("nothing selected to download");
+            return;
+        };
+        let Some(mount) = self.pvc.mount.clone() else {
+            return;
+        };
+        let src = pvc::join_path(self.pvc.current_dir(), &entry.name);
+        let dest = self.pvc.local_path.join(&entry.name);
+        let ns = self.pvc.namespace.clone();
+        let dest = dest.to_string_lossy().into_owned();
+        if !self.transferable(&entry, &src, &dest) {
+            return;
+        }
+        // A download writes to the user's own disk, so no guardrail applies —
+        // but overwriting a local file on one keystroke, with no undo, is not
+        // something to do silently.
+        if std::fs::symlink_metadata(&dest).is_ok() {
+            self.confirm_return = Mode::PvcExplore;
+            self.confirm_label = format!("{dest} already exists. Overwrite it?");
+            self.confirm_action = Some(ConfirmAction::Transfer {
+                ns,
+                pod: mount.pod,
+                container: Some(mount.container),
+                // A download, not an upload: without this the confirmation
+                // would run the copy backwards and write into the cluster,
+                // past read-only mode and both upload guardrails.
+                upload: false,
+                src,
+                dest,
+            });
+            self.mode = Mode::Confirm;
+            return;
+        }
+        self.start_transfer(ns, mount.pod, Some(mount.container), false, src, dest);
+    }
+
+    fn pvc_upload(&mut self) {
+        let Some(entry) = self.pvc.selected_local().cloned() else {
+            self.flash_warn("nothing selected to upload");
+            return;
+        };
+        let Some(mount) = self.pvc.mount.clone() else {
+            return;
+        };
+        if mount.read_only {
+            self.flash_warn(&format!(
+                "{} is mounted read-only in {} — uploads would fail",
+                self.pvc.claim, mount.pod
+            ));
+            return;
+        }
+        if self.deny_readonly() {
+            return;
+        }
+        let src = self.pvc.local_path.join(&entry.name);
+        let dest = pvc::join_path(self.pvc.current_dir(), &entry.name);
+        let src = src.to_string_lossy().into_owned();
+        if !self.transferable(&entry, &src, &dest) {
+            return;
+        }
+        let claim = self.pvc.claim.clone();
+        let ns = self.pvc.namespace.clone();
+        let targets = [(claim.clone(), ns.clone())];
+        // Gated twice, because it is two things at once. `transfer` against
+        // the serving pod is the rule an operator already wrote to stop `t`
+        // uploads into prod, and reaching the same pod through a claim it
+        // mounts must not defeat it; `pvc-upload` against the claim is the
+        // rule for protecting a volume whichever pod exposes it. The stronger
+        // confirmation of the two wins.
+        let Some(pod_level) = self.guard(
+            "transfer",
+            "pods",
+            &[(mount.pod.clone(), ns.clone())],
+            ConfirmLevel::None,
+        ) else {
+            return;
+        };
+        let Some(level) = self.guard("pvc-upload", "persistentvolumeclaims", &targets, pod_level)
+        else {
+            return;
+        };
+        let label = format!("Upload {src} into {claim}:{dest}?");
+        self.begin_guarded(
+            ConfirmAction::Transfer {
+                ns,
+                pod: mount.pod,
+                container: Some(mount.container),
+                upload: true,
+                src,
+                dest,
+            },
+            label,
+            level,
+            claim,
+        );
+    }
+
+    /// Whether `kubectl cp` can address this entry at all, flashing why not.
+    /// `cp` splits each argument on the first `:` to separate pod from path,
+    /// so a name containing one is unaddressable however it is quoted — and a
+    /// name that lost bytes to lossy UTF-8 decoding no longer names anything.
+    fn transferable(&mut self, entry: &Entry, src: &str, dest: &str) -> bool {
+        if !entry.addressable() {
+            self.flash_warn(&format!(
+                "{} is not valid UTF-8 — sofka cannot address it",
+                entry.name
+            ));
+            return false;
+        }
+        // The whole path, not just the leaf: a parent directory named `a:b` —
+        // or a local working directory with a colon in it — breaks `cp` just
+        // as thoroughly as the file's own name would.
+        if let Some(bad) = [src, dest].into_iter().find(|p| p.contains(':')) {
+            self.flash_warn(&format!(
+                "kubectl cp cannot address {bad:?} — a ':' separates pod from path"
+            ));
+            return false;
+        }
+        true
+    }
+
+    /// Both panes after a copy landed, so the new file shows up where it went
+    /// without the user having to ask.
+    pub(super) fn refresh_pvc_panes(&mut self) {
+        if !self.pvc.active {
+            return;
+        }
+        self.reload_local();
+        let path = self.pvc.current_dir().to_string();
+        self.open_remote_dir(path, None);
+    }
+
+    // ----- lifecycle -----------------------------------------------------
+
+    /// An interactive command the run loop suspended for has finished. A shell
+    /// launched from a PVC row owns its (possibly created) pod for exactly that
+    /// long; one launched from inside the browser does not, because the browser
+    /// is still using it.
+    pub fn after_suspend(&mut self) {
+        if !std::mem::take(&mut self.pvc.shell_pending) || self.pvc.active {
+            return;
+        }
+        self.cleanup_pvc_helper();
+        self.pvc.mount = None;
+    }
+
+    /// Leave the browser, taking any helper pod with it.
+    pub(super) fn close_pvc_explore(&mut self) {
+        self.leave_pvc_explore();
+        self.mode = self.return_mode;
+        if self.return_mode == Mode::Table {
+            self.restore_selection();
+        }
+    }
+
+    /// Tear the browser down without deciding where to go next. Called both by
+    /// `esc` and by anything that navigates out from under the browser — a
+    /// palette jump, a bookmark — so a helper pod is never orphaned and the
+    /// overlays stop drawing panes that are no longer on screen.
+    pub(super) fn leave_pvc_explore(&mut self) {
+        self.cleanup_pvc_helper();
+        self.pvc.active = false;
+        self.pvc.mount = None;
+        self.pvc.shell_pending = false;
+        self.pvc.loading = false;
+        self.pvc.remote.clear();
+        self.pvc.local.clear();
+        // Paths belong to the claim we just left; a failed first listing on
+        // the next one would otherwise show this one's directory in the title.
+        self.pvc.remote_path.clear();
+        self.pvc.displayed_path.clear();
+        self.pvc.want_select = None;
+    }
+
+    /// Delete the helper pod, if this session created one. Best effort and
+    /// fire-and-forget: `activeDeadlineSeconds` on the pod is the backstop for
+    /// a sofka that never gets to run this (a crash, a `ctrl-c`).
+    pub(super) fn cleanup_pvc_helper(&mut self) {
+        let Some(mount) = self.pvc.mount.take() else {
+            return;
+        };
+        if !mount.helper {
+            self.pvc.mount = Some(mount);
+            return;
+        }
+        let ns = self.pvc.namespace.clone();
+        self.delete_helper(ns, mount);
+    }
+
+    /// A resolve arrived for a generation that is over — a dashboard opened, a
+    /// context switched, the watch restarted. The pod it names may already
+    /// have been created, so delete it rather than let it sit out its TTL
+    /// holding the volume. Only when it is still this cluster's: after a
+    /// `:ctx` switch the client points somewhere else, and a name that
+    /// resolves in both clusters would be somebody else's pod.
+    pub(super) fn discard_pvc_target(
+        &mut self,
+        namespace: String,
+        context: String,
+        result: Result<Option<Mount>, String>,
+    ) {
+        if context != self.cluster.context {
+            // Deleting it would target the wrong cluster. Its own TTL will
+            // reap it, but the user is the only one who can do it sooner.
+            if matches!(&result, Ok(Some(m)) if m.helper) {
+                self.flash_warn(&format!(
+                    "a PVC helper pod was left in {context}/{namespace} — :ctx back and :pvc-clean to remove it now"
+                ));
+            }
+            return;
+        }
+        if let Ok(Some(mount)) = result {
+            self.delete_helper(namespace, mount);
+        }
+    }
+
+    /// Delete one helper pod, fire and forget. Only ever called with a pod
+    /// this session created, so a `helper: false` mount is a no-op rather than
+    /// an accidental delete of somebody's workload.
+    fn delete_helper(&mut self, ns: String, mount: Mount) {
+        if !mount.helper {
+            return;
+        }
+        // Deleting a pod is a mutation, and `:journal` is where the session's
+        // mutations are accounted for — including the ones it undoes for you.
+        self.note_action(
+            "pvc-explore helper pod removed",
+            format!("{} in {ns}", mount.pod),
+        );
+        let client = self.cluster.client.clone();
+        tokio::spawn(async move {
+            let pods: Api<Pod> = Api::namespaced(client, &ns);
+            let _ = pods.delete(&mount.pod, &DeleteParams::default()).await;
+        });
+    }
+
+    /// Await the helper pod's deletion instead of spawning it. The browser's
+    /// own `esc` can spawn and forget; process exit cannot, because the
+    /// runtime stops before a spawned task is polled.
+    pub async fn shutdown_pvc_helper(&mut self) {
+        let Some(mount) = self.pvc.mount.take() else {
+            return;
+        };
+        if !mount.helper {
+            return;
+        }
+        let pods: Api<Pod> = Api::namespaced(self.cluster.client.clone(), &self.pvc.namespace);
+        let _ = pods.delete(&mount.pod, &DeleteParams::default()).await;
+    }
+
+    /// `:pvc-clean` — delete helper pods left behind by a session that exited
+    /// without cleaning up. Deleting pods is a mutation like any other: it is
+    /// blocked in read-only mode, matched by the `pvc-explore` guardrail, and
+    /// always confirmed, because the sweep is by label and the user cannot see
+    /// what it will hit first.
+    pub(super) fn request_pvc_clean(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
+        let scope = self.pvc_clean_scope();
+        let where_ = match &scope {
+            Some(ns) => ns.clone(),
+            None => "all namespaces".into(),
+        };
+        let targets = [(String::from("*"), scope.clone().unwrap_or_default())];
+        // A cluster-wide sweep has no one namespace to match, so a
+        // `namespaces = ["prod"]` rule would be skipped entirely unless the
+        // guard is told the scope is every namespace (as `:sanitize` does).
+        let Some(level) = self.guard_scope(
+            "pvc-explore",
+            "persistentvolumeclaims",
+            &targets,
+            ConfirmLevel::Plain,
+            scope.is_none(),
+        ) else {
+            return;
+        };
+        self.begin_guarded(
+            ConfirmAction::PvcClean { scope },
+            // Honest about the blast radius: it cannot tell a leftover from a
+            // pod another sofka session is browsing through right now.
+            format!(
+                "Delete every sofka PVC-explore helper pod in {where_}, including any another session is using?"
+            ),
+            level,
+            where_,
+        );
+    }
+
+    /// Namespace the sweep covers: the current one, or every namespace when
+    /// the view is across all of them. A helper leaked in another namespace
+    /// would otherwise be invisible to the command meant to find it.
+    fn pvc_clean_scope(&self) -> Option<String> {
+        (!self.namespace.is_empty()).then(|| self.namespace.clone())
+    }
+
+    pub(super) fn cleanup_pvc_helpers(&mut self, scope: Option<String>) {
+        let where_ = scope.clone().unwrap_or_else(|| "all namespaces".into());
+        self.note_action("pvc-clean", where_.clone());
+        let status = self.claim_status(format!("cleaning up PVC helper pods in {where_}…"));
+        let client = self.cluster.client.clone();
+        let tx = self.tx.clone();
+        let genr = self.generation;
+        // The browser's own pod is not litter — sweeping it would break the
+        // view the user is looking at.
+        let keep = self
+            .pvc
+            .mount
+            .as_ref()
+            .filter(|m| m.helper)
+            .map(|m| m.pod.clone());
+        tokio::spawn(async move {
+            let pods: Api<Pod> = match &scope {
+                Some(ns) => Api::namespaced(client, ns),
+                None => Api::all(client),
+            };
+            let selector = format!("{}={}", HELPER_LABEL.0, HELPER_LABEL.1);
+            let mut deleted = 0usize;
+            let mut failed = Vec::new();
+            match pods.list(&ListParams::default().labels(&selector)).await {
+                Ok(list) => {
+                    for pod in list.items {
+                        let Some(name) = pod.metadata.name.clone() else {
+                            continue;
+                        };
+                        // Name prefix as well as the label: a pod that only
+                        // happens to carry the label is not ours to delete.
+                        if !name.starts_with(HELPER_PREFIX)
+                            || keep.as_deref() == Some(name.as_str())
+                        {
+                            continue;
+                        }
+                        let ns = pod.metadata.namespace.clone().unwrap_or_default();
+                        let api: Api<Pod> = Api::namespaced(pods.clone().into_client(), &ns);
+                        match api.delete(&name, &DeleteParams::default()).await {
+                            Ok(_) => deleted += 1,
+                            Err(e) => failed.push(format!("{ns}/{name}: {e}")),
+                        }
+                    }
+                }
+                Err(e) => failed.push(format!("listing pods in {where_}: {e}")),
+            }
+            let _ = tx
+                .send(Msg::PvcHelpersCleaned {
+                    generation: genr,
+                    claim: status,
+                    deleted,
+                    failed,
+                })
+                .await;
+        });
+    }
+
+    // ----- input ---------------------------------------------------------
+
+    pub(super) fn key_pvc_explore(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.close_pvc_explore(),
+            KeyCode::Tab | KeyCode::BackTab => self.pvc.focus = self.other_pane(),
+            KeyCode::Left => self.pvc.focus = Pane::Local,
+            KeyCode::Right => self.pvc.focus = Pane::Remote,
+            KeyCode::Char('j') | KeyCode::Down => self.step_pane(true),
+            KeyCode::Char('k') | KeyCode::Up => self.step_pane(false),
+            KeyCode::Char('g') | KeyCode::Home => self.jump_pane(true),
+            KeyCode::Char('G') | KeyCode::End => self.jump_pane(false),
+            KeyCode::Enter => self.descend_pane(),
+            KeyCode::Backspace | KeyCode::Char('-') => self.ascend_pane(),
+            KeyCode::Char('c') => self.copy_across(),
+            KeyCode::Char('r') => self.refresh_pvc_panes(),
+            KeyCode::Char('s') => self.pvc_shell_here(),
+            _ => {}
+        }
+    }
+
+    /// `s` in the browser: a shell at the directory the remote pane is showing,
+    /// not at the mount root — you have already navigated to where you want to
+    /// be.
+    fn pvc_shell_here(&mut self) {
+        if self.deny_readonly() {
+            return;
+        }
+        let path = self.pvc.current_dir().to_string();
+        self.pvc_shell_at(&path);
+    }
+
+    fn other_pane(&self) -> Pane {
+        match self.pvc.focus {
+            Pane::Local => Pane::Remote,
+            Pane::Remote => Pane::Local,
+        }
+    }
+
+    fn step_pane(&mut self, down: bool) {
+        match self.pvc.focus {
+            Pane::Local => {
+                let len = self.pvc.local.len();
+                list_step(&mut self.pvc.local_state, len, down);
+            }
+            Pane::Remote => {
+                let len = self.pvc.remote.len();
+                list_step(&mut self.pvc.remote_state, len, down);
+            }
+        }
+    }
+
+    fn jump_pane(&mut self, top: bool) {
+        let (state, len) = match self.pvc.focus {
+            Pane::Local => (&mut self.pvc.local_state, self.pvc.local.len()),
+            Pane::Remote => (&mut self.pvc.remote_state, self.pvc.remote.len()),
+        };
+        if len > 0 {
+            state.select(Some(if top { 0 } else { len - 1 }));
+        }
+    }
+
+    fn descend_pane(&mut self) {
+        match self.pvc.focus {
+            Pane::Local => {
+                let Some(entry) = self.pvc.selected_local().cloned() else {
+                    return;
+                };
+                // A symlink is worth trying: `read_local` reports the link, not
+                // its target, so the only way to know is to look.
+                if entry.kind == crate::pvcexplore::EntryKind::File {
+                    return;
+                }
+                let next = self.pvc.local_path.join(&entry.name);
+                let previous = std::mem::replace(&mut self.pvc.local_path, next);
+                // The rollback re-read must land on the row we came from: the
+                // failed read has already cleared the cursor, so the name has
+                // to be carried across it by hand.
+                let here = entry.name.clone();
+                self.reload_local_selecting(None);
+                // The rollback re-read succeeds and clears the error, so the
+                // reason has to be kept — otherwise the keystroke is a silent
+                // no-op, while the remote pane flashes on the same failure.
+                if let Some(why) = self.pvc.local_error.clone() {
+                    self.pvc.local_path = previous;
+                    self.reload_local_selecting(Some(here));
+                    self.flash_warn(&why);
+                }
+            }
+            Pane::Remote => {
+                let Some(entry) = self.pvc.selected_remote().cloned() else {
+                    return;
+                };
+                if entry.kind == crate::pvcexplore::EntryKind::File {
+                    return;
+                }
+                if !entry.addressable() {
+                    self.flash_warn(&format!(
+                        "{} is not valid UTF-8 — sofka cannot address it",
+                        entry.name
+                    ));
+                    return;
+                }
+                let next = pvc::join_path(self.pvc.current_dir(), &entry.name);
+                self.open_remote_dir(next, None);
+            }
+        }
+    }
+
+    fn ascend_pane(&mut self) {
+        match self.pvc.focus {
+            Pane::Local => {
+                let Some(parent) = self.pvc.local_path.parent().map(PathBuf::from) else {
+                    self.flash_warn("already at the filesystem root");
+                    return;
+                };
+                // Stepping out lands on the directory just left, the way
+                // every file manager does it — `reload_local` would otherwise
+                // reselect whatever the *child's* cursor was named, which in
+                // the parent is a coincidence at best.
+                let left = self
+                    .pvc
+                    .local_path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned());
+                let here = self.pvc.selected_local().map(|e| e.name.clone());
+                let previous = std::mem::replace(&mut self.pvc.local_path, parent);
+                self.reload_local_selecting(left);
+                // Symmetric with descending, and with the remote pane: an
+                // unreadable directory leaves the view — and the cursor —
+                // where they were, and says why.
+                if let Some(why) = self.pvc.local_error.clone() {
+                    self.pvc.local_path = previous;
+                    self.reload_local_selecting(here);
+                    self.flash_warn(&why);
+                }
+            }
+            Pane::Remote => {
+                let root = self.pvc.root().to_string();
+                let here = self.pvc.current_dir().to_string();
+                match pvc::parent_path(&here, &root) {
+                    Some(parent) => {
+                        // Land back on the directory just left, not at the top.
+                        let left = here
+                            .trim_end_matches('/')
+                            .rsplit('/')
+                            .next()
+                            .map(str::to_string)
+                            .filter(|s| !s.is_empty());
+                        self.open_remote_dir(parent, left);
+                    }
+                    None => self.flash_warn("already at the top of the volume"),
+                }
+            }
+        }
+    }
+}
+
+/// The pods `ApiResource`, built without discovery. The resolve task runs
+/// outside the UI thread and so has no access to the cluster registry, and
+/// `v1/Pod` is not a kind whose group could differ between clusters.
+fn pod_resource() -> kube::discovery::ApiResource {
+    kube::discovery::ApiResource::erase::<Pod>(&())
+}
+
+/// Create the helper pod and poll until it is `Running` (or fails), returning
+/// the mount to browse it through.
+async fn start_helper(client: Client, ns: &str, manifest: Value) -> Result<Mount, String> {
+    let spec: Pod = serde_json::from_value(manifest).map_err(|e| e.to_string())?;
+    let pods: Api<Pod> = Api::namespaced(client, ns);
+    let created = pods
+        .create(&PostParams::default(), &spec)
+        .await
+        .map_err(|e| format!("creating helper pod: {e}"))?;
+    let name = created.metadata.name.clone().unwrap_or_default();
+
+    let deadline = tokio::time::Instant::now() + HELPER_READY_TIMEOUT;
+    loop {
+        match pods.get(&name).await {
+            Ok(pod) => match pod.status.as_ref().and_then(|s| s.phase.as_deref()) {
+                Some("Running") => {
+                    return Ok(Mount {
+                        pod: name,
+                        container: "explore".into(),
+                        path: HELPER_MOUNT.into(),
+                        read_only: false,
+                        helper: true,
+                    });
+                }
+                // A pod that reaches a terminal phase is never coming up; say
+                // why rather than waiting out the timeout.
+                Some(phase @ ("Failed" | "Succeeded")) => {
+                    let reason = pod
+                        .status
+                        .as_ref()
+                        .and_then(|s| s.reason.clone())
+                        .unwrap_or_else(|| phase.to_string());
+                    let _ = pods.delete(&name, &DeleteParams::default()).await;
+                    return Err(format!("helper pod {name}: {reason}"));
+                }
+                _ => {}
+            },
+            Err(e) => {
+                let _ = pods.delete(&name, &DeleteParams::default()).await;
+                return Err(format!("waiting for helper pod {name}: {e}"));
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let _ = pods.delete(&name, &DeleteParams::default()).await;
+            return Err(format!(
+                "helper pod {name} did not start within {}s (image pull? unschedulable claim?)",
+                HELPER_READY_TIMEOUT.as_secs()
+            ));
+        }
+        tokio::time::sleep(HELPER_POLL).await;
+    }
+}
+
+/// Run one `kubectl exec … ls` and turn it into entries. Exit code
+/// [`EXIT_NOT_A_DIRECTORY`] is the script's own signal, not a tool failure, so
+/// it gets a sentence rather than kubectl's stderr.
+async fn run_listing(argv: &[String], nonce: &str) -> crate::store::PvcListingResult {
+    let run = tokio::process::Command::new(&argv[0])
+        .args(&argv[1..])
+        .kill_on_drop(true)
+        .output();
+    let out = match tokio::time::timeout(LIST_TIMEOUT, run).await {
+        Err(_) => {
+            return Err(format!(
+                "listing timed out after {}s",
+                LIST_TIMEOUT.as_secs()
+            ));
+        }
+        Ok(r) => r.map_err(|e| format!("kubectl exec failed to start: {e}"))?,
+    };
+    pvc::interpret_listing(
+        nonce,
+        out.status.code(),
+        &String::from_utf8_lossy(&out.stdout),
+        &String::from_utf8_lossy(&out.stderr),
+    )
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11915,3 +11915,1348 @@ async fn faults_watch_changes_preserve_pod_identity_or_clear_selection() {
     });
     assert_eq!(app.table_state.selected(), None);
 }
+
+// ----- PVC explore -------------------------------------------------------
+
+/// A PVC view with one bound claim selected. PVCs aren't in `Cluster::fake`'s
+/// standing registry, so the fixture declares the kind itself.
+fn app_with_pvc(phase: &str) -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    app.cluster
+        .register_kind("", "PersistentVolumeClaim", "persistentvolumeclaims", true);
+    app.switch_kind("persistentvolumeclaims");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "PersistentVolumeClaim",
+               "metadata": {"name": "data", "namespace": "default"},
+               "status": {"phase": phase}}),
+    );
+    app.table_state.select(Some(0));
+    (app, rx)
+}
+
+fn pvc_mount() -> crate::pvcexplore::Mount {
+    crate::pvcexplore::Mount {
+        pod: "api-0".into(),
+        container: "app".into(),
+        path: "/srv".into(),
+        read_only: false,
+        helper: false,
+    }
+}
+
+fn pvc_entry(
+    name: &str,
+    kind: crate::pvcexplore::EntryKind,
+    size: u64,
+) -> crate::pvcexplore::Entry {
+    crate::pvcexplore::Entry {
+        name: name.into(),
+        kind,
+        size: Some(size),
+        link_target: String::new(),
+    }
+}
+
+/// Hand the browser the target its resolve task would have produced.
+fn resolve_pvc(app: &mut App, result: Result<Option<crate::pvcexplore::Mount>, String>) {
+    let claim = current_claim(app);
+    app.handle_msg(Msg::PvcTarget {
+        generation: app.generation,
+        run: app.pvc.run,
+        namespace: "default".into(),
+        context: app.cluster.context.clone(),
+        claim,
+        result,
+    });
+}
+
+fn listing(entries: Vec<crate::pvcexplore::Entry>) -> crate::pvcexplore::Listing {
+    crate::pvcexplore::Listing {
+        entries,
+        unparsed: 0,
+        unnameable: 0,
+        truncated: false,
+        status: Some(0),
+    }
+}
+
+fn list_pvc(app: &mut App, path: &str, entries: Vec<crate::pvcexplore::Entry>) {
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: app.pvc.run,
+        path: path.into(),
+        result: Ok((listing(entries), None)),
+    });
+}
+
+#[tokio::test]
+async fn pvc_browser_opens_once_a_mounting_pod_resolves() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    // Nothing is on screen until we know which pod can serve the volume.
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("finding a pod"), "{}", app.flash);
+
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert_eq!(app.mode, Mode::PvcExplore);
+    assert!(app.pvc.active);
+    // The remote pane starts at the mount point, not at "/".
+    assert_eq!(app.pvc.remote_path, "/srv");
+    assert_eq!(app.pvc.focus, Pane::Remote);
+}
+
+#[tokio::test]
+async fn pvc_listing_fills_the_remote_pane_and_enter_descends() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![
+            pvc_entry("logs", EntryKind::Dir, 0),
+            pvc_entry("a.txt", EntryKind::File, 12),
+        ],
+    );
+    assert_eq!(app.pvc.remote.len(), 2);
+    assert_eq!(app.pvc.remote_state.selected(), Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.pvc.remote_path, "/srv/logs");
+    assert!(app.pvc.loading);
+
+    // A file is not a directory: enter does nothing rather than erroring.
+    list_pvc(
+        &mut app,
+        "/srv/logs",
+        vec![pvc_entry("app.log", EntryKind::File, 4)],
+    );
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.pvc.remote_path, "/srv/logs");
+}
+
+#[tokio::test]
+async fn pvc_browser_will_not_walk_above_the_mount_point() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(&mut app, "/srv", vec![pvc_entry("logs", EntryKind::Dir, 0)]);
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    list_pvc(&mut app, "/srv/logs", vec![]);
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    assert_eq!(app.pvc.remote_path, "/srv");
+
+    list_pvc(&mut app, "/srv", vec![]);
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    assert_eq!(app.pvc.remote_path, "/srv");
+    assert!(app.flash.contains("top of the volume"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_listing_for_a_directory_already_left_is_dropped() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(&mut app, "/srv", vec![pvc_entry("logs", EntryKind::Dir, 0)]);
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // bumps the run counter
+
+    let stale = app.pvc.run - 1;
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: stale,
+        path: "/srv".into(),
+        result: Ok((
+            listing(vec![pvc_entry("stale.txt", EntryKind::File, 1)]),
+            None,
+        )),
+    });
+    assert_eq!(app.pvc.remote_path, "/srv/logs");
+    assert!(app.pvc.remote.iter().all(|e| e.name != "stale.txt"));
+}
+
+#[tokio::test]
+async fn tab_switches_panes_and_copy_follows_the_focus() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("a.txt", EntryKind::File, 12)],
+    );
+
+    // Focus starts on the volume, so `c` copies out of it.
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.flash.contains("api-0:/srv/a.txt"), "{}", app.flash);
+
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.pvc.focus, Pane::Local);
+}
+
+#[tokio::test]
+async fn uploading_into_a_read_only_mount_is_refused() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    let mount = crate::pvcexplore::Mount {
+        read_only: true,
+        ..pvc_mount()
+    };
+    resolve_pvc(&mut app, Ok(Some(mount)));
+    app.pvc.local = vec![pvc_entry(
+        "notes.txt",
+        crate::pvcexplore::EntryKind::File,
+        3,
+    )];
+    app.pvc.local_state.select(Some(0));
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.flash.contains("read-only"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_claim_nothing_mounts_offers_a_helper_pod() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(None));
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("Nothing mounts data"),
+        "{}",
+        app.confirm_label
+    );
+    assert!(
+        app.confirm_label.contains(&app.pvc_cfg.image),
+        "{}",
+        app.confirm_label
+    );
+}
+
+#[tokio::test]
+async fn read_only_mode_refuses_the_helper_pod_rather_than_creating_one() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.readonly = true;
+    // Browsing itself is a read: `x` is allowed, the write it would need isn't.
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(None));
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("read-only"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn an_unbound_claim_is_not_browsable() {
+    let (mut app, _rx) = app_with_pvc("Pending");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("not Bound"), "{}", app.flash);
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn shell_on_a_pvc_row_execs_at_the_mount_point() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    // The shell is requested from the resolve message, not the keystroke, so
+    // the run loop has to pick it up there too.
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("no shell queued");
+    };
+    assert_eq!(&argv[..3], ["kubectl", "--context", "test"]);
+    assert!(argv.contains(&"api-0".to_string()));
+    assert_eq!(argv.last().unwrap(), "/srv");
+    // Never opens the browser — `s` asked for a terminal.
+    assert_eq!(app.mode, Mode::Table);
+    assert!(!app.pvc.active);
+}
+
+#[tokio::test]
+async fn esc_leaves_the_pvc_browser() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(!app.pvc.active);
+}
+
+#[tokio::test]
+async fn a_failed_resolve_reports_the_error_instead_of_opening_the_browser() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Err("listing pods in default: forbidden".into()));
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("forbidden"), "{}", app.flash);
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn navigating_out_of_the_pvc_browser_tears_it_down() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert!(app.pvc.active);
+
+    // The palette stays over the browser…
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert!(app.pvc.active);
+    // …but jumping to another kind leaves it, so no helper pod is orphaned and
+    // the overlays stop drawing panes that are gone.
+    for c in "pods".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.kind_plural, "pods");
+    assert!(!app.pvc.active);
+}
+
+#[tokio::test]
+async fn a_shell_from_a_pvc_row_keeps_its_pod_until_the_shell_returns() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    let helper = crate::pvcexplore::Mount {
+        pod: "sofka-pvc-explore-abc".into(),
+        container: "explore".into(),
+        path: "/pvc".into(),
+        read_only: false,
+        helper: true,
+    };
+    resolve_pvc(&mut app, Ok(Some(helper)));
+    // The shell is queued but has not run yet: the pod it needs is still held.
+    assert!(app.pending.is_some());
+    assert!(app.pvc.mount.as_ref().is_some_and(|m| m.helper));
+
+    app.pending.take();
+    app.after_suspend(); // the run loop's post-suspend hook
+    assert!(app.pvc.mount.is_none());
+    assert!(!app.pvc.shell_pending);
+}
+
+#[tokio::test]
+async fn a_shell_from_inside_the_browser_keeps_the_browser_and_its_pod() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    let helper = crate::pvcexplore::Mount {
+        pod: "sofka-pvc-explore-abc".into(),
+        container: "explore".into(),
+        path: "/pvc".into(),
+        read_only: false,
+        helper: true,
+    };
+    resolve_pvc(&mut app, Ok(Some(helper)));
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    assert!(app.pending.is_some());
+    app.pending.take();
+    app.after_suspend();
+    // Still browsing, so the pod stays.
+    assert!(app.pvc.active);
+    assert!(app.pvc.mount.as_ref().is_some_and(|m| m.helper));
+}
+
+#[tokio::test]
+async fn a_shell_guardrail_covers_the_pvc_shell_too() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    // "no shells in this context" must not be defeated by reaching the same
+    // pod through a claim it mounts.
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["shell".into()],
+        deny: true,
+        reason: Some("prod is locked".into()),
+        ..Default::default()
+    }];
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert!(app.pending.is_none(), "guardrail did not block the exec");
+    assert!(app.flash.contains("prod is locked"), "{}", app.flash);
+    // Nothing is left holding a pod for a shell that will never run.
+    assert!(!app.pvc.shell_pending);
+    assert!(app.pvc.mount.is_none());
+}
+
+#[tokio::test]
+async fn a_confirmed_pvc_shell_can_be_cancelled_without_stranding_state() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["shell".into()],
+        confirmation: Some("confirm".into()),
+        ..Default::default()
+    }];
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert_eq!(app.mode, Mode::Confirm);
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert!(app.pending.is_none());
+    assert!(!app.pvc.shell_pending);
+    assert!(app.pvc.mount.is_none());
+}
+
+#[tokio::test]
+async fn pvc_clean_is_a_mutation_and_is_gated_like_one() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.readonly = true;
+    palette(&mut app, "pvc-clean");
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(app.flash.contains("read-only"), "{}", app.flash);
+
+    app.readonly = false;
+    palette(&mut app, "pvc-clean");
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("helper pod"),
+        "{}",
+        app.confirm_label
+    );
+    // The current namespace, not a hardcoded default.
+    assert!(
+        app.confirm_label.contains("default"),
+        "{}",
+        app.confirm_label
+    );
+
+    // An all-namespaces view sweeps all namespaces, or a helper leaked
+    // elsewhere would be invisible to the command meant to find it.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.namespace.clear();
+    palette(&mut app, "pvc-clean");
+    assert!(
+        app.confirm_label.contains("all namespaces"),
+        "{}",
+        app.confirm_label
+    );
+}
+
+/// Run a palette command by typing it, the way a user would.
+fn palette(app: &mut App, command: &str) {
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in command.chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+}
+
+#[tokio::test]
+async fn a_namespace_guardrail_still_covers_a_cluster_wide_pvc_clean() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.guardrails = vec![crate::config::Guardrail {
+        namespaces: vec!["prod".into()],
+        actions: vec!["pvc-explore".into()],
+        deny: true,
+        reason: Some("prod volumes are hands-off".into()),
+        ..Default::default()
+    }];
+    // An all-namespaces sweep has no single namespace to match against, so
+    // without the all-namespaces scope the rule would simply be skipped.
+    app.namespace.clear();
+    palette(&mut app, "pvc-clean");
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(
+        app.flash.contains("prod volumes are hands-off"),
+        "{}",
+        app.flash
+    );
+}
+
+#[tokio::test]
+async fn pvc_is_still_the_kubectl_alias_for_the_resource() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.cluster.add_aliases(&std::collections::HashMap::from([(
+        "pvc".to_string(),
+        "persistentvolumeclaims".to_string(),
+    )]));
+    app.switch_kind("pods");
+    // A palette command outranks a kind, so `:pvc-explore` must not claim the
+    // bare `pvc` alias people already use to navigate.
+    palette(&mut app, "pvc");
+    assert_eq!(app.kind_plural, "persistentvolumeclaims");
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn a_helper_pod_that_lands_after_a_generation_bump_is_not_stranded() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    let claim = current_claim(&app);
+    let run = app.pvc.run;
+    let context = app.cluster.context.clone();
+    let helper = crate::pvcexplore::Mount {
+        pod: "sofka-pvc-explore-xyz".into(),
+        container: "explore".into(),
+        path: "/pvc".into(),
+        read_only: false,
+        helper: true,
+    };
+    // Anything that restarts the watch (`:pulse`, `:ctx`, ctrl-r) bumps the
+    // generation while the helper pod is still coming up. The message must
+    // still reach the delete path, not the generic stale-message arm.
+    let stale = app.generation;
+    app.bump_generation();
+    let journal_before = app.journal.len();
+    app.handle_msg(Msg::PvcTarget {
+        generation: stale,
+        run,
+        namespace: "default".into(),
+        context,
+        claim,
+        result: Ok(Some(helper)),
+    });
+    assert!(!app.pvc.active);
+    assert_eq!(
+        app.journal.len(),
+        journal_before + 1,
+        "the abandoned helper pod was not deleted"
+    );
+    let logged = app.journal.lines().join("\n");
+    assert!(logged.contains("helper pod removed"), "{logged}");
+    assert!(logged.contains("sofka-pvc-explore-xyz"), "{logged}");
+}
+
+#[tokio::test]
+async fn a_helper_pod_from_another_cluster_is_left_alone() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    let claim = current_claim(&app);
+    let run = app.pvc.run;
+    let stale = app.generation;
+    app.bump_generation();
+    let journal_before = app.journal.len();
+    // A `:ctx` switch bumps the generation *and* swaps the client, so the pod
+    // name would resolve against the wrong cluster.
+    app.handle_msg(Msg::PvcTarget {
+        generation: stale,
+        run,
+        namespace: "default".into(),
+        context: "some-other-cluster".into(),
+        claim,
+        result: Ok(Some(crate::pvcexplore::Mount {
+            pod: "sofka-pvc-explore-xyz".into(),
+            container: "explore".into(),
+            path: "/pvc".into(),
+            read_only: false,
+            helper: true,
+        })),
+    });
+    assert_eq!(
+        app.journal.len(),
+        journal_before,
+        "deleted a pod against a cluster it was never created in"
+    );
+}
+
+#[tokio::test]
+async fn a_mismatched_typed_confirmation_does_not_strand_the_shell_state() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["shell".into()],
+        confirmation: Some("type-resource-name".into()),
+        ..Default::default()
+    }];
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert_eq!(app.mode, Mode::Prompt);
+    // Enter on an empty prompt is the natural way to back out.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.pending.is_none());
+    assert!(!app.pvc.shell_pending);
+    assert!(app.pvc.mount.is_none());
+}
+
+#[tokio::test]
+async fn a_failed_listing_steps_back_to_the_directory_it_came_from() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(&mut app, "/srv", vec![pvc_entry("logs", EntryKind::Dir, 0)]);
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: app.pvc.run,
+        path: "/srv/logs".into(),
+        result: Err("not a directory, or permission denied".into()),
+    });
+    // The entries on screen still belong to /srv, so the title must too.
+    assert_eq!(app.pvc.remote_path, "/srv");
+    assert_eq!(app.pvc.remote.len(), 1);
+    assert!(app.flash.contains("permission denied"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_block_volume_is_refused_before_anything_is_created() {
+    let (mut app, _rx) = test_app();
+    app.cluster
+        .register_kind("", "PersistentVolumeClaim", "persistentvolumeclaims", true);
+    app.switch_kind("persistentvolumeclaims");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "PersistentVolumeClaim",
+               "metadata": {"name": "raw", "namespace": "default"},
+               "spec": {"volumeMode": "Block"},
+               "status": {"phase": "Bound"}}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("block volume"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_resolve_landing_after_the_user_moved_on_does_not_hijack_the_screen() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    // The resolve is slow; meanwhile the user opens the YAML view.
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(!app.pvc.active);
+}
+
+#[tokio::test]
+async fn a_superseded_resolve_never_opens_the_browser() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    let claim = current_claim(&app);
+    let stale = app.pvc.run;
+    app.handle_key(press(KeyCode::Char('x'))).unwrap(); // supersedes it
+    app.handle_msg(Msg::PvcTarget {
+        generation: app.generation,
+        run: stale,
+        namespace: "default".into(),
+        context: app.cluster.context.clone(),
+        claim,
+        result: Ok(Some(pvc_mount())),
+    });
+    assert!(!app.pvc.active);
+    assert!(app.pvc.mount.is_none());
+}
+
+#[tokio::test]
+async fn downloading_over_an_existing_local_file_asks_first() {
+    use crate::pvcexplore::EntryKind;
+    let dir = std::env::temp_dir().join(format!("sofka-pvc-test-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("a.txt"), b"old").unwrap();
+
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local_path = dir.clone();
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("a.txt", EntryKind::File, 12)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("Overwrite"),
+        "{}",
+        app.confirm_label
+    );
+    // Declining returns to the browser, not to the table underneath it.
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.mode, Mode::PvcExplore);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn escaping_a_pvc_shell_dialog_with_the_palette_releases_its_pod() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["shell".into()],
+        confirmation: Some("confirm".into()),
+        ..Default::default()
+    }];
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    resolve_pvc(
+        &mut app,
+        Ok(Some(crate::pvcexplore::Mount {
+            pod: "sofka-pvc-explore-xyz".into(),
+            container: "explore".into(),
+            path: "/pvc".into(),
+            read_only: false,
+            helper: true,
+        })),
+    );
+    assert_eq!(app.mode, Mode::Confirm);
+    // `:` is accepted from a confirm dialog and simply abandons the action —
+    // nothing else will ever run the suspend the pod was created for.
+    let journal_before = app.journal.len();
+    palette(&mut app, "pods");
+    assert!(!app.pvc.shell_pending);
+    assert!(app.pvc.mount.is_none());
+    assert!(app.pending.is_none());
+    assert_eq!(
+        app.journal.len(),
+        journal_before + 1,
+        "the abandoned helper pod was not deleted"
+    );
+}
+
+#[tokio::test]
+async fn a_background_message_that_takes_the_screen_leaves_the_browser() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert!(app.pvc.active);
+
+    // A describe requested before the browser opened finally lands. It takes
+    // the screen without a keystroke, so the key-path sweep never sees it.
+    let claim = app.claim_status("describing…");
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        claim,
+        title: "data — describe".into(),
+        lines: vec!["Name: data".into()],
+        warn: None,
+    });
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(
+        !app.pvc.active,
+        "the browser was left drawing behind a document"
+    );
+}
+
+#[tokio::test]
+async fn only_the_browsers_own_dialog_draws_over_its_panes() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    // A dialog raised from somewhere else must not be drawn as though it were
+    // about the two panes.
+    app.confirm_return = Mode::Table;
+    assert!(!app.over_pvc_browser());
+    app.confirm_return = Mode::PvcExplore;
+    assert!(app.over_pvc_browser());
+}
+
+#[tokio::test]
+async fn pvc_explore_is_reachable_from_the_palette() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    palette(&mut app, "pvc-explore");
+    assert!(app.flash.contains("finding a pod"), "{}", app.flash);
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert_eq!(app.mode, Mode::PvcExplore);
+}
+
+#[tokio::test]
+async fn a_denied_shell_never_creates_a_helper_pod_to_be_refused_in() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["shell".into()],
+        deny: true,
+        reason: Some("prod is locked".into()),
+        ..Default::default()
+    }];
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    // Nothing mounts the claim, so this would normally offer a helper pod —
+    // one that exists only to host a shell the guardrail is going to refuse.
+    resolve_pvc(&mut app, Ok(None));
+    assert_ne!(app.mode, Mode::Confirm, "offered a pod for a denied shell");
+    assert!(app.flash.contains("blocked by guardrail"), "{}", app.flash);
+    assert!(
+        app.journal.is_empty(),
+        "created something for a denied shell"
+    );
+}
+
+#[tokio::test]
+async fn browsing_still_offers_a_helper_pod_when_only_shells_are_denied() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["shell".into()],
+        deny: true,
+        ..Default::default()
+    }];
+    // Browsing is not shelling: the lookahead must not over-reach.
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(None));
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(
+        app.confirm_label.contains("Nothing mounts data"),
+        "{}",
+        app.confirm_label
+    );
+}
+
+#[tokio::test]
+async fn confirming_an_overwrite_downloads_rather_than_uploading() {
+    use crate::pvcexplore::EntryKind;
+    let dir = std::env::temp_dir().join(format!("sofka-pvc-dl-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("a.txt"), b"old").unwrap();
+
+    let (mut app, _rx) = app_with_pvc("Bound");
+    // Read-only mode must not change the answer: a download writes to the
+    // user's own disk, never to the cluster.
+    app.readonly = true;
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local_path = dir.clone();
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("a.txt", EntryKind::File, 12)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+
+    // Accepting it must run the copy in the direction that was asked for.
+    // `ConfirmAction::Transfer` used to be upload-only, so confirming a
+    // download here wrote the local file *into the cluster* — past read-only
+    // mode and both upload guardrails.
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    let dest = dir.join("a.txt");
+    assert!(
+        app.flash
+            .contains(&format!("api-0:/srv/a.txt → {}", dest.display())),
+        "{}",
+        app.flash
+    );
+    assert!(!app.journal.lines().join("\n").contains("cp upload"));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn names_kubectl_cp_cannot_address_are_refused_with_a_reason() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+
+    // `kubectl cp` splits each argument on the first ':' to separate pod from
+    // path, so an ISO-8601 timestamped log — which is what volumes are full of
+    // — cannot be addressed however it is quoted.
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("2026-01-01T00:00:00Z.log", EntryKind::File, 12)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert_ne!(app.mode, Mode::Confirm);
+    assert!(
+        app.flash.contains("kubectl cp cannot address"),
+        "{}",
+        app.flash
+    );
+
+    // A name that lost bytes to lossy UTF-8 decoding names nothing at all.
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("caf\u{FFFD}.txt", EntryKind::File, 12)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.flash.contains("not valid UTF-8"), "{}", app.flash);
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.flash.contains("not valid UTF-8"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_failed_listing_never_mislabels_the_entries_on_screen() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![
+            pvc_entry("a", EntryKind::Dir, 0),
+            pvc_entry("b", EntryKind::Dir, 0),
+        ],
+    );
+    // Two descents in flight: the first never lands, the second fails. The
+    // title must return to the directory whose entries are actually shown,
+    // not to the one the first descent was heading for.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.pvc.remote_state.select(Some(1));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: app.pvc.run,
+        path: "/srv/b".into(),
+        result: Err("not a directory, or permission denied".into()),
+    });
+    assert_eq!(app.pvc.remote_path, "/srv");
+    assert_eq!(app.pvc.remote.len(), 2);
+}
+
+#[tokio::test]
+async fn a_transfer_guardrail_on_pods_still_covers_a_pvc_upload() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    // The rule an operator already wrote to stop `t` uploads into prod pods.
+    // Reaching the same pod through a claim it mounts must not defeat it.
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["transfer".into()],
+        resources: vec!["pods".into()],
+        deny: true,
+        reason: Some("no uploads into prod".into()),
+        ..Default::default()
+    }];
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local = vec![pvc_entry("notes.txt", EntryKind::File, 3)];
+    app.pvc.local_state.select(Some(0));
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.flash.contains("no uploads into prod"), "{}", app.flash);
+    assert!(app.status_claim.is_none(), "the copy started anyway");
+}
+
+#[tokio::test]
+async fn refreshing_keeps_the_cursor_where_it_was() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    let entries = || {
+        vec![
+            pvc_entry("a.txt", EntryKind::File, 1),
+            pvc_entry("b.txt", EntryKind::File, 2),
+            pvc_entry("c.txt", EntryKind::File, 3),
+        ]
+    };
+    list_pvc(&mut app, "/srv", entries());
+    app.pvc.remote_state.select(Some(2));
+
+    // `r` — and the reload after every completed copy — must not send the
+    // cursor back to the top; in a real directory that means re-finding your
+    // place after every single file.
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    list_pvc(&mut app, "/srv", entries());
+    assert_eq!(app.pvc.remote_state.selected(), Some(2));
+    assert_eq!(
+        app.pvc.selected_remote().map(|e| e.name.as_str()),
+        Some("c.txt")
+    );
+
+    // An entry that has gone away falls back to the top rather than to a
+    // stale index.
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("a.txt", EntryKind::File, 1)],
+    );
+    assert_eq!(app.pvc.remote_state.selected(), Some(0));
+
+    // Stepping into a *new* directory starts at the top, even though the
+    // entry it lands on has the same name as the one the cursor was on.
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![
+            pvc_entry("logs", EntryKind::Dir, 0),
+            pvc_entry("a.txt", EntryKind::File, 1),
+        ],
+    );
+    app.pvc.remote_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.pvc.remote_path, "/srv/logs", "did not descend");
+    list_pvc(
+        &mut app,
+        "/srv/logs",
+        vec![
+            pvc_entry("x.log", EntryKind::File, 1),
+            pvc_entry("logs", EntryKind::File, 1),
+        ],
+    );
+    // Row 0, not the row named "logs": a new directory starts at the top even
+    // when the name the cursor was on happens to exist there too.
+    assert_eq!(app.pvc.remote_state.selected(), Some(0));
+    assert_eq!(
+        app.pvc.selected_remote().map(|e| e.name.as_str()),
+        Some("x.log")
+    );
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn a_failed_local_navigation_keeps_both_the_path_and_the_cursor() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = std::env::temp_dir().join(format!("sofka-local-nav-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("locked")).unwrap();
+    std::fs::write(dir.join("a.txt"), b"x").unwrap();
+
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local_path = dir.clone();
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    // Put the cursor on a directory that is about to become unreadable.
+    let idx = app
+        .pvc
+        .local
+        .iter()
+        .position(|e| e.name == "locked")
+        .expect("the directory is listed");
+    app.pvc.local_state.select(Some(idx));
+    // Still there, just not readable — so the rollback listing does contain
+    // the row the cursor was on.
+    std::fs::set_permissions(dir.join("locked"), std::fs::Permissions::from_mode(0o000)).unwrap();
+    if std::fs::read_dir(dir.join("locked")).is_ok() {
+        // Running as root (a devcontainer, a root CI image): the directory is
+        // readable anyway, so there is no failed navigation to assert on.
+        std::fs::set_permissions(dir.join("locked"), std::fs::Permissions::from_mode(0o755)).ok();
+        std::fs::remove_dir_all(&dir).ok();
+        return;
+    }
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    // Back where it started, cursor included — the rollback re-read would
+    // otherwise land on row 0.
+    assert_eq!(app.pvc.local_path, dir);
+    assert_eq!(
+        app.pvc.selected_local().map(|e| e.name.as_str()),
+        Some("locked"),
+        "the rollback lost the cursor"
+    );
+
+    std::fs::set_permissions(dir.join("locked"), std::fs::Permissions::from_mode(0o755)).ok();
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn a_failed_first_listing_leaves_the_title_on_the_mount_root() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    // Nothing has ever listed successfully. Restoring "the previously shown
+    // directory" would blank the path — and `cd -- ""` succeeds in every
+    // shell, so `r` would then list the container's working directory under
+    // an empty title.
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: app.pvc.run,
+        path: "/srv".into(),
+        result: Err("permission denied".into()),
+    });
+    assert_eq!(app.pvc.remote_path, "/srv");
+    assert!(!app.pvc.loading);
+}
+
+#[tokio::test]
+async fn a_watch_restart_does_not_leave_the_pane_loading_forever() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert!(app.pvc.loading);
+    let stale = app.generation;
+    app.bump_generation();
+    app.handle_msg(Msg::PvcListing {
+        generation: stale,
+        run: app.pvc.run,
+        path: "/srv".into(),
+        result: Ok((listing(vec![]), None)),
+    });
+    assert!(!app.pvc.loading, "the pane would say loading… until `r`");
+}
+
+#[tokio::test]
+async fn a_resolve_landing_over_a_dialog_does_not_discard_the_decision() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    // A confirmation the user has not answered yet.
+    app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    assert_eq!(
+        app.mode,
+        Mode::Confirm,
+        "the browser took over a live dialog"
+    );
+    assert!(app.confirm_action.is_some());
+    assert!(!app.pvc.active);
+}
+
+#[tokio::test]
+async fn an_unreadable_volume_root_says_so_instead_of_reading_empty() {
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: app.pvc.run,
+        path: "/srv".into(),
+        result: Err("ls: cannot open directory '.': Permission denied".into()),
+    });
+    // The flash expires after eight seconds; the pane is what the user is
+    // still looking at after that, and "empty" is the one thing an unreadable
+    // volume must never claim.
+    assert_eq!(
+        app.pvc.remote_error.as_deref(),
+        Some("ls: cannot open directory '.': Permission denied")
+    );
+    assert!(app.pvc.remote.is_empty());
+}
+
+#[tokio::test]
+async fn a_later_good_listing_clears_the_error() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: app.pvc.run,
+        path: "/srv".into(),
+        result: Err("permission denied".into()),
+    });
+    assert!(app.pvc.remote_error.is_some());
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("a.txt", EntryKind::File, 1)],
+    );
+    assert!(app.pvc.remote_error.is_none());
+}
+
+#[tokio::test]
+async fn stepping_out_of_a_directory_lands_back_on_it() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    let parent = || {
+        vec![
+            pvc_entry("archive", EntryKind::Dir, 0),
+            pvc_entry("logs", EntryKind::Dir, 0),
+            pvc_entry("uploads", EntryKind::Dir, 0),
+        ]
+    };
+    list_pvc(&mut app, "/srv", parent());
+    app.pvc.remote_state.select(Some(2)); // "uploads"
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    list_pvc(&mut app, "/srv/uploads", vec![]);
+
+    // `⌫` returns to the parent — and to the row you came out of, not row 0.
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    list_pvc(&mut app, "/srv", parent());
+    assert_eq!(app.pvc.remote_path, "/srv");
+    assert_eq!(
+        app.pvc.selected_remote().map(|e| e.name.as_str()),
+        Some("uploads")
+    );
+}
+
+#[tokio::test]
+async fn an_action_taken_mid_listing_targets_the_directory_on_screen() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![
+            pvc_entry("logs", EntryKind::Dir, 0),
+            pvc_entry("a.txt", EntryKind::File, 12),
+        ],
+    );
+    // Step into `logs` and act before the listing lands. The pane still shows
+    // /srv, so /srv is what the action must use — targeting the directory
+    // being navigated to would copy from, and write into, a directory the
+    // user has never seen.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.pvc.loading);
+    app.pvc.remote_state.select(Some(1)); // a.txt
+
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.flash.contains("api-0:/srv/a.txt"), "{}", app.flash);
+    assert!(!app.flash.contains("/srv/logs/"), "{}", app.flash);
+
+    // Same for a shell…
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("no shell queued");
+    };
+    assert_eq!(argv.last().unwrap(), "/srv");
+}
+
+#[tokio::test]
+async fn an_upload_mid_listing_writes_where_the_user_is_looking() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(&mut app, "/srv", vec![pvc_entry("logs", EntryKind::Dir, 0)]);
+    app.pvc.local = vec![pvc_entry("notes.txt", EntryKind::File, 3)];
+    app.pvc.local_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap(); // into logs, still loading
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    // With no guardrail this runs immediately, with no dialog naming the
+    // destination — so the destination had better be the visible one.
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.flash.contains("api-0:/srv/notes.txt"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_failed_step_out_does_not_steer_the_next_listing() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    let parent = || {
+        vec![
+            pvc_entry("a.txt", EntryKind::File, 1),
+            pvc_entry("logs", EntryKind::Dir, 0),
+        ]
+    };
+    list_pvc(&mut app, "/srv", parent());
+    app.pvc.remote_state.select(Some(1));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    list_pvc(
+        &mut app,
+        "/srv/logs",
+        vec![pvc_entry("x.log", EntryKind::File, 1)],
+    );
+
+    // Step out — which asks the next listing to land on "logs" — and have that
+    // listing fail. The request is over, so its hint must die with it.
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    app.handle_msg(Msg::PvcListing {
+        generation: app.generation,
+        run: app.pvc.run,
+        path: "/srv".into(),
+        result: Err("permission denied".into()),
+    });
+    // Now an ordinary refresh of the directory we never left.
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    list_pvc(
+        &mut app,
+        "/srv/logs",
+        vec![pvc_entry("x.log", EntryKind::File, 1)],
+    );
+    assert_eq!(app.pvc.remote_path, "/srv/logs");
+    assert_eq!(
+        app.pvc.selected_remote().map(|e| e.name.as_str()),
+        Some("x.log"),
+        "a stale step-out hint steered an unrelated listing"
+    );
+    // …and a failed step-out must not label the directory on screen unreadable.
+    assert!(app.pvc.remote_error.is_none());
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn the_local_pane_steps_out_onto_the_directory_it_left() {
+    let dir = std::env::temp_dir().join(format!("sofka-local-up-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("work")).unwrap();
+    std::fs::create_dir_all(dir.join("zzz")).unwrap();
+    // A name shared by parent and child: reselecting "the child's cursor" in
+    // the parent would land here instead of on "work".
+    std::fs::write(dir.join("notes.md"), b"x").unwrap();
+    std::fs::write(dir.join("work/notes.md"), b"x").unwrap();
+
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local_path = dir.join("work");
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert_eq!(
+        app.pvc.selected_local().map(|e| e.name.as_str()),
+        Some("notes.md")
+    );
+
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    assert_eq!(app.pvc.local_path, dir);
+    assert_eq!(
+        app.pvc.selected_local().map(|e| e.name.as_str()),
+        Some("work"),
+        "stepping out must land on the directory left, not on a name coincidence"
+    );
+
+    // And stepping back in starts at the top, not on a name coincidence.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.pvc.local_path, dir.join("work"));
+    assert_eq!(app.pvc.local_state.selected(), Some(0));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn a_failed_local_navigation_says_why() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = std::env::temp_dir().join(format!("sofka-local-why-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("locked")).unwrap();
+
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local_path = dir.clone();
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    std::fs::set_permissions(dir.join("locked"), std::fs::Permissions::from_mode(0o000)).unwrap();
+    if std::fs::read_dir(dir.join("locked")).is_ok() {
+        std::fs::set_permissions(dir.join("locked"), std::fs::Permissions::from_mode(0o755)).ok();
+        std::fs::remove_dir_all(&dir).ok();
+        return; // running as root: nothing fails, nothing to report
+    }
+
+    // The rollback re-read succeeds and clears the error, so without carrying
+    // the reason across it the keystroke is a silent no-op — while the remote
+    // pane flashes on the identical failure.
+    app.flash.clear();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(
+        app.flash.contains("locked"),
+        "silent no-op: {:?}",
+        app.flash
+    );
+    assert!(app.flash_err);
+    assert_eq!(app.pvc.local_path, dir);
+
+    std::fs::set_permissions(dir.join("locked"), std::fs::Permissions::from_mode(0o755)).ok();
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn a_failed_step_out_on_the_local_pane_says_why_too() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = std::env::temp_dir().join(format!("sofka-local-up-why-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("child")).unwrap();
+
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local_path = dir.join("child");
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    // Traversable but not readable: `⌫` into it fails where `cd` would not.
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o111)).unwrap();
+    if std::fs::read_dir(&dir).is_ok() {
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).ok();
+        std::fs::remove_dir_all(&dir).ok();
+        return; // running as root
+    }
+
+    app.flash.clear();
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    assert!(app.flash_err, "stepping out failed silently");
+    assert!(!app.flash.is_empty(), "stepping out failed silently");
+    assert_eq!(app.pvc.local_path, dir.join("child"));
+
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).ok();
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,8 @@ pub struct Config {
     pub debug: DebugConfig,
     /// Diagnostic-bundle (`:bundle`) options — see [`BundleConfig`].
     pub bundle: BundleConfig,
+    /// Helper-pod defaults for the PVC browser — see [`PvcExploreConfig`].
+    pub pvc_explore: PvcExploreConfig,
     /// Log-view options — see [`LogsConfig`].
     pub logs: LogsConfig,
     /// Cross-context fleet dashboard (`:fleet`) — see [`FleetConfig`].
@@ -428,6 +430,64 @@ impl Default for BundleConfig {
             max_pods: 3,
         }
     }
+}
+
+/// Fallback TTL for a PVC-explore helper pod when [`PvcExploreConfig::ttl`] is
+/// unreadable. Also the default itself.
+pub const PVC_DEFAULT_TTL_SECS: u64 = 1_800;
+
+/// Defaults for the PVC browser (`x` on a PVC, `:pvc-explore`).
+///
+/// A claim that some running pod already mounts is browsed through that pod
+/// and none of this applies. When nothing mounts it, sofka offers to create a
+/// short-lived pod that does — these are that pod's image and lifetime.
+///
+/// ```toml
+/// [pvc_explore]
+/// image = "busybox:1.37"   # helper-pod image; needs a shell and `ls`
+/// ttl = "30m"              # helper pod self-destructs after this
+/// ```
+///
+/// The image needs `sh`, `ls`, and — for transfers, which go through
+/// `kubectl cp` — `tar`. busybox has all three.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct PvcExploreConfig {
+    /// Image for the helper pod.
+    pub image: String,
+    /// How long the helper pod lives before it deletes itself, as a duration
+    /// like `"30m"`. Set on the pod as both a `sleep` and
+    /// `activeDeadlineSeconds`, so it expires even if sofka never gets to
+    /// delete it. Validated by [`pvc_explore_warnings`].
+    pub ttl: String,
+}
+
+impl Default for PvcExploreConfig {
+    fn default() -> Self {
+        Self {
+            image: "busybox:1.37".into(),
+            ttl: "30m".into(),
+        }
+    }
+}
+
+/// Validate `[pvc_explore]`: an empty image or an unparseable/absurd TTL.
+pub fn pvc_explore_warnings(cfg: &PvcExploreConfig) -> Vec<String> {
+    let mut out = Vec::new();
+    if cfg.image.trim().is_empty() {
+        out.push("pvc_explore: image is empty — helper pods cannot be created".into());
+    }
+    match crate::providers::parse_lookback(&cfg.ttl) {
+        Err(e) => out.push(format!("pvc_explore: ttl: {e}; using 30m")),
+        Ok(secs) if secs <= 0 => {
+            out.push(format!(
+                "pvc_explore: ttl {:?} must be positive; using 30m",
+                cfg.ttl
+            ));
+        }
+        Ok(_) => {}
+    }
+    out
 }
 
 /// Defaults for `:debug`, which attaches an ephemeral debug container to the
@@ -982,8 +1042,8 @@ pub fn workspace_warnings(workspaces: &[Workspace]) -> Vec<String> {
 /// A declarative safety policy: match dangerous actions by context, namespace,
 /// resource, and action, then require extra confirmation, deny them, or cap a
 /// bulk selection. Gates `delete`, `force-delete`, `drain`, `restart`,
-/// `shell`, `debug`, and `node-debug` today. Empty match lists mean "any";
-/// glob `*` supported.
+/// `shell`, `debug`, `node-debug`, `transfer`, `pvc-explore`, and
+/// `pvc-upload` today. Empty match lists mean "any"; glob `*` supported.
 ///
 /// ```toml
 /// [[guardrails]]
@@ -1012,7 +1072,8 @@ pub struct Guardrail {
     /// Resource plurals/kinds this applies to (globs). Empty = any.
     pub resources: Vec<String>,
     /// Actions this applies to: `delete`, `force-delete`, `drain`, `restart`,
-    /// `shell`, `debug`, `node-debug`, `transfer`. Empty = any.
+    /// `shell`, `debug`, `node-debug`, `transfer`, `pvc-explore` (creating or
+    /// sweeping a PVC-explore helper pod), `pvc-upload`. Empty = any.
     pub actions: Vec<String>,
     /// Block the action outright.
     pub deny: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod logfilter;
 pub mod nsmem;
 pub mod plugins;
 pub mod providers;
+pub mod pvcexplore;
 pub mod rightsize;
 pub mod sanitize;
 pub mod snapshot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,6 +278,7 @@ async fn run_main(args: Args) -> Result<()> {
     app.guardrails = cfg.guardrails.clone();
     app.debug = cfg.debug.clone();
     app.bundle_cfg = cfg.bundle.clone();
+    app.pvc_cfg = cfg.pvc_explore.clone();
     app.logs_cfg = cfg.logs.clone();
     // Seed the session toggle once; later `F` presses (and per-context config
     // reloads) don't fight the user's in-session choice.
@@ -292,6 +293,7 @@ async fn run_main(args: Args) -> Result<()> {
         .chain(config::guardrail_warnings(&app.guardrails))
         .chain(config::forward_warnings(&app.forwards_cfg))
         .chain(config::notify_warnings(&app.notify_cfg))
+        .chain(config::pvc_explore_warnings(&app.pvc_cfg))
     {
         eprintln!("warning: {w}");
         config_warnings.push(w);
@@ -381,6 +383,9 @@ async fn run_main(args: Args) -> Result<()> {
     }
     install_panic_hook(panic_tx);
     let result = run(&mut terminal, &mut app, &mut rx, mouse).await;
+    // Still inside the runtime, so this actually completes — a spawned delete
+    // would not, and the helper pod would sit out its TTL holding the volume.
+    app.shutdown_pvc_helper().await;
     // Disable before leaving the alternate screen so the shell never sees
     // mouse-report sequences (harmless if capture was never enabled).
     let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
@@ -651,14 +656,24 @@ fn dispatch(
     }
     for key in keys {
         app.handle_key(key)?;
-        if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
-            suspend_and_run(terminal, &argv, captured);
-            app.flash = format!("ran: {}", argv.join(" "));
-            app.flash_err = false;
-        }
+        take_suspend(terminal, app, captured);
     }
     terminal.draw(|f| ui::draw(f, app))?;
     Ok(true)
+}
+
+/// Run whatever interactive command the app just queued, if any. Called after
+/// every path that can queue one — a keystroke, a mouse click, and a background
+/// message (the PVC browser resolves which pod to exec into asynchronously, so
+/// its shell is requested from a message, not from the keystroke that asked
+/// for it).
+fn take_suspend(terminal: &mut ratatui::DefaultTerminal, app: &mut App, captured: bool) {
+    if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
+        suspend_and_run(terminal, &argv, captured);
+        app.flash = format!("ran: {}", argv.join(" "));
+        app.flash_err = false;
+        app.after_suspend();
+    }
 }
 
 async fn run(
@@ -726,11 +741,7 @@ async fn run(
                     }
                     Some(Ok(Event::Mouse(m))) => {
                         app.handle_mouse(m)?;
-                        if let Some(app::Suspend::Shell(argv)) = app.pending.take() {
-                            suspend_and_run(terminal, &argv, captured);
-                            app.flash = format!("ran: {}", argv.join(" "));
-                            app.flash_err = false;
-                        }
+                        take_suspend(terminal, app, captured);
                         dirty = true;
                     }
                     Some(Err(_)) | None => return Ok(()),
@@ -749,6 +760,7 @@ async fn run(
                     app.run_notify_command(&text);
                     ring_notification(&text, &app.notify_cfg);
                 }
+                take_suspend(terminal, app, captured);
                 dirty = true;
             }
             _ = frame.tick(), if dirty => {

--- a/src/pvcexplore.rs
+++ b/src/pvcexplore.rs
@@ -18,14 +18,36 @@ use serde_json::{Value, json};
 /// change a path nobody types.
 pub const HELPER_MOUNT: &str = "/pvc";
 
-/// `metadata.generateName` for helper pods. `:pvc-clean` requires both this
-/// prefix and [`HELPER_LABEL`] before it deletes anything, so a pod that only
-/// happens to carry the label is never swept up.
+/// `metadata.generateName` for helper pods. `:pvc-clean` requires this prefix,
+/// both of [`HELPER_LABELS`], and the [`HELPER_ANNOTATION`] naming the claim
+/// before it deletes anything.
+///
+/// None of that is unforgeable — every label and annotation sofka writes on
+/// creation, anything else can write too — so it is not a permission check.
+/// It is there to make an *accidental* match essentially impossible; a
+/// deliberate one is bounded instead by the sweep being confirmed, journalled,
+/// blocked in read-only mode, and gated by the `pvc-explore` guardrail.
 pub const HELPER_PREFIX: &str = "sofka-pvc-explore-";
 
 /// Label every helper pod carries, so a leftover is identifiable as sofka's
 /// even after the annotation naming the claim is gone.
-pub const HELPER_LABEL: (&str, &str) = ("sofka.dev/component", "pvc-explore");
+pub const HELPER_LABELS: [(&str, &str); 2] = [
+    ("app.kubernetes.io/managed-by", "sofka"),
+    ("sofka.dev/component", "pvc-explore"),
+];
+
+/// Annotation naming the claim a helper pod was created for. Also part of the
+/// evidence [`HELPER_PREFIX`] describes.
+pub const HELPER_ANNOTATION: &str = "sofka.dev/pvc";
+
+/// The label selector `:pvc-clean` lists with.
+pub fn helper_selector() -> String {
+    HELPER_LABELS
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
 
 /// Cap on entries read from one directory. A volume with a million files in
 /// one directory is a real thing (a cache, a spool), and the cap is applied by
@@ -113,6 +135,10 @@ fn nonce() -> String {
 /// symlinks, so a link on the volume pointing at `/` would land the browser in
 /// the serving pod's root with every path still looking like it was under the
 /// mount. Comparing the *resolved* directory is the only check that sees it.
+///
+/// Both sides get a trailing slash before they are compared, which makes the
+/// boundary explicit — `/pvcx` is not inside `/pvc` — and keeps a root of `/`
+/// working without depending on a glob subtlety to say so.
 pub fn list_probe(root: &str) -> ListingProbe {
     let nonce = nonce();
     ListingProbe {
@@ -126,9 +152,8 @@ pub fn list_probe(root: &str) -> ListingProbe {
             r#"[ -n "$1" ] && [ -n "$2" ] || exit {EXIT_NOT_A_DIRECTORY}
 unset TIME_STYLE QUOTING_STYLE BLOCK_SIZE LS_BLOCK_SIZE
 root=$(cd -- "$2" 2>/dev/null && pwd -P) || exit {EXIT_NOT_A_DIRECTORY}
-root=${{root%/}}
 cd -- "$1" 2>/dev/null || exit {EXIT_NOT_A_DIRECTORY}
-case "$(pwd -P)" in "$root"|"$root"/*) ;; *) exit {EXIT_OUTSIDE_MOUNT} ;; esac
+case "$(pwd -P)/" in "${{root%/}}/"*) ;; *) exit {EXIT_OUTSIDE_MOUNT} ;; esac
 {{ LC_ALL=C ls -A -l; echo "{STATUS_MARKER}{nonce}:$?"; }} | head -n {}"#,
             MAX_ENTRIES + 2
         ),
@@ -491,12 +516,12 @@ pub fn helper_pod(claim: &str, image: &str, ttl_secs: u64) -> Value {
         "metadata": {
             "generateName": HELPER_PREFIX,
             "labels": {
-                "app.kubernetes.io/managed-by": "sofka",
-                HELPER_LABEL.0: HELPER_LABEL.1,
+                HELPER_LABELS[0].0: HELPER_LABELS[0].1,
+                HELPER_LABELS[1].0: HELPER_LABELS[1].1,
             },
             // A label value can't hold every legal claim name (63 chars, and
             // claims may be longer), so the claim goes in an annotation.
-            "annotations": { "sofka.dev/pvc": claim },
+            "annotations": { HELPER_ANNOTATION: claim },
         },
         "spec": {
             "restartPolicy": "Never",
@@ -1437,6 +1462,22 @@ mod tests {
     }
 
     #[test]
+    fn the_helper_pod_carries_every_piece_of_evidence_the_sweep_requires() {
+        let spec = helper_pod("data", "busybox:1.37", 900);
+        for (k, v) in HELPER_LABELS {
+            assert_eq!(spec["metadata"]["labels"][k], v);
+        }
+        assert_eq!(spec["metadata"]["annotations"][HELPER_ANNOTATION], "data");
+        assert_eq!(spec["metadata"]["generateName"], HELPER_PREFIX);
+        // The selector `:pvc-clean` lists with must name every label, or the
+        // extra evidence buys nothing.
+        let selector = helper_selector();
+        for (k, v) in HELPER_LABELS {
+            assert!(selector.contains(&format!("{k}={v}")), "{selector}");
+        }
+    }
+
+    #[test]
     fn a_link_that_leaves_the_mount_is_refused_by_its_own_exit_code() {
         let err = interpret(Some(EXIT_OUTSIDE_MOUNT), "", "").unwrap_err();
         assert!(err.contains("outside the volume"), "{err}");
@@ -1452,10 +1493,14 @@ mod tests {
                 .script
                 .contains(r#"root=$(cd -- "$2" 2>/dev/null && pwd -P)"#)
         );
+        // Trailing slash on both sides: the boundary is explicit, so `/pvcx`
+        // is not inside `/pvc` and a root of `/` needs no special case.
         assert!(
             probe
                 .script
-                .contains(r#"case "$(pwd -P)" in "$root"|"$root"/*)"#)
+                .contains(r#"case "$(pwd -P)/" in "${root%/}/"*)"#),
+            "{}",
+            probe.script
         );
         assert!(probe.script.contains(&format!("exit {EXIT_OUTSIDE_MOUNT}")));
         assert_eq!(probe.root, "/srv");

--- a/src/pvcexplore.rs
+++ b/src/pvcexplore.rs
@@ -1,0 +1,1503 @@
+//! PVC explore — reading and transferring the contents of a
+//! PersistentVolumeClaim.
+//!
+//! A PVC has no API of its own to read: the only way to see what is on a
+//! volume is from inside a pod that mounts it. This module is the pure half of
+//! that — picking the pod, describing the helper pod for a claim nothing
+//! mounts, parsing the directory listing that comes back, and reading the
+//! local side of the split view. Everything that talks to a cluster or the UI
+//! lives in `app/pvcexplore.rs`.
+
+use std::path::Path;
+
+use kube::core::DynamicObject;
+use serde_json::{Value, json};
+
+/// Where the helper pod mounts the claim. Fixed rather than configurable: it
+/// only ever exists inside a pod sofka created, and a knob here would only
+/// change a path nobody types.
+pub const HELPER_MOUNT: &str = "/pvc";
+
+/// `metadata.generateName` for helper pods. `:pvc-clean` requires both this
+/// prefix and [`HELPER_LABEL`] before it deletes anything, so a pod that only
+/// happens to carry the label is never swept up.
+pub const HELPER_PREFIX: &str = "sofka-pvc-explore-";
+
+/// Label every helper pod carries, so a leftover is identifiable as sofka's
+/// even after the annotation naming the claim is gone.
+pub const HELPER_LABEL: (&str, &str) = ("sofka.dev/component", "pvc-explore");
+
+/// Cap on entries read from one directory. A volume with a million files in
+/// one directory is a real thing (a cache, a spool), and the cap is applied by
+/// `head` inside the container rather than after the fact, so neither the pipe
+/// nor this process ever holds the whole listing.
+pub const MAX_ENTRIES: usize = 5_000;
+
+/// Prefix of the line `ls`'s own exit status is reported on, since piping
+/// through `head` replaces the pipeline's status with `head`'s.
+///
+/// The prefix alone is forgeable: GNU `ls` prints file names raw when its
+/// output is a pipe, so a file called `x\nsofka-ls-status:0` puts a line
+/// through that looks exactly like the real marker — and, arriving before the
+/// real one, would let a truncated listing pass itself off as complete. Every
+/// run therefore mints a nonce (see [`ListingProbe`]) that a name on the
+/// volume cannot predict.
+const STATUS_MARKER: &str = "sofka-ls-status:";
+
+/// Exit code the listing script uses for a path it could not enter.
+pub const EXIT_NOT_A_DIRECTORY: i32 = 3;
+
+/// Exit code the listing script uses for a path that resolved outside the
+/// mount. Only a symlink can do that — the browser never builds such a path
+/// itself — but a volume's contents are not sofka's to trust.
+pub const EXIT_OUTSIDE_MOUNT: i32 = 4;
+
+/// One listing command and the nonce needed to read its output back.
+#[derive(Debug, Clone)]
+pub struct ListingProbe {
+    pub script: String,
+    pub nonce: String,
+    /// The mount root the listing may not leave, passed as `$2`. The script
+    /// resolves it itself, so it is the raw mount path.
+    pub root: String,
+}
+
+/// A value a file name on the volume cannot guess: the nanosecond clock plus a
+/// per-process counter, hex-encoded so it is safe to embed in the script
+/// unquoted. It never leaves the exec, so it needs to be unpredictable, not
+/// cryptographically random.
+fn nonce() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let t = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or_default();
+    format!("{t:016x}{n:x}")
+}
+
+/// The listing command, run as `sh -c <script> sh <path>` so the path arrives
+/// as a positional parameter and is never spliced into the script.
+///
+/// `-A` includes dotfiles but not `.`/`..`; `-l` is the only long format both
+/// GNU coreutils and busybox agree on. `LC_ALL=C` pins the month names — not
+/// that [`parse_listing`] reads them, but a stable width is one less thing to
+/// go wrong.
+///
+/// The `unset` line matters more than it looks: GNU `ls` reshapes its output
+/// from the environment, and the container's environment is not sofka's to
+/// choose. `TIME_STYLE=long-iso` prints a two-field date instead of three and
+/// shifts the name column, leaving nothing parseable; `QUOTING_STYLE=shell`
+/// wraps every name in quotes, so each one lists but none of them resolves;
+/// `BLOCK_SIZE`/`LS_BLOCK_SIZE` scale the size column, which would report a
+/// 100 kB file as `1B`. busybox ignores all four, and `unset` on an unset name
+/// is free, so this is unconditional.
+///
+/// A failed `cd` exits 3 so the caller can say "not a directory" rather than
+/// surface a shell error.
+///
+/// The cap is applied by `head` inside the container, so a spool directory
+/// with a million files is never streamed out in full. That costs the
+/// pipeline's exit status — it becomes `head`'s — which matters because `ls`
+/// distinguishes three outcomes the pane must not confuse: everything listed
+/// (0), listed but some entry could not be stat'd (non-zero, output still
+/// good), and could not read the directory at all (non-zero, no output).
+/// Hence the trailing marker: it carries `ls`'s real status, and its *absence*
+/// means `head` cut the output short, which is exactly the truncation signal.
+/// `$1` is the directory to list and `$2` the mount root it may not leave;
+/// both arrive as positional parameters, never spliced into the script.
+///
+/// The `pwd -P` check is what makes "confined to the mount" true rather than
+/// aspirational. Path arithmetic alone cannot enforce it: `cd` follows
+/// symlinks, so a link on the volume pointing at `/` would land the browser in
+/// the serving pod's root with every path still looking like it was under the
+/// mount. Comparing the *resolved* directory is the only check that sees it.
+pub fn list_probe(root: &str) -> ListingProbe {
+    let nonce = nonce();
+    ListingProbe {
+        // Both sides are resolved with `pwd -P` before they are compared: a
+        // mount path can itself sit behind a symlink (as `/tmp` does on
+        // macOS), and comparing the raw strings would then refuse the mount's
+        // own root. Trimming a trailing slash keeps the `"$root"/*` pattern
+        // meaningful when the root is `/` — not a legal mountPath, but the
+        // script must not misbehave if one ever arrives.
+        script: format!(
+            r#"[ -n "$1" ] && [ -n "$2" ] || exit {EXIT_NOT_A_DIRECTORY}
+unset TIME_STYLE QUOTING_STYLE BLOCK_SIZE LS_BLOCK_SIZE
+root=$(cd -- "$2" 2>/dev/null && pwd -P) || exit {EXIT_NOT_A_DIRECTORY}
+root=${{root%/}}
+cd -- "$1" 2>/dev/null || exit {EXIT_NOT_A_DIRECTORY}
+case "$(pwd -P)" in "$root"|"$root"/*) ;; *) exit {EXIT_OUTSIDE_MOUNT} ;; esac
+{{ LC_ALL=C ls -A -l; echo "{STATUS_MARKER}{nonce}:$?"; }} | head -n {}"#,
+            MAX_ENTRIES + 2
+        ),
+        nonce,
+        root: root.to_string(),
+    }
+}
+
+/// What one [`list_probe`] run produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Listing {
+    pub entries: Vec<Entry>,
+    /// Body lines that produced no entry. A few are ordinary — a forged row,
+    /// a device node in an unfamiliar shape. *All* of them means the output
+    /// was not the format we parse, and calling that an empty directory would
+    /// tell the user their volume holds nothing.
+    pub unparsed: usize,
+    /// Rows `ls` produced with no name of their own. A file named `"\nfoo"`
+    /// prints its metadata, then the newline ends the row before the name
+    /// starts — so this row is the *head*, and `foo` arrives on the next line
+    /// as an unparseable one. They are real files sofka cannot name, which is
+    /// neither an unreadable listing nor an empty directory.
+    pub unnameable: usize,
+    /// `head` cut the output short: there are more entries than [`MAX_ENTRIES`].
+    pub truncated: bool,
+    /// `ls`'s own exit status. `None` when the marker never arrived — either
+    /// the output was truncated, or the command never ran at all.
+    pub status: Option<i32>,
+}
+
+/// Turn one run of [`list_probe`] into either a listing or the reason there
+/// isn't one. Pure, so every branch is testable without a cluster: `exit_code`
+/// is the process's, `stdout`/`stderr` its output.
+pub fn interpret_listing(
+    nonce: &str,
+    exit_code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+) -> Result<(Listing, Option<String>), String> {
+    if exit_code == Some(EXIT_NOT_A_DIRECTORY) {
+        return Err("not a directory, or permission denied".into());
+    }
+    if exit_code == Some(EXIT_OUTSIDE_MOUNT) {
+        return Err(
+            "that link points outside the volume — the browser stays inside the mount".into(),
+        );
+    }
+    let listing = parse_output(nonce, stdout);
+    let message = last_error_line(stderr);
+    let fail = |m: String| {
+        Err(if m.is_empty() {
+            match exit_code {
+                Some(c) => format!("listing failed (exit {c})"),
+                None => "listing failed".into(),
+            }
+        } else {
+            m
+        })
+    };
+    match listing.status {
+        // Truncated: `ls` was still producing output when `head` closed the
+        // pipe, so it plainly read the directory — but "plenty of output, none
+        // of it parseable" is still unreadable, however much of it there was.
+        None if listing.truncated && !listing.entries.is_empty() => Ok((listing, None)),
+        None if listing.truncated => Err(unreadable(listing.unparsed)),
+        // No marker and no truncation: the command never got as far as
+        // reporting a status — a missing shell, a pod that isn't running, a
+        // denied exec. Whatever stderr says is the real answer.
+        None => fail(message),
+        // `ls` succeeded and had something to say, but none of it parsed:
+        // some other `ls`, or one whose columns the environment reshaped.
+        // Files whose names contain a newline: they are there, and no path
+        // sofka builds could reach them. Saying so beats an empty pane — and
+        // beats "unreadable output", because each such name also leaves its
+        // remainder behind as an unparseable line. That accounting is what
+        // tells the two apart: at most one leftover per unnameable row means
+        // these are newlines in names, more than that means the format itself
+        // is one we do not read.
+        Some(0) if listing.unnameable > 0 && listing.unparsed <= listing.unnameable => {
+            let n = listing.unnameable;
+            Ok((listing, Some(unnameable_note(n))))
+        }
+        Some(0) if listing.entries.is_empty() && listing.unparsed > 0 => {
+            Err(unreadable(listing.unparsed))
+        }
+        Some(0) => Ok((listing, None)),
+        // `ls` failed but still listed entries: it could not stat some of
+        // them. Show what there is and say why it is incomplete.
+        Some(_) if !listing.entries.is_empty() => {
+            Ok((listing, (!message.is_empty()).then_some(message)))
+        }
+        // `ls` failed with nothing to show — an unreadable directory. This is
+        // the case that must never render as "empty".
+        Some(_) => fail(message),
+    }
+}
+
+fn unnameable_note(n: usize) -> String {
+    format!(
+        "{n} entr{} here contain a newline in the name and cannot be opened or copied",
+        if n == 1 { "y" } else { "ies" }
+    )
+}
+
+fn unreadable(lines: usize) -> String {
+    format!("could not read this listing — {lines} lines of unexpected `ls` output")
+}
+
+/// The last line of stderr that says something. The real cause comes before
+/// kubectl's generic "command terminated with exit code" trailer.
+fn last_error_line(stderr: &str) -> String {
+    stderr
+        .lines()
+        .map(str::trim)
+        .rev()
+        .find(|l| !l.is_empty() && !l.starts_with("command terminated"))
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn parse_output(nonce: &str, stdout: &str) -> Listing {
+    let marker = format!("{STATUS_MARKER}{nonce}:");
+    let mut status = None;
+    let mut body = String::with_capacity(stdout.len());
+    let mut lines = 0usize;
+    for line in stdout.lines() {
+        lines += 1;
+        match line.strip_prefix(marker.as_str()) {
+            Some(code) => status = Some(code.trim().parse().unwrap_or(-1)),
+            None => {
+                body.push_str(line);
+                body.push('\n');
+            }
+        }
+    }
+    // Counted in *lines*, not entries: a file name containing a newline is
+    // several lines and one entry (or none), so counting entries would call a
+    // truncated listing complete. `head` emits at most MAX_ENTRIES + 2, so
+    // reaching that with no marker means it cut the output short.
+    let truncated = status.is_none() && lines >= MAX_ENTRIES + 2;
+    let (mut entries, unparsed, unnameable) = parse_body(&body);
+    entries.truncate(MAX_ENTRIES);
+    Listing {
+        entries,
+        unparsed,
+        unnameable,
+        truncated,
+        status,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    Dir,
+    File,
+    /// A symlink. Kept distinct from the two above because `ls -l` reports the
+    /// link's own size and type, not the target's — descending into one is
+    /// something we try, not something we can promise.
+    Link,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    pub name: String,
+    pub kind: EntryKind,
+    /// `None` when nothing could stat the entry — distinct from an empty
+    /// file, which the pane would otherwise render identically.
+    pub size: Option<u64>,
+    /// The `-> target` tail of a symlink line, for display. Empty otherwise.
+    pub link_target: String,
+}
+
+impl Entry {
+    pub fn is_dir(&self) -> bool {
+        self.kind == EntryKind::Dir
+    }
+
+    /// Whether the name survived the round trip intact. `ls` output is decoded
+    /// lossily, so a name that is not valid UTF-8 comes back with replacement
+    /// characters — it lists, but no path built from it would resolve, so
+    /// descending into it or copying it can only fail confusingly.
+    pub fn addressable(&self) -> bool {
+        !self.name.contains('\u{FFFD}')
+    }
+}
+
+/// Whether `ls` could plausibly have produced this name. A directory entry can
+/// never contain `/` and is never `.` or `..`, so anything that does is a
+/// forgery: GNU `ls` writes names raw into a pipe, which lets a file called
+/// `x\ndrwxr-xr-x 2 root root 4096 Jan 1 00:00 ..` inject a whole extra row —
+/// and a symlink *target* is arbitrary bytes, so it can carry an absolute
+/// path. Both would otherwise escape the mount on `enter` and, on download,
+/// escape the destination directory (`Path::join` with an absolute path
+/// replaces rather than appends).
+fn plausible_name(name: &str) -> bool {
+    !name.is_empty() && !name.contains('/') && name != "." && name != ".."
+}
+
+/// The container to exec into, and where the claim is mounted inside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Mount {
+    pub pod: String,
+    pub container: String,
+    pub path: String,
+    /// The mount is `readOnly` in the pod spec: writes will fail, so an upload
+    /// is refused up front instead of failing halfway through a `kubectl cp`.
+    pub read_only: bool,
+    /// sofka created this pod and owns deleting it.
+    pub helper: bool,
+}
+
+/// Pick the pod to browse `claim` through: a running pod that already mounts
+/// it. Prefers a writable mount over a read-only one, so uploads work whenever
+/// any consumer could do them at all.
+///
+/// `None` means nothing running mounts the claim — the caller's cue to offer a
+/// helper pod ([`helper_pod`]).
+pub fn find_mount(pods: &[DynamicObject], claim: &str) -> Option<Mount> {
+    let mut best: Option<Mount> = None;
+    for pod in pods {
+        if phase(pod) != "Running" {
+            continue;
+        }
+        // A pod on its way out will take the exec with it, and its volume is
+        // about to be released.
+        if pod.metadata.deletion_timestamp.is_some() {
+            continue;
+        }
+        let Some(mount) = mount_in(pod, claim) else {
+            continue;
+        };
+        if !mount.read_only {
+            return Some(mount);
+        }
+        best.get_or_insert(mount);
+    }
+    best
+}
+
+/// Names of the pod's containers that are in the `running` state right now,
+/// across all three kinds. Anything else cannot be exec'd into.
+fn running_containers(pod: &DynamicObject) -> std::collections::HashSet<&str> {
+    let Some(status) = pod.data.get("status") else {
+        return std::collections::HashSet::new();
+    };
+    [
+        "containerStatuses",
+        "initContainerStatuses",
+        "ephemeralContainerStatuses",
+    ]
+    .iter()
+    .filter_map(|k| status.get(k))
+    .filter_map(Value::as_array)
+    .flatten()
+    .filter(|c| c.get("state").is_some_and(|s| s.get("running").is_some()))
+    .filter_map(|c| c.get("name").and_then(Value::as_str))
+    .collect()
+}
+
+fn phase(pod: &DynamicObject) -> &str {
+    pod.data
+        .get("status")
+        .and_then(|s| s.get("phase"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+}
+
+/// The first container in `pod` that mounts `claim`, with its mount path.
+fn mount_in(pod: &DynamicObject, claim: &str) -> Option<Mount> {
+    let spec = pod.data.get("spec")?;
+    // Volume names are unique within a pod, so the claim resolves to at most
+    // one of them.
+    let volume = spec
+        .get("volumes")?
+        .as_array()?
+        .iter()
+        .find(|v| {
+            v.get("persistentVolumeClaim")
+                .and_then(|p| p.get("claimName"))
+                .and_then(Value::as_str)
+                == Some(claim)
+        })
+        .and_then(|v| v.get("name"))
+        .and_then(Value::as_str)?;
+
+    let mut best: Option<Mount> = None;
+    let running = running_containers(pod);
+    // Sidecars (init containers with `restartPolicy: Always`, GA since 1.29)
+    // and debug containers run alongside the app and mount the same volumes;
+    // skipping them would report a claim as unmounted and offer a helper pod
+    // for a volume that is already attached — which, for ReadWriteOnce, would
+    // then never schedule.
+    //
+    // `status.phase == "Running"` is not enough on its own to exec into any
+    // one of them: a pod in CrashLoopBackOff is `Running` with nothing to
+    // enter, and a *completed* init container is in the spec forever. Picking
+    // either would report the claim as reachable and suppress the helper-pod
+    // offer, leaving the user in a dead end — so each candidate is checked
+    // against its own status.
+    let candidates = [
+        ("containers", false),
+        ("initContainers", true),
+        ("ephemeralContainers", false),
+    ]
+    .into_iter()
+    .filter_map(|(key, sidecar_only)| Some((spec.get(key)?.as_array()?, sidecar_only)))
+    .flat_map(|(list, sidecar_only)| list.iter().map(move |c| (c, sidecar_only)));
+    for (c, sidecar_only) in candidates {
+        let Some(name) = c.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        if !running.contains(name) {
+            continue;
+        }
+        // A plain init container that happens to be running right now is
+        // mid-initialisation and about to exit; only a native sidecar stays.
+        if sidecar_only && c.get("restartPolicy").and_then(Value::as_str) != Some("Always") {
+            continue;
+        }
+        let mounts = c
+            .get("volumeMounts")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        for m in mounts {
+            if m.get("name").and_then(Value::as_str) != Some(volume) {
+                continue;
+            }
+            let Some(path) = m.get("mountPath").and_then(Value::as_str) else {
+                continue;
+            };
+            // A subPath mount shows only part of the volume, but it is still
+            // the only view that container has of it — browsing it is correct,
+            // and the alternative is refusing to browse at all.
+            let mount = Mount {
+                pod: pod.metadata.name.clone().unwrap_or_default(),
+                container: name.to_string(),
+                path: path.to_string(),
+                read_only: m.get("readOnly").and_then(Value::as_bool).unwrap_or(false),
+                helper: false,
+            };
+            if !mount.read_only {
+                return Some(mount);
+            }
+            best.get_or_insert(mount);
+        }
+    }
+    best
+}
+
+/// The helper pod sofka creates when nothing mounts the claim: one sleeping
+/// container with the volume at [`HELPER_MOUNT`], `generateName` so two
+/// sessions never collide, and two independent expiries — the shell's `sleep`
+/// and `activeDeadlineSeconds` — so the pod goes away even if sofka is killed
+/// before it can delete it.
+pub fn helper_pod(claim: &str, image: &str, ttl_secs: u64) -> Value {
+    json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "generateName": HELPER_PREFIX,
+            "labels": {
+                "app.kubernetes.io/managed-by": "sofka",
+                HELPER_LABEL.0: HELPER_LABEL.1,
+            },
+            // A label value can't hold every legal claim name (63 chars, and
+            // claims may be longer), so the claim goes in an annotation.
+            "annotations": { "sofka.dev/pvc": claim },
+        },
+        "spec": {
+            "restartPolicy": "Never",
+            "activeDeadlineSeconds": ttl_secs,
+            "terminationGracePeriodSeconds": 0,
+            "automountServiceAccountToken": false,
+            "securityContext": { "seccompProfile": { "type": "RuntimeDefault" } },
+            "containers": [{
+                "name": "explore",
+                "image": image,
+                "command": ["sh", "-c", format!("sleep {ttl_secs}")],
+                "volumeMounts": [{ "name": "pvc", "mountPath": HELPER_MOUNT }],
+                "resources": { "requests": { "cpu": "10m", "memory": "16Mi" } },
+                "securityContext": {
+                    "allowPrivilegeEscalation": false,
+                    "capabilities": { "drop": ["ALL"] },
+                },
+            }],
+            "volumes": [{
+                "name": "pvc",
+                "persistentVolumeClaim": { "claimName": claim },
+            }],
+        },
+    })
+}
+
+/// Parse `ls -A -l` output into entries, sorted directories-first then by name.
+///
+/// Both GNU coreutils and busybox lay the line out as mode, links, owner,
+/// group, size, then three date fields, then the name — so the name is
+/// everything past the eighth field, spaces and all. Device nodes replace the
+/// single size field with `major, minor`, which shifts the name by one; the
+/// mode's leading character says when that happens.
+pub fn parse_listing(stdout: &str) -> Vec<Entry> {
+    parse_body(stdout).0
+}
+
+/// [`parse_listing`], plus a count of body lines that produced no entry —
+/// the signal that separates "this directory is empty" from "this is not the
+/// `ls` output we know how to read".
+fn parse_body(stdout: &str) -> (Vec<Entry>, usize, usize) {
+    let mut out = Vec::new();
+    let mut unparsed = 0usize;
+    let mut unnameable = 0usize;
+    for line in stdout.lines() {
+        if line.is_empty() || line.starts_with("total ") {
+            continue;
+        }
+        // From here, anything that bails out is a line we could not read.
+        let Some(kind) = line.chars().next().and_then(entry_kind) else {
+            unparsed += 1;
+            continue;
+        };
+        // `ls` could not stat this entry, so it printed placeholders: the mode
+        // is all `?` and the owner/size columns collapse to one `?` each with
+        // a single `?` for the whole timestamp — six fields, not eight.
+        // Dropping the line would hide the file entirely; it exists, we just
+        // can't size it.
+        let unknown = unstattable(line);
+        let fields = match () {
+            _ if unknown => 6,
+            // Device nodes print "major, minor" where a file prints its size.
+            _ if matches!(line.as_bytes()[0], b'b' | b'c') => 9,
+            _ => 8,
+        };
+        let Some((head, rest)) = split_fields(line, fields) else {
+            unparsed += 1;
+            continue;
+        };
+        // A row whose name field is empty is a file whose name *begins* with
+        // a newline: a real file, just not one that can be named. Counted
+        // apart from `unparsed`, so a single such name neither makes a
+        // readable directory look unreadable nor lets one holding only such
+        // files read as empty.
+        if rest.is_empty() {
+            unnameable += 1;
+            continue;
+        }
+        let (name, link_target) = match kind {
+            EntryKind::Link => match rest.split_once(" -> ") {
+                Some((n, t)) => (n, t),
+                None => (rest, ""),
+            },
+            _ => (rest, ""),
+        };
+        if !plausible_name(name) {
+            unparsed += 1;
+            continue;
+        }
+        out.push(Entry {
+            name: name.to_string(),
+            kind,
+            // A directory's `ls` size is its own inode's, not the tree's;
+            // reporting it would be worse than reporting nothing.
+            size: if kind == EntryKind::Dir || unknown {
+                None
+            } else {
+                head[4].parse().ok()
+            },
+            link_target: link_target.to_string(),
+        });
+    }
+    sort_entries(&mut out);
+    (out, unparsed, unnameable)
+}
+
+/// Whether `ls` printed this row's metadata as `?` placeholders. The type
+/// character is still real (`ls` gets it from the directory entry), so only
+/// the permission bits after it are checked.
+fn unstattable(line: &str) -> bool {
+    let mode = line.split_whitespace().next().unwrap_or_default();
+    mode.len() > 1 && mode[1..].bytes().all(|b| b == b'?')
+}
+
+fn entry_kind(mode: char) -> Option<EntryKind> {
+    match mode {
+        'd' => Some(EntryKind::Dir),
+        'l' => Some(EntryKind::Link),
+        // A filesystem without `d_type` (NFS, XFS without ftype) makes `ls`
+        // print `?` for the type as well when it could not stat the entry.
+        // It is still a thing that exists on the volume.
+        '-' | 'b' | 'c' | 'p' | 's' | '?' => Some(EntryKind::File),
+        _ => None,
+    }
+}
+
+/// Split the first `n` whitespace-separated fields off `line`, returning them
+/// with the untouched remainder — which keeps any run of spaces inside a file
+/// name that `split_whitespace` would have eaten.
+fn split_fields(line: &str, n: usize) -> Option<(Vec<&str>, &str)> {
+    let mut rest = line;
+    let mut fields = Vec::with_capacity(n);
+    for _ in 0..n {
+        rest = rest.trim_start();
+        let end = rest.find(char::is_whitespace)?;
+        fields.push(&rest[..end]);
+        rest = &rest[end..];
+    }
+    // Both implementations pad *between* columns but put exactly one space
+    // before the name, so only that one is a separator: trimming the run would
+    // rename a file called " report.txt" and make one called " " vanish.
+    let mut chars = rest.chars();
+    if !chars.next()?.is_whitespace() {
+        return None;
+    }
+    Some((fields, chars.as_str()))
+}
+
+/// Directories first, then case-insensitive by name — the ordering every file
+/// manager uses, and the one that makes a deep tree navigable by eye.
+pub fn sort_entries(entries: &mut [Entry]) {
+    entries.sort_by(|a, b| {
+        b.is_dir()
+            .cmp(&a.is_dir())
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+}
+
+/// Read one local directory for the left pane. Sizes come from the metadata we
+/// already have; symlinks are reported as links without following them, so a
+/// dangling one lists instead of erroring.
+pub fn read_local(dir: &Path) -> Result<(Vec<Entry>, bool), String> {
+    let read = std::fs::read_dir(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    let mut out = Vec::new();
+    let mut truncated = false;
+    for entry in read {
+        // Capped like the remote pane, and for the same reason: a spool or
+        // cache directory with a million files would otherwise be read and
+        // sorted in full, on the UI thread, before the first frame.
+        if out.len() >= MAX_ENTRIES {
+            truncated = true;
+            break;
+        }
+        let Ok(entry) = entry else { continue };
+        // An entry we cannot stat still exists — the remote pane goes out of
+        // its way to keep those visible, so this one must not drop them.
+        let meta = entry.metadata().ok();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let kind = match meta.as_ref() {
+            Some(m) if m.file_type().is_symlink() => EntryKind::Link,
+            Some(m) if m.is_dir() => EntryKind::Dir,
+            Some(_) => EntryKind::File,
+            // `read_dir` gave us the name but not the metadata; treat it as a
+            // file of unknown size rather than pretending it isn't there.
+            None => EntryKind::File,
+        };
+        // The remote pane gets link targets from `ls -l` for free; read them
+        // here too, so both sides describe a symlink the same way.
+        let link_target = match kind {
+            EntryKind::Link => std::fs::read_link(entry.path())
+                .map(|t| t.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            _ => String::new(),
+        };
+        out.push(Entry {
+            name,
+            kind,
+            size: match (kind, meta) {
+                (EntryKind::Dir, _) => None,
+                (_, Some(m)) => Some(m.len()),
+                (_, None) => None,
+            },
+            link_target,
+        });
+    }
+    sort_entries(&mut out);
+    Ok((out, truncated))
+}
+
+/// Append `name` to `base` as a POSIX path. `base` is always absolute here —
+/// it starts at a mount path and only ever grows by one component at a time.
+pub fn join_path(base: &str, name: &str) -> String {
+    if base.ends_with('/') {
+        format!("{base}{name}")
+    } else {
+        format!("{base}/{name}")
+    }
+}
+
+/// The parent of `path`, or `None` at `root`. The browser is confined to the
+/// mount: there is nothing above it worth showing, and the rest of the
+/// container's filesystem is not what the user asked to look at.
+pub fn parent_path(path: &str, root: &str) -> Option<String> {
+    let trimmed = path.trim_end_matches('/');
+    let root_trimmed = root.trim_end_matches('/');
+    if trimmed == root_trimmed || trimmed.is_empty() {
+        return None;
+    }
+    let parent = match trimmed.rfind('/') {
+        Some(0) | None => "/".to_string(),
+        Some(i) => trimmed[..i].to_string(),
+    };
+    // A mount path deeper than "/" means the root itself has a parent we must
+    // not walk into. Compared on a path boundary, not as a bare prefix, or
+    // "/pvcx" would pass for a root of "/pvc".
+    let inside = parent == root_trimmed
+        || parent
+            .strip_prefix(root_trimmed)
+            .is_some_and(|tail| tail.starts_with('/'));
+    if !root_trimmed.is_empty() && !inside {
+        return Some(root.to_string());
+    }
+    Some(parent)
+}
+
+/// Bytes as a short human-readable size: at most three significant figures,
+/// no space before the unit. Binary units, like `ls -h` — deliberately not the
+/// PVC table's CAPACITY cell, which passes the Kubernetes quantity string
+/// (`10Gi`) through untouched.
+pub fn human_size(bytes: u64) -> String {
+    const UNITS: [&str; 6] = ["B", "K", "M", "G", "T", "P"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes}B")
+    } else if value < 10.0 {
+        format!("{value:.1}{}", UNITS[unit])
+    } else {
+        format!("{value:.0}{}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pod(v: Value) -> DynamicObject {
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn parses_gnu_and_busybox_long_listings() {
+        // First block is GNU coreutils, second is busybox — different column
+        // widths, same field order.
+        let out = "total 12\n\
+             drwxr-xr-x 2 root root 4096 Jan  1 00:00 subdir\n\
+             -rw-r--r-- 1 root root  128 Jan  1 00:00 data.json\n\
+             lrwxrwxrwx 1 root root    9 Jan  1 00:00 current -> data.json\n\
+             -rw-r--r--    1 root     root            12 Jan  1 00:00 busybox.txt\n";
+        let entries = parse_listing(out);
+        assert_eq!(
+            entries.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            ["subdir", "busybox.txt", "current", "data.json"]
+        );
+        assert_eq!(entries[0].kind, EntryKind::Dir);
+        assert_eq!(entries[1].size, Some(12));
+        let link = entries.iter().find(|e| e.name == "current").unwrap();
+        assert_eq!(link.kind, EntryKind::Link);
+        assert_eq!(link.link_target, "data.json");
+    }
+
+    #[test]
+    fn entries_ls_could_not_stat_still_list() {
+        // GNU prints placeholders for an entry it cannot stat (an NFS
+        // root_squash mount) and exits non-zero, but the rest of the listing
+        // is good — dropping the line would hide the file entirely.
+        let out = "total 0\n\
+             -????????? ? ? ? ?            ? secret.dat\n\
+             -rw-r--r-- 1 root root 12 Jan  1 00:00 readable.txt\n";
+        let entries = parse_listing(out);
+        assert_eq!(
+            entries.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            ["readable.txt", "secret.dat"]
+        );
+        assert_eq!(entries[1].size, None, "an unstattable entry has no size");
+    }
+
+    #[test]
+    fn a_link_target_containing_an_arrow_splits_at_the_first_one() {
+        let entries = parse_listing("lrwxrwxrwx 1 root root 9 Jan  1 00:00 a -> b -> c\n");
+        assert_eq!(entries[0].name, "a");
+        assert_eq!(entries[0].link_target, "b -> c");
+    }
+
+    #[test]
+    fn every_run_mints_a_fresh_nonce() {
+        assert_ne!(list_probe("/srv").nonce, list_probe("/srv").nonce);
+    }
+
+    #[test]
+    fn the_listing_script_caps_output_and_carries_ls_status() {
+        let probe = list_probe("/srv");
+        let script = probe.script;
+        assert!(
+            script.contains(&format!("exit {EXIT_NOT_A_DIRECTORY}")),
+            "{script}"
+        );
+        // The cap is applied in the pod, not after the fact…
+        assert!(
+            script.contains(&format!("head -n {}", MAX_ENTRIES + 2)),
+            "{script}"
+        );
+        // …which costs the pipeline's status, so `ls`'s own is echoed, keyed
+        // by a nonce a file name on the volume cannot predict.
+        assert!(
+            script.contains(&format!("{STATUS_MARKER}{}:", probe.nonce)),
+            "{script}"
+        );
+        // The path is only ever "$1" — never interpolated into the script.
+        assert!(script.contains(r#"cd -- "$1""#), "{script}");
+    }
+
+    #[test]
+    fn leading_spaces_belong_to_the_file_name() {
+        // `ls` pads *between* columns but puts exactly one space before the
+        // name, so a name that starts with a space is data, not padding.
+        // Trimming the run renamed " report.txt" and made " " vanish while the
+        // local pane still showed it.
+        let entries = parse_listing(
+            "-rw-r--r-- 1 root root 0 Jan  1 00:00  report.txt\n\
+             -rw-r--r-- 1 root root 0 Jan  1 00:00   two\n\
+             -rw-r--r-- 1 root root 0 Jan  1 00:00  \n",
+        );
+        assert_eq!(
+            entries.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            [" ", "  two", " report.txt"]
+        );
+    }
+
+    #[test]
+    fn read_local_sorts_keeps_and_caps_like_the_remote_pane() {
+        let dir = std::env::temp_dir().join(format!("sofka-read-local-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("Beta")).unwrap();
+        std::fs::create_dir_all(dir.join("alpha")).unwrap();
+        std::fs::write(dir.join("z.txt"), b"hello").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("z.txt", dir.join("link")).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("nowhere", dir.join("dangling")).unwrap();
+
+        let (entries, truncated) = read_local(&dir).expect("readable");
+        assert!(!truncated);
+        // Directories first, then case-insensitive by name.
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(&names[..2], ["alpha", "Beta"]);
+        assert!(entries[0].is_dir() && entries[1].is_dir());
+        assert_eq!(entries[0].size, None, "a directory reports no size");
+
+        let file = entries.iter().find(|e| e.name == "z.txt").unwrap();
+        assert_eq!(file.size, Some(5));
+
+        #[cfg(unix)]
+        {
+            let link = entries.iter().find(|e| e.name == "link").unwrap();
+            assert_eq!(link.kind, EntryKind::Link);
+            assert_eq!(link.link_target, "z.txt", "both panes describe links alike");
+            // A dangling link still lists — `DirEntry::metadata` is `lstat`
+            // on Unix, so it describes the link itself, exactly as `ls -l`
+            // does on the other side rather than following it to nowhere.
+            let dangling = entries.iter().find(|e| e.name == "dangling").unwrap();
+            assert_eq!(dangling.kind, EntryKind::Link);
+            assert_eq!(dangling.link_target, "nowhere");
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_local_stops_at_the_cap() {
+        let dir = std::env::temp_dir().join(format!("sofka-read-cap-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        for i in 0..MAX_ENTRIES + 5 {
+            std::fs::write(dir.join(format!("f{i:05}")), b"").unwrap();
+        }
+        let (entries, truncated) = read_local(&dir).expect("readable");
+        assert_eq!(entries.len(), MAX_ENTRIES);
+        assert!(truncated, "the local pane must cap like the remote one");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_local_reports_a_directory_it_cannot_open() {
+        let missing = std::env::temp_dir().join("sofka-does-not-exist-9e3f");
+        assert!(read_local(&missing).is_err());
+
+        // The case that actually happens on a volume: the directory is there,
+        // the process just cannot read it. Never an empty listing.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = std::env::temp_dir().join(format!("sofka-noread-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("hidden"), b"x").unwrap();
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+            // Running as root would read it anyway, and the assertion would be
+            // about the test environment rather than the code.
+            if std::fs::read_dir(&dir).is_err() {
+                let err = read_local(&dir).unwrap_err();
+                assert!(err.contains(&dir.display().to_string()), "{err}");
+            }
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).ok();
+            std::fs::remove_dir_all(&dir).ok();
+        }
+    }
+
+    #[test]
+    fn keeps_spaces_inside_file_names() {
+        let entries = parse_listing("-rw-r--r-- 1 root root 5 Jan  1 00:00 two  words.txt\n");
+        assert_eq!(entries[0].name, "two  words.txt");
+    }
+
+    #[test]
+    fn device_nodes_do_not_shift_the_name() {
+        // "1, 3" occupies two fields where a regular file has one.
+        let entries = parse_listing("crw-rw-rw- 1 root root 1, 3 Jan  1 00:00 null\n");
+        assert_eq!(entries[0].name, "null");
+        assert_eq!(entries[0].kind, EntryKind::File);
+    }
+
+    /// A pod spec plus the container statuses that say it is actually up —
+    /// `find_mount` needs both, since `status.phase` alone says nothing about
+    /// whether any individual container can be exec'd into.
+    fn running_pod(name: &str, claim: &str, containers: Value, statuses: Value) -> DynamicObject {
+        pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": name, "namespace": "default"},
+            "spec": {
+                "volumes": [{"name": "vol", "persistentVolumeClaim": {"claimName": claim}}],
+                "containers": containers,
+            },
+            "status": {"phase": "Running", "containerStatuses": statuses},
+        }))
+    }
+
+    fn mounted(name: &str, path: &str, read_only: bool) -> Value {
+        json!([{ "name": name, "volumeMounts": [
+            {"name": "vol", "mountPath": path, "readOnly": read_only}]}])
+    }
+
+    fn up(name: &str) -> Value {
+        json!([{ "name": name, "state": {"running": {"startedAt": "2026-01-01T00:00:00Z"}} }])
+    }
+
+    #[test]
+    fn find_mount_prefers_a_writable_running_consumer() {
+        let ro = pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "reader", "namespace": "default"},
+            "spec": {
+                "volumes": [{"name": "data", "persistentVolumeClaim": {"claimName": "shared"}}],
+                "containers": [{"name": "app", "volumeMounts": [
+                    {"name": "data", "mountPath": "/data", "readOnly": true}]}],
+            },
+            "status": {"phase": "Running", "containerStatuses": up("app")},
+        }));
+        let rw = running_pod("writer", "shared", mounted("app", "/srv", false), up("app"));
+        let found = find_mount(&[ro, rw], "shared").expect("a consumer");
+        assert_eq!(found.pod, "writer");
+        assert_eq!(found.path, "/srv");
+        assert!(!found.read_only);
+    }
+
+    #[test]
+    fn find_mount_ignores_pods_that_are_not_running() {
+        let pending = pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "pending", "namespace": "default"},
+            "spec": {
+                "volumes": [{"name": "vol", "persistentVolumeClaim": {"claimName": "shared"}}],
+                "containers": [{"name": "app", "volumeMounts": [
+                    {"name": "vol", "mountPath": "/srv"}]}],
+            },
+            "status": {"phase": "Pending"},
+        }));
+        assert!(find_mount(&[pending], "shared").is_none());
+    }
+
+    #[test]
+    fn find_mount_ignores_a_claim_the_pod_does_not_use() {
+        let other = running_pod(
+            "other",
+            "elsewhere",
+            mounted("app", "/srv", false),
+            up("app"),
+        );
+        assert!(find_mount(&[other], "shared").is_none());
+    }
+
+    #[test]
+    fn a_crashlooping_pod_is_not_a_way_into_the_volume() {
+        // The pod is `Running`; its only container is not. Exec would fail
+        // with "container not running", and returning it here would suppress
+        // the helper-pod offer and leave the user in a dead end.
+        let crashing = pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "crasher", "namespace": "default"},
+            "spec": {
+                "volumes": [{"name": "vol", "persistentVolumeClaim": {"claimName": "shared"}}],
+                "containers": [{"name": "app", "volumeMounts": [
+                    {"name": "vol", "mountPath": "/srv"}]}],
+            },
+            "status": {"phase": "Running", "containerStatuses": [
+                {"name": "app", "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]},
+        }));
+        assert!(find_mount(&[crashing], "shared").is_none());
+    }
+
+    #[test]
+    fn a_finished_init_container_is_not_a_way_into_the_volume() {
+        // `initContainers` stays in the spec forever. The seed container has
+        // exited; only the app container is up, and it mounts nothing.
+        let seeded = pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "seeded", "namespace": "default"},
+            "spec": {
+                "volumes": [{"name": "vol", "persistentVolumeClaim": {"claimName": "shared"}}],
+                "initContainers": [{"name": "seed", "volumeMounts": [
+                    {"name": "vol", "mountPath": "/seed"}]}],
+                "containers": [{"name": "app"}],
+            },
+            "status": {"phase": "Running",
+                       "containerStatuses": up("app"),
+                       "initContainerStatuses": [
+                           {"name": "seed", "state": {"terminated": {"exitCode": 0}}}]},
+        }));
+        assert!(find_mount(&[seeded], "shared").is_none());
+    }
+
+    #[test]
+    fn a_running_sidecar_is_a_way_into_the_volume() {
+        // A native sidecar — an init container with `restartPolicy: Always`,
+        // GA since 1.29 — runs for the pod's whole life and mounts the volume.
+        let sidecar = pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "with-sidecar", "namespace": "default"},
+            "spec": {
+                "volumes": [{"name": "vol", "persistentVolumeClaim": {"claimName": "shared"}}],
+                "initContainers": [{"name": "log-shipper", "restartPolicy": "Always",
+                                    "volumeMounts": [{"name": "vol", "mountPath": "/logs"}]}],
+                "containers": [{"name": "app"}],
+            },
+            "status": {"phase": "Running",
+                       "containerStatuses": up("app"),
+                       "initContainerStatuses": up("log-shipper")},
+        }));
+        let found = find_mount(&[sidecar], "shared").expect("the sidecar mounts it");
+        assert_eq!(found.container, "log-shipper");
+        assert_eq!(found.path, "/logs");
+    }
+
+    #[test]
+    fn a_running_ephemeral_container_is_a_way_into_the_volume() {
+        let debugged = pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "debugged", "namespace": "default"},
+            "spec": {
+                "volumes": [{"name": "vol", "persistentVolumeClaim": {"claimName": "shared"}}],
+                "containers": [{"name": "app"}],
+                "ephemeralContainers": [{"name": "debugger", "volumeMounts": [
+                    {"name": "vol", "mountPath": "/mnt"}]}],
+            },
+            "status": {"phase": "Running",
+                       "containerStatuses": up("app"),
+                       "ephemeralContainerStatuses": up("debugger")},
+        }));
+        let found = find_mount(&[debugged], "shared").expect("the debugger mounts it");
+        assert_eq!(found.container, "debugger");
+    }
+
+    #[test]
+    fn find_mount_skips_a_pod_on_its_way_out() {
+        // Its exec would be torn down with it, and its volume released.
+        let dying = pod(json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "dying", "namespace": "default",
+                         "deletionTimestamp": "2026-01-01T00:00:00Z"},
+            "spec": {
+                "volumes": [{"name": "vol", "persistentVolumeClaim": {"claimName": "shared"}}],
+                "containers": [{"name": "app", "volumeMounts": [
+                    {"name": "vol", "mountPath": "/srv"}]}],
+            },
+            "status": {"phase": "Running", "containerStatuses": up("app")},
+        }));
+        assert!(find_mount(&[dying], "shared").is_none());
+    }
+
+    const NONCE: &str = "0123456789abcdef0";
+
+    /// Build the stdout a complete run would produce.
+    fn output(body: &str, status: i32) -> String {
+        format!("{body}sofka-ls-status:{NONCE}:{status}\n")
+    }
+
+    fn interpret(
+        exit_code: Option<i32>,
+        stdout: &str,
+        stderr: &str,
+    ) -> Result<(Listing, Option<String>), String> {
+        interpret_listing(NONCE, exit_code, stdout, stderr)
+    }
+
+    /// `ls -l` lines for `n` plain files, as GNU emits them into a pipe.
+    fn files(n: usize) -> String {
+        (0..n)
+            .map(|i| format!("-rw-r--r-- 1 root root 1 Jan  1 00:00 f{i}\n"))
+            .collect()
+    }
+
+    #[test]
+    fn an_unreadable_directory_is_an_error_not_an_empty_one() {
+        // Real busybox and GNU behaviour for a directory with mode 0111: `cd`
+        // succeeds, `ls` writes only "total 0" and fails. Rendering that as
+        // "empty" would tell the user their volume has nothing on it.
+        let err = interpret(
+            Some(0),
+            &output("total 0\n", 1),
+            "ls: can't open '.': Permission denied\n",
+        )
+        .expect_err("an unreadable directory must not read as empty");
+        assert!(err.contains("Permission denied"), "{err}");
+    }
+
+    #[test]
+    fn a_partly_unstattable_directory_lists_with_a_warning() {
+        let (listing, warn) = interpret(
+            Some(0),
+            &output(
+                "total 0\n\
+                 -????????? ? ? ? ?            ? locked\n\
+                 -rw-r--r-- 1 root root 12 Jan  1 00:00 fine.txt\n",
+                1,
+            ),
+            "ls: cannot access 'locked': Permission denied\n",
+        )
+        .expect("entries came back, so this is a partial success");
+        assert_eq!(listing.entries.len(), 2);
+        assert!(!listing.truncated);
+        assert!(warn.is_some_and(|w| w.contains("Permission denied")));
+    }
+
+    #[test]
+    fn a_command_that_never_ran_is_an_error_even_with_empty_output() {
+        // No marker and no truncation: `sh`/`ls` never reported a status —
+        // a missing binary, a pod that isn't running, a denied exec.
+        let err = interpret(Some(126), "", "sh: ls: not found\n")
+            .expect_err("a failed exec must not read as an empty directory");
+        assert!(err.contains("not found"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_marker_with_a_full_buffer_means_truncated_not_failed() {
+        // `head` closed the pipe before `ls` could print the marker.
+        let body = files(MAX_ENTRIES + 2);
+        let (listing, warn) = interpret(Some(0), &body, "").expect("a truncated listing");
+        assert!(listing.truncated);
+        assert_eq!(listing.entries.len(), MAX_ENTRIES);
+        assert!(warn.is_none());
+    }
+
+    #[test]
+    fn a_file_name_cannot_forge_the_status_marker() {
+        // GNU `ls` prints names raw into a pipe, so a file called
+        // "evil\nsofka-ls-status:0" puts a marker-shaped line through — before
+        // the real marker, which `head` then cuts. Without the nonce that
+        // makes a truncated listing claim to be complete.
+        let mut body = String::from("-rw-r--r-- 1 root root 1 Jan  1 00:00 evil\n");
+        body.push_str("sofka-ls-status:0\n");
+        body.push_str(&files(MAX_ENTRIES + 1));
+        let (listing, _) = interpret(Some(0), &body, "").expect("a listing");
+        assert!(
+            listing.truncated,
+            "a forged marker made a truncated listing look complete"
+        );
+        assert!(listing.status.is_none());
+    }
+
+    #[test]
+    fn names_containing_newlines_do_not_fake_truncation() {
+        // Truncation is measured in lines, not parsed entries: 3000 files
+        // whose names contain a newline are 6000 lines and 3000 entries, and
+        // `ls` read the directory perfectly.
+        let body: String = (0..3_000)
+            .map(|i| format!("-rw-r--r-- 1 root root 1 Jan  1 00:00 a{i}\nb{i}\n"))
+            .collect();
+        let (listing, warn) = interpret(Some(0), &output(&body, 0), "").expect("a clean listing");
+        assert!(!listing.truncated, "a complete listing reported truncation");
+        assert!(warn.is_none());
+    }
+
+    #[test]
+    fn an_unreadable_ls_format_is_an_error_not_an_empty_directory() {
+        // GNU `ls` honours TIME_STYLE from the container's environment, and
+        // `long-iso` prints a two-field date where the parser expects three —
+        // shifting the name column so nothing parses. The script unsets it,
+        // but any other `ls` (toybox, a future format) does the same, and
+        // reporting a full volume as "empty" is the one outcome to avoid.
+        let err = interpret(
+            Some(0),
+            &output(
+                "total 8\n\
+                 -rw-r--r-- 1 root root 3 2026-09-06 22:24 plain.txt\n\
+                 drwxr-xr-x 2 root root 4096 2026-09-06 22:24 sub\n",
+                0,
+            ),
+            "",
+        )
+        .expect_err("an unparseable listing must not read as empty");
+        assert!(err.contains("unexpected `ls` output"), "{err}");
+    }
+
+    #[test]
+    fn a_truncated_listing_that_parsed_to_nothing_is_still_an_error() {
+        // Plenty of output, none of it in a shape we read. "Unreadable" does
+        // not become "empty" just because there was a lot of it.
+        let body: String = (0..MAX_ENTRIES + 2)
+            .map(|i| format!("-rw-r--r-- 1 root root 3 2026-09-06 22:24 f{i}\n"))
+            .collect();
+        let err = interpret(Some(0), &body, "").unwrap_err();
+        assert!(err.contains("unexpected `ls` output"), "{err}");
+    }
+
+    #[test]
+    fn a_name_beginning_with_a_newline_is_reported_as_such_not_as_garbage() {
+        // The head row carries the metadata and no name; the remainder lands
+        // on the next line and cannot be parsed. One leftover per unnameable
+        // row is the signature of a newline in a name — more than that is a
+        // format we do not read, which is a different message.
+        let (listing, warn) = interpret(
+            Some(0),
+            &output("total 0\n-rw-r--r-- 1 root root 0 Jan  1 00:00 \nfoo\n", 0),
+            "",
+        )
+        .expect("readable, just unnameable");
+        assert_eq!(listing.unnameable, 1);
+        assert_eq!(listing.unparsed, 1, "the name's remainder");
+        assert!(warn.is_some_and(|w| w.contains("newline")), "wrong message");
+    }
+
+    #[test]
+    fn one_empty_name_row_does_not_excuse_a_garbage_listing() {
+        // The negative side of the `unparsed <= unnameable` guard: a format we
+        // cannot read stays an error even when one row happens to look like a
+        // newline-leading name.
+        let err = interpret(
+            Some(0),
+            &output(
+                "total 0\n\
+                 -rw-r--r-- 1 root root 0 Jan  1 00:00 \n\
+                 -rw-r--r-- 1 root root 3 2026-09-06 22:24 a.txt\n\
+                 -rw-r--r-- 1 root root 3 2026-09-06 22:24 b.txt\n",
+                0,
+            ),
+            "",
+        )
+        .unwrap_err();
+        assert!(err.contains("unexpected `ls` output"), "{err}");
+    }
+
+    #[test]
+    fn a_directory_of_only_unnameable_files_is_not_empty() {
+        // Its one file is named "\n": `ls` prints a row with no name and then
+        // the tail. Nothing parses, but the directory is neither unreadable
+        // nor empty — it holds a file sofka has no way to name.
+        let (listing, warn) = interpret(
+            Some(0),
+            &output("total 0\n-rw-r--r-- 1 root root 0 Jan  1 00:00 \n\n", 0),
+            "",
+        )
+        .expect("readable, just unnameable");
+        assert!(listing.entries.is_empty());
+        assert_eq!(listing.unnameable, 1);
+        assert!(
+            warn.is_some_and(|w| w.contains("newline")),
+            "the pane would have said 'empty'"
+        );
+    }
+
+    #[test]
+    fn one_name_containing_a_newline_does_not_make_a_directory_unreadable() {
+        // The tail of such a name is a row with no name field of its own.
+        // Counting it as unparseable would let a single adversarial file name
+        // hide a directory that `ls` read perfectly.
+        let (listing, warn) = interpret(
+            Some(0),
+            &output(
+                "total 0\n\
+                 -rw-r--r-- 1 root root 0 Jan  1 00:00 \n\
+                 tail-of-the-name\n\
+                 -rw-r--r-- 1 root root 3 Jan  1 00:00 real.txt\n",
+                0,
+            ),
+            "",
+        )
+        .expect("the directory is readable");
+        assert!(listing.entries.iter().any(|e| e.name == "real.txt"));
+        // The readable entry is listed, and the one that cannot be named is
+        // reported rather than silently dropped.
+        assert!(warn.is_some_and(|w| w.contains("newline")));
+    }
+
+    #[test]
+    fn a_genuinely_empty_directory_is_still_empty() {
+        let (listing, warn) = interpret(Some(0), &output("total 0\n", 0), "").expect("a listing");
+        assert!(listing.entries.is_empty());
+        assert_eq!(listing.unparsed, 0);
+        assert!(warn.is_none());
+    }
+
+    #[test]
+    fn the_listing_script_pins_the_output_format_and_needs_both_paths() {
+        let script = list_probe("/srv").script;
+        // GNU `ls` reshapes its columns from the environment; a container
+        // exporting TIME_STYLE would otherwise make every entry unparseable.
+        // GNU `ls` takes its date format, its quoting and its size units from
+        // the environment; a container that exports any of them would make the
+        // listing unparseable, unaddressable, or silently misreport sizes.
+        let unset = script
+            .lines()
+            .find(|l| l.starts_with("unset "))
+            .expect("the script unsets nothing");
+        for var in ["TIME_STYLE", "QUOTING_STYLE", "BLOCK_SIZE", "LS_BLOCK_SIZE"] {
+            assert!(unset.contains(var), "{var} is not unset: {unset}");
+        }
+        // `cd ""` succeeds in dash and busybox ash, so neither argument may
+        // be allowed through empty.
+        assert!(script.contains(r#"[ -n "$1" ] && [ -n "$2" ]"#), "{script}");
+    }
+
+    #[test]
+    fn a_complete_listing_reports_no_truncation() {
+        let (listing, warn) = interpret(
+            Some(0),
+            &output("total 0\n-rw-r--r-- 1 root root 1 Jan  1 00:00 a\n", 0),
+            "",
+        )
+        .expect("a clean listing");
+        assert_eq!(listing.entries.len(), 1);
+        assert!(!listing.truncated);
+        assert!(warn.is_none());
+    }
+
+    #[test]
+    fn a_path_that_is_not_a_directory_says_so() {
+        let err = interpret(Some(EXIT_NOT_A_DIRECTORY), "", "").unwrap_err();
+        assert!(err.contains("not a directory"), "{err}");
+    }
+
+    #[test]
+    fn a_file_name_cannot_inject_a_row_that_escapes_the_mount() {
+        // Exactly what GNU `ls` writes into a pipe for a directory holding a
+        // file called "x\ndrwxr-xr-x 2 root root 4096 Jan  1 00:00 ..": names
+        // go through raw, so the second half arrives as its own row.
+        let entries = parse_listing(
+            "total 4\n\
+             -rw-r--r-- 1 root root    0 Jan  1 00:00 x\n\
+             drwxr-xr-x 2 root root 4096 Jan  1 00:00 ..\n",
+        );
+        assert_eq!(
+            entries.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            ["x"],
+            "a forged '..' row would walk the browser out of the mount"
+        );
+    }
+
+    #[test]
+    fn a_symlink_target_cannot_inject_an_absolute_path() {
+        // A link target is arbitrary bytes, so unlike a file name it can carry
+        // "/" — and `Path::join` with an absolute path replaces rather than
+        // appends, which on download would write anywhere on the local disk.
+        let entries = parse_listing(
+            "lrwxrwxrwx 1 root root 51 Jan  1 00:00 evil -> t\n\
+             -rw-r--r-- 1 root root  7 Jan  1 00:00 /etc/passwd\n",
+        );
+        assert_eq!(
+            entries.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            ["evil"]
+        );
+    }
+
+    #[test]
+    fn relative_and_separator_bearing_names_never_survive() {
+        for forged in [
+            "..",
+            ".",
+            "a/b",
+            "/etc/passwd",
+            "../../.ssh/authorized_keys",
+        ] {
+            let line = format!("-rw-r--r-- 1 root root 1 Jan  1 00:00 {forged}\n");
+            assert!(
+                parse_listing(&line).is_empty(),
+                "{forged:?} survived parsing"
+            );
+        }
+        // …while a name that merely contains a dot is ordinary.
+        assert_eq!(
+            parse_listing("-rw-r--r-- 1 root root 1 Jan  1 00:00 ..hidden\n")[0].name,
+            "..hidden"
+        );
+    }
+
+    #[test]
+    fn a_link_that_leaves_the_mount_is_refused_by_its_own_exit_code() {
+        let err = interpret(Some(EXIT_OUTSIDE_MOUNT), "", "").unwrap_err();
+        assert!(err.contains("outside the volume"), "{err}");
+    }
+
+    #[test]
+    fn the_listing_script_resolves_both_sides_before_comparing_them() {
+        let probe = list_probe("/srv");
+        // A mount path can itself sit behind a symlink; comparing the raw
+        // strings would refuse the mount's own root.
+        assert!(
+            probe
+                .script
+                .contains(r#"root=$(cd -- "$2" 2>/dev/null && pwd -P)"#)
+        );
+        assert!(
+            probe
+                .script
+                .contains(r#"case "$(pwd -P)" in "$root"|"$root"/*)"#)
+        );
+        assert!(probe.script.contains(&format!("exit {EXIT_OUTSIDE_MOUNT}")));
+        assert_eq!(probe.root, "/srv");
+    }
+
+    #[test]
+    fn parent_path_stops_at_the_mount_root() {
+        assert_eq!(parent_path("/pvc/a/b", "/pvc").as_deref(), Some("/pvc/a"));
+        assert_eq!(parent_path("/pvc/a", "/pvc").as_deref(), Some("/pvc"));
+        assert_eq!(parent_path("/pvc", "/pvc"), None);
+        assert_eq!(parent_path("/pvc/", "/pvc"), None);
+        // A one-component root: the parent of its child is the root, not "/".
+        assert_eq!(parent_path("/data/x", "/data").as_deref(), Some("/data"));
+    }
+
+    #[test]
+    fn join_path_does_not_double_the_separator() {
+        assert_eq!(join_path("/pvc", "a"), "/pvc/a");
+        assert_eq!(join_path("/", "a"), "/a");
+    }
+
+    #[test]
+    fn human_size_keeps_three_significant_figures() {
+        assert_eq!(human_size(0), "0B");
+        assert_eq!(human_size(512), "512B");
+        assert_eq!(human_size(1536), "1.5K");
+        assert_eq!(human_size(1024 * 1024 * 20), "20M");
+    }
+
+    #[test]
+    fn helper_pod_mounts_the_claim_and_expires_twice() {
+        let spec = helper_pod("data", "busybox:1.37", 900);
+        assert_eq!(spec["spec"]["activeDeadlineSeconds"], 900);
+        assert_eq!(spec["spec"]["containers"][0]["command"][2], "sleep 900");
+        assert_eq!(
+            spec["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"],
+            "data"
+        );
+        assert_eq!(
+            spec["spec"]["containers"][0]["volumeMounts"][0]["mountPath"],
+            HELPER_MOUNT
+        );
+        assert_eq!(spec["metadata"]["generateName"], HELPER_PREFIX);
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,6 +10,11 @@ use kube::core::DynamicObject;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct StatusClaim(pub(crate) u64);
 
+/// One remote directory read, or why there isn't one. Named because the
+/// tuple inside the `Result` would otherwise need a type-complexity waiver
+/// every time it is written out.
+pub type PvcListingResult = Result<(crate::pvcexplore::Listing, Option<String>), String>;
+
 /// Messages flowing from watch tasks to the UI loop. Tagged with a
 /// `generation` so messages from a superseded watch can be discarded.
 pub enum Msg {
@@ -189,6 +194,39 @@ pub enum Msg {
         claim: StatusClaim,
         deleted: usize,
         failed: Vec<String>,
+    },
+    /// Result of a `:pvc-clean` sweep for leftover PVC-explore helper pods.
+    PvcHelpersCleaned {
+        generation: u64,
+        claim: StatusClaim,
+        deleted: usize,
+        failed: Vec<String>,
+    },
+    /// The pod a PVC can be browsed through, resolved off-thread. `Ok(None)`
+    /// means nothing running mounts the claim — the cue to offer a helper pod.
+    PvcTarget {
+        generation: u64,
+        /// Matched against the browser's own counter so a resolve for a claim
+        /// the user has already navigated away from is dropped.
+        run: u64,
+        /// Namespace the resolve ran in, so a helper pod that arrives after
+        /// the browser moved on can still be deleted rather than leaked.
+        namespace: String,
+        /// Context it ran against. A `:ctx` switch bumps the generation *and*
+        /// swaps the client, so a late helper is only safe to delete when this
+        /// still names the cluster it was created in.
+        context: String,
+        claim: StatusClaim,
+        result: Result<Option<crate::pvcexplore::Mount>, String>,
+    },
+    /// One directory listing for the remote pane of the PVC browser.
+    PvcListing {
+        generation: u64,
+        run: u64,
+        path: String,
+        /// The listing, plus a warning when `ls` produced it but could not
+        /// stat every entry in it.
+        result: PvcListingResult,
     },
     /// An assembled diagnostic bundle (`:bundle`), ready to preview and save.
     Bundle {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::widgets::{
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::app::{App, DEFAULT_SORT_LABEL, Mode, SuggestKind, TRANSFER_MENU_ITEMS};
+use crate::app::{App, DEFAULT_SORT_LABEL, Mode, Pane, SuggestKind, TRANSFER_MENU_ITEMS};
 use crate::{columns, theme};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -152,6 +152,14 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
         Mode::Fleet => draw_fleet(frame, app, chunks[1]),
         Mode::Find => draw_find(frame, app, chunks[1]),
+        Mode::PvcExplore => draw_pvc_explore(frame, app, chunks[1]),
+        // A transfer confirmation or a guardrail prompt raised from the PVC
+        // browser keeps the two panes underneath it, so you can still see what
+        // is being copied where. Only that dialog: drawing an unrelated one
+        // over the panes would suggest it was about them.
+        Mode::Confirm | Mode::Prompt if app.over_pvc_browser() => {
+            draw_pvc_explore(frame, app, chunks[1])
+        }
         // While the palette is open, keep drawing the view it was opened
         // from, so a global `:` never flashes the table underneath it.
         Mode::Command => match app.palette_return {
@@ -168,6 +176,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             Mode::PortForwards => draw_port_forwards(frame, app, chunks[1]),
             Mode::Fleet => draw_fleet(frame, app, chunks[1]),
             Mode::Find => draw_find(frame, app, chunks[1]),
+            Mode::PvcExplore => draw_pvc_explore(frame, app, chunks[1]),
             Mode::Containers => {
                 draw_table(frame, app, chunks[1]);
                 draw_containers(frame, app, chunks[1]);
@@ -510,6 +519,11 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
         "secrets" => vec![
             hint_line(&[("x", "decode"), ("y", "yaml"), ("d", "describe")]),
             hint_line(&[("e", "edit"), ("E", "events"), ("c", "copy name")]),
+            hint_line(&[("^d", "delete")]),
+        ],
+        "persistentvolumeclaims" => vec![
+            hint_line(&[("x", "browse"), ("s", "shell"), ("d", "describe")]),
+            hint_line(&[("y", "yaml"), ("E", "events"), ("c", "copy name")]),
             hint_line(&[("^d", "delete")]),
         ],
         _ => vec![
@@ -2156,7 +2170,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind(
             "x",
-            "secrets: show data base64-decoded (also inside YAML/describe)",
+            "secrets: show data base64-decoded (also inside YAML/describe) · PVCs: browse the volume",
         ),
         bind(
             "shift-x · :explain",
@@ -2181,7 +2195,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(Span::styled("  Act", theme::title())),
         bind("e", "edit in $EDITOR (kubectl edit)"),
-        bind("s", "shell into pod / scale workload"),
+        bind("s", "shell into pod / PVC volume · scale workload"),
         bind("a", "attach to pod"),
         bind(
             ":debug",
@@ -2217,6 +2231,28 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         bind(
             "ctrl-d · ctrl-k",
             "delete · force-delete (in confirm: f force, c cascade)",
+        ),
+        Line::from(""),
+        Line::from(Span::styled("  PVC explore (x on a PVC)", theme::title())),
+        bind(
+            "x · s · :pvc-explore",
+            "browse the volume (local left, PVC right; also :pvc-browse) · shell into it at the mount point",
+        ),
+        bind(
+            "tab · ←/→",
+            "switch pane · j/k g/G move · ⏎ open directory · ⌫ or - go up (stops at the mount)",
+        ),
+        bind(
+            "esc · q",
+            "close the browser (and delete the helper pod, if any)",
+        ),
+        bind(
+            "c · r",
+            "copy the selection into the other pane (download or upload) · refresh both",
+        ),
+        bind(
+            ":pvc-clean",
+            "delete helper pods left behind by a session that exited uncleanly (:pvc-cleanup)",
         ),
         Line::from(""),
         Line::from(Span::styled("  Logs view", theme::title())),
@@ -3264,6 +3300,193 @@ fn draw_gitops(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+/// The PVC browser: local files on the left, the volume on the right, one
+/// cursor per pane and a copy that always runs from the focused pane into the
+/// other one.
+fn draw_pvc_explore(frame: &mut Frame, app: &mut App, area: Rect) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    let local_title = format!(" local · {} ", app.pvc.local_path.display());
+    let mut remote_title = format!(" {} · {} ", app.pvc.claim, app.pvc.remote_path);
+    if let Some(mount) = &app.pvc.mount {
+        if mount.helper {
+            remote_title.push_str("· helper pod ");
+        } else {
+            remote_title.push_str(&format!("· via {} ", mount.pod));
+        }
+        if mount.read_only {
+            remote_title.push_str("· read-only ");
+        }
+    }
+    if app.pvc.loading {
+        remote_title.push_str("· loading… ");
+    }
+
+    let local_items = pvc_pane_items(
+        &app.pvc.local,
+        app.pvc.local_error.as_deref(),
+        cols[0].width,
+        app.pvc.local_truncated,
+    );
+    let remote_items = pvc_pane_items(
+        &app.pvc.remote,
+        app.pvc.remote_error.as_deref(),
+        cols[1].width,
+        app.pvc.truncated,
+    );
+    let focus = app.pvc.focus;
+
+    render_pvc_pane(
+        frame,
+        cols[0],
+        local_items,
+        local_title,
+        &mut app.pvc.local_state,
+        focus == Pane::Local,
+    );
+    render_pvc_pane(
+        frame,
+        cols[1],
+        remote_items,
+        remote_title,
+        &mut app.pvc.remote_state,
+        focus == Pane::Remote,
+    );
+}
+
+fn render_pvc_pane(
+    frame: &mut Frame,
+    area: Rect,
+    items: Vec<ListItem<'static>>,
+    title: String,
+    state: &mut ListState,
+    focused: bool,
+) {
+    let (border, title_style) = if focused {
+        (theme::border_focused(), theme::title())
+    } else {
+        (theme::border(), theme::dim())
+    };
+    let list = List::new(items)
+        .highlight_style(if focused {
+            theme::selected_row()
+        } else {
+            // The unfocused pane keeps its cursor visible but quiet, so you
+            // can see where a copy would land without it competing for
+            // attention with the pane you are driving.
+            Style::default().add_modifier(Modifier::REVERSED)
+        })
+        .highlight_symbol("▌ ")
+        .highlight_spacing(HighlightSpacing::Always)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(border)
+                .title(Span::styled(title, title_style)),
+        );
+    frame.render_stateful_widget(list, area, state);
+}
+
+/// One pane's rows. Sizes are right-aligned against the pane width so both
+/// sides line up as a pair of columns rather than two ragged lists.
+fn pvc_pane_items(
+    entries: &[crate::pvcexplore::Entry],
+    error: Option<&str>,
+    width: u16,
+    truncated: bool,
+) -> Vec<ListItem<'static>> {
+    use crate::pvcexplore::EntryKind;
+
+    if let Some(e) = error {
+        return vec![ListItem::new(Line::from(Span::styled(
+            e.to_string(),
+            Style::default().fg(theme::red()),
+        )))];
+    }
+    if entries.is_empty() {
+        return vec![ListItem::new(Line::from(Span::styled(
+            "empty".to_string(),
+            theme::dim(),
+        )))];
+    }
+    // 2 borders + the 2-cell highlight symbol.
+    let inner = usize::from(width).saturating_sub(4);
+    let size_width = 8usize;
+    let name_width = inner.saturating_sub(size_width + 1).max(4);
+
+    let mut items: Vec<ListItem<'static>> = entries
+        .iter()
+        .map(|e| {
+            let (label, color) = match e.kind {
+                EntryKind::Dir => (format!("{}/", e.name), theme::sapphire()),
+                EntryKind::Link if !e.link_target.is_empty() => {
+                    (format!("{} → {}", e.name, e.link_target), theme::teal())
+                }
+                EntryKind::Link => (e.name.clone(), theme::teal()),
+                EntryKind::File => (e.name.clone(), theme::text()),
+            };
+            // Padded by terminal columns, not characters: a CJK filename is
+            // twice as wide as it is long, and `{:<n}` would push the size
+            // column through the pane border.
+            let label = clip_to_width(&label, name_width);
+            let pad = name_width.saturating_sub(label.width());
+            let size = match (e.kind, e.size) {
+                (EntryKind::Dir, _) => String::new(),
+                (_, Some(bytes)) => crate::pvcexplore::human_size(bytes),
+                // Nothing could stat it — not the same as an empty file.
+                (_, None) => "?".to_string(),
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{label}{:pad$}", "", pad = pad),
+                    Style::default().fg(color),
+                ),
+                Span::styled(format!(" {size:>size_width$}"), theme::dim()),
+            ]))
+        })
+        .collect();
+    if truncated {
+        // Not "N more": both panes stop at the cap without counting past it —
+        // the volume side because `head` closes the pipe inside the container.
+        items.push(ListItem::new(Line::from(Span::styled(
+            format!(
+                "… showing the first {} entries",
+                crate::pvcexplore::MAX_ENTRIES
+            ),
+            Style::default().fg(theme::peach()),
+        ))));
+    }
+    items
+}
+
+/// Truncate to `max` terminal columns, ending with an ellipsis when cut.
+/// [`crate::text::ellipsize`] counts characters, which is the wrong unit for
+/// arbitrary file names off a volume.
+fn clip_to_width(s: &str, max: usize) -> String {
+    if s.width() <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    let mut used = 0usize;
+    for c in s.chars() {
+        let w = c.width().unwrap_or(0);
+        if used + w > max.saturating_sub(1) {
+            break;
+        }
+        out.push(c);
+        used += w;
+    }
+    out.push('…');
+    out
+}
+
 /// Session-local timeline: the state changes observed for one object while
 /// sofka has been watching, oldest first.
 fn draw_timeline(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -3546,6 +3769,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             "  j/k: move   ⏎: open the object   esc: close",
             theme::dim(),
         )),
+        Mode::PvcExplore => Line::from(Span::styled(
+            "  tab/←→: pane   j/k: move   ⏎: open   ⌫/-: up   c: copy to other pane   s: shell   r: refresh   esc: back",
+            theme::dim(),
+        )),
         _ => {
             // Per-resource verbs live in the header hint column when it
             // fits; only repeat the full line when the header dropped it.
@@ -3578,6 +3805,9 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
 fn sync_indicator(mode: Mode, doc_filter_return: Mode, synced: bool) -> (&'static str, Color) {
     let static_doc = match mode {
         Mode::Detail | Mode::Diff => true,
+        // A directory listing is fetched once by exec, not watched — `r`
+        // re-reads it. Calling it live would be a lie.
+        Mode::PvcExplore => true,
         // `/` search over one of those documents — same underlying snapshot.
         Mode::DocFilter => matches!(doc_filter_return, Mode::Detail | Mode::Diff),
         _ => false,
@@ -3719,6 +3949,26 @@ fn centered_rect_with_min(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The PVC browser pads file names into a fixed column. A CJK name is
+    /// twice as wide as it is long, so counting characters would push the size
+    /// column through the pane border.
+    #[test]
+    fn clip_to_width_measures_terminal_columns() {
+        assert_eq!(clip_to_width("abc", 5), "abc");
+        assert_eq!(clip_to_width("abcdef", 4), "abc…");
+        // Six characters, twelve columns wide.
+        assert_eq!("日本語ファイル".width(), 14);
+        let clipped = clip_to_width("日本語ファイル", 8);
+        assert!(
+            clipped.width() <= 8,
+            "{clipped:?} is {} wide",
+            clipped.width()
+        );
+        assert!(clipped.ends_with('…'));
+        // No room even for the ellipsis.
+        assert_eq!(clip_to_width("abc", 0), "");
+    }
 
     /// A describe/YAML/diff document is a snapshot — the status bar must not
     /// claim it's live (#175 follow-up report from Discord).


### PR DESCRIPTION
A PersistentVolumeClaim exposes no API that returns what is on it. The only way to see a volume's contents is from inside a pod that mounts it — so answering something as ordinary as "is the cache directory full?" means finding a consumer, remembering its `mountPath`, and hand-writing a `kubectl exec`, or writing a throwaway pod when nothing mounts it.

`x` on a PVC row does that work and puts the answer on screen.

## What it does

- **`x`** opens a two-pane browser: the local filesystem on the left, the volume on the right. `tab`/`←→` switch panes, `⏎` descends, `⌫` (or `-`) goes up, `r` re-reads both, `c` copies the focused pane's selection into the other one — so the direction is the focus and there is never a question about which way it went.
- **`s`** opens a shell inside the volume instead, at the directory the pane is showing.
- **`:pvc-explore`** / **`:pvc-clean`** are the palette equivalents (`:pvc` still navigates to the PVC list — the command deliberately does not claim that alias).
- **`[pvc_explore]`** configures the helper pod's `image` and `ttl`.

## How it reaches the volume

It prefers a pod that is already there: a running pod in the claim's namespace that mounts it, preferring a writable mount. Candidates are checked against their own container statuses, so a `CrashLoopBackOff` pod or a finished init container is not mistaken for a way in — sidecars (`restartPolicy: Always`) and ephemeral containers are. Nothing is created on this path, so it works in read-only mode.

When nothing qualifies it offers a short-lived helper pod that mounts the claim at `/pvc`. That is a write: blocked in read-only mode, matched by the `pvc-explore` guardrail, always confirmed. The pod expires twice over — a `sleep` and `activeDeadlineSeconds` — so it cannot outlive a crashed session, and it is deleted when the browser closes, when sofka quits, when the context switches, and by `:pvc-clean` for anything an earlier session left behind.

## Treating the volume as untrusted

The contents of a volume are input, not data sofka owns:

- **Row injection.** GNU `ls` writes file names into a pipe unescaped, so a name containing a newline injects what looks like an extra row, and a symlink *target* can carry an absolute path. Entries naming `.`, `..`, or anything containing `/` are discarded — that is what stops a forged row walking out of the mount or, on download, out of the destination directory (`Path::join` with an absolute path replaces rather than appends).
- **Symlinks.** Path arithmetic cannot enforce a mount floor, because `cd` follows links. Every listing re-checks with `pwd -P` that it landed inside the volume, resolving both sides so a symlinked `mountPath` still works, and refuses anything that did not.
- **Exit status.** The listing pipes through `head` inside the container so a spool directory is never streamed out in full — which costs the pipeline's exit status, so `ls`'s real one comes back on a marker line keyed by a per-run nonce. Without the nonce a file could forge that line and make a truncated listing pass itself off as complete. The three outcomes that must not be confused — read it all, read it with some entries unstattable, could not read it at all — stay distinguishable, so an unreadable directory reports why instead of rendering as "empty".
- **Environment.** `TIME_STYLE`, `QUOTING_STYLE` and the `BLOCK_SIZE` pair are unset: GNU `ls` reshapes its columns from the environment, and a container exporting any of them would otherwise leave every entry unparseable, unaddressable, or reported at 1/1024th of its size.

## Safety

Reaching a pod through a claim it mounts does not get past the rules that already protect that pod. The shell passes the `shell` guardrail against the serving pod, and an upload passes `transfer` — in addition to the claim-scoped `pvc-explore` and `pvc-upload`, with the stronger confirmation winning. A shell a guardrail will refuse is refused before a helper pod is created, not after. Uploads are blocked in read-only mode and refused up front when the mount is `readOnly`; a download that would overwrite a local file confirms first.

## Notes

- Listings use `ls -A -l` over `kubectl exec`, so the serving pod needs a shell and `ls`; transfers additionally need `tar`, as `kubectl cp` always does.
- The helper pod satisfies the `baseline` Pod Security Standard but not `restricted`, which wants `runAsNonRoot` — that would break reading root-owned volume data. Documented, with the workaround.
- `x` on a PVC now takes that chord from a user plugin or bookmark scoped to `persistentvolumeclaims`, the same way `x` on secrets already does.
- Docs updated per AGENTS.md: `docs/keys.md`, `docs/features.md`, `docs/configuration.md`, `docs/safety.md`, `docs/architecture.md`, and the `?` help.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings` and `cargo test --locked` are all clean on this branch — 816 tests pass, and clippy reports the same lints on `main` as on this branch, none from the new code. Pure logic (which pod mounts a claim, the helper-pod manifest, the `ls` parser, the local read) lives in `src/pvcexplore.rs` and is unit-tested without a cluster; `src/app/pvcexplore.rs` drives it, and its behaviour is tested through `handle_key`.
