### PR TITLE
fix: report pending workload updates and desired readiness

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -266,3 +266,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Local checks** validate package manifests and reports without a cluster.
 
 See [Create a plugin package](plugin-authoring.md).
+
+Workload STATUS shows `Progressing` until the controller observes the current
+specification and an active rolling update reaches its target. StatefulSet
+partitions and `OnDelete` strategies retain their update semantics. Deployment
+READY compares ready replicas with the desired count from the specification.

--- a/docs/features.md
+++ b/docs/features.md
@@ -271,3 +271,6 @@ Workload STATUS shows `Progressing` until the controller observes the current
 specification and an active rolling update reaches its target. StatefulSet
 partitions and `OnDelete` strategies retain their update semantics. Deployment
 READY compares ready replicas with the desired count from the specification.
+An active rollout with some ready replicas shows `Progressing` even when
+`Available=False`. A workload with no ready replicas shows `Unavailable`. A
+failed rollout shows `Stalled`.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12056,3 +12056,52 @@ async fn workload_table_reports_rollout_generation_and_desired_readiness() {
         );
     }
 }
+
+#[tokio::test]
+async fn workload_table_keeps_active_rollouts_progressing_when_unavailable() {
+    for (current, ready, updated, stalled, expected) in [
+        (3, 1, 1, false, "Progressing"),
+        (4, 2, 3, false, "Progressing"),
+        (2, 1, 2, false, "Progressing"),
+        (3, 0, 1, false, "Unavailable"),
+        (3, 2, 3, false, "Unavailable"),
+        (3, 3, 3, false, "Unavailable"),
+        (3, 1, 1, true, "Stalled"),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.cluster
+            .register_kind("apps", "Deployment", "deployments", true);
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for ch in "deployments".chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        let mut conditions = vec![json!({"type": "Available", "status": "False"})];
+        if stalled {
+            conditions.push(json!({"type": "Progressing", "status": "False", "reason": "ProgressDeadlineExceeded"}));
+        }
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "apps/v1", "kind": "Deployment",
+                "metadata": {"name": "web", "namespace": "default", "generation": 2},
+                "spec": {"replicas": 3},
+                "status": {
+                    "observedGeneration": 2, "replicas": current,
+                    "readyReplicas": ready, "updatedReplicas": updated,
+                    "conditions": conditions,
+                },
+            }),
+        );
+        let headers = app.display_headers().to_vec();
+        let rows = app.rows();
+        app.ensure_table_cell_cache(&rows);
+        let cache = app.table_cell_cache();
+        let (cells, _) = cache.get(&row_key(rows[0])).unwrap();
+        assert_eq!(
+            cells[headers.iter().position(|h| h == "STATUS").unwrap()],
+            expected,
+            "current={current}, ready={ready}, updated={updated}, stalled={stalled}"
+        );
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11915,3 +11915,144 @@ async fn faults_watch_changes_preserve_pod_identity_or_clear_selection() {
     });
     assert_eq!(app.table_state.selected(), None);
 }
