### PR TITLE
fix: read DaemonSet availability in Explain

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -15,6 +15,8 @@ are `True`. `NetworkUnavailable=True` is also a warning. These conditions do
 not produce warnings when they are `False`. `Unknown` remains a warning, and
 the `Ready` condition is assessed separately.
 
+The DaemonSet rollout summary reads available pods from `status.numberAvailable`.
+
 ## Timeline (`T`)
 
 A per-object timestamped log of every state change the watch saw this session:

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14425,3 +14425,28 @@ async fn explain_key_reports_node_pressure_without_warning_on_healthy_conditions
         assert_eq!(app.mode, Mode::Table);
     }
 }
+
+#[tokio::test]
+async fn explain_key_shows_reported_daemonset_availability() {
+    let (mut app, _rx) = test_app();
+    app.cluster
+        .register_kind("apps", "DaemonSet", "daemonsets", true);
+    app.switch_kind("daemonsets");
+    apply(
+        &mut app,
+        json!({"apiVersion": "apps/v1", "kind": "DaemonSet",
+        "metadata": {"name": "agent", "namespace": "default"},
+        "status": {"desiredNumberScheduled": 3, "currentNumberScheduled": 3,
+            "updatedNumberScheduled": 3, "numberReady": 3, "numberAvailable": 3}}),
+    );
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    explain_selected_with_pure_evidence(&mut app);
+    assert_eq!(app.explain_items[0].text, "DaemonSet/agent is healthy");
+    assert!(
+        app.explain_items
+            .iter()
+            .any(|f| f.text == "desired 3 · ready 3 · available 3")
+    );
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+}

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -106,7 +106,6 @@ fn explain_workload(ev: &Evidence, name: &str, out: &mut Vec<Finding>) {
     let spec_replicas = ptr_i64(d, "/spec/replicas");
     let ready = ptr_i64(d, "/status/readyReplicas").unwrap_or(0);
     let updated = ptr_i64(d, "/status/updatedReplicas").unwrap_or(0);
-    let available = ptr_i64(d, "/status/availableReplicas").unwrap_or(0);
 
     // DaemonSets count differently — desired is scheduled onto matching nodes.
     let (desired, ds) = match ev.plural {
@@ -118,6 +117,15 @@ fn explain_workload(ev: &Evidence, name: &str, out: &mut Vec<Finding>) {
     };
     let ds_ready = ptr_i64(d, "/status/numberReady").unwrap_or(0);
     let ready = if ds { ds_ready } else { ready };
+    let available = ptr_i64(
+        d,
+        if ds {
+            "/status/numberAvailable"
+        } else {
+            "/status/availableReplicas"
+        },
+    )
+    .unwrap_or(0);
 
     let healthy = ready >= desired && desired > 0
         || (desired == 0 && ptr_i64(d, "/status/replicas").unwrap_or(0) == 0);
@@ -830,5 +838,22 @@ mod tests {
                 .iter()
                 .any(|f| f.level == Level::Warn && f.text.starts_with("MemoryPressure"))
         );
+    }
+    #[test]
+    fn daemonset_available_count_uses_its_status_field() {
+        for available in [Some(3), Some(1), Some(0), None] {
+            let mut daemonset = obj(json!({"apiVersion": "apps/v1", "kind": "DaemonSet",
+                "metadata": {"name": "agent"}, "status": {"desiredNumberScheduled": 3,
+                    "currentNumberScheduled": 3, "updatedNumberScheduled": 3, "numberReady": 3}}));
+            if let Some(n) = available {
+                daemonset.data["status"]["numberAvailable"] = json!(n);
+            }
+            let findings = explain(&ev("DaemonSet", "daemonsets", &daemonset, &[], &[]));
+            assert_eq!(findings[0].level, Level::Good);
+            assert!(
+                findings.iter().any(|f| f.text
+                    == format!("desired 3 · ready 3 · available {}", available.unwrap_or(0)))
+            );
+        }
     }
 }


### PR DESCRIPTION
DaemonSet Explain now reads numberAvailable. It no longer reports zero available Pods when the controller has available Pods.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #282

Depends on #296. After that pull request merges, set this pull request base to `main` before merging.
