### PR TITLE
fix: parse Kubernetes memory quantity units

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -111,7 +111,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `utilization` thresholds and sortable, so "which node is full" is one glance
   and one `S`. The container picker shows per-container CPU and memory, usage as
   a percent of request and of limit (`-` marks an unset one), and the pod QoS
-  class. All of it degrades cleanly when metrics-server isn't installed.
+  class. Memory quantities use Kubernetes units, including decimal `k`, `P`,
+  and `E`, and binary `Pi` and `Ei`, in metrics and filters. Fractional bytes
+  round up to the next whole byte.
+  All of it degrades cleanly when metrics-server isn't installed.
 - **Configurable thresholds** for the RESTARTS/CPU/MEM/request-limit coloring,
   globally and per resource and per context. See
   [Views and thresholds](views.md#thresholds).

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15249,3 +15249,72 @@ async fn log_lookback_keys_keep_tail_limits_in_api_requests() {
         }
     }
 }
+
+#[tokio::test]
+async fn memory_filter_accepts_kubernetes_quantity_suffixes() {
+    for (quantity, bytes) in [
+        ("100500k", 100_500_000),
+        ("1P", 1_000_000_000_000_000),
+        ("1E", 1_000_000_000_000_000_000),
+        ("1Pi", 1_i64 << 50),
+        ("1Ei", 1_i64 << 60),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("nodes");
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Node",
+                "metadata": {"name": "sample"},
+                "status": {"allocatable": {"cpu": "2", "memory": quantity}}
+            }),
+        );
+        app.handle_msg(Msg::Metrics {
+            generation: app.generation,
+            data: HashMap::from([("sample".into(), (100, bytes))]),
+            containers: HashMap::new(),
+        });
+        type_filter(&mut app, &format!("memory={quantity}"));
+        assert_eq!(row_names(&app), ["sample"], "{quantity}");
+        let obj = app.rows()[0].clone();
+        assert_eq!(crate::columns::node_allocatable(&obj).1, Some(bytes));
+        assert_eq!(crate::views::parse_quantity(quantity), Some(bytes as f64));
+    }
+}
+
+#[tokio::test]
+async fn memory_filter_rounds_fractional_bytes_up() {
+    for (quantity, bytes) in [("100m", 1), ("1.5", 2)] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("nodes");
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Node",
+                "metadata": {"name": "sample"},
+                "status": {"allocatable": {"cpu": "2", "memory": quantity}}
+            }),
+        );
+        app.handle_msg(Msg::Metrics {
+            generation: app.generation,
+            data: HashMap::from([("sample".into(), (100, bytes))]),
+            containers: HashMap::new(),
+        });
+        type_filter(&mut app, &format!("memory={quantity}"));
+        assert_eq!(row_names(&app), ["sample"], "{quantity}");
+        assert_eq!(
+            crate::columns::node_allocatable(app.rows()[0]).1,
+            Some(bytes)
+        );
+    }
+}
+
+#[tokio::test]
+async fn memory_filter_rejects_invalid_quantities() {
+    for quantity in ["1K", "1Xi", "-1Mi", "NaN", "inf"] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        type_filter(&mut app, &format!("memory>{quantity}"));
+        assert!(app.filter_error().is_some(), "{quantity}");
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1887,23 +1887,14 @@ pub fn parse_cpu_milli(s: &str) -> i64 {
 
 /// Parse a Kubernetes memory quantity (e.g. `512Mi`, `1Gi`, `2000000`) into bytes.
 pub fn parse_mem_bytes(s: &str) -> i64 {
-    let s = s.trim();
-    let suffixes: &[(&str, f64)] = &[
-        ("Ki", 1024.0),
-        ("Mi", 1024.0 * 1024.0),
-        ("Gi", 1024.0 * 1024.0 * 1024.0),
-        ("Ti", 1024.0f64.powi(4)),
-        ("K", 1e3),
-        ("M", 1e6),
-        ("G", 1e9),
-        ("T", 1e12),
-    ];
-    for (suf, mult) in suffixes {
-        if let Some(num) = s.strip_suffix(suf) {
-            return (num.trim().parse::<f64>().unwrap_or(0.0) * mult) as i64;
-        }
-    }
-    s.parse::<f64>().unwrap_or(0.0) as i64
+    parse_memory_quantity(s).unwrap_or(0)
+}
+
+/// Parse a nonnegative memory quantity with the same units as view columns.
+pub(crate) fn parse_memory_quantity(s: &str) -> Option<i64> {
+    crate::views::parse_quantity(s)
+        .filter(|n| n.is_finite() && *n >= 0.0)
+        .map(|n| n.ceil() as i64)
 }
 
 /// A node's allocatable CPU (millicores) and memory (bytes) from

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -329,25 +329,7 @@ fn parse_cpu(s: &str) -> Option<i64> {
 /// Memory quantity → bytes: `1Gi`, `512Mi`, `2000000`. Validating twin of
 /// [`crate::columns::parse_mem_bytes`].
 fn parse_mem(s: &str) -> Option<i64> {
-    let s = s.trim();
-    let suffixes: &[(&str, f64)] = &[
-        ("Ki", 1024.0),
-        ("Mi", 1024.0 * 1024.0),
-        ("Gi", 1024.0 * 1024.0 * 1024.0),
-        ("Ti", 1024.0f64.powi(4)),
-        ("K", 1e3),
-        ("M", 1e6),
-        ("G", 1e9),
-        ("T", 1e12),
-    ];
-    for (suf, mult) in suffixes {
-        if let Some(num) = s.strip_suffix(suf) {
-            let v: f64 = num.trim().parse().ok()?;
-            return (v >= 0.0).then(|| (v * mult) as i64);
-        }
-    }
-    let v: f64 = s.parse().ok()?;
-    (v >= 0.0).then_some(v as i64)
+    crate::columns::parse_memory_quantity(s)
 }
 
 /// Duration → seconds: `90s`, `2h`, `1d2h`, `1h30m`, bare `300` (seconds).


### PR DESCRIPTION
Memory values now use one parser for Kubernetes decimal, binary, exponent, and fractional quantities. Positive fractions round up to whole bytes.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #281

Depends on #300. After that pull request merges, set this pull request base to `main` before merging.