+
+#[tokio::test]
+async fn workload_table_reports_rollout_generation_and_desired_readiness() {
+    for (plural, kind, spec, status, generation, expected_ready, expected_status) in [
+        (
+            "deployments",
+            "Deployment",
+            json!({"replicas": 3}),
+            json!({"replicas": 4, "readyReplicas": 4, "updatedReplicas": 3, "observedGeneration": 2}),
+            2,
+            "4/3",
+            "Progressing",
+        ),
+        (
+            "deployments",
+            "Deployment",
+            json!({}),
+            json!({"replicas": 1, "readyReplicas": 1, "updatedReplicas": 1, "observedGeneration": 2}),
+            2,
+            "1/1",
+            "Ready",
+        ),
+        (
+            "deployments",
+            "Deployment",
+            json!({"replicas": 0}),
+            json!({"observedGeneration": 1}),
+            2,
+            "0/0",
+            "Progressing",
+        ),
+        (
+            "statefulsets",
+            "StatefulSet",
+            json!({"replicas": 3, "ordinals": {"start": 5}, "updateStrategy": {"rollingUpdate": {"partition": 6}}}),
+            json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 2, "observedGeneration": 2}),
+            2,
+            "3/3",
+            "Ready",
+        ),
+        (
+            "deployments",
+            "Deployment",
+            json!({"replicas": 3}),
+            json!({"replicas": 4, "readyReplicas": 3, "updatedReplicas": 1, "observedGeneration": 2}),
+            2,
+            "3/3",
+            "Progressing",
+        ),
+        (
+            "deployments",
+            "Deployment",
+            json!({"replicas": 3}),
+            json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 3, "observedGeneration": 1}),
+            2,
+            "3/3",
+            "Progressing",
+        ),
+        (
+            "deployments",
+            "Deployment",
+            json!({"replicas": 3}),
+            json!({"replicas": 2, "readyReplicas": 2, "updatedReplicas": 2, "observedGeneration": 2}),
+            2,
+            "2/3",
+            "Progressing",
+        ),
+        (
+            "statefulsets",
+            "StatefulSet",
+            json!({"replicas": 3}),
+            json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 1, "observedGeneration": 2}),
+            2,
+            "3/3",
+            "Progressing",
+        ),
+        (
+            "statefulsets",
+            "StatefulSet",
+            json!({"replicas": 3, "updateStrategy": {"rollingUpdate": {"partition": 2}}}),
+            json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 1, "observedGeneration": 2}),
+            2,
+            "3/3",
+            "Ready",
+        ),
+        (
+            "statefulsets",
+            "StatefulSet",
+            json!({"replicas": 3, "updateStrategy": {"type": "OnDelete"}}),
+            json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 0, "observedGeneration": 2}),
+            2,
+            "3/3",
+            "Ready",
+        ),
+        (
+            "daemonsets",
+            "DaemonSet",
+            json!({}),
+            json!({"desiredNumberScheduled": 3, "currentNumberScheduled": 3, "numberReady": 3, "updatedNumberScheduled": 1, "observedGeneration": 2}),
+            2,
+            "3",
+            "Progressing",
+        ),
+        (
+            "daemonsets",
+            "DaemonSet",
+            json!({"updateStrategy": {"type": "OnDelete"}}),
+            json!({"desiredNumberScheduled": 3, "currentNumberScheduled": 3, "numberReady": 3, "updatedNumberScheduled": 1, "observedGeneration": 2}),
+            2,
+            "3",
+            "Ready",
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.cluster.register_kind("apps", kind, plural, true);
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for ch in plural.chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        apply(
+            &mut app,
+            json!({"apiVersion": "apps/v1", "kind": kind, "metadata": {"name": "web", "namespace": "default", "generation": generation, "resourceVersion": format!("{spec}{status}")}, "spec": spec, "status": status}),
+        );
+        let headers = app.display_headers().to_vec();
+        let rows = app.rows();
+        app.ensure_table_cell_cache(&rows);
+        let cache = app.table_cell_cache();
+        let (cells, _) = cache.get(&row_key(rows[0])).unwrap();
+        assert_eq!(
+            cells[headers.iter().position(|h| h == "READY").unwrap()],
+            expected_ready,
+            "{kind}"
+        );
+        assert_eq!(
+            cells[headers.iter().position(|h| h == "STATUS").unwrap()],
+            expected_status,
+            "{kind}"
+        );
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -852,11 +852,14 @@ fn workload_status(obj: &DynamicObject, c: WorkloadCounts) -> String {
     {
         return "Stalled".into();
     }
-    if c.ready == 0 || condition_is(d, "Available", "False") {
+    if c.ready == 0 {
         return "Unavailable".into();
     }
     if c.updated < c.desired || c.current != c.desired {
         return "Progressing".into();
+    }
+    if condition_is(d, "Available", "False") {
+        return "Unavailable".into();
     }
     if c.ready >= c.desired {
         return "Ready".into();

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -669,7 +669,7 @@ fn col_deploy_ready<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     Cow::Owned(format!(
         "{}/{}",
         iget(ctx.data, &["status", "readyReplicas"]),
-        iget(ctx.data, &["status", "replicas"])
+        iopt(ctx.data, &["spec", "replicas"]).unwrap_or(1)
     ))
 }
 
@@ -722,7 +722,7 @@ fn col_deploy_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
         return "Terminating".into();
     }
     Cow::Owned(workload_status(
-        ctx.data,
+        ctx.obj,
         WorkloadCounts::deployment(ctx.data),
     ))
 }
@@ -732,7 +732,7 @@ fn col_sts_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
         return "Terminating".into();
     }
     Cow::Owned(workload_status(
-        ctx.data,
+        ctx.obj,
         WorkloadCounts::statefulset(ctx.data),
     ))
 }
