### PR TITLE
fix: refresh health reports from current objects

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -128,6 +128,11 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   and recent Warning events. No AI, no external service. `⏎`, `E`, or `l` jumps
   from a finding to the pod, its events, or its logs. After opening evidence,
   `esc` returns to Explain before another `esc` returns to the table.
+  Opening the view or pressing `r` reads the selected resource from the API
+  before gathering its evidence. A failed read or a changed UID produces a
+  warning instead of findings from an old snapshot. Only the latest requested
+  report can update the findings. Closing the view with `esc` or `q` cancels
+  pending results.
 - **Session-local timeline** (`T` / `:timeline`) - a per-object timestamped log
   of every state change the watch saw: generation bumps, replica and readiness
   changes, pod phase, restarts, waiting reasons, condition flips. Computed from
@@ -160,7 +165,11 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   chain for the selection: the owning Kustomization/HelmRelease, its source
   (GitRepository/OCIRepository/HelmRepository) with applied and latest revision,
   the `dependsOn` edges, and ready status. Each item is a finding you can `⏎`
-  into.
+  into. Opening the view or pressing `r` reads the original resource again,
+  then follows its current owner labels, source, and dependencies. A missing
+  or replaced resource produces a warning. These reads require `get` access.
+  Only the latest requested report can update the findings. Closing the view
+  with `esc` or `q` cancels pending results.
 - **Native Helm inspector** (`:helm` / `:hm`) - sofka decodes Helm's release
   storage Secrets directly (double base64 → gunzip → JSON, same as Helm) and
   lists one row per release at its latest revision, like `helm list`. `⏎` opens

--- a/docs/features.md
+++ b/docs/features.md
@@ -133,8 +133,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   warning instead of findings from an old snapshot. Only the latest requested
   report can update the findings. Closing the view with `esc` or `q` cancels
   pending results and clears the report progress message. Navigation to
-  evidence, a target resource, or a palette destination also cancels pending
-  results.
+  a target resource or a palette destination also cancels pending results.
+  Temporary Events and Logs views keep the parent report active. New findings
+  update that report without changing the evidence view. Refresh keeps the
+  previous findings until new results arrive.
 - **Session-local timeline** (`T` / `:timeline`) - a per-object timestamped log
   of every state change the watch saw: generation bumps, replica and readiness
   changes, pod phase, restarts, waiting reasons, condition flips. Computed from

--- a/docs/features.md
+++ b/docs/features.md
@@ -133,7 +133,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   warning instead of findings from an old snapshot. Only the latest requested
   report can update the findings. Closing the view with `esc` or `q` cancels
   pending results and clears the report progress message. Navigation to
-  evidence or a target resource also cancels pending results.
+  evidence, a target resource, or a palette destination also cancels pending
+  results.
 - **Session-local timeline** (`T` / `:timeline`) - a per-object timestamped log
   of every state change the watch saw: generation bumps, replica and readiness
   changes, pod phase, restarts, waiting reasons, condition flips. Computed from
@@ -171,7 +172,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   or replaced resource produces a warning. These reads require `get` access.
   Only the latest requested report can update the findings. Closing the view
   with `esc` or `q` cancels pending results and clears the report progress
-  message. Navigation to a target resource also cancels pending results.
+  message. Navigation to a target resource or a palette destination also
+  cancels pending results.
 - **Native Helm inspector** (`:helm` / `:hm`) - sofka decodes Helm's release
   storage Secrets directly (double base64 → gunzip → JSON, same as Helm) and
   lists one row per release at its latest revision, like `helm list`. `⏎` opens

--- a/docs/features.md
+++ b/docs/features.md
@@ -132,7 +132,7 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   before gathering its evidence. A failed read or a changed UID produces a
   warning instead of findings from an old snapshot. Only the latest requested
   report can update the findings. Closing the view with `esc` or `q` cancels
-  pending results.
+  pending results and clears the report progress message.
 - **Session-local timeline** (`T` / `:timeline`) - a per-object timestamped log
   of every state change the watch saw: generation bumps, replica and readiness
   changes, pod phase, restarts, waiting reasons, condition flips. Computed from
@@ -169,7 +169,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   then follows its current owner labels, source, and dependencies. A missing
   or replaced resource produces a warning. These reads require `get` access.
   Only the latest requested report can update the findings. Closing the view
-  with `esc` or `q` cancels pending results.
+  with `esc` or `q` cancels pending results and clears the report progress
+  message.
 - **Native Helm inspector** (`:helm` / `:hm`) - sofka decodes Helm's release
   storage Secrets directly (double base64 → gunzip → JSON, same as Helm) and
   lists one row per release at its latest revision, like `helm list`. `⏎` opens

--- a/docs/features.md
+++ b/docs/features.md
@@ -132,7 +132,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   before gathering its evidence. A failed read or a changed UID produces a
   warning instead of findings from an old snapshot. Only the latest requested
   report can update the findings. Closing the view with `esc` or `q` cancels
-  pending results and clears the report progress message.
+  pending results and clears the report progress message. Navigation to
+  evidence or a target resource also cancels pending results.
 - **Session-local timeline** (`T` / `:timeline`) - a per-object timestamped log
   of every state change the watch saw: generation bumps, replica and readiness
   changes, pod phase, restarts, waiting reasons, condition flips. Computed from
@@ -170,7 +171,7 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   or replaced resource produces a warning. These reads require `get` access.
   Only the latest requested report can update the findings. Closing the view
   with `esc` or `q` cancels pending results and clears the report progress
-  message.
+  message. Navigation to a target resource also cancels pending results.
 - **Native Helm inspector** (`:helm` / `:hm`) - sofka decodes Helm's release
   storage Secrets directly (double base64 → gunzip → JSON, same as Helm) and
   lists one row per release at its latest revision, like `helm list`. `⏎` opens

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -25,7 +25,7 @@ impl App {
         self.explain_title = format!("{name} — explain");
         self.explain_items.clear();
         self.explain_state.select(None);
-        self.gitops_request = self.gitops_request.wrapping_add(1);
+        self.cancel_gitops_request();
         self.explain_source = Some(obj);
         self.mode = Mode::Explain;
         self.spawn_explain();
@@ -64,6 +64,7 @@ impl App {
             obj.metadata.name.clone().unwrap_or_default()
         ));
 
+        self.explain_claim = Some(claim);
         self.explain_request = self.explain_request.wrapping_add(1);
         let request = self.explain_request;
         tokio::spawn(async move {
@@ -122,11 +123,18 @@ impl App {
         });
     }
 
