### PR TITLE
fix: retain the initial log line limit

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -80,9 +80,15 @@ the buffer size, and an optional `since` lookback:
 [logs]
 tail = 300         # initial lines fetched per stream (kubectl --tail)
 buffer = 5000      # max lines kept while following (oldest dropped)
-since = "1h"       # optional: only logs newer than this — replaces tail
+since = "1h"       # optional: only logs newer than this, within the tail limit
 fullscreen = false # open log views fullscreen (F toggles per session)
 ```
+
+The `since` window and the `1`–`5` time anchors keep the initial line limit.
+A pod stream requests at most `tail` initial lines per container. Workload and
+Service streams request at most `min(tail, 100)` initial lines per container.
+The time window can reduce this number. Live following continues after these
+initial lines. Previous-container logs keep their full history.
 
 In the view, `/` filters with a case-insensitive substring, a `/regex/`, or a
 leading `!` to invert (keep lines that don't match). A malformed regex is flagged

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -433,14 +433,12 @@ impl App {
         let (tail, since) = self.log_tail_and_since();
         let handle = tokio::spawn(async move {
             let api: Api<Pod> = Api::namespaced(client, &ns);
-            // `since` and `tail` are mutually exclusive in the API; prefer the
-            // configured lookback when set. Previous-container logs take neither.
+            // The API applies the tail limit within the lookback window.
+            // Previous-container logs retain their full history.
             let (tail_lines, since_seconds) = if previous {
                 (None, None)
-            } else if since.is_some() {
-                (None, since)
             } else {
-                (Some(tail), None)
+                (Some(tail), since)
             };
             let lp = LogParams {
                 follow: !previous,
@@ -562,16 +560,12 @@ impl App {
                     let (pn, pns) = (pod_name.clone(), pod_ns.clone());
                     streams.spawn(async move {
                         let api: Api<Pod> = Api::namespaced(client, &pns);
-                        let (tail_lines, since_seconds) = match since {
-                            Some(s) => (None, Some(s)),
-                            None => (Some(per_pod_tail), None),
-                        };
                         let lp = LogParams {
                             follow: true,
                             container: Some(c),
                             timestamps,
-                            tail_lines,
-                            since_seconds,
+                            tail_lines: Some(per_pod_tail),
+                            since_seconds: since,
                             ..Default::default()
                         };
                         forward_log_stream(api, pn, lp, prefix, tx, genr, flag).await;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15172,3 +15172,80 @@ async fn leaving_health_view_rejects_its_pending_response() {
         }
     }
 }
+
+async fn next_log_query(rx: &mut Receiver<String>) -> HashMap<String, String> {
+    let query = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .unwrap()
+        .expect("log request");
+    form_urlencoded::parse(query.as_bytes())
+        .into_owned()
+        .collect()
+}
+
+#[tokio::test]
+async fn log_lookback_keys_keep_tail_limits_in_api_requests() {
+    for aggregate in [false, true] {
+        for tail in [40, 300] {
+            let (mut app, _rx) = test_app();
+            app.switch_kind(if aggregate { "deployments" } else { "pods" });
+            let pod = json!({"apiVersion":"v1","kind":"Pod","metadata":{"name":"web","namespace":"default"},"spec":{"containers":[{"name":"app","image":"test"}]},"status":{"phase":"Running"}});
+            apply(
+                &mut app,
+                if aggregate {
+                    expression_workload(true)
+                } else {
+                    pod.clone()
+                },
+            );
+            app.table_state.select(Some(0));
+            app.logs_cfg.tail = tail;
+            app.logs_cfg.since = Some("4h".into());
+            let (tx, mut queries) = mpsc::channel(32);
+            app.cluster.client = kube::Client::new(
+                tower::service_fn(move |request: http::Request<kube::client::Body>| {
+                    assert_eq!(request.method(), http::Method::GET);
+                    let response = if request.uri().path().ends_with("/log") {
+                        tx.try_send(request.uri().query().unwrap_or_default().to_owned())
+                            .unwrap();
+                        "line\n".to_owned()
+                    } else {
+                        assert_eq!(request.uri().path(), "/api/v1/namespaces/default/pods");
+                        json!({"apiVersion":"v1","kind":"PodList","metadata":{},"items":[pod]})
+                            .to_string()
+                    };
+                    async move {
+                        Ok::<_, std::convert::Infallible>(http::Response::new(
+                            http_body_util::Full::new(hyper::body::Bytes::from(response)),
+                        ))
+                    }
+                }),
+                "default",
+            );
+            app.handle_key(press(KeyCode::Char('l'))).unwrap();
+            let expected_tail = if aggregate { tail.min(100) } else { tail }.to_string();
+            let query = next_log_query(&mut queries).await;
+            assert_eq!(query.get("tailLines"), Some(&expected_tail));
+            assert_eq!(query.get("sinceSeconds").map(String::as_str), Some("14400"));
+            assert_eq!(query.get("follow").map(String::as_str), Some("true"));
+            app.handle_key(press(KeyCode::Char('2'))).unwrap();
+            let query = next_log_query(&mut queries).await;
+            assert_eq!(query.get("tailLines"), Some(&expected_tail));
+            assert_eq!(query.get("sinceSeconds").map(String::as_str), Some("300"));
+            app.handle_key(press(KeyCode::Char('0'))).unwrap();
+            let query = next_log_query(&mut queries).await;
+            assert_eq!(query.get("tailLines"), Some(&expected_tail));
+            assert!(!query.contains_key("sinceSeconds"));
+            app.handle_key(press(KeyCode::Esc)).unwrap();
+            if !aggregate {
+                app.handle_key(press(KeyCode::Char('p'))).unwrap();
+                let query = next_log_query(&mut queries).await;
+                assert_eq!(query.get("previous").map(String::as_str), Some("true"));
+                assert!(!query.contains_key("tailLines"));
+                assert!(!query.contains_key("sinceSeconds"));
+                assert!(!query.contains_key("follow"));
+                app.handle_key(press(KeyCode::Esc)).unwrap();
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,7 +372,7 @@ pub struct FleetConfig {
 /// [logs]
 /// tail = 300         # initial lines fetched per stream
 /// buffer = 5000      # max lines retained while following (bounded tail)
-/// since = "1h"       # optional: only logs newer than this (overrides tail)
+/// since = "1h"       # optional: only logs newer than this, within the tail limit
 /// fullscreen = false # open log views fullscreen (F toggles; k9s fullScreenLogs)
 /// ```
 #[derive(Debug, Clone, Deserialize)]
@@ -384,7 +384,7 @@ pub struct LogsConfig {
     /// dropped (keeps a chatty pod from growing memory without bound).
     pub buffer: usize,
     /// Optional lookback (`30m`, `4h`, `2d`): stream only logs newer than this.
-    /// When set it replaces `tail` (Kubernetes accepts one or the other).
+    /// The initial request also keeps the configured `tail` limit.
     pub since: Option<String>,
     /// Start log views fullscreen — the pane takes the whole frame, without
     /// header or borders (k9s `fullScreenLogs`). `F` toggles per session.


### PR DESCRIPTION
Log lookback now keeps the configured tail line limit. Initial log requests can use both the time window and line limit.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #290

Depends on #299. After that pull request merges, set this pull request base to `main` before merging.