@@ -742,7 +742,7 @@ fn col_rs_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
         return "Terminating".into();
     }
     Cow::Owned(workload_status(
-        ctx.data,
+        ctx.obj,
         WorkloadCounts::replicaset(ctx.data),
     ))
 }
@@ -752,7 +752,7 @@ fn col_ds_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
         return "Terminating".into();
     }
     Cow::Owned(workload_status(
-        ctx.data,
+        ctx.obj,
         WorkloadCounts::daemonset(ctx.data),
     ))
 }
@@ -764,8 +764,8 @@ struct WorkloadCounts {
     desired: i64,
     current: i64,
     ready: i64,
-    /// Replicas already on the current template revision — below `desired`
-    /// means a rollout is still replacing pods.
+    /// Replicas that satisfy the update policy, including replicas retained
+    /// by a StatefulSet partition or an OnDelete strategy.
     updated: i64,
 }
 
@@ -781,7 +781,15 @@ impl WorkloadCounts {
     }
 
     fn statefulset(d: &Value) -> Self {
-        Self::deployment(d)
+        let mut counts = Self::deployment(d);
+        if sget(d, &["spec", "updateStrategy", "type"]) == Some("OnDelete") {
+            counts.updated = counts.desired;
+        } else {
+            let partition = iget(d, &["spec", "updateStrategy", "rollingUpdate", "partition"]);
+            let start = iget(d, &["spec", "ordinals", "start"]);
+            counts.updated += (partition - start).clamp(0, counts.desired.max(0));
+        }
+        counts
     }
 
     fn replicaset(d: &Value) -> Self {
@@ -800,7 +808,11 @@ impl WorkloadCounts {
             desired: iget(d, &["status", "desiredNumberScheduled"]),
             current: iget(d, &["status", "currentNumberScheduled"]),
             ready: iget(d, &["status", "numberReady"]),
-            updated: iget(d, &["status", "updatedNumberScheduled"]),
+            updated: if sget(d, &["spec", "updateStrategy", "type"]) == Some("OnDelete") {
+                iget(d, &["status", "desiredNumberScheduled"])
+            } else {
+                iget(d, &["status", "updatedNumberScheduled"])
+            },
         }
     }
 }
@@ -820,7 +832,13 @@ impl WorkloadCounts {
 ///   failing probes, unschedulable (red)
 /// - `Stalled` — the Progressing condition gave up
 ///   (ProgressDeadlineExceeded) or ReplicaFailure is set (red)
-fn workload_status(d: &Value, c: WorkloadCounts) -> String {
+fn workload_status(obj: &DynamicObject, c: WorkloadCounts) -> String {
+    let d = &obj.data;
+    if let Some(generation) = obj.metadata.generation
+        && iopt(d, &["status", "observedGeneration"]).unwrap_or(0) < generation
+    {
+        return "Progressing".into();
+    }
     if c.desired == 0 {
         return if c.current == 0 {
             "ScaledDown".into()
@@ -834,18 +852,14 @@ fn workload_status(d: &Value, c: WorkloadCounts) -> String {
     {
         return "Stalled".into();
     }
-    if c.ready >= c.desired {
-        return if condition_is(d, "Available", "False") {
-            "Unavailable".into()
-        } else {
-            "Ready".into()
-        };
-    }
-    if c.ready == 0 {
+    if c.ready == 0 || condition_is(d, "Available", "False") {
         return "Unavailable".into();
     }
-    if c.updated < c.desired || c.current < c.desired {
+    if c.updated < c.desired || c.current != c.desired {
         return "Progressing".into();
+    }
+    if c.ready >= c.desired {
+        return "Ready".into();
     }
     "Degraded".into()
 }


### PR DESCRIPTION
Workloads with enough ready Pods could show Ready while old replicas were still being replaced or the controller had not observed a new specification. STATUS now checks reconciliation and update targets first, including StatefulSet partitions and OnDelete strategies. Deployment READY uses the desired replica count.

Validation: `just check` passed before the final edge cases; commit hooks passed formatting, clippy, and the full test suite with the final code. Keyboard-driven tests cover active rollouts, stale generations, scale-up, partitions with custom ordinals, and OnDelete.

Closes #266
Closes #267
Closes #269
