### PR TITLE
fix: preserve Pod identity and data during drain

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -94,3 +94,18 @@ The pattern `plugin:*` matches all plugins.
 Read-only mode blocks mutating plugins and plugins with `network_load = true`.
 Network-load plugins require confirmation, even when they do not change Kubernetes resources.
 See [Plugin safety controls](plugin-authoring.md#safety-controls).
+
+## Node drain
+
+A drain first cordons the node, then checks its pods. It stops for that node
+if an eligible pod has no controller, uses an `emptyDir` volume, or has no UID.
+The error identifies the pod and the reason. No pods on that node are evicted
+when this check fails. The node remains cordoned. Other selected nodes can
+still be processed.
+
+Drain uses the eviction API with the listed pod's UID. It does not use direct
+pod deletion if eviction fails. This preserves PodDisruptionBudget checks and
+prevents eviction of a replacement pod with the same name. A pod-specific
+not-found response means the original pod is already gone. Other API errors
+are reported, including an unavailable eviction endpoint. Drain has no override
+for unmanaged pods or `emptyDir` data loss.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -345,35 +345,55 @@ impl App {
                     }
                 };
 
+                let blocked: Vec<String> = pod_list
+                    .items
+                    .iter()
+                    .filter(|pod| drainable_pod(pod))
+                    .filter_map(|pod| {
+                        drain_blocker(pod).map(|reason| {
+                            format!(
+                                "{}/{}: {reason}",
+                                pod.metadata.namespace.as_deref().unwrap_or("default"),
+                                pod.metadata.name.as_deref().unwrap_or("<unknown>"),
+                            )
+                        })
+                    })
+                    .collect();
+                if !blocked.is_empty() {
+                    failed = true;
+                    let _ = tx.send(Msg::Flash {
+                        generation: genr,
+                        claim,
+                        message: format!("drain {node} blocked: {}. Node remains cordoned; no pods were evicted from this node", blocked.join("; ")),
+                        err: true,
+                    }).await;
+                    continue;
+                }
+
                 for pod in pod_list.items.iter().filter(|pod| drainable_pod(pod)) {
                     let Some(name) = pod.metadata.name.as_deref() else {
                         continue;
                     };
                     let ns = pod.metadata.namespace.as_deref().unwrap_or("default");
                     let pod_api: Api<Pod> = Api::namespaced(client.clone(), ns);
-                    let evict = EvictParams {
-                        delete_options: Some(DeleteParams::default()),
-                        ..Default::default()
-                    };
-                    match pod_api.evict(name, &evict).await {
+                    // kube 4.2 serializes EvictParams as delete_options. The API
+                    // requires deleteOptions to enforce the UID precondition.
+                    let eviction = serde_json::json!({
+                        "apiVersion": "policy/v1",
+                        "kind": "Eviction",
+                        "metadata": { "name": name, "namespace": ns },
+                        "deleteOptions": { "preconditions": { "uid": pod.metadata.uid } },
+                    });
+                    let result: Result<kube::core::Status, kube::Error> = pod_api
+                        .create_subresource("eviction", name, &PostParams::default(), &eviction)
+                        .await;
+                    match result {
                         Ok(_) => {}
-                        Err(e) if eviction_unsupported(&e) => {
-                            if let Err(delete_err) =
-                                pod_api.delete(name, &DeleteParams::default()).await
-                            {
-                                failed = true;
-                                let _ = tx
-                                    .send(Msg::Flash {
-                                        generation: genr,
-                                        claim,
-                                        message: format!(
-                                            "drain {node}: delete {ns}/{name} failed after eviction fallback: {delete_err}"
-                                        ),
-                                        err: true,
-                                    })
-                                    .await;
-                            }
-                        }
+                        Err(kube::Error::Api(e))
+                            if e.code == 404
+                                && e.details.as_ref().is_some_and(|details| {
+                                    details.kind == "pods" && details.name == name
+                                }) => {}
                         Err(e) => {
                             failed = true;
                             let _ = tx

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -322,8 +322,27 @@ pub(super) fn drainable_pod(pod: &Pod) -> bool {
     )
 }
 
-pub(super) fn eviction_unsupported(err: &kube::Error) -> bool {
-    matches!(err, kube::Error::Api(api_err) if matches!(api_err.code, 404 | 405))
+pub(super) fn drain_blocker(pod: &Pod) -> Option<&'static str> {
+    if !pod
+        .metadata
+        .owner_references
+        .as_ref()
+        .is_some_and(|owners| owners.iter().any(|owner| owner.controller == Some(true)))
+    {
+        return Some("pod has no controller and will not be replaced");
+    }
+    if pod
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.volumes.as_ref())
+        .is_some_and(|volumes| volumes.iter().any(|volume| volume.empty_dir.is_some()))
+    {
+        return Some("pod has emptyDir data that eviction would delete");
+    }
+    if pod.metadata.uid.as_deref().is_none_or(str::is_empty) {
+        return Some("pod UID is missing; cannot verify the eviction target");
+    }
+    None
 }
 
 /// Pick a version name to query a CRD's custom resources: the storage version

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,8 +18,7 @@ use futures_util::StreamExt;
 use k8s_openapi::api::core::v1::Pod;
 use kube::Client;
 use kube::api::{
-    Api, DeleteParams, EvictParams, ListParams, LogParams, Patch, PatchParams, PostParams,
-    PropagationPolicy,
+    Api, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams, PropagationPolicy,
 };
 use kube::core::{DynamicObject, TypeMeta};
 use kube::discovery::ApiResource;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11915,3 +11915,144 @@ async fn faults_watch_changes_preserve_pod_identity_or_clear_selection() {
     });
     assert_eq!(app.table_state.selected(), None);
 }
