### PR TITLE
fix: show scheduling-disabled nodes

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1823,6 +1823,49 @@ async fn pod_status_changes_keep_column_positions_stable() {
 }
 
 #[tokio::test]
+async fn cordoned_node_renders_scheduling_disabled_status() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let (mut app, _rx) = test_app();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "nodes".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "nodes");
+
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Node",
+            "metadata": {"name": "worker-1"},
+            "spec": {"unschedulable": true},
+            "status": {"conditions": [{"type": "Ready", "status": "True"}]}
+        }),
+    );
+
+    let mut terminal = Terminal::new(TestBackend::new(160, 24)).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let hit = app.table_hit.borrow().clone().unwrap();
+    let status_index = app
+        .display_headers()
+        .iter()
+        .position(|header| header == "STATUS")
+        .unwrap();
+    let &(start, end, _) = hit
+        .cols
+        .iter()
+        .find(|(_, _, index)| *index == status_index)
+        .unwrap();
+    let status_cell: String = (start..end)
+        .map(|x| terminal.backend().buffer()[(x, hit.rows_y)].symbol())
+        .collect();
+    assert_eq!(status_cell.trim(), "Ready,SchedulingDisabled");
+}
+
+#[tokio::test]
 async fn scrolling_pods_keeps_column_positions_stable() {
     use ratatui::{Terminal, backend::TestBackend};
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1823,8 +1823,25 @@ async fn pod_status_changes_keep_column_positions_stable() {
 }
 
 #[tokio::test]
-async fn cordoned_node_renders_scheduling_disabled_status() {
-    use ratatui::{Terminal, backend::TestBackend};
+async fn cordoned_node_statuses_keep_readiness_colors() {
+    use crate::theme;
+    use ratatui::{Terminal, backend::TestBackend, style::Color};
+
+    fn cell_text(terminal: &Terminal<TestBackend>, start: u16, end: u16, y: u16) -> String {
+        (start..end)
+            .map(|x| terminal.backend().buffer()[(x, y)].symbol())
+            .collect::<String>()
+            .trim()
+            .to_string()
+    }
+
+    fn cell_color(terminal: &Terminal<TestBackend>, start: u16, end: u16, y: u16) -> Color {
+        (start..end)
+            .map(|x| &terminal.backend().buffer()[(x, y)])
+            .find(|cell| !cell.symbol().trim().is_empty())
+            .map(|cell| cell.fg)
+            .unwrap()
+    }
 
     let (mut app, _rx) = test_app();
     app.handle_key(press(KeyCode::Char(':'))).unwrap();
@@ -1834,35 +1851,95 @@ async fn cordoned_node_renders_scheduling_disabled_status() {
     app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.kind_plural, "nodes");
 
-    apply(
-        &mut app,
+    let node = |name: &str, ready: Option<&str>| {
+        let conditions = ready.map_or_else(
+            || json!([]),
+            |status| json!([{"type": "Ready", "status": status}]),
+        );
         json!({
             "apiVersion": "v1", "kind": "Node",
-            "metadata": {"name": "worker-1"},
+            "metadata": {"name": name},
             "spec": {"unschedulable": true},
-            "status": {"conditions": [{"type": "Ready", "status": "True"}]}
-        }),
-    );
+            "status": {"conditions": conditions}
+        })
+    };
+    apply(&mut app, node("a-ready", Some("True")));
+    apply(&mut app, node("b-not-ready", Some("False")));
+    apply(&mut app, node("c-unknown", None));
 
+    // Select the last row so the first two retain their semantic foregrounds.
+    app.handle_key(press(KeyCode::End)).unwrap();
     let mut terminal = Terminal::new(TestBackend::new(160, 24)).unwrap();
     terminal
         .draw(|frame| crate::ui::draw(frame, &mut app))
         .unwrap();
     let hit = app.table_hit.borrow().clone().unwrap();
-    let status_index = app
-        .display_headers()
-        .iter()
-        .position(|header| header == "STATUS")
+    let headers = app.display_headers();
+    let column_range = |header: &str| {
+        let index = headers.iter().position(|h| h == header).unwrap();
+        hit.cols
+            .iter()
+            .find(|(_, _, i)| *i == index)
+            .map(|&(start, end, _)| (start, end))
+            .unwrap()
+    };
+    let (name_start, name_end) = column_range("NAME");
+    let (status_start, status_end) = column_range("STATUS");
+    let ready_y = hit.rows_y;
+    let not_ready_y = ready_y + 1;
+    let unknown_y = ready_y + 2;
+
+    assert_eq!(
+        cell_text(&terminal, name_start, name_end, ready_y),
+        "a-ready"
+    );
+    assert_eq!(
+        cell_text(&terminal, status_start, status_end, ready_y),
+        "Ready,SchedulingDisabled"
+    );
+    assert_eq!(
+        cell_color(&terminal, name_start, name_end, ready_y),
+        theme::blue()
+    );
+    assert_eq!(
+        cell_color(&terminal, status_start, status_end, ready_y),
+        theme::green()
+    );
+
+    assert_eq!(
+        cell_text(&terminal, name_start, name_end, not_ready_y),
+        "b-not-ready"
+    );
+    assert_eq!(
+        cell_text(&terminal, status_start, status_end, not_ready_y),
+        "NotReady,SchedulingDisabled"
+    );
+    assert_eq!(
+        cell_color(&terminal, name_start, name_end, not_ready_y),
+        theme::red()
+    );
+    assert_eq!(
+        cell_color(&terminal, status_start, status_end, not_ready_y),
+        theme::red()
+    );
+
+    // Move selection away from Unknown and redraw before checking its colors.
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
         .unwrap();
-    let &(start, end, _) = hit
-        .cols
-        .iter()
-        .find(|(_, _, index)| *index == status_index)
-        .unwrap();
-    let status_cell: String = (start..end)
-        .map(|x| terminal.backend().buffer()[(x, hit.rows_y)].symbol())
-        .collect();
-    assert_eq!(status_cell.trim(), "Ready,SchedulingDisabled");
+    assert_eq!(
+        cell_text(&terminal, status_start, status_end, unknown_y),
+        "Unknown,SchedulingDisabled"
+    );
+    assert_eq!(
+        cell_color(&terminal, name_start, name_end, unknown_y),
+        theme::blue()
+    );
+    assert_eq!(
+        cell_color(&terminal, status_start, status_end, unknown_y),
+        theme::overlay1()
+    );
 }
 
 #[tokio::test]

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -887,7 +887,7 @@ fn col_service_ports<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 }
 
 fn col_node_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
