### PR TITLE
fix: show Pod init failures and readiness

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -17,6 +17,11 @@ generation bumps, replica and readiness changes, pod phase, restarts, waiting
 reasons, condition flips. Diffed from the watch stream, bounded in size, never
 written to disk.
 
+Restart history includes normal init containers and native sidecars. It keeps
+completed init restart counts in its total, so the end of initialization does
+not reset the count. The pod table excludes normal init restarts after
+initialization is complete.
+
 ## Diff (`:diff`)
 
 A unified diff of the live object against its `last-applied-configuration`. When

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,6 +19,18 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   26 characters so status changes do not move adjacent columns. A configured
   column width takes priority. Column widths use the full filtered list so
   vertical scrolling does not move the columns.
+- **Pod health** shows init progress and failure reasons, Pod reasons such as
+  `Evicted`, scheduling gates, and termination signals or exit codes.
+  Init progress appears after the kubelet reports init state. Until then, the
+  table keeps the Pod phase or reason, including `SchedulingGated`.
+  Normal init containers count toward RESTARTS during initialization, but not READY.
+  Native sidecars count toward READY and RESTARTS. Their failures remain
+  visible after initialization, without adding restarts from completed normal init containers.
+  Application waiting and termination reasons take precedence after initialization.
+  A blocked readiness gate
+  gives a Running pod warning colors even when all containers are ready.
+  Failure reasons use red rows and status text, including init failures and
+  the `Lost` PVC state.
 - **Horizontal scrolling** - Left and Right move the table by five text positions.
   NAME and NAMESPACE stay fixed. Other columns keep their widths while you
   scroll. Arrows in the title show where more content is available. When all
@@ -217,7 +229,7 @@ right - so a download or an upload is one keystroke rather than a hand-written
   execs into that container at its `mountPath`. Nothing is created, so this
   works in read-only mode.
 - **Otherwise it offers a helper pod.** When nothing mounts the claim - the
-  common case for a volume you are trying to inspect *because* its workload is
+  common case for a volume you are trying to inspect _because_ its workload is
   scaled to zero - sofka asks before creating a short-lived pod that mounts it
   at `/pvc`. That is a write: it is blocked in read-only mode, matches the
   `pvc-explore` guardrail action, and always confirms, naming the image and the
@@ -230,11 +242,11 @@ right - so a download or an upload is one keystroke rather than a hand-written
   skipping the pod your own open browser is using. None of that evidence is
   unforgeable - anything sofka writes on creation, anything else can write too
   - so it is there to make an accidental match essentially impossible, not as
-  a permission check; the confirmation, the guardrail and read-only mode are
-  what bound a deliberate one. It cannot tell a leftover from a pod *another* session is browsing
-  through right now, so the confirmation says so. Deleting pods is a mutation
-  like any other: blocked in read-only mode, matched by the `pvc-explore`
-  guardrail, recorded in `:journal`.
+    a permission check; the confirmation, the guardrail and read-only mode are
+    what bound a deliberate one. It cannot tell a leftover from a pod _another_ session is browsing
+    through right now, so the confirmation says so. Deleting pods is a mutation
+    like any other: blocked in read-only mode, matched by the `pvc-explore`
+    guardrail, recorded in `:journal`.
 - **Navigation is confined to the mount.** `⌫` stops at the mount point, and
   every listing verifies with `pwd -P` that it actually landed inside the
   volume - so a symlink on the volume pointing at `/` is refused rather than
@@ -333,8 +345,9 @@ pod is rejected; browse through a pod that already mounts the claim instead.
 - **`:sanitize`** deletes the pods a namespace has finished with - completed
   jobs, failed and evicted pods, and optionally the wedged ones. It ships with
   sofka and needs no runtime on `PATH`; the adapter is the sofka binary.
-  `states` selects `terminal` (the default), `stuck`, or `all`, named after the
-  STATUS values the pods view shows. `dry_run=true` reports without deleting.
+  `states` selects `terminal` (the default), `stuck`, or `all`, based on
+  application container state and Pod phase. Specific table reason labels do
+  not add deletion categories. `dry_run=true` reports without deleting.
   It confirms before running, is blocked in read-only mode, and matches
   guardrails as `plugin:sanitize`. It never deletes a pod that is terminating,
   still has a running container, or was replaced since the scan.

--- a/plugins/sanitize/README.md
+++ b/plugins/sanitize/README.md
@@ -30,8 +30,11 @@ requires confirmation, because the package is declared mutating.
 
 ## Deletion states
 
-The names are the STATUS values the pods view shows, so what you read in the
-table is what `states` selects.
+The categories use application container waiting or termination reasons, then
+Pod phase when no such reason applies. The table can show a more specific
+reason. For example, a failed Pod shown as `Evicted` still belongs to the
+terminal set. A Pod shown as `SchedulingGated` belongs to the Pending category.
+Init failure labels and numeric exit labels do not add deletion categories.
 
 | `states`   | Deletes                                                                       |
 | ---------- | ----------------------------------------------------------------------------- |

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14088,3 +14088,281 @@ async fn workload_table_keeps_active_rollouts_progressing_when_unavailable() {
         );
     }
 }
