### PR TITLE
fix: report active Node pressure conditions

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -10,6 +10,11 @@ failed probes), and recent Warning events. No AI, no external service.
 `j`/`k` move, `⏎` goes to the resource behind a finding, `E` its events, `l` its
 logs, `r` gathers again. A finding you can drill into has a trailing `→`.
 
+For Nodes, memory, disk, and PID pressure are warnings when their conditions
+are `True`. `NetworkUnavailable=True` is also a warning. These conditions do
+not produce warnings when they are `False`. `Unknown` remains a warning, and
+the `Ready` condition is assessed separately.
+
 ## Timeline (`T`)
 
 A per-object timestamped log of every state change the watch saw this session:

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14366,3 +14366,62 @@ async fn sidecar_failures_remain_visible_after_initialization() {
         assert_eq!(health_row_color(&mut app, "a-sidecar", "a-sidecar"), color);
     }
 }
+
+fn explain_selected_with_pure_evidence(app: &mut App) {
+    app.handle_key(press(KeyCode::Char('X'))).unwrap();
+    assert_eq!(app.mode, Mode::Explain);
+    let source = app.explain_source.as_ref().unwrap();
+    let findings = crate::explain::explain(&crate::explain::Evidence {
+        kind: &app.kind.as_ref().unwrap().ar.kind,
+        plural: &app.kind_plural,
+        obj: source,
+        pods: &[],
+        events: &[],
+        events_v1: false,
+    });
+    app.handle_msg(Msg::Explain {
+        generation: app.generation,
+        claim: current_claim(app),
+        title: app.explain_title.clone(),
+        findings,
+    });
+}
+
+#[tokio::test]
+async fn explain_key_reports_node_pressure_without_warning_on_healthy_conditions() {
+    for state in ["False", "True", "Unknown"] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("nodes");
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node",
+            "metadata": {"name": "worker"}, "status": {"conditions": [
+                {"type": "Ready", "status": "True"},
+                {"type": "MemoryPressure", "status": state, "reason": "MemoryCondition"},
+                {"type": "DiskPressure", "status": state},
+                {"type": "PIDPressure", "status": state},
+                {"type": "NetworkUnavailable", "status": state}]}}),
+        );
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        explain_selected_with_pure_evidence(&mut app);
+        assert_eq!(app.explain_items[0].text, "Node/worker is Ready");
+        for condition in [
+            "MemoryPressure",
+            "DiskPressure",
+            "PIDPressure",
+            "NetworkUnavailable",
+        ] {
+            let finding = app
+                .explain_items
+                .iter()
+                .find(|f| f.text.starts_with(condition));
+            if state == "False" {
+                assert!(finding.is_none(), "{condition}");
+            } else {
+                assert_eq!(finding.unwrap().level, crate::explain::Level::Warn);
+            }
+        }
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode, Mode::Table);
+    }
+}

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -300,14 +300,20 @@ fn explain_generic(ev: &Evidence, name: &str, out: &mut Vec<Finding>) {
         }
     }
 
-    // Any other False/Unknown conditions add detail.
+    // Node pressure conditions report a problem when True; Ready and generic
+    // conditions report a problem when False. Unknown remains a warning.
     for cond in conditions(ev.obj) {
-        if cstr(cond, "type") == "Ready" {
+        let ty = cstr(cond, "type");
+        if ty == "Ready" {
             continue;
         }
         let status = cstr(cond, "status");
-        if status == "False" || status == "Unknown" {
-            let ty = cstr(cond, "type");
+        let pressure = ev.plural == "nodes"
+            && matches!(
+                ty,
+                "MemoryPressure" | "DiskPressure" | "PIDPressure" | "NetworkUnavailable"
+            );
+        if status == "Unknown" || status == if pressure { "True" } else { "False" } {
             let detail = join_reason(cstr(cond, "reason"), cstr(cond, "message"));
             out.push(Finding::new(1, Level::Warn, format!("{ty}: {detail}")));
         }
@@ -779,5 +785,50 @@ mod tests {
         assert_eq!(ev_lines.len(), 2, "only Warnings, Normal dropped");
         assert!(ev_lines[0].text.contains("Failed: newer"), "newest first");
         assert!(ev_lines[1].text.contains("BackOff: older"));
+    }
+    #[test]
+    fn node_pressure_polarity_is_separate_from_readiness() {
+        for condition in [
+            "MemoryPressure",
+            "DiskPressure",
+            "PIDPressure",
+            "NetworkUnavailable",
+        ] {
+            for state in ["True", "False", "Unknown"] {
+                let node = obj(
+                    json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "worker"},
+                    "status": {"conditions": [{"type": "Ready", "status": "True"},
+                        {"type": condition, "status": state, "reason": "ConditionReason"}]}}),
+                );
+                let findings = explain(&ev("Node", "nodes", &node, &[], &[]));
+                assert_eq!(findings[0].level, Level::Good);
+                let pressure = findings.iter().find(|f| f.text.starts_with(condition));
+                if state == "False" {
+                    assert!(pressure.is_none(), "{condition}={state}");
+                } else {
+                    assert_eq!(pressure.unwrap().level, Level::Warn, "{condition}={state}");
+                    assert!(pressure.unwrap().text.contains("ConditionReason"));
+                }
+            }
+        }
+        for (state, level) in [("False", Level::Critical), ("Unknown", Level::Warn)] {
+            let node = obj(
+                json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "worker"},
+                "status": {"conditions": [{"type": "Ready", "status": state}]}}),
+            );
+            assert_eq!(
+                explain(&ev("Node", "nodes", &node, &[], &[]))[0].level,
+                level
+            );
+        }
+        let custom = obj(
+            json!({"metadata": {"name": "custom"}, "status": {"conditions": [
+            {"type": "MemoryPressure", "status": "False"}]}}),
+        );
+        assert!(
+            explain(&ev("Custom", "customs", &custom, &[], &[]))
+                .iter()
+                .any(|f| f.level == Level::Warn && f.text.starts_with("MemoryPressure"))
+        );
     }
 }


### PR DESCRIPTION
Node Explain now reports pressure when its condition is True. False pressure conditions no longer produce warnings.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #277

Depends on #295. After that pull request merges, set this pull request base to `main` before merging.
