### PR TITLE
fix: include workload selector expressions

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -43,6 +43,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Drill-down navigation** with a breadcrumb stack: workload/service → pods,
   cronjob → its jobs, node → its pods, pod → containers, namespace → re-scope,
   CRD → its custom resources. `esc` goes back.
+  Workload pod selection includes both `matchLabels` and `matchExpressions`.
+  Drill-down, logs, Explain, and diagnostic bundles apply all requirements,
+  including `In`, `NotIn`, `Exists`, and `DoesNotExist`. Services use their
+  plain label map.
 - **Resource cycling** (`Tab` / `Shift-Tab`) - browse pods → services →
   deployments → statefulsets → daemonsets → secrets → configmaps → ingresses →
   PVCs, wrapping in either direction without configuration. Keeps the current

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -361,28 +361,22 @@ pub(super) fn crd_served_version(d: &Value) -> Option<String> {
     pick.get("name").and_then(Value::as_str).map(String::from)
 }
 
-/// Build a `k=v,k2=v2` selector string from `spec/<field>` (matchLabels for
-/// workloads, selector map for services).
+/// Build a complete workload selector or a Service's equality selector.
 pub(super) fn label_selector(obj: &DynamicObject, field: &str) -> Option<String> {
-    let path = if field == "matchLabels" {
-        vec!["spec", "selector", "matchLabels"]
-    } else {
-        vec!["spec", "selector"]
-    };
-    let mut cur = &obj.data;
-    for p in path {
-        cur = cur.get(p)?;
+    let value = obj.data.pointer("/spec/selector")?;
+    if field == "matchLabels" {
+        let selector: k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector =
+            serde_json::from_value(value.clone()).ok()?;
+        let selector = kube::core::Selector::try_from(selector).ok()?.to_string();
+        return (!selector.is_empty()).then_some(selector);
     }
-    let map = cur.as_object()?;
-    if map.is_empty() {
-        return None;
-    }
+    let map = value.as_object()?;
     let mut parts: Vec<String> = map
         .iter()
-        .filter_map(|(k, v)| v.as_str().map(|vs| format!("{k}={vs}")))
-        .collect();
+        .map(|(key, value)| value.as_str().map(|value| format!("{key}={value}")))
+        .collect::<Option<_>>()?;
     parts.sort();
-    Some(parts.join(","))
+    (!parts.is_empty()).then(|| parts.join(","))
 }
 
 pub(super) fn container_names(obj: &DynamicObject) -> Vec<String> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14450,3 +14450,88 @@ async fn explain_key_shows_reported_daemonset_availability() {
     app.handle_key(press(KeyCode::Esc)).unwrap();
     assert_eq!(app.mode, Mode::Table);
 }
+
+fn expression_workload(include_labels: bool) -> serde_json::Value {
+    let mut workload = json!({"apiVersion":"apps/v1","kind":"Deployment",
+        "metadata":{"name":"web","namespace":"default","uid":"workload-uid"},
+        "spec":{"replicas":1,"selector":{"matchExpressions":[
+            {"key":"tier","operator":"In","values":["frontend","api"]},
+            {"key":"environment","operator":"NotIn","values":["test"]},
+            {"key":"enabled","operator":"Exists"},
+            {"key":"disabled","operator":"DoesNotExist"}
+        ]}}, "status":{"replicas":1,"readyReplicas":1,"updatedReplicas":1}});
+    if include_labels {
+        workload["spec"]["selector"]["matchLabels"] = json!({"app":"web"});
+    }
+    workload
+}
+
+#[tokio::test]
+async fn workload_enter_preserves_all_selector_requirements() {
+    for include_labels in [false, true] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("deployments");
+        apply(&mut app, expression_workload(include_labels));
+        app.table_state.select(Some(0));
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.kind_plural, "pods");
+        let expected = if include_labels {
+            "app=web,tier in (api,frontend),environment notin (test),enabled,!disabled"
+        } else {
+            "tier in (api,frontend),environment notin (test),enabled,!disabled"
+        };
+        assert_eq!(app.labels.as_deref(), Some(expected));
+    }
+}
+
+#[tokio::test]
+async fn workload_explain_requests_complete_expression_selector() {
+    let (mut app, mut rx) = test_app();
+    app.switch_kind("deployments");
+    let workload = expression_workload(true);
+    apply(&mut app, workload.clone());
+    app.table_state.select(Some(0));
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = requests.clone();
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            seen.lock().unwrap().push(request.uri().to_string());
+            let response = if request.uri().path().ends_with("/pods") {
+                json!({"apiVersion":"v1","kind":"PodList","metadata":{},"items":[]})
+            } else if request.uri().path().ends_with("/web") {
+                workload.clone()
+            } else {
+                json!({"apiVersion":"v1","kind":"EventList","metadata":{},"items":[]})
+            };
+            async move {
+                Ok::<_, std::convert::Infallible>(http::Response::new(http_body_util::Full::new(
+                    hyper::body::Bytes::from(response.to_string()),
+                )))
+            }
+        }),
+        "default",
+    );
+    app.handle_key(press(KeyCode::Char('X'))).unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if matches!(rx.recv().await, Some(Msg::Explain { .. })) {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+    let requests = requests.lock().unwrap();
+    let pods = requests
+        .iter()
+        .find(|uri| uri.contains("/pods?"))
+        .expect("owned pods requested");
+    let params: std::collections::HashMap<_, _> =
+        form_urlencoded::parse(pods.split_once('?').unwrap().1.as_bytes())
+            .into_owned()
+            .collect();
+    assert_eq!(
+        params.get("labelSelector").map(String::as_str),
+        Some("app=web,tier in (api,frontend),environment notin (test),enabled,!disabled")
+    );
+}


### PR DESCRIPTION
Workload Pod selection now includes matchExpressions with matchLabels. Pod lists, logs, and health reports use the complete selector.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #286

Depends on #297. After that pull request merges, set this pull request base to `main` before merging.