+
+async fn drain_api_case(
+    pods: serde_json::Value,
+    eviction_code: u16,
+    pod_missing: bool,
+) -> (String, bool, Vec<serde_json::Value>) {
+    use http_body_util::BodyExt;
+    let (mut app, mut rx) = test_app();
+    app.switch_kind("nodes");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Node", "metadata":{"name":"node-a"}}),
+    );
+    app.table_state.select(Some(0));
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = requests.clone();
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            let seen = seen.clone();
+            let pods = pods.clone();
+            async move {
+                let method = request.method().to_string();
+                let path = request.uri().path().to_owned();
+                let body = request.into_body().collect().await.unwrap().to_bytes();
+                let body: serde_json::Value = serde_json::from_slice(&body).unwrap_or(json!(null));
+                seen.lock()
+                    .unwrap()
+                    .push(json!({"method":method,"path":path,"body":body}));
+                let (code, response) = match (method.as_str(), path.as_str()) {
+                    ("PATCH", "/api/v1/nodes/node-a") => (
+                        200,
+                        json!({"apiVersion":"v1","kind":"Node","metadata":{"name":"node-a"}}),
+                    ),
+                    ("GET", "/api/v1/pods") => (
+                        200,
+                        json!({"apiVersion":"v1","kind":"PodList","metadata":{},"items":pods}),
+                    ),
+                    ("POST", "/api/v1/namespaces/default/pods/web/eviction") => (
+                        eviction_code,
+                        json!({"apiVersion":"v1","kind":"Status","code":eviction_code,"status":if eviction_code < 300 {"Success"} else {"Failure"},"reason":"NotFound","message":"mock eviction response", "details":if pod_missing { json!({"kind":"pods","name":"web"}) } else {json!({})}}),
+                    ),
+                    _ => panic!("unexpected drain request: {method} {path}"),
+                };
+                Ok::<_, std::convert::Infallible>(
+                    http::Response::builder()
+                        .status(code)
+                        .body(http_body_util::Full::new(hyper::body::Bytes::from(
+                            response.to_string(),
+                        )))
+                        .unwrap(),
+                )
+            }
+        }),
+        "default",
+    );
+    app.handle_key(press(KeyCode::Char('D'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    let (message, err) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(Msg::Flash { message, err, .. }) = rx.recv().await
+                && message.starts_with("drain")
+            {
+                break (message, err);
+            }
+        }
+    })
+    .await
+    .expect("drain did not finish");
+    let captured = requests.lock().unwrap().clone();
+    (message, err, captured)
+}
+
+fn drain_managed_pod() -> serde_json::Value {
+    json!({"apiVersion":"v1","kind":"Pod","metadata":{"name":"web","namespace":"default","uid":"original-uid","ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","name":"web","uid":"controller-uid","controller":true}]},"spec":{"nodeName":"node-a","containers":[{"name":"app","image":"test"}]},"status":{"phase":"Running"}})
+}
+
+#[tokio::test]
+async fn drain_key_pins_uid_and_never_falls_back_to_delete() {
+    for (code, missing, expected_error) in [
+        (201, false, false),
+        (404, true, false),
+        (404, false, true),
+        (405, false, true),
+        (409, false, true),
+        (429, false, true),
+    ] {
+        let (_, err, requests) = drain_api_case(json!([drain_managed_pod()]), code, missing).await;
+        assert_eq!(
+            err, expected_error,
+            "eviction code {code}, missing {missing}"
+        );
+        assert_eq!(requests.len(), 3);
+        assert_eq!(requests[2]["method"], "POST");
+        assert_eq!(
+            requests[2]["body"]["deleteOptions"]["preconditions"]["uid"],
+            "original-uid"
+        );
+    }
+}
+
+#[tokio::test]
+async fn drain_key_blocks_unmanaged_pods_before_any_evictions() {
+    for controller in [json!(null), json!(false)] {
+        let mut unsafe_pod = drain_managed_pod();
+        unsafe_pod["metadata"]["name"] = json!("standalone");
+        unsafe_pod["metadata"]["ownerReferences"][0]["controller"] = controller;
+        let (message, err, requests) =
+            drain_api_case(json!([drain_managed_pod(), unsafe_pod]), 201, false).await;
+        assert!(err);
+        assert!(
+            message.contains("default/standalone: pod has no controller"),
+            "{message}"
+        );
+        assert_eq!(requests.len(), 2);
+    }
+}
+
+#[tokio::test]
+async fn drain_key_blocks_emptydir_before_any_evictions() {
+    let mut unsafe_pod = drain_managed_pod();
+    unsafe_pod["spec"]["volumes"] = json!([{"name":"data","emptyDir":{}}]);
+    let (message, err, requests) =
+        drain_api_case(json!([drain_managed_pod(), unsafe_pod]), 201, false).await;
+    assert!(err);
+    assert!(message.contains("emptyDir data"), "{message}");
+    assert_eq!(requests.len(), 2);
+}
+
+#[tokio::test]
+async fn drain_key_blocks_missing_uid_before_any_evictions() {
+    let mut unsafe_pod = drain_managed_pod();
+    unsafe_pod["metadata"]
+        .as_object_mut()
+        .unwrap()
+        .remove("uid");
+    let (message, err, requests) = drain_api_case(json!([unsafe_pod]), 201, false).await;
+    assert!(err);
+    assert!(message.contains("UID is missing"), "{message}");
+    assert_eq!(requests.len(), 2);
+}


### PR DESCRIPTION
Drain could delete a replacement Pod after an eviction returned 404, and could remove unmanaged Pods or emptyDir data after only a generic confirmation. It now checks eligible Pods before eviction, refuses unsafe targets, sends UID preconditions, and never falls back to direct deletion. Blocked nodes remain cordoned.

Validation: `just check` and all commit hooks passed (723 tests passed, 1 ignored). Keyboard-driven mock API tests check the eviction request body, blocked targets, Pod-specific 404, endpoint errors, conflicts, and PDB rejection.

Closes #284
Closes #287
Closes #288