-    Cow::Borrowed(node_ready(ctx.data))
+    Cow::Borrowed(node_status(ctx.data))
 }
 
 fn col_node_roles<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
@@ -1492,8 +1492,9 @@ fn svc_ports(d: &Value) -> String {
         .unwrap_or_else(|| "<none>".into())
 }
 
-fn node_ready(d: &Value) -> &'static str {
-    d.pointer("/status/conditions")
+fn node_status(d: &Value) -> &'static str {
+    let ready = d
+        .pointer("/status/conditions")
         .and_then(Value::as_array)
         .and_then(|conds| {
             conds
@@ -1507,7 +1508,17 @@ fn node_ready(d: &Value) -> &'static str {
                 "NotReady"
             }
         })
-        .unwrap_or("Unknown")
+        .unwrap_or("Unknown");
+
+    if d.pointer("/spec/unschedulable").and_then(Value::as_bool) == Some(true) {
+        match ready {
+            "Ready" => "Ready,SchedulingDisabled",
+            "NotReady" => "NotReady,SchedulingDisabled",
+            _ => "Unknown,SchedulingDisabled",
+        }
+    } else {
+        ready
+    }
 }
 
 fn node_roles(obj: &DynamicObject) -> String {
@@ -2136,6 +2147,35 @@ mod tests {
         let bare = obj(json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "w-1"}}));
         let (bare_cells, _) = cells(&bare, "nodes", now_secs());
         assert_eq!(bare_cells[3], "0");