+    pub(super) fn cancel_explain_request(&mut self) {
+        self.explain_request = self.explain_request.wrapping_add(1);
+        if let Some(claim) = self.explain_claim.take() {
+            self.clear_claimed_status(claim);
+        }
+    }
+
     pub(super) fn key_explain(&mut self, key: KeyEvent) {
         let len = self.explain_items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.explain_request = self.explain_request.wrapping_add(1);
+                self.cancel_explain_request();
                 let destination = self.explain_return;
                 self.mode = destination;
                 self.explain_return = Mode::Table;

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -25,6 +25,7 @@ impl App {
         self.explain_title = format!("{name} — explain");
         self.explain_items.clear();
         self.explain_state.select(None);
+        self.gitops_request = self.gitops_request.wrapping_add(1);
         self.explain_source = Some(obj);
         self.mode = Mode::Explain;
         self.spawn_explain();
@@ -52,14 +53,6 @@ impl App {
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
         let title = self.explain_title.clone();
 
-        // A workload's pods are found by its own pod selector; a pod explains
-        // itself; everything else has no owned pods to correlate.
-        let selector = match plural.as_str() {
-            "deployments" | "statefulsets" | "daemonsets" | "replicasets" => {
-                label_selector(&obj, "matchLabels")
-            }
-            _ => None,
-        };
         let pods_kind = self.cluster.resolve("pods").map(|k| (k.ar, k.namespaced));
         let events_kind = self.cluster.resolve("events").map(|k| (k.ar, k.namespaced));
 
@@ -71,40 +64,58 @@ impl App {
             obj.metadata.name.clone().unwrap_or_default()
         ));
 
+        self.explain_request = self.explain_request.wrapping_add(1);
+        let request = self.explain_request;
         tokio::spawn(async move {
-            let mut warn = None;
-            let pods: Vec<DynamicObject> = if plural == "pods" {
-                vec![obj.clone()]
-            } else if let (Some((ar, nsd)), Some(sel)) = (&pods_kind, &selector) {
-                list_selected(&client, ar, *nsd, &ns, sel, &mut warn).await
-            } else {
-                Vec::new()
-            };
+            let gathered: Result<_, String> = async {
+                let obj = report_source(&client, &kind.ar, kind.namespaced, &obj).await?;
+                // A workload's pods are found by its own pod selector; a pod explains
+                // itself; everything else has no owned pods to correlate.
+                let selector = match plural.as_str() {
+                    "deployments" | "statefulsets" | "daemonsets" | "replicasets" => {
+                        label_selector(&obj, "matchLabels")
+                    }
+                    _ => None,
+                };
+                let mut warn = None;
+                let pods: Vec<DynamicObject> = if plural == "pods" {
+                    vec![obj.clone()]
+                } else if let (Some((ar, nsd)), Some(sel)) = (&pods_kind, &selector) {
+                    list_selected(&client, ar, *nsd, &ns, sel, &mut warn).await
+                } else {
+                    Vec::new()
+                };
 
-            let (events, events_v1) = match &events_kind {
-                Some((ar, nsd)) => {
-                    let v1 = ar.group == "events.k8s.io";
-                    let all = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
-                    (filter_events(&all, &obj, &pods, v1), v1)
-                }
-                None => (Vec::new(), false),
-            };
+                let (events, events_v1) = match &events_kind {
+                    Some((ar, nsd)) => {
+                        let v1 = ar.group == "events.k8s.io";
+                        let all = list_or_warn(&client, ar, *nsd, &ns, &mut warn).await;
+                        (filter_events(&all, &obj, &pods, v1), v1)
+                    }
+                    None => (Vec::new(), false),
+                };
 
-            let evidence = crate::explain::Evidence {
-                kind: &kind_name,
-                plural: &plural,
-                obj: &obj,
-                pods: &pods,
-                events: &events,
-                events_v1,
-            };
-            let mut findings = crate::explain::explain(&evidence);
-            prepend_warn_finding(&mut findings, warn);
+                let evidence = crate::explain::Evidence {
+                    kind: &kind_name,
+                    plural: &plural,
+                    obj: &obj,
+                    pods: &pods,
+                    events: &events,
+                    events_v1,
+                };
+                let mut findings = crate::explain::explain(&evidence);
+                prepend_warn_finding(&mut findings, warn);
+                Ok((obj, findings))
+            }
+            .await;
+            let (source, findings) = report_result(gathered);
             let _ = tx
                 .send(Msg::Explain {
                     generation: genr,
+                    request,
                     claim,
                     title,
+                    source,
                     findings,
                 })
                 .await;
@@ -115,6 +126,7 @@ impl App {
         let len = self.explain_items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
+                self.explain_request = self.explain_request.wrapping_add(1);
                 let destination = self.explain_return;
                 self.mode = destination;
                 self.explain_return = Mode::Table;

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -34,7 +34,6 @@ impl App {
     /// `r` in the explain view — re-gather the evidence for the same object.
     pub(super) fn refresh_explain(&mut self) {
         if self.explain_source.is_some() {
-            self.explain_items.clear();
             self.spawn_explain();
         }
     }
@@ -163,7 +162,7 @@ impl App {
             KeyCode::Char('l') => self.explain_logs(),
             _ => {}
         }
-        if self.mode != Mode::Explain {
+        if !matches!(self.mode, Mode::Explain | Mode::Events | Mode::Logs) {
             self.cancel_explain_request();
         }
     }

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -134,7 +134,6 @@ impl App {
         let len = self.explain_items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.cancel_explain_request();
                 let destination = self.explain_return;
                 self.mode = destination;
                 self.explain_return = Mode::Table;
@@ -163,6 +162,9 @@ impl App {
             KeyCode::Char('E') => self.explain_events(),
             KeyCode::Char('l') => self.explain_logs(),
             _ => {}
+        }
+        if self.mode != Mode::Explain {
+            self.cancel_explain_request();
         }
     }
 

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -29,6 +29,7 @@ impl App {
         self.gitops_title = format!("{name} — GitOps");
         self.gitops_items.clear();
         self.gitops_state.select(None);
+        self.explain_request = self.explain_request.wrapping_add(1);
         self.gitops_source = Some(obj);
         self.mode = Mode::Gitops;
         self.spawn_gitops();
@@ -55,81 +56,91 @@ impl App {
         let subject = format!("{}/{name}", kind.ar.kind);
         let title = self.gitops_title.clone();
 
-        // The selection is itself the owner (a Kustomization/HelmRelease), or
-        // it's a managed object naming its owner via toolkit labels.
-        let self_is_owner = gitops::is_owner_plural(&plural);
-        let owner_ref = if self_is_owner {
-            Some(FluxRef {
-                kind: kind.ar.kind.clone(),
-                name,
-                namespace: ns,
-            })
-        } else {
-            gitops::owner_ref(&obj)
-        };
-        let owner_inline = self_is_owner.then(|| obj.clone());
-        let owner_plural_inline = self_is_owner.then(|| plural.clone());
-
         let flux = self.flux_kind_map();
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
         let claim = self.claim_status(format!("GitOps: {}…", subject));
 
+        self.gitops_request = self.gitops_request.wrapping_add(1);
+        let request = self.gitops_request;
         tokio::spawn(async move {
-            let mut warn = None;
-            // Owner: the selection itself, or fetched from its label reference.
-            let owner = match owner_ref {
-                None => None,
-                Some(r) => {
-                    let (plural, obj) = match (owner_inline, owner_plural_inline) {
-                        (Some(o), Some(p)) => (p, Some(o)),
-                        _ => fetch_flux(&client, &flux, &r, &mut warn).await,
-                    };
-                    Some(Node {
-                        reference: r,
-                        plural,
-                        obj,
+            let gathered: Result<_, String> = async {
+                let obj = report_source(&client, &kind.ar, kind.namespaced, &obj).await?;
+                // The selection is itself the owner (a Kustomization/HelmRelease), or
+                // it's a managed object naming its owner via toolkit labels.
+                let self_is_owner = gitops::is_owner_plural(&plural);
+                let owner_ref = if self_is_owner {
+                    Some(FluxRef {
+                        kind: kind.ar.kind.clone(),
+                        name,
+                        namespace: ns,
                     })
-                }
-            };
+                } else {
+                    gitops::owner_ref(&obj)
+                };
+                let owner_inline = self_is_owner.then(|| obj.clone());
+                let owner_plural_inline = self_is_owner.then(|| plural.clone());
 
-            // Source + dependencies, read from the owner object.
-            let mut source = None;
-            let mut deps = Vec::new();
-            if let Some(owner_obj) = owner.as_ref().and_then(|n| n.obj.as_ref()) {
-                if let Some(sr) = gitops::source_ref(owner_obj) {
-                    let (plural, obj) = fetch_flux(&client, &flux, &sr, &mut warn).await;
-                    source = Some(Node {
-                        reference: sr,
-                        plural,
-                        obj,
-                    });
+                let mut warn = None;
+                // Owner: the selection itself, or fetched from its label reference.
+                let owner = match owner_ref {
+                    None => None,
+                    Some(r) => {
+                        let (plural, obj) = match (owner_inline, owner_plural_inline) {
+                            (Some(o), Some(p)) => (p, Some(o)),
+                            _ => fetch_flux(&client, &flux, &r, &mut warn).await,
+                        };
+                        Some(Node {
+                            reference: r,
+                            plural,
+                            obj,
+                        })
+                    }
+                };
+
+                // Source + dependencies, read from the owner object.
+                let mut source = None;
+                let mut deps = Vec::new();
+                if let Some(owner_obj) = owner.as_ref().and_then(|n| n.obj.as_ref()) {
+                    if let Some(sr) = gitops::source_ref(owner_obj) {
+                        let (plural, obj) = fetch_flux(&client, &flux, &sr, &mut warn).await;
+                        source = Some(Node {
+                            reference: sr,
+                            plural,
+                            obj,
+                        });
+                    }
+                    for dr in gitops::depends_on(owner_obj) {
+                        let (plural, obj) = fetch_flux(&client, &flux, &dr, &mut warn).await;
+                        deps.push(Node {
+                            reference: dr,
+                            plural,
+                            obj,
+                        });
+                    }
                 }
-                for dr in gitops::depends_on(owner_obj) {
-                    let (plural, obj) = fetch_flux(&client, &flux, &dr, &mut warn).await;
-                    deps.push(Node {
-                        reference: dr,
-                        plural,
-                        obj,
-                    });
-                }
+
+                let ev = gitops::Evidence {
+                    subject,
+                    self_is_owner,
+                    owner,
+                    source,
+                    deps,
+                };
+                let mut findings = gitops::describe(&ev);
+                prepend_warn_finding(&mut findings, warn);
+                Ok((obj, findings))
             }
-
-            let ev = gitops::Evidence {
-                subject,
-                self_is_owner,
-                owner,
-                source,
-                deps,
-            };
-            let mut findings = gitops::describe(&ev);
-            prepend_warn_finding(&mut findings, warn);
+            .await;
+            let (source, findings) = report_result(gathered);
             let _ = tx
                 .send(Msg::Gitops {
                     generation: genr,
+                    request,
                     claim,
                     title,
+                    source,
                     findings,
                 })
                 .await;
@@ -164,6 +175,7 @@ impl App {
         let len = self.gitops_items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
+                self.gitops_request = self.gitops_request.wrapping_add(1);
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
                     self.restore_selection();

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -38,7 +38,6 @@ impl App {
     /// `r` in the GitOps view — re-gather for the same object.
     pub(super) fn refresh_gitops(&mut self) {
         if self.gitops_source.is_some() {
-            self.gitops_items.clear();
             self.spawn_gitops();
         }
     }

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -183,7 +183,6 @@ impl App {
         let len = self.gitops_items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.cancel_gitops_request();
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
                     self.restore_selection();
@@ -207,6 +206,9 @@ impl App {
                 }
             }
             _ => {}
+        }
+        if self.mode != Mode::Gitops {
+            self.cancel_gitops_request();
         }
     }
 }

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -29,7 +29,7 @@ impl App {
         self.gitops_title = format!("{name} — GitOps");
         self.gitops_items.clear();
         self.gitops_state.select(None);
-        self.explain_request = self.explain_request.wrapping_add(1);
+        self.cancel_explain_request();
         self.gitops_source = Some(obj);
         self.mode = Mode::Gitops;
         self.spawn_gitops();
@@ -62,6 +62,7 @@ impl App {
         let genr = self.generation;
         let claim = self.claim_status(format!("GitOps: {}…", subject));
 
+        self.gitops_claim = Some(claim);
         self.gitops_request = self.gitops_request.wrapping_add(1);
         let request = self.gitops_request;
         tokio::spawn(async move {
@@ -171,11 +172,18 @@ impl App {
         m
     }
 
+    pub(super) fn cancel_gitops_request(&mut self) {
+        self.gitops_request = self.gitops_request.wrapping_add(1);
+        if let Some(claim) = self.gitops_claim.take() {
+            self.clear_claimed_status(claim);
+        }
+    }
+
     pub(super) fn key_gitops(&mut self, key: KeyEvent) {
         let len = self.gitops_items.len();
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.gitops_request = self.gitops_request.wrapping_add(1);
+                self.cancel_gitops_request();
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
                     self.restore_selection();

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -913,6 +913,54 @@ pub(super) async fn list_or_warn(
     }
 }
 
+/// Read the same resource instance before a health report gathers its evidence.
+pub(super) async fn report_source(
+    client: &Client,
+    ar: &ApiResource,
+    namespaced: bool,
+    source: &DynamicObject,
+) -> Result<DynamicObject, String> {
+    let name = source
+        .metadata
+        .name
+        .as_deref()
+        .ok_or("resource name is missing")?;
+    let api: Api<DynamicObject> = if namespaced {
+        let ns = source
+            .metadata
+            .namespace
+            .as_deref()
+            .ok_or("resource namespace is missing")?;
+        Api::namespaced_with(client.clone(), ns, ar)
+    } else {
+        Api::all_with(client.clone(), ar)
+    };
+    let fresh = api
+        .get(name)
+        .await
+        .map_err(|error| format!("reading {}/{name}: {error}", ar.plural))?;
+    if source.metadata.uid.is_some() && source.metadata.uid != fresh.metadata.uid {
+        return Err(format!(
+            "{}/{name} was replaced; return to the table and select the new resource",
+            ar.plural
+        ));
+    }
+    Ok(fresh)
+}
+
+pub(super) fn report_result(
+    result: Result<(DynamicObject, Vec<crate::explain::Finding>), String>,
+) -> (Option<Box<DynamicObject>>, Vec<crate::explain::Finding>) {
+    match result {
+        Ok((source, findings)) => (Some(Box::new(source)), findings),
+        Err(error) => {
+            let mut findings = Vec::new();
+            prepend_warn_finding(&mut findings, Some(error));
+            (None, findings)
+        }
+    }
+}
+
 /// Prepend an "evidence incomplete" warning to a findings list when one of
 /// the gather reads failed — the analysis below it saw only partial data.
 pub(super) fn prepend_warn_finding(

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -420,6 +420,8 @@ impl App {
         match source {
             Mode::Logs => self.stop_log_stream(),
             Mode::Events => self.stop_event_stream(),
+            Mode::Explain => self.cancel_explain_request(),
+            Mode::Gitops => self.cancel_gitops_request(),
             _ => {}
         }
         self.help_return = Mode::Table;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -420,10 +420,10 @@ impl App {
         match source {
             Mode::Logs => self.stop_log_stream(),
             Mode::Events => self.stop_event_stream(),
-            Mode::Explain => self.cancel_explain_request(),
-            Mode::Gitops => self.cancel_gitops_request(),
             _ => {}
         }
+        self.cancel_explain_request();
+        self.cancel_gitops_request();
         self.help_return = Mode::Table;
         self.palette_return = Mode::Table;
         // `:kind namespace` switches both at once (`:deploy social`,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1049,7 +1049,6 @@ impl App {
                     .unwrap_or(0);
                 self.explain_state
                     .select((!self.explain_items.is_empty()).then_some(first));
-                self.mode = Mode::Explain;
                 // As in the `Msg::Gitops` arm below: the "explaining X…"
                 // progress flash has done its job now the findings are up.
                 self.clear_claimed_status(claim);
@@ -1075,7 +1074,6 @@ impl App {
                     .unwrap_or(0);
                 self.gitops_state
                     .select((!self.gitops_items.is_empty()).then_some(first));
-                self.mode = Mode::Gitops;
                 self.clear_claimed_status(claim);
             }
             Msg::PluginOutput {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1035,6 +1035,7 @@ impl App {
                 source,
                 findings,
             } if generation == self.generation && request == self.explain_request => {
+                self.explain_claim = None;
                 if let Some(source) = source {
                     self.explain_source = Some(*source);
                 }
@@ -1061,6 +1062,7 @@ impl App {
                 source,
                 findings,
             } if generation == self.generation && request == self.gitops_request => {
+                self.gitops_claim = None;
                 if let Some(source) = source {
                     self.gitops_source = Some(*source);
                 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1029,10 +1029,15 @@ impl App {
             }
             Msg::Explain {
                 generation,
+                request,
                 claim,
                 title,
+                source,
                 findings,
-            } if generation == self.generation => {
+            } if generation == self.generation && request == self.explain_request => {
+                if let Some(source) = source {
+                    self.explain_source = Some(*source);
+                }
                 self.explain_items = findings;
                 self.explain_title = title;
                 // Land the cursor on the first navigable finding, else the top.
@@ -1050,10 +1055,15 @@ impl App {
             }
             Msg::Gitops {
                 generation,
+                request,
                 claim,
                 title,
+                source,
                 findings,
-            } if generation == self.generation => {
+            } if generation == self.generation && request == self.gitops_request => {
+                if let Some(source) = source {
+                    self.gitops_source = Some(*source);
+                }
                 self.gitops_items = findings;
                 self.gitops_title = title;
                 let first = self

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1885,6 +1885,8 @@ pub struct App {
     pub explain_title: String,
     /// The object the explain view is investigating, kept so `r` can re-gather.
     pub explain_source: Option<DynamicObject>,
+    /// Latest Explain request, independent of the table watch generation.
+    explain_request: u64,
     /// Parent of the explain view. Kept separately because an evidence view
     /// (logs/events) temporarily uses `return_mode` to return to Explain.
     explain_return: Mode,
@@ -1894,6 +1896,8 @@ pub struct App {
     pub gitops_state: ListState,
     pub gitops_title: String,
     pub gitops_source: Option<DynamicObject>,
+    /// Latest GitOps request, independent of the table watch generation.
+    gitops_request: u64,
     /// Session-local per-object state-change history, fed by the table watch.
     pub timeline: crate::timeline::Timeline,
     /// Table geometry from the last frame, for mouse hit-testing. A RefCell
@@ -2127,11 +2131,13 @@ impl App {
             explain_state: ListState::default(),
             explain_title: String::new(),
             explain_source: None,
+            explain_request: 0,
             explain_return: Mode::Table,
             gitops_items: Vec::new(),
             gitops_state: ListState::default(),
             gitops_title: String::new(),
             gitops_source: None,
+            gitops_request: 0,
             timeline: crate::timeline::Timeline::default(),
             table_hit: RefCell::new(None),
             notify_tasks: HashMap::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1887,6 +1887,7 @@ pub struct App {
     pub explain_source: Option<DynamicObject>,
     /// Latest Explain request, independent of the table watch generation.
     explain_request: u64,
+    explain_claim: Option<StatusClaim>,
     /// Parent of the explain view. Kept separately because an evidence view
     /// (logs/events) temporarily uses `return_mode` to return to Explain.
     explain_return: Mode,
@@ -1898,6 +1899,7 @@ pub struct App {
     pub gitops_source: Option<DynamicObject>,
     /// Latest GitOps request, independent of the table watch generation.
     gitops_request: u64,
+    gitops_claim: Option<StatusClaim>,
     /// Session-local per-object state-change history, fed by the table watch.
     pub timeline: crate::timeline::Timeline,
     /// Table geometry from the last frame, for mouse hit-testing. A RefCell
@@ -2132,12 +2134,14 @@ impl App {
             explain_title: String::new(),
             explain_source: None,
             explain_request: 0,
+            explain_claim: None,
             explain_return: Mode::Table,
             gitops_items: Vec::new(),
             gitops_state: ListState::default(),
             gitops_title: String::new(),
             gitops_source: None,
             gitops_request: 0,
+            gitops_claim: None,
             timeline: crate::timeline::Timeline::default(),
             table_hit: RefCell::new(None),
             notify_tasks: HashMap::new(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14965,6 +14965,82 @@ async fn report_navigation_keeps_its_destination_after_a_late_reply() {
 }
 
 #[tokio::test]
+async fn palette_navigation_cancels_pending_health_reports() {
+    for gitops in [false, true] {
+        for through_help in [false, true] {
+            for command in ["detail", "diff", "events", "timeline", "can-i"] {
+                let (mut app, _rx) = test_app();
+                app.switch_kind("deployments");
+                apply(&mut app, expression_workload(true));
+                app.table_state.select(Some(0));
+                open_health_report_key(&mut app, gitops);
+                let claim = current_claim(&app);
+                let request = if gitops {
+                    app.gitops_request
+                } else {
+                    app.explain_request
+                };
+                let reply = if gitops {
+                    Msg::Gitops {
+                        generation: app.generation,
+                        request,
+                        claim,
+                        title: "cancelled report".into(),
+                        source: None,
+                        findings: Vec::new(),
+                    }
+                } else {
+                    Msg::Explain {
+                        generation: app.generation,
+                        request,
+                        claim,
+                        title: "cancelled report".into(),
+                        source: None,
+                        findings: Vec::new(),
+                    }
+                };
+                if through_help {
+                    app.handle_key(press(KeyCode::Char('?'))).unwrap();
+                    assert_eq!(app.mode, Mode::Help);
+                }
+                app.handle_key(press(KeyCode::Char(':'))).unwrap();
+                assert_eq!(
+                    current_claim(&app),
+                    claim,
+                    "opening the palette retains the report"
+                );
+                for key in command.chars() {
+                    app.handle_key(press(KeyCode::Char(key))).unwrap();
+                }
+                app.handle_key(press(KeyCode::Enter)).unwrap();
+                let destination = app.mode;
+                let current_request = if gitops {
+                    app.gitops_request
+                } else {
+                    app.explain_request
+                };
+                assert_ne!(current_request, request, "{command} must cancel the report");
+                assert!(
+                    app.status_claim
+                        .as_ref()
+                        .is_none_or(|status| status.claim != claim)
+                );
+                let flash = app.flash.clone();
+                app.handle_msg(reply);
+                assert_eq!(app.mode, destination);
+                assert_eq!(app.flash, flash);
+                let title = if gitops {
+                    &app.gitops_title
+                } else {
+                    &app.explain_title
+                };
+                assert_ne!(title, "cancelled report");
+            }
+        }
+    }
+}
+
+#[tokio::test]
 async fn leaving_health_view_rejects_its_pending_response() {
     for gitops in [false, true] {
         for close in [KeyCode::Esc, KeyCode::Char('q')] {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14870,7 +14870,18 @@ async fn health_refresh_keys_preserve_the_newest_error_over_older_success() {
             .lock()
             .unwrap()
             .insert(path.into(), (200, old_success));
+        let previous = if gitops {
+            app.gitops_items.clone()
+        } else {
+            app.explain_items.clone()
+        };
         app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        let pending = if gitops {
+            &app.gitops_items
+        } else {
+            &app.explain_items
+        };
+        assert_eq!(pending, &previous, "refresh retains the last report");
         let old_reply = take_health_report(&mut rx, gitops).await;
         responses.lock().unwrap().insert(path.into(), (403, json!({"kind":"Status","apiVersion":"v1","status":"Failure","code":403,"reason":"Forbidden","message":"latest access denied"})));
         app.handle_key(press(KeyCode::Char('r'))).unwrap();
@@ -14943,7 +14954,7 @@ async fn report_navigation_keeps_its_destination_after_a_late_reply() {
         };
         app.handle_key(press(key)).unwrap();
         assert_eq!(app.mode, destination);
-        if destination != Mode::Command {
+        if destination == Mode::Table {
             let current = if gitops {
                 app.gitops_request
             } else {
@@ -15037,6 +15048,89 @@ async fn palette_navigation_cancels_pending_health_reports() {
                 assert_ne!(title, "cancelled report");
             }
         }
+    }
+}
+
+#[tokio::test]
+async fn explain_evidence_views_keep_pending_findings_and_refresh_history() {
+    for refresh in [false, true] {
+        for key in ['E', 'l'] {
+            for reply_before_return in [false, true] {
+                let root = expression_workload(true);
+                let (mut app, mut rx, responses, _) =
+                    health_report_app("deployments", root.clone());
+                let path = "/apis/apps/v1/namespaces/default/deployments/web";
+                responses
+                    .lock()
+                    .unwrap()
+                    .insert(path.into(), (200, root.clone()));
+                open_health_report_key(&mut app, false);
+                let mut reply = take_health_report(&mut rx, false).await;
+                let previous = if refresh {
+                    app.handle_msg(reply);
+                    let previous = app.explain_items.clone();
+                    assert!(!previous.is_empty());
+                    let mut updated = root;
+                    updated["status"]["readyReplicas"] = json!(0);
+                    responses
+                        .lock()
+                        .unwrap()
+                        .insert(path.into(), (200, updated));
+                    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+                    assert_eq!(app.explain_items, previous);
+                    reply = take_health_report(&mut rx, false).await;
+                    previous
+                } else {
+                    Vec::new()
+                };
+                let request = app.explain_request;
+                app.handle_key(press(KeyCode::Char(key))).unwrap();
+                let evidence_mode = if key == 'E' { Mode::Events } else { Mode::Logs };
+                assert_eq!(app.mode, evidence_mode);
+                assert_eq!(app.explain_request, request);
+                if reply_before_return {
+                    app.handle_msg(reply);
+                    assert_eq!(app.mode, evidence_mode);
+                    app.handle_key(press(KeyCode::Esc)).unwrap();
+                } else {
+                    app.handle_key(press(KeyCode::Esc)).unwrap();
+                    assert_eq!(app.explain_items, previous);
+                    app.handle_msg(reply);
+                }
+                assert_eq!(app.mode, Mode::Explain);
+                assert!(!app.explain_items.is_empty());
+                if refresh {
+                    assert_ne!(app.explain_items, previous);
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn palette_exit_from_evidence_cancels_the_parent_report() {
+    for key in ['E', 'l'] {
+        let root = expression_workload(true);
+        let (mut app, mut rx, responses, _) = health_report_app("deployments", root.clone());
+        responses.lock().unwrap().insert(
+            "/apis/apps/v1/namespaces/default/deployments/web".into(),
+            (200, root),
+        );
+        open_health_report_key(&mut app, false);
+        let reply = take_health_report(&mut rx, false).await;
+        let request = app.explain_request;
+        app.handle_key(press(KeyCode::Char(key))).unwrap();
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for key in "timeline".chars() {
+            app.handle_key(press(KeyCode::Char(key))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.mode, Mode::Timeline);
+        assert_ne!(app.explain_request, request);
+        assert!(app.explain_claim.is_none());
+        app.handle_msg(reply);
+        assert_eq!(app.mode, Mode::Timeline);
+        assert!(app.explain_items.is_empty());
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4152,7 +4152,7 @@ async fn explain_findings_clear_the_progress_flash() {
         findings: Vec::new(),
     });
 
-    assert_eq!(app.mode, Mode::Explain);
+    assert_eq!(app.mode, Mode::Table);
     assert!(app.flash.is_empty(), "{}", app.flash);
     assert!(!app.flash_err);
 }
@@ -4214,7 +4214,7 @@ async fn a_finished_report_only_clears_its_own_status_claim() {
         source: None,
         findings: Vec::new(),
     });
-    assert_eq!(app.mode, Mode::Explain);
+    assert_eq!(app.mode, Mode::Detail);
     assert!(app.flash_err);
     assert!(app.flash.contains("forbidden"), "{}", app.flash);
 }
@@ -14898,6 +14898,69 @@ async fn health_refresh_keys_preserve_the_newest_error_over_older_success() {
             &app.explain_source
         };
         assert_eq!(source.as_ref().unwrap().data["status"]["readyReplicas"], 2);
+    }
+}
+
+#[tokio::test]
+async fn report_navigation_keeps_its_destination_after_a_late_reply() {
+    for (gitops, key, destination) in [
+        (false, KeyCode::Enter, Mode::Table),
+        (false, KeyCode::Char('E'), Mode::Events),
+        (false, KeyCode::Char('l'), Mode::Logs),
+        (true, KeyCode::Enter, Mode::Table),
+        (false, KeyCode::Char(':'), Mode::Command),
+        (true, KeyCode::Char(':'), Mode::Command),
+    ] {
+        let root = expression_workload(true);
+        let (mut app, mut rx, responses, _) = health_report_app("deployments", root.clone());
+        responses.lock().unwrap().insert(
+            "/apis/apps/v1/namespaces/default/deployments/web".into(),
+            (200, root),
+        );
+        open_health_report_key(&mut app, gitops);
+        let reply = take_health_report(&mut rx, gitops).await;
+        let finding = crate::explain::Finding {
+            indent: 0,
+            level: crate::explain::Level::Warn,
+            text: "inspect Pod".into(),
+            target: Some(crate::explain::Target {
+                plural: "pods".into(),
+                namespace: Some("default".into()),
+                name: "web".into(),
+            }),
+        };
+        if gitops {
+            app.gitops_items = vec![finding];
+            app.gitops_state.select(Some(0));
+        } else {
+            app.explain_items = vec![finding];
+            app.explain_state.select(Some(0));
+        }
+        let request = if gitops {
+            app.gitops_request
+        } else {
+            app.explain_request
+        };
+        app.handle_key(press(key)).unwrap();
+        assert_eq!(app.mode, destination);
+        if destination != Mode::Command {
+            let current = if gitops {
+                app.gitops_request
+            } else {
+                app.explain_request
+            };
+            assert_ne!(current, request, "navigation must cancel the report");
+        }
+        app.handle_msg(reply);
+        assert_eq!(
+            app.mode, destination,
+            "a reply must preserve the destination"
+        );
+        if gitops {
+            assert!(app.gitops_claim.is_none());
+        } else {
+            assert!(app.explain_claim.is_none());
+        }
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14904,17 +14904,38 @@ async fn health_refresh_keys_preserve_the_newest_error_over_older_success() {
 #[tokio::test]
 async fn leaving_health_view_rejects_its_pending_response() {
     for gitops in [false, true] {
-        let root = expression_workload(true);
-        let (mut app, mut rx, responses, _) = health_report_app("deployments", root.clone());
-        responses.lock().unwrap().insert(
-            "/apis/apps/v1/namespaces/default/deployments/web".into(),
-            (200, root),
-        );
-        open_health_report_key(&mut app, gitops);
-        let reply = take_health_report(&mut rx, gitops).await;
-        app.handle_key(press(KeyCode::Esc)).unwrap();
-        assert_eq!(app.mode, Mode::Table);
-        app.handle_msg(reply);
-        assert_eq!(app.mode, Mode::Table);
+        for close in [KeyCode::Esc, KeyCode::Char('q')] {
+            for newer_status in [false, true] {
+                let root = expression_workload(true);
+                let (mut app, mut rx, responses, _) =
+                    health_report_app("deployments", root.clone());
+                responses.lock().unwrap().insert(
+                    "/apis/apps/v1/namespaces/default/deployments/web".into(),
+                    (200, root),
+                );
+                open_health_report_key(&mut app, gitops);
+                let reply = take_health_report(&mut rx, gitops).await;
+                assert!(app.status_claim.as_ref().unwrap().pending);
+                let newer_claim = newer_status.then(|| app.claim_status("loading another report"));
+                app.handle_key(press(close)).unwrap();
+                assert_eq!(app.mode, Mode::Table);
+                if let Some(claim) = newer_claim {
+                    assert_eq!(current_claim(&app), claim);
+                    assert_eq!(app.flash, "loading another report");
+                } else {
+                    assert!(app.status_claim.is_none(), "closing must release progress");
+                    assert!(app.flash.is_empty(), "closing must clear report progress");
+                }
+                app.handle_msg(reply);
+                assert_eq!(app.mode, Mode::Table);
+                if let Some(claim) = newer_claim {
+                    assert_eq!(current_claim(&app), claim);
+                    assert_eq!(app.flash, "loading another report");
+                } else {
+                    assert!(app.status_claim.is_none());
+                    assert!(app.flash.is_empty());
+                }
+            }
+        }
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4145,8 +4145,10 @@ async fn explain_findings_clear_the_progress_flash() {
     // so the handler has to clear it — as the `Msg::Gitops` arm does.
     app.handle_msg(Msg::Explain {
         generation: app.generation,
+        request: app.explain_request,
         claim,
         title: "explain — web".into(),
+        source: None,
         findings: Vec::new(),
     });
 
@@ -4206,8 +4208,10 @@ async fn a_finished_report_only_clears_its_own_status_claim() {
     });
     app.handle_msg(Msg::Explain {
         generation: app.generation,
+        request: app.explain_request,
         claim: explain_claim,
         title: "explain — web".into(),
+        source: None,
         findings: Vec::new(),
     });
     assert_eq!(app.mode, Mode::Explain);
@@ -14383,6 +14387,8 @@ fn explain_selected_with_pure_evidence(app: &mut App) {
         generation: app.generation,
         claim: current_claim(app),
         title: app.explain_title.clone(),
+        request: app.explain_request,
+        source: None,
         findings,
     });
 }
@@ -14534,4 +14540,381 @@ async fn workload_explain_requests_complete_expression_selector() {
         params.get("labelSelector").map(String::as_str),
         Some("app=web,tier in (api,frontend),environment notin (test),enabled,!disabled")
     );
+}
+
+type HealthResponses = Arc<std::sync::Mutex<HashMap<String, (u16, serde_json::Value)>>>;
+
+fn health_report_app(
+    plural: &str,
+    resource: serde_json::Value,
+) -> (
+    App,
+    Receiver<Msg>,
+    HealthResponses,
+    Arc<std::sync::Mutex<Vec<String>>>,
+) {
+    let (mut app, rx) = test_app();
+    app.switch_kind(plural);
+    apply(&mut app, resource);
+    app.table_state.select(Some(0));
+    let responses: HealthResponses = Arc::default();
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let replies = responses.clone();
+    let seen = requests.clone();
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            assert_eq!(request.method(), http::Method::GET);
+            let path = request.uri().path().to_owned();
+            seen.lock().unwrap().push(path.clone());
+            let (code, response) = replies.lock().unwrap().get(&path).cloned().unwrap_or_else(
+                || {
+                    if path.ends_with("/namespaces") {
+                        (200, json!({"apiVersion":"v1","kind":"NamespaceList","metadata":{},"items":[]}))
+                    } else if path.ends_with("/events") {
+                        (
+                            200,
+                            json!({"apiVersion":"v1","kind":"EventList","metadata":{},"items":[]}),
+                        )
+                    } else if path.ends_with("/pods") {
+                        (
+                            200,
+                            json!({"apiVersion":"v1","kind":"PodList","metadata":{},"items":[]}),
+                        )
+                    } else {
+                        panic!("unexpected report GET {path}")
+                    }
+                },
+            );
+            async move {
+                Ok::<_, std::convert::Infallible>(
+                    http::Response::builder()
+                        .status(code)
+                        .body(http_body_util::Full::new(hyper::body::Bytes::from(
+                            response.to_string(),
+                        )))
+                        .unwrap(),
+                )
+            }
+        }),
+        "default",
+    );
+    (app, rx, responses, requests)
+}
+
+fn open_health_report_key(app: &mut App, gitops: bool) {
+    if gitops {
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for key in "gitops".chars() {
+            app.handle_key(press(KeyCode::Char(key))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+    } else {
+        app.handle_key(press(KeyCode::Char('X'))).unwrap();
+    }
+}
+
+async fn receive_health_report(app: &mut App, rx: &mut Receiver<Msg>, gitops: bool) {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while let Some(message) = rx.recv().await {
+            let report = if gitops {
+                matches!(message, Msg::Gitops { .. })
+            } else {
+                matches!(message, Msg::Explain { .. })
+            };
+            if report {
+                app.handle_msg(message);
+                break;
+            }
+        }
+    })
+    .await
+    .expect("health report did not finish");
+}
+
+#[tokio::test]
+async fn explain_refresh_reads_current_resource_without_watch_updates() {
+    let root = expression_workload(true);
+    let (mut app, mut rx, responses, requests) = health_report_app("deployments", root.clone());
+    let path = "/apis/apps/v1/namespaces/default/deployments/web";
+    responses
+        .lock()
+        .unwrap()
+        .insert(path.into(), (200, root.clone()));
+    open_health_report_key(&mut app, false);
+    receive_health_report(&mut app, &mut rx, false).await;
+    assert!(
+        app.explain_items
+            .iter()
+            .any(|finding| finding.text.contains("is healthy"))
+    );
+    let mut fresh = root;
+    fresh["status"]["readyReplicas"] = json!(0);
+    responses.lock().unwrap().insert(path.into(), (200, fresh));
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    receive_health_report(&mut app, &mut rx, false).await;
+    assert!(
+        app.explain_items
+            .iter()
+            .any(|finding| finding.text.contains("is unavailable"))
+    );
+    assert_eq!(
+        app.explain_source.as_ref().unwrap().data["status"]["readyReplicas"],
+        0
+    );
+    assert_eq!(
+        requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|request| *request == path)
+            .count(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn gitops_refresh_reads_current_owner_and_source_reference() {
+    let root = json!({"apiVersion":"kustomize.toolkit.fluxcd.io/v1","kind":"Kustomization",
+        "metadata":{"name":"web","namespace":"default","uid":"owner-uid"},
+        "spec":{"sourceRef":{"kind":"GitRepository","name":"old-source"}},
+        "status":{"conditions":[{"type":"Ready","status":"True"}]}});
+    let (mut app, mut rx, responses, requests) = health_report_app("kustomizations", root.clone());
+    let kind = app.kind.as_ref().unwrap();
+    let path = format!(
+        "/apis/{}/namespaces/default/kustomizations/web",
+        kind.ar.api_version
+    );
+    app.cluster.register_kind(
+        "source.toolkit.fluxcd.io",
+        "GitRepository",
+        "gitrepositories",
+        true,
+    );
+    let source_kind = app.cluster.resolve("gitrepositories").unwrap();
+    let source_path = format!(
+        "/apis/{}/namespaces/default/gitrepositories",
+        source_kind.ar.api_version
+    );
+    {
+        let mut replies = responses.lock().unwrap();
+        replies.insert(path.clone(), (200, root.clone()));
+        for name in ["old-source", "new-source"] {
+            replies.insert(format!("{source_path}/{name}"), (200, json!({"apiVersion":source_kind.ar.api_version,"kind":"GitRepository","metadata":{"name":name,"namespace":"default"},"status":{"conditions":[{"type":"Ready","status":"True"}]}})));
+        }
+    }
+    open_health_report_key(&mut app, true);
+    receive_health_report(&mut app, &mut rx, true).await;
+    let mut fresh = root;
+    fresh["status"]["conditions"][0]["status"] = json!("False");
+    fresh["spec"]["sourceRef"]["name"] = json!("new-source");
+    responses.lock().unwrap().insert(path.clone(), (200, fresh));
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    receive_health_report(&mut app, &mut rx, true).await;
+    assert!(
+        app.gitops_items
+            .iter()
+            .any(|finding| finding.text.contains("Ready: False"))
+    );
+    assert_eq!(
+        app.gitops_source.as_ref().unwrap().data["spec"]["sourceRef"]["name"],
+        "new-source"
+    );
+    let requests = requests.lock().unwrap();
+    assert_eq!(
+        requests.iter().filter(|request| **request == path).count(),
+        2
+    );
+    assert!(requests.contains(&format!("{source_path}/new-source")));
+}
+
+#[tokio::test]
+async fn health_refresh_does_not_analyze_replacements_or_failed_root_reads() {
+    for gitops in [false, true] {
+        let root = expression_workload(true);
+        let (mut app, mut rx, responses, _) = health_report_app("deployments", root.clone());
+        let path = "/apis/apps/v1/namespaces/default/deployments/web";
+        responses
+            .lock()
+            .unwrap()
+            .insert(path.into(), (200, root.clone()));
+        open_health_report_key(&mut app, gitops);
+        receive_health_report(&mut app, &mut rx, gitops).await;
+        let mut replacement = root;
+        replacement["metadata"]["uid"] = json!("replacement-uid");
+        let cases = [
+            (200, replacement, "was replaced"),
+            (
+                404,
+                json!({"kind":"Status","apiVersion":"v1","status":"Failure","code":404,"reason":"NotFound","message":"resource is gone"}),
+                "resource is gone",
+            ),
+            (
+                403,
+                json!({"kind":"Status","apiVersion":"v1","status":"Failure","code":403,"reason":"Forbidden","message":"access denied"}),
+                "access denied",
+            ),
+        ];
+        for (code, response, expected) in cases {
+            responses
+                .lock()
+                .unwrap()
+                .insert(path.into(), (code, response));
+            app.handle_key(press(KeyCode::Char('r'))).unwrap();
+            receive_health_report(&mut app, &mut rx, gitops).await;
+            let (source, findings) = if gitops {
+                (&app.gitops_source, &app.gitops_items)
+            } else {
+                (&app.explain_source, &app.explain_items)
+            };
+            assert_eq!(findings.len(), 1);
+            assert_eq!(findings[0].level, crate::explain::Level::Warn);
+            assert!(findings[0].text.contains(expected), "{}", findings[0].text);
+            assert_eq!(
+                source.as_ref().unwrap().metadata.uid.as_deref(),
+                Some("workload-uid")
+            );
+        }
+    }
+}
+
+async fn take_health_report(rx: &mut Receiver<Msg>, gitops: bool) -> Msg {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while let Some(message) = rx.recv().await {
+            if if gitops {
+                matches!(message, Msg::Gitops { .. })
+            } else {
+                matches!(message, Msg::Explain { .. })
+            } {
+                return message;
+            }
+        }
+        panic!("health response channel closed");
+    })
+    .await
+    .expect("health response did not arrive")
+}
+
+#[tokio::test]
+async fn health_report_keys_reject_an_older_resource_response() {
+    for gitops in [false, true] {
+        let first = expression_workload(true);
+        let mut second = first.clone();
+        second["metadata"]["name"] = json!("zzz");
+        second["metadata"]["uid"] = json!("second-uid");
+        let (mut app, mut rx, responses, requests) =
+            health_report_app("deployments", first.clone());
+        apply(&mut app, second.clone());
+        let first_path = "/apis/apps/v1/namespaces/default/deployments/web";
+        let second_path = "/apis/apps/v1/namespaces/default/deployments/zzz";
+        {
+            let mut responses = responses.lock().unwrap();
+            responses.insert(first_path.into(), (200, first));
+            responses.insert(second_path.into(), (200, second));
+        }
+        let generation = app.generation;
+        open_health_report_key(&mut app, gitops);
+        let old_reply = take_health_report(&mut rx, gitops).await;
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        app.handle_key(press(KeyCode::Char('j'))).unwrap();
+        assert_eq!(
+            app.selected().unwrap().metadata.name.as_deref(),
+            Some("zzz")
+        );
+        open_health_report_key(&mut app, gitops);
+        let new_reply = take_health_report(&mut rx, gitops).await;
+        assert_eq!(
+            app.generation, generation,
+            "both requests share the watch generation"
+        );
+        app.handle_msg(new_reply);
+        app.handle_msg(old_reply);
+        let (source, title) = if gitops {
+            (&app.gitops_source, &app.gitops_title)
+        } else {
+            (&app.explain_source, &app.explain_title)
+        };
+        assert_eq!(
+            source.as_ref().unwrap().metadata.uid.as_deref(),
+            Some("second-uid")
+        );
+        assert!(title.starts_with("zzz"), "{title}");
+        app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        app.handle_msg(take_health_report(&mut rx, gitops).await);
+        let requests = requests.lock().unwrap();
+        assert_eq!(
+            requests.iter().filter(|path| *path == first_path).count(),
+            1
+        );
+        assert_eq!(
+            requests.iter().filter(|path| *path == second_path).count(),
+            2
+        );
+    }
+}
+
+#[tokio::test]
+async fn health_refresh_keys_preserve_the_newest_error_over_older_success() {
+    for gitops in [false, true] {
+        let root = expression_workload(true);
+        let (mut app, mut rx, responses, _) = health_report_app("deployments", root.clone());
+        let path = "/apis/apps/v1/namespaces/default/deployments/web";
+        responses
+            .lock()
+            .unwrap()
+            .insert(path.into(), (200, root.clone()));
+        open_health_report_key(&mut app, gitops);
+        app.handle_msg(take_health_report(&mut rx, gitops).await);
+        let mut old_success = root.clone();
+        old_success["status"]["readyReplicas"] = json!(0);
+        responses
+            .lock()
+            .unwrap()
+            .insert(path.into(), (200, old_success));
+        app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        let old_reply = take_health_report(&mut rx, gitops).await;
+        responses.lock().unwrap().insert(path.into(), (403, json!({"kind":"Status","apiVersion":"v1","status":"Failure","code":403,"reason":"Forbidden","message":"latest access denied"})));
+        app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        app.handle_msg(take_health_report(&mut rx, gitops).await);
+        app.handle_msg(old_reply);
+        let (source, findings) = if gitops {
+            (&app.gitops_source, &app.gitops_items)
+        } else {
+            (&app.explain_source, &app.explain_items)
+        };
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].text.contains("latest access denied"));
+        assert_eq!(source.as_ref().unwrap().data["status"]["readyReplicas"], 1);
+        let mut current = root;
+        current["status"]["readyReplicas"] = json!(2);
+        responses
+            .lock()
+            .unwrap()
+            .insert(path.into(), (200, current));
+        app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        app.handle_msg(take_health_report(&mut rx, gitops).await);
+        let source = if gitops {
+            &app.gitops_source
+        } else {
+            &app.explain_source
+        };
+        assert_eq!(source.as_ref().unwrap().data["status"]["readyReplicas"], 2);
+    }
+}
+
+#[tokio::test]
+async fn leaving_health_view_rejects_its_pending_response() {
+    for gitops in [false, true] {
+        let root = expression_workload(true);
+        let (mut app, mut rx, responses, _) = health_report_app("deployments", root.clone());
+        responses.lock().unwrap().insert(
+            "/apis/apps/v1/namespaces/default/deployments/web".into(),
+            (200, root),
+        );
+        open_health_report_key(&mut app, gitops);
+        let reply = take_health_report(&mut rx, gitops).await;
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode, Mode::Table);
+        app.handle_msg(reply);
+        assert_eq!(app.mode, Mode::Table);
+    }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -80,15 +80,19 @@ pub enum Msg {
     /// Findings for the explain-unhealthy view, gathered off-thread.
     Explain {
         generation: u64,
+        request: u64,
         claim: StatusClaim,
         title: String,
+        source: Option<Box<DynamicObject>>,
         findings: Vec<crate::explain::Finding>,
     },
     /// Reconciliation-chain findings for the GitOps view, gathered off-thread.
     Gitops {
         generation: u64,
+        request: u64,
         claim: StatusClaim,
         title: String,
+        source: Option<Box<DynamicObject>>,
         findings: Vec<crate::explain::Finding>,
     },
     /// Captured output of an `output = "popup"` plugin run.


### PR DESCRIPTION
Explain and GitOps refresh now fetch the current resource before gathering findings. Request counters reject late replies after a newer request or a closed report. Closing a report releases its progress message and preserves status from newer operations. Navigation to a target or a palette destination cancels pending replies, including commands opened through Help. Temporary Events and Logs views retain their parent report so it can finish in the background. Refresh keeps previous findings until replacement results arrive. Report completion preserves the active view and open overlays.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #279

Depends on #298. After that pull request merges, set this pull request base to `main` before merging.