+
+fn health_test_pod(name: &str) -> Value {
+    json!({"apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": name, "namespace": "default", "uid": name, "resourceVersion": "1"},
+        "spec": {"containers": [{"name": "app"}]},
+        "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}],
+            "containerStatuses": [{"name": "app", "ready": true, "restartCount": 0,
+                "state": {"running": {}}}]}})
+}
+
+fn health_row_color(app: &mut App, name: &str, text: &str) -> ratatui::style::Color {
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(150, 24)).unwrap();
+    terminal.draw(|frame| crate::ui::draw(frame, app)).unwrap();
+    let buffer = terminal.backend().buffer();
+    for y in 0..buffer.area.height {
+        let line: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, y)].symbol())
+            .collect();
+        if line.contains(name)
+            && let Some(offset) = line.find(text)
+        {
+            let x = line[..offset].chars().count() as u16;
+            return buffer[(x, y)].fg;
+        }
+    }
+    panic!("missing {text} in row {name}");
+}
+
+#[tokio::test]
+async fn pod_init_states_and_restarts_are_visible_through_filter_keys() {
+    for (state, status) in [
+        (json!({"running": {}}), "Init:0/1"),
+        (
+            json!({"waiting": {"reason": "CrashLoopBackOff"}}),
+            "Init:CrashLoopBackOff",
+        ),
+        (
+            json!({"terminated": {"reason": "Error", "exitCode": 1}}),
+            "Init:Error",
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        let mut pod = health_test_pod("init-target");
+        pod["spec"]["initContainers"] = json!([{"name": "init"}]);
+        pod["status"]["phase"] = json!("Pending");
+        pod["status"]["conditions"] = json!([]);
+        pod["status"]["containerStatuses"][0] = json!({"name": "app", "ready": false,
+            "restartCount": 0, "state": {"waiting": {"reason": "PodInitializing"}}});
+        pod["status"]["initContainerStatuses"] = json!([{"name": "init", "ready": false,
+            "restartCount": 7, "state": state}]);
+        apply(&mut app, pod);
+        apply(&mut app, health_test_pod("healthy"));
+        type_filter(&mut app, &format!("status={status} restarts>=7"));
+        assert_eq!(row_names(&app), ["init-target"]);
+        let (headers, rows) = app.snapshot_table();
+        let cell = |header| &rows[0][headers.iter().position(|h| h == header).unwrap()];
+        assert_eq!(cell("READY"), "0/1");
+        assert_eq!(cell("STATUS"), status);
+        assert_eq!(cell("RESTARTS"), "7");
+    }
+}
+
+#[tokio::test]
+async fn pod_specific_reasons_are_visible_through_filter_keys() {
+    for (status, expected) in [
+        (json!({"phase": "Failed", "reason": "Evicted"}), "Evicted"),
+        (
+            json!({"phase": "Pending", "conditions": [{"type": "PodScheduled", "status": "False",
+            "reason": "SchedulingGated"}]}),
+            "SchedulingGated",
+        ),
+        (
+            json!({"phase": "Running", "containerStatuses": [{"state": {"terminated": {"exitCode": 42}}}]}),
+            "ExitCode:42",
+        ),
+        (
+            json!({"phase": "Running", "containerStatuses": [{"state": {"terminated": {"reason": "", "signal": 9, "exitCode": 137}}}]}),
+            "Signal:9",
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        let mut pod = health_test_pod("reason-target");
+        pod["spec"]["initContainers"] = json!([{"name": "init"}]);
+        pod["status"] = status;
+        apply(&mut app, pod);
+        apply(&mut app, health_test_pod("healthy"));
+        type_filter(&mut app, &format!("status={expected}"));
+        assert_eq!(row_names(&app), ["reason-target"]);
+        let (headers, rows) = app.snapshot_table();
+        assert_eq!(
+            rows[0][headers.iter().position(|h| h == "STATUS").unwrap()],
+            expected
+        );
+    }
+}
+
+#[tokio::test]
+async fn readiness_gate_colors_follow_watch_updates_after_faults_key() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let mut pod = health_test_pod("a-gated");
+    pod["spec"]["readinessGates"] = json!([{"conditionType": "example.com/ready"}]);
+    pod["status"]["conditions"] = json!([{"type": "Ready", "status": "False"}]);
+    apply(&mut app, pod.clone());
+    apply(&mut app, health_test_pod("z-selected"));
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    assert_eq!(row_names(&app), ["a-gated"]);
+    app.handle_key(ctrl(KeyCode::Char('z'))).unwrap();
+    app.handle_key(press(KeyCode::End)).unwrap();
+    assert_eq!(
+        health_row_color(&mut app, "a-gated", "Running"),
+        crate::theme::yellow()
+    );
+    assert_eq!(
+        health_row_color(&mut app, "a-gated", "a-gated"),
+        crate::theme::peach()
+    );
+    pod["metadata"]["resourceVersion"] = json!("2");
+    pod["status"]["conditions"] = json!([
+        {"type": "Ready", "status": "True"}, {"type": "example.com/ready", "status": "True"}]);
+    apply(&mut app, pod.clone());
+    assert_eq!(
+        health_row_color(&mut app, "a-gated", "Running"),
+        crate::theme::green()
+    );
+    pod["metadata"]["resourceVersion"] = json!("3");
+    pod["status"]["conditions"][1]["status"] = json!("Unknown");
+    apply(&mut app, pod);
+    assert_eq!(
+        health_row_color(&mut app, "a-gated", "Running"),
+        crate::theme::yellow()
+    );
+}
+
+#[tokio::test]
+async fn specific_failure_colors_render_after_navigation_keys() {
+    for reason in [
+        "CreateContainerConfigError",
+        "InvalidImageName",
+        "ContainerCannotRun",
+        "DeadlineExceeded",
+    ] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        let mut pod = health_test_pod("a-failure");
+        pod["status"]["containerStatuses"][0]["state"] = json!({"waiting": {"reason": reason}});
+        apply(&mut app, pod);
+        apply(&mut app, health_test_pod("z-selected"));
+        app.handle_key(press(KeyCode::End)).unwrap();
+        assert_eq!(
+            health_row_color(&mut app, "a-failure", reason),
+            crate::theme::red()
+        );
+        assert_eq!(
+            health_row_color(&mut app, "a-failure", "a-failure"),
+            crate::theme::red()
+        );
+    }
+    let (mut app, _rx) = test_app();
+    app.cluster
+        .register_kind("", "PersistentVolumeClaim", "persistentvolumeclaims", true);
+    app.switch_kind("persistentvolumeclaims");
+    for (name, phase) in [("a-lost", "Lost"), ("z-selected", "Bound")] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "PersistentVolumeClaim",
+            "metadata": {"name": name, "namespace": "default"}, "status": {"phase": phase}}),
+        );
+    }
+    app.handle_key(press(KeyCode::End)).unwrap();
+    assert_eq!(
+        health_row_color(&mut app, "a-lost", "Lost"),
+        crate::theme::red()
+    );
+    assert_eq!(
+        health_row_color(&mut app, "a-lost", "a-lost"),
+        crate::theme::red()
+    );
+}
+
+#[tokio::test]
+async fn timeline_key_shows_init_and_sidecar_restart_updates() {
+    for sidecar in [false, true] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        let mut pod = health_test_pod("restart-target");
+        pod["spec"]["initContainers"] = json!([{"name": "init"}]);
+        if sidecar {
+            pod["spec"]["initContainers"][0]["restartPolicy"] = json!("Always");
+        } else {
+            pod["status"]["phase"] = json!("Pending");
+        }
+        pod["status"]["initContainerStatuses"] = json!([{"name": "init", "restartCount": 2,
+            "state": {"running": {}}}]);
+        apply(&mut app, pod.clone());
+        pod["metadata"]["resourceVersion"] = json!("2");
+        pod["status"]["initContainerStatuses"][0]["restartCount"] = json!(3);
+        apply(&mut app, pod);
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        app.handle_key(press(KeyCode::Char('T'))).unwrap();
+        assert_eq!(app.mode, Mode::Timeline);
+        let (plural, key) = app.timeline_target.as_ref().unwrap();
+        let entries = app.timeline.entries(plural, key).unwrap();
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.level == crate::timeline::Level::Warn
+                    && entry.text == "container restart (2 → 3 total)")
+        );
+    }
+}
+#[tokio::test]
+async fn sidecar_failures_remain_visible_after_initialization() {
+    for (app_state, phase, expected) in [
+        (json!({"running": {}}), "Running", "Init:CrashLoopBackOff"),
+        (
+            json!({"waiting": {"reason": "ImagePullBackOff"}}),
+            "Pending",
+            "ImagePullBackOff",
+        ),
+        (
+            json!({"terminated": {"reason": "Error", "exitCode": 1}}),
+            "Failed",
+            "Error",
+        ),
+        (
+            json!({"terminated": {"reason": "Completed", "exitCode": 0}}),
+            "Succeeded",
+            "Succeeded",
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        let mut pod = health_test_pod("a-sidecar");
+        pod["spec"]["initContainers"] = json!([
+            {"name": "setup"}, {"name": "proxy", "restartPolicy": "Always"}
+        ]);
+        pod["status"]["phase"] = json!(phase);
+        pod["status"]["conditions"] = json!([
+            {"type": "Initialized", "status": "True"},
+            {"type": "Ready", "status": "False"}
+        ]);
+        pod["status"]["containerStatuses"][0]["ready"] = json!(app_state.get("running").is_some());
+        pod["status"]["containerStatuses"][0]["state"] = app_state;
+        pod["status"]["initContainerStatuses"] = json!([
+            {"name": "setup", "ready": true, "restartCount": 5,
+             "state": {"terminated": {"reason": "Completed", "exitCode": 0}}},
+            {"name": "proxy", "ready": false, "started": false, "restartCount": 3,
+             "state": {"waiting": {"reason": "CrashLoopBackOff"}}}
+        ]);
+        apply(&mut app, pod);
+        apply(&mut app, health_test_pod("z-selected"));
+        type_filter(&mut app, &format!("status={expected} restarts=3"));
+        assert_eq!(row_names(&app), ["a-sidecar"], "{expected}");
+        let (headers, rows) = app.snapshot_table();
+        if expected == "Init:CrashLoopBackOff" {
+            assert_eq!(
+                rows[0][headers.iter().position(|h| h == "READY").unwrap()],
+                "1/2"
+            );
+        }
+        assert_eq!(
+            rows[0][headers.iter().position(|h| h == "RESTARTS").unwrap()],
+            "3"
+        );
+        retype_filter(&mut app, "");
+        app.handle_key(press(KeyCode::End)).unwrap();
+        let color = if expected == "Succeeded" {
+            crate::theme::overlay0()
+        } else {
+            crate::theme::red()
+        };
+        assert_eq!(health_row_color(&mut app, "a-sidecar", expected), color);
+        assert_eq!(health_row_color(&mut app, "a-sidecar", "a-sidecar"), color);
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1431,57 +1431,158 @@ fn pod_summary(obj: &DynamicObject) -> (String, String, String) {
         .filter(|s| sidecars(d).any(|c| c.get("name") == s.get("name")));
 
     let mut ready = 0usize;
-    let mut restarts = 0i64;
     for c in statuses.iter().chain(sidecar_statuses) {
         if c.get("ready").and_then(Value::as_bool).unwrap_or(false) {
             ready += 1;
         }
-        restarts += c.get("restartCount").and_then(Value::as_i64).unwrap_or(0);
     }
 
     (
         format!("{ready}/{total}"),
         pod_status(obj),
-        restarts.to_string(),
+        pod_restarts(obj).to_string(),
     )
 }
 
-/// A pod's STATUS cell. Exposed so the `:sanitize` plugin selects pods by the
-/// status the pods view shows, rather than a second, drifting derivation.
+/// Restarts shown in the pod row. Normal init restarts apply only while the
+/// pod initializes; native sidecars continue to count after initialization.
+pub(crate) fn pod_restarts(obj: &DynamicObject) -> i64 {
+    let d = &obj.data;
+    let initializing = !pod_initialized(obj) && pod_init_status(obj).is_some();
+    array(d, "/status/containerStatuses")
+        .iter()
+        .chain(
+            array(d, "/status/initContainerStatuses")
+                .iter()
+                .filter(|s| initializing || sidecars(d).any(|c| c.get("name") == s.get("name"))),
+        )
+        .filter_map(|c| c.get("restartCount").and_then(Value::as_i64))
+        .sum()
+}
+
+fn pod_initialized(obj: &DynamicObject) -> bool {
+    array(&obj.data, "/status/conditions").iter().any(|c| {
+        c.get("type").and_then(Value::as_str) == Some("Initialized")
+            && c.get("status").and_then(Value::as_str) == Some("True")
+    })
+}
+
+/// Init state can still report a sidecar failure after the pod initializes.
+fn pod_init_status(obj: &DynamicObject) -> Option<String> {
+    let d = &obj.data;
+    let init = array(d, "/spec/initContainers");
+    let statuses = array(d, "/status/initContainerStatuses");
+    for (i, container) in init.iter().enumerate() {
+        let Some(status) = statuses
+            .iter()
+            .find(|s| s.get("name") == container.get("name"))
+        else {
+            // Before the kubelet reports init state, keep the Pod reason or
+            // scheduling condition instead of inventing init progress.
+            continue;
+        };
+        if status
+            .pointer("/state/terminated/exitCode")
+            .and_then(Value::as_i64)
+            == Some(0)
+        {
+            continue;
+        }
+        let sidecar = container.get("restartPolicy").and_then(Value::as_str) == Some("Always");
+        if sidecar
+            && (status.get("started").and_then(Value::as_bool) == Some(true)
+                || (status.get("started").is_none() && status.pointer("/state/running").is_some()))
+        {
+            continue;
+        }
+        if let Some(terminated) = status.pointer("/state/terminated") {
+            return Some(format!("Init:{}", termination_reason(terminated)));
+        }
+        if let Some(reason) = status
+            .pointer("/state/waiting/reason")
+            .and_then(Value::as_str)
+            && !reason.is_empty()
+            && reason != "PodInitializing"
+        {
+            return Some(format!("Init:{reason}"));
+        }
+        return Some(format!("Init:{i}/{}", init.len()));
+    }
+    None
+}
+
+fn termination_reason(terminated: &Value) -> String {
+    if let Some(reason) = terminated
+        .get("reason")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+    {
+        return reason.to_string();
+    }
+    let signal = terminated
+        .get("signal")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    if signal != 0 {
+        format!("Signal:{signal}")
+    } else {
+        format!(
+            "ExitCode:{}",
+            terminated
+                .get("exitCode")
+                .and_then(Value::as_i64)
+                .unwrap_or(0)
+        )
+    }
+}
+
+/// A pod's STATUS cell, including initialization and specific failure reasons.
 pub fn pod_status(obj: &DynamicObject) -> String {
     let d = &obj.data;
-    let empty = vec![];
-    let statuses = d
-        .get("status")
-        .and_then(|s| s.get("containerStatuses"))
-        .and_then(|c| c.as_array())
-        .unwrap_or(&empty);
+    if obj.metadata.deletion_timestamp.is_some() {
+        return "Terminating".to_string();
+    }
+    let init_status = match pod_init_status(obj) {
+        Some(status) if !pod_initialized(obj) => return status,
+        status => status,
+    };
+    let statuses = array(d, "/status/containerStatuses");
 
     let mut waiting_reason: Option<String> = None;
     let mut terminated_reason: Option<String> = None;
+    let mut completed = false;
     for c in statuses {
         if let Some(r) = c.pointer("/state/waiting/reason").and_then(Value::as_str)
+            && !r.is_empty()
             && (r != "ContainerCreating" || waiting_reason.is_none())
         {
             waiting_reason = Some(r.to_string());
         }
-        if let Some(r) = c
-            .pointer("/state/terminated/reason")
-            .and_then(Value::as_str)
-            && r != "Completed"
-        {
-            terminated_reason = Some(r.to_string());
+        if let Some(terminated) = c.pointer("/state/terminated") {
+            let reason = termination_reason(terminated);
+            if reason == "Completed" {
+                completed = true;
+            } else {
+                terminated_reason = Some(reason);
+            }
         }
     }
 
-    if obj.metadata.deletion_timestamp.is_some() {
-        "Terminating".to_string()
-    } else if let Some(r) = waiting_reason {
+    if let Some(r) = waiting_reason {
         r
     } else if let Some(r) = terminated_reason {
         r
+    } else if let Some(status) = init_status.filter(|_| !completed) {
+        status
+    } else if array(d, "/status/conditions").iter().any(|c| {
+        c.get("type").and_then(Value::as_str) == Some("PodScheduled")
+            && c.get("reason").and_then(Value::as_str) == Some("SchedulingGated")
+    }) {
+        "SchedulingGated".to_string()
     } else {
-        sget(d, &["status", "phase"])
+        sget(d, &["status", "reason"])
+            .filter(|r| !r.is_empty())
+            .or_else(|| sget(d, &["status", "phase"]))
             .unwrap_or("Unknown")
             .to_string()
     }
@@ -2854,5 +2955,151 @@ mod tests {
             SortValue::Num(n) => assert_eq!(n, 1.0),
             SortValue::Text(t) => panic!("pod READY must sort numerically, got '{t}'"),
         }
+    }
+
+    #[test]
+    fn pod_init_status_and_restart_counts_follow_initialization() {
+        let mut pod = obj(json!({
+            "apiVersion": "v1", "kind": "Pod", "metadata": {"name": "init"},
+            "spec": {"containers": [{"name": "app"}],
+                "initContainers": [{"name": "first"}, {"name": "second"}]},
+            "status": {"phase": "Pending", "containerStatuses": [{"name": "app",
+                "ready": false, "restartCount": 0, "state": {"waiting": {"reason": "PodInitializing"}}}],
+                "initContainerStatuses": [
+                    {"name": "first", "restartCount": 2, "state": {"terminated": {"exitCode": 0}}},
+                    {"name": "second", "restartCount": 3, "state": {"running": {}}}]}
+        }));
+        assert_eq!(
+            pod_summary(&pod),
+            ("0/1".into(), "Init:1/2".into(), "5".into())
+        );
+        for (state, expected) in [
+            (
+                json!({"waiting": {"reason": "CrashLoopBackOff"}}),
+                "Init:CrashLoopBackOff",
+            ),
+            (
+                json!({"terminated": {"reason": "Error", "exitCode": 1}}),
+                "Init:Error",
+            ),
+            (json!({"terminated": {"exitCode": 42}}), "Init:ExitCode:42"),
+            (
+                json!({"terminated": {"reason": "", "exitCode": 137, "signal": 9}}),
+                "Init:Signal:9",
+            ),
+        ] {
+            pod.data["status"]["initContainerStatuses"][1]["state"] = state;
+            assert_eq!(pod_status(&pod), expected);
+            assert_eq!(pod_restarts(&pod), 5);
+        }
+        pod.data["status"]["initContainerStatuses"][1]["state"] =
+            json!({"terminated": {"exitCode": 0}});
+        pod.data["status"]["phase"] = json!("Running");
+        pod.data["status"]["containerStatuses"][0] = json!({"name": "app", "ready": true,
+            "restartCount": 1, "state": {"running": {}}});
+        assert_eq!(
+            pod_summary(&pod),
+            ("1/1".into(), "Running".into(), "1".into())
+        );
+        pod.data["status"]["initContainerStatuses"] = json!([]);
+        assert_eq!(pod_status(&pod), "Running");
+        pod.data["status"]["conditions"] = json!([{"type": "Initialized", "status": "True"}]);
+        assert_eq!(pod_status(&pod), "Running");
+    }
+
+    #[test]
+    fn pod_reason_and_termination_fallbacks_preserve_precedence() {
+        let mut pod = obj(
+            json!({"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "reason"},
+            "status": {"phase": "Failed", "reason": "Evicted"}}),
+        );
+        assert_eq!(pod_status(&pod), "Evicted");
+        pod.data["status"]["reason"] = json!("");
+        assert_eq!(pod_status(&pod), "Failed");
+        pod.data["status"]["phase"] = json!("Pending");
+        pod.data["status"]["conditions"] =
+            json!([{"type": "PodScheduled", "status": "False", "reason": "SchedulingGated"}]);
+        assert_eq!(pod_status(&pod), "SchedulingGated");
+        for (terminated, expected) in [
+            (json!({"exitCode": 42}), "ExitCode:42"),
+            (json!({"reason": "", "exitCode": 42}), "ExitCode:42"),
+            (json!({"signal": 9, "exitCode": 137}), "Signal:9"),
+            (
+                json!({"reason": "OOMKilled", "signal": 9, "exitCode": 137}),
+                "OOMKilled",
+            ),
+        ] {
+            pod.data["status"]["containerStatuses"] =
+                json!([{"state": {"terminated": terminated}}]);
+            assert_eq!(pod_status(&pod), expected);
+        }
+        pod.data["status"]["containerStatuses"] = json!([
+            {"state": {"waiting": {"reason": "CrashLoopBackOff"}}},
+            {"state": {"waiting": {"reason": "ContainerCreating"}}}
+        ]);
+        assert_eq!(pod_status(&pod), "CrashLoopBackOff");
+        pod.metadata.deletion_timestamp =
+            Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                "2026-09-07T00:00:00Z".parse().unwrap(),
+            ));
+        assert_eq!(pod_status(&pod), "Terminating");
+    }
+    #[test]
+    fn absent_init_status_preserves_pod_and_scheduling_reasons() {
+        for (status, expected) in [
+            (json!({"phase": "Pending"}), "Pending"),
+            (json!({"phase": "Failed", "reason": "Evicted"}), "Evicted"),
+            (
+                json!({"phase": "Pending", "conditions": [{"type": "PodScheduled",
+                "status": "False", "reason": "SchedulingGated"}]}),
+                "SchedulingGated",
+            ),
+        ] {
+            let pod = obj(
+                json!({"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "pending"},
+                "spec": {"containers": [{"name": "app"}], "initContainers": [{"name": "init"}]},
+                "status": status}),
+            );
+            assert_eq!(pod_status(&pod), expected);
+            assert_eq!(pod_restarts(&pod), 0);
+        }
+    }
+
+    #[test]
+    fn sidecar_startup_is_separate_from_readiness() {
+        let mut pod = obj(
+            json!({"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "sidecar"},
+            "spec": {"containers": [{"name": "app"}],
+                "initContainers": [{"name": "proxy", "restartPolicy": "Always"}]},
+            "status": {"phase": "Pending", "containerStatuses": [{"name": "app", "ready": false,
+                "state": {"waiting": {"reason": "PodInitializing"}}}],
+                "initContainerStatuses": [{"name": "proxy", "started": false, "ready": false,
+                    "restartCount": 2, "state": {"running": {}}}]}}),
+        );
+        assert_eq!(
+            pod_summary(&pod),
+            ("0/2".into(), "Init:0/1".into(), "2".into())
+        );
+        pod.data["status"]["initContainerStatuses"][0]["started"] = json!(true);
+        pod.data["status"]["phase"] = json!("Running");
+        pod.data["status"]["containerStatuses"][0] = json!({"name": "app", "ready": true,
+            "restartCount": 0, "state": {"running": {}}});
+        assert_eq!(
+            pod_summary(&pod),
+            ("1/2".into(), "Running".into(), "2".into())
+        );
+        pod.data["status"]["initContainerStatuses"][0]["ready"] = json!(true);
+        assert_eq!(
+            pod_summary(&pod),
+            ("2/2".into(), "Running".into(), "2".into())
+        );
+        // The Kubernetes printer skips successful terminations before checking
+        // started. Keep that display rule separate from READY and cleanup.
+        pod.data["status"]["initContainerStatuses"][0] = json!({"name": "proxy", "started": false,
+            "ready": false, "restartCount": 2, "state": {"terminated": {"exitCode": 0}}});
+        assert_eq!(
+            pod_summary(&pod),
+            ("1/2".into(), "Running".into(), "2".into())
+        );
     }
 }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -60,12 +60,49 @@ fn wanted(states: &str) -> Option<Vec<&'static str>> {
 /// They are infrastructure for the workload rather than the workload, and
 /// counting them would make an identical crash-looping pod exempt from
 /// `states = stuck` purely because something injected a proxy into it. The
-/// STATUS column ignores them for the same reason, so the two agree.
+/// cleanup rules keep this distinction even when table status becomes more detailed.
 fn running(pod: &DynamicObject) -> bool {
     pod.data
         .pointer("/status/containerStatuses")
         .and_then(Value::as_array)
         .is_some_and(|cs| cs.iter().any(|c| c.pointer("/state/running").is_some()))
+}
+
+/// Cleanup uses application state and pod phase, not display-only reason labels.
+/// Init failures and numeric exit labels must not widen the deletion categories.
+fn matches_states(pod: &DynamicObject, wanted: &[&str]) -> bool {
+    if pod.metadata.deletion_timestamp.is_some() || running(pod) {
+        return false;
+    }
+    let mut waiting = None;
+    let mut terminated = None;
+    if let Some(statuses) = pod
+        .data
+        .pointer("/status/containerStatuses")
+        .and_then(Value::as_array)
+    {
+        for status in statuses {
+            if let Some(reason) = status
+                .pointer("/state/waiting/reason")
+                .and_then(Value::as_str)
+                && (reason != "ContainerCreating" || waiting.is_none())
+            {
+                waiting = Some(reason);
+            }
+            if let Some(reason) = status
+                .pointer("/state/terminated/reason")
+                .and_then(Value::as_str)
+                && reason != "Completed"
+            {
+                terminated = Some(reason);
+            }
+        }
+    }
+    let category = waiting
+        .or(terminated)
+        .or_else(|| pod.data.pointer("/status/phase").and_then(Value::as_str))
+        .unwrap_or("Unknown");
+    wanted.contains(&category)
 }
 
 struct Target {
@@ -153,7 +190,7 @@ async fn sanitize(
         let next = page.metadata.continue_.clone();
         for pod in page {
             let status = crate::columns::pod_status(&pod);
-            if !wanted.contains(&status.as_str()) || running(&pod) {
+            if !matches_states(&pod, &wanted) {
                 continue;
             }
             targets.push(Target {
@@ -226,8 +263,7 @@ async fn sanitize(
                 }
             };
             let still_selected = fresh.metadata.uid.as_deref() == Some(target.uid.as_str())
-                && wanted.contains(&crate::columns::pod_status(&fresh).as_str())
-                && !running(&fresh);
+                && matches_states(&fresh, &wanted);
             if !still_selected {
                 changed += 1;
                 continue;
@@ -976,8 +1012,8 @@ mod tests {
             "metadata": {"name": "gone", "namespace": "default"},
             "status": {"phase": "Failed", "reason": "Evicted"}
         }));
-        assert_eq!(crate::columns::pod_status(&evicted), "Failed");
-        assert!(wanted("terminal").unwrap().contains(&"Failed"));
+        assert_eq!(crate::columns::pod_status(&evicted), "Evicted");
+        assert!(matches_states(&evicted, &wanted("terminal").unwrap()));
     }
 
     #[test]
@@ -1093,5 +1129,38 @@ mod tests {
                 .unwrap()
                 .starts_with("20 more rows")
         );
+    }
+
+    #[test]
+    fn display_reason_changes_do_not_expand_cleanup_categories() {
+        let mut p = pod(json!({"metadata": {"name": "p", "namespace": "default"},
+            "status": {"phase": "Failed", "reason": "Evicted"}}));
+        assert!(matches_states(&p, &wanted("terminal").unwrap()));
+        p.data["status"]["reason"] = json!("DeadlineExceeded");
+        assert!(matches_states(&p, &wanted("terminal").unwrap()));
+        p.data["status"] = json!({"phase": "Pending", "conditions": [
+            {"type": "PodScheduled", "status": "False", "reason": "SchedulingGated"}]});
+        assert!(!matches_states(&p, &wanted("terminal").unwrap()));
+        assert!(!matches_states(&p, &wanted("stuck").unwrap()));
+        assert!(matches_states(&p, &wanted("all").unwrap()));
+        p.data["spec"] = json!({"initContainers": [{"name": "init"}]});
+        p.data["status"] = json!({"phase": "Pending", "initContainerStatuses": [
+            {"name": "init", "state": {"waiting": {"reason": "CrashLoopBackOff"}}}],
+            "containerStatuses": [{"state": {"waiting": {"reason": "PodInitializing"}}}]});
+        assert_eq!(crate::columns::pod_status(&p), "Init:CrashLoopBackOff");
+        assert!(!matches_states(&p, &wanted("all").unwrap()));
+        p.data["spec"] = json!({});
+        p.data["status"] = json!({"phase": "Running", "containerStatuses": [
+            {"state": {"terminated": {"exitCode": 42}}}]});
+        assert_eq!(crate::columns::pod_status(&p), "ExitCode:42");
+        assert!(!matches_states(&p, &wanted("all").unwrap()));
+        p.data["status"] = json!({"phase": "Failed", "reason": "Evicted", "containerStatuses": [
+            {"ready": false, "state": {"running": {}}}]});
+        assert!(!matches_states(&p, &wanted("all").unwrap()));
+        p.data["status"]["containerStatuses"] = json!([]);
+        p.metadata.deletion_timestamp = Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+            "2026-09-07T00:00:00Z".parse().unwrap(),
+        ));
+        assert!(!matches_states(&p, &wanted("all").unwrap()));
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -515,21 +515,55 @@ pub fn accent() -> Style {
 /// against the row tint.
 pub fn status_color(s: &str) -> Color {
     match s {
+        s if failure_status(s) => red(),
+        s if s.starts_with("Init:") => yellow(),
         "Running" | "Ready" | "Active" | "Bound" | "True" | "deployed" => green(),
         // Faded, not "healthy green" — a finished pod isn't running, and a
         // scaled-to-zero workload isn't serving.
         "Succeeded" | "Completed" | "superseded" | "uninstalled" | "ScaledDown" => overlay0(),
-        "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" | "pending-install"
-        | "pending-upgrade" | "pending-rollback" => yellow(),
+        "Pending" | "ContainerCreating" | "PodInitializing" | "SchedulingGated" | "Progressing"
+        | "pending-install" | "pending-upgrade" | "pending-rollback" => yellow(),
         // Matches row_color's killColor — a distinct "on its way out" hue,
         // not the same bucket as Pending.
         "Terminating" | "uninstalling" => mauve(),
-        "Failed" | "Error" | "CrashLoopBackOff" | "ImagePullBackOff" | "ErrImagePull"
-        | "Evicted" | "OOMKilled" | "NotReady" | "False" | "failed" | "Degraded"
-        | "Unavailable" | "Stalled" => red(),
         "Unknown" | "" | "unknown" => overlay1(),
         _ => text(),
     }
+}
+
+fn failure_status(status: &str) -> bool {
+    let status = status.strip_prefix("Init:").unwrap_or(status);
+    matches!(
+        status,
+        "Failed"
+            | "Error"
+            | "CrashLoopBackOff"
+            | "ImagePullBackOff"
+            | "ErrImagePull"
+            | "Evicted"
+            | "OOMKilled"
+            | "NotReady"
+            | "Unhealthy"
+            | "False"
+            | "failed"
+            | "Degraded"
+            | "Unavailable"
+            | "Stalled"
+            | "CreateContainerConfigError"
+            | "CreateContainerError"
+            | "InvalidImageName"
+            | "ContainerCannotRun"
+            | "RunContainerError"
+            | "ErrImageNeverPull"
+            | "StartError"
+            | "DeadlineExceeded"
+            | "Lost"
+            | "ContainerStatusUnknown"
+    ) || status
+        .strip_prefix("Signal:")
+        .or_else(|| status.strip_prefix("ExitCode:"))
+        .and_then(|n| n.parse::<i64>().ok())
+        .is_some_and(|n| n != 0)
 }
 
 /// k9s-style whole-row color: every table row is tinted a single color chosen
@@ -544,11 +578,10 @@ pub fn status_color(s: &str) -> Color {
 ///   standard row color (blue), so healthy rows read blue like k9s, not white.
 pub fn row_color(s: &str) -> Color {
     match s {
-        "Failed" | "Error" | "CrashLoopBackOff" | "ImagePullBackOff" | "ErrImagePull"
-        | "Evicted" | "OOMKilled" | "NotReady" | "Unhealthy" | "False" | "failed" | "Degraded"
-        | "Unavailable" | "Stalled" => red(),
-        "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" | "pending-install"
-        | "pending-upgrade" | "pending-rollback" => peach(),
+        s if failure_status(s) => red(),
+        s if s.starts_with("Init:") => peach(),
+        "Pending" | "ContainerCreating" | "PodInitializing" | "SchedulingGated" | "Progressing"
+        | "pending-install" | "pending-upgrade" | "pending-rollback" => peach(),
         "Completed" | "Succeeded" | "superseded" | "uninstalled" | "ScaledDown" => overlay0(),
         // k9s killColor — terminating/deleting rows.
         "Terminating" | "uninstalling" => mauve(),
@@ -737,5 +770,35 @@ mod tests {
         // No TTY in the test harness, so this should return `None` promptly
         // rather than panicking or blocking on the query timeout.
         let _ = detect_terminal_mode();
+    }
+
+    #[test]
+    fn failure_colors_cover_specific_reasons_and_init_failures() {
+        for status in [
+            "CreateContainerConfigError",
+            "CreateContainerError",
+            "InvalidImageName",
+            "ContainerCannotRun",
+            "RunContainerError",
+            "ErrImageNeverPull",
+            "StartError",
+            "DeadlineExceeded",
+            "Lost",
+            "ContainerStatusUnknown",
+            "Init:CrashLoopBackOff",
+            "Init:Error",
+            "Init:ExitCode:42",
+            "Signal:9",
+            "ExitCode:42",
+        ] {
+            assert_eq!(row_color(status), red(), "{status}");
+            assert_eq!(status_color(status), red(), "{status}");
+        }
+        for status in ["Init:0/2", "Init:1/2", "SchedulingGated"] {
+            assert_eq!(row_color(status), peach(), "{status}");
+            assert_eq!(status_color(status), yellow(), "{status}");
+        }
+        assert_ne!(row_color("ExitCode:0"), red());
+        assert_ne!(status_color("ExitCode:0"), red());
     }
 }

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -326,15 +326,14 @@ fn i_at(obj: &DynamicObject, ptr: &str) -> i64 {
 }
 
 fn restarts_sum(obj: &DynamicObject) -> i64 {
-    obj.data
-        .pointer("/status/containerStatuses")
-        .and_then(Value::as_array)
-        .map(|cs| {
-            cs.iter()
-                .filter_map(|c| c.get("restartCount").and_then(Value::as_i64))
-                .sum()
-        })
-        .unwrap_or(0)
+    // Keep completed init counts in history so initialization does not reset
+    // the baseline or hide a restart in the same update that completes init.
+    ["/status/containerStatuses", "/status/initContainerStatuses"]
+        .into_iter()
+        .filter_map(|path| obj.data.pointer(path).and_then(Value::as_array))
+        .flatten()
+        .filter_map(|c| c.get("restartCount").and_then(Value::as_i64))
+        .sum()
 }
 
 fn waiting_reason(obj: &DynamicObject) -> Option<String> {
@@ -530,5 +529,31 @@ mod tests {
     fn clock_formats_hms() {
         // 08:45:12 UTC on 2026-07-13 → 1_752_396_312.
         assert_eq!(clock(1_752_396_312), "08:45:12");
+    }
+
+    #[test]
+    fn init_restart_history_survives_initialization_completion() {
+        let before = obj(
+            json!({"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "p"},
+            "status": {"phase": "Pending", "initContainerStatuses": [
+                {"name": "init", "restartCount": 2, "state": {"running": {}}}],
+                "containerStatuses": [{"name": "app", "restartCount": 0}]}}),
+        );
+        let mut after = before.clone();
+        after.data["status"]["phase"] = json!("Running");
+        after.data["status"]["initContainerStatuses"][0] = json!({"name": "init", "restartCount": 3,
+            "state": {"terminated": {"exitCode": 0}}});
+        let changes = transitions(&before, &after, "pods");
+        assert!(changes.iter().any(
+            |(level, text)| *level == Level::Warn && text == "container restart (2 → 3 total)"
+        ));
+        let mut app_restart = after.clone();
+        app_restart.data["status"]["containerStatuses"][0]["restartCount"] = json!(1);
+        assert!(
+            transitions(&after, &app_restart, "pods")
+                .iter()
+                .any(|(_, text)| text == "container restart (3 → 4 total)")
+        );
+        assert!(transitions(&app_restart, &app_restart, "pods").is_empty());
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -800,9 +800,10 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             // every container passes its readiness probe — until READY is n/n,
             // paint it as transitional, not healthy.
             let running_not_ready = status_val == "Running"
-                && ready_idx
+                && (ready_idx
                     .and_then(|i| cells.get(i))
-                    .is_some_and(|r| !all_ready(r.as_str()));
+                    .is_some_and(|r| !all_ready(r.as_str()))
+                    || (app.kind_plural == "pods" && pod_readiness_blocked(obj)));
             let status_key = if running_not_ready {
                 "PodInitializing"
             } else {
@@ -1187,6 +1188,30 @@ fn all_ready(ready: &str) -> bool {
         Some((r, t)) => r == t,
         None => true,
     }
+}
+
+fn pod_readiness_blocked(obj: &kube::core::DynamicObject) -> bool {
+    let conditions = obj
+        .data
+        .pointer("/status/conditions")
+        .and_then(serde_json::Value::as_array);
+    let condition = |name: &str| {
+        conditions
+            .and_then(|conditions| conditions.iter().find(|c| c["type"].as_str() == Some(name)))
+    };
+    condition("Ready").is_some_and(|c| c["status"].as_str() != Some("True"))
+        || obj
+            .data
+            .pointer("/spec/readinessGates")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|gates| {
+                gates.iter().any(|gate| {
+                    gate["conditionType"]
+                        .as_str()
+                        .and_then(condition)
+                        .is_none_or(|c| c["status"].as_str() != Some("True"))
+                })
+            })
 }
 
 /// Render the NAME cell, highlighting characters that matched the active


### PR DESCRIPTION
Pod rows now show init progress, container failures, exit details, and Pod reasons. Readiness gates affect health colors. Restart totals and the timeline include restartable init containers.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #264

Closes #265

Closes #271

Closes #276

Closes #289

This is the first pull request in the remaining bug fix set. Merge it into `main` before the dependent pull requests.