+    }
+
+    #[test]
+    fn node_status_matches_kubernetes_state_matrix() {
+        let cases = [
+            (Some("True"), false, "Ready"),
+            (Some("True"), true, "Ready,SchedulingDisabled"),
+            (Some("False"), false, "NotReady"),
+            (Some("False"), true, "NotReady,SchedulingDisabled"),
+            (Some("Unknown"), false, "NotReady"),
+            (Some("Unknown"), true, "NotReady,SchedulingDisabled"),
+            (None, false, "Unknown"),
+            (None, true, "Unknown,SchedulingDisabled"),
+        ];
+
+        for (ready, unschedulable, expected) in cases {
+            let conditions = ready.map_or_else(
+                || json!([]),
+                |status| json!([{"type": "Ready", "status": status}]),
+            );
+            let n = obj(json!({
+                "apiVersion": "v1", "kind": "Node",
+                "metadata": {"name": "worker-1"},
+                "spec": {"unschedulable": unschedulable},
+                "status": {"conditions": conditions}
+            }));
+
+            assert_eq!(cells(&n, "nodes", now_secs()).0[1], expected);
+        }
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -514,7 +514,7 @@ pub fn accent() -> Style {
 /// (healthy, pending, error) keep a distinct pop color so they stand out
 /// against the row tint.
 pub fn status_color(s: &str) -> Color {
-    match s {
+    match s.strip_suffix(",SchedulingDisabled").unwrap_or(s) {
         "Running" | "Ready" | "Active" | "Bound" | "True" | "deployed" => green(),
         // Faded, not "healthy green" — a finished pod isn't running, and a
         // scaled-to-zero workload isn't serving.
@@ -543,7 +543,7 @@ pub fn status_color(s: &str) -> Color {
 /// - everything healthy (Running/Ready/Bound/…) **or without a status** → the
 ///   standard row color (blue), so healthy rows read blue like k9s, not white.
 pub fn row_color(s: &str) -> Color {
-    match s {
+    match s.strip_suffix(",SchedulingDisabled").unwrap_or(s) {
         "Failed" | "Error" | "CrashLoopBackOff" | "ImagePullBackOff" | "ErrImagePull"
         | "Evicted" | "OOMKilled" | "NotReady" | "Unhealthy" | "False" | "failed" | "Degraded"
         | "Unavailable" | "Stalled" => red(),
@@ -658,6 +658,9 @@ mod tests {
         assert_eq!(row_color("Pending"), peach());
         assert_eq!(row_color("Completed"), overlay0());
         assert_eq!(row_color("Terminating"), mauve());
+        assert_eq!(row_color("Ready,SchedulingDisabled"), blue());
+        assert_eq!(row_color("NotReady,SchedulingDisabled"), red());
+        assert_eq!(row_color("Unknown,SchedulingDisabled"), blue());
     }
 
     #[test]
@@ -677,6 +680,9 @@ mod tests {
         // Pending pops distinct from the row's peach.
         assert_eq!(status_color("Pending"), yellow());
         assert_ne!(status_color("Pending"), row_color("Pending"));
+        assert_eq!(status_color("Ready,SchedulingDisabled"), green());
+        assert_eq!(status_color("NotReady,SchedulingDisabled"), red());
+        assert_eq!(status_color("Unknown,SchedulingDisabled"), overlay1());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -626,6 +626,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(i) = sort_col {
         needed[i] = needed[i].max(cell_width(&headers[i]).saturating_add(2));
     }
+    let status_width = if app.kind_plural == "nodes" { 27 } else { 26 };
     // Compute widths from all columns before applying the viewport offset.
     let col_rules: Vec<(ColWidth, u16)> = headers
         .iter()
@@ -651,9 +652,9 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                     "CPU" | "MEM" => ColWidth::Exact(8),
                     "%CPU" | "%MEM" => ColWidth::Exact(5),
                     "PODS" => ColWidth::Exact(5),
-                    // Keep status changes from moving the other columns.
-                    // Allow room for CreateContainerConfigError.
-                    "STATUS" => ColWidth::Exact(26),
+                    // Keep status changes from moving the other columns. Nodes
+                    // need one extra cell for NotReady,SchedulingDisabled.
+                    "STATUS" => ColWidth::Exact(status_width),
                     "READY" | "RESTARTS" => ColWidth::Cap(10),
                     // CRD view: group domains run long (e.g.
                     // "kustomize.toolkit.fluxcd.io"), so GROUP/KIND/VERSIONS


### PR DESCRIPTION
## Summary

- show `SchedulingDisabled` in the node STATUS column when `spec.unschedulable` is true
- preserve the node readiness state, producing values such as `Ready,SchedulingDisabled`
- match the upstream Kubernetes node printer across every readiness and scheduling combination
- preserve readiness-based semantic colors for composite scheduling-disabled statuses
- render the longest node status, `NotReady,SchedulingDisabled`, without truncation

## Root cause

The node STATUS extractor only inspected the `Ready` condition. Cordon sets `spec.unschedulable` without changing that condition, so a cordoned healthy node continued to appear simply as `Ready`.

The resulting composite status strings also needed to retain the base readiness semantics used by the theme. Without normalization, `NotReady,SchedulingDisabled` missed the exact `NotReady` theme match and appeared as a healthy blue row. The existing 26-cell STATUS width was also one cell too short for that value.

## Status behavior

| Ready condition | Schedulable | Cordoned |
| --- | --- | --- |
| `True` | `Ready` | `Ready,SchedulingDisabled` |
| `False` or `Unknown` | `NotReady` | `NotReady,SchedulingDisabled` |
| Missing | `Unknown` | `Unknown,SchedulingDisabled` |

This mirrors the [upstream Kubernetes node printer](https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/internalversion/printers.go#L2021-L2047), which summarizes the Ready condition and appends `SchedulingDisabled` when the node is unschedulable. Other node conditions such as memory, disk, PID pressure, and network availability are not folded into this STATUS field upstream.

For display styling, the scheduling suffix is removed only while selecting semantic colors, so Ready stays healthy, NotReady stays red, and Unknown keeps its unknown-state badge color. Node views receive a 27-cell STATUS column while other resource layouts retain their existing width.

## Tests

- added a table-driven renderer test covering `True`, `False`, `Unknown`, and a missing Ready condition, each with scheduling enabled and disabled
- added theme coverage for the row and STATUS badge colors of all three cordoned readiness states
- added an application-level regression test that opens `:nodes` through `handle_key`, draws the actual table with `TestBackend`, and verifies complete text plus row and badge colors for Ready, NotReady, and Unknown cordoned nodes
- ran `just check`: formatting and Clippy pass; 890 tests pass and 1 existing test is ignored

Closes #258

