### PR TITLE
fix: preserve missing metrics as unknown

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -114,6 +114,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   class. Memory quantities use Kubernetes units, including decimal `k`, `P`,
   and `E`, and binary `Pi` and `Ei`, in metrics and filters. Fractional bytes
   round up to the next whole byte.
+  Missing samples show `-` and do not match numeric CPU or memory filters.
+  Measured zero shows `0m`, `0Mi`, or `0%`. Missing metric values sort before
+  measured values in ascending order and after them in descending order.
   All of it degrades cleanly when metrics-server isn't installed.
 - **Configurable thresholds** for the RESTARTS/CPU/MEM/request-limit coloring,
   globally and per resource and per context. See

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -942,7 +942,7 @@ impl App {
                 self.metrics_error = None;
                 self.metrics = data;
                 self.container_metrics = containers;
-                if sort_uses_metrics {
+                if sort_uses_metrics || self.parsed_filter().uses_metrics() {
                     self.invalidate_rows();
                 }
             }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -199,8 +199,12 @@ impl App {
     fn eval_cmp(&self, o: &DynamicObject, cmp: &crate::filter::Cmp, now: i64) -> bool {
         use crate::filter::CmpValue;
         match &cmp.value {
-            CmpValue::Cpu(want) => cmp.op.eval(self.metrics_for(o).0.cmp(want)),
-            CmpValue::Mem(want) => cmp.op.eval(self.metrics_for(o).1.cmp(want)),
+            CmpValue::Cpu(want) => self
+                .metrics_for(o)
+                .is_some_and(|(cpu, _)| cmp.op.eval(cpu.cmp(want))),
+            CmpValue::Mem(want) => self
+                .metrics_for(o)
+                .is_some_and(|(_, mem)| cmp.op.eval(mem.cmp(want))),
             CmpValue::Duration(want) => match crate::columns::age_secs(o, now) {
                 Some(age) => cmp.op.eval(age.cmp(want)),
                 None => false,
@@ -740,14 +744,34 @@ impl App {
     }
 
     /// Latest (cpu_millicores, mem_bytes) for an object from the metrics map.
-    pub(super) fn metrics_for(&self, o: &DynamicObject) -> (i64, i64) {
+    pub(crate) fn metrics_for(&self, o: &DynamicObject) -> Option<(i64, i64)> {
         let name = o.metadata.name.clone().unwrap_or_default();
         let key = if self.kind_plural == "pods" {
             format!("{}/{}", o.metadata.namespace.as_deref().unwrap_or(""), name)
         } else {
             name
         };
-        self.metrics.get(&key).copied().unwrap_or((0, 0))
+        self.metrics.get(&key).copied()
+    }
+
+    pub(super) fn metric_cells(&self, obj: &DynamicObject) -> Vec<String> {
+        let metrics = self.metrics_for(obj);
+        let cpu = metrics.map(|(cpu, _)| cpu);
+        let mem = metrics.map(|(_, mem)| mem);
+        let mut cells = vec![
+            crate::columns::fmt_cpu_sample(cpu),
+            crate::columns::fmt_mem_sample(mem),
+        ];
+        if self.node_capacity_columns() {
+            let (alloc_cpu, alloc_mem) = crate::columns::node_allocatable(obj);
+            cells.push(crate::columns::fmt_pct(
+                cpu.and_then(|cpu| crate::columns::usage_pct(cpu, alloc_cpu)),
+            ));
+            cells.push(crate::columns::fmt_pct(
+                mem.and_then(|mem| crate::columns::usage_pct(mem, alloc_mem)),
+            ));
+        }
+        cells
     }
 
     /// Latest pod count for a node from the pods poll; `None` before the
@@ -789,28 +813,36 @@ impl App {
             ),
             // Unknown timestamps sort last (oldest-unknown) in ascending order.
             "AGE" => SortKey::Num(crate::columns::age_secs(o, now).unwrap_or(i64::MAX) as f64),
-            "CPU" => SortKey::Num(self.metrics_for(o).0 as f64),
-            "MEM" => SortKey::Num(self.metrics_for(o).1 as f64),
+            "CPU" => SortKey::Num(
+                self.metrics_for(o)
+                    .map(|(cpu, _)| cpu as f64)
+                    .unwrap_or(-1.0),
+            ),
+            "MEM" => SortKey::Num(
+                self.metrics_for(o)
+                    .map(|(_, mem)| mem as f64)
+                    .unwrap_or(-1.0),
+            ),
             // Unknown counts (poll hasn't landed) sort below every real count.
             "PODS" if self.node_capacity_columns() => {
                 SortKey::Num(self.node_pods_for(o).map(|c| c as f64).unwrap_or(-1.0))
             }
             // Unknown allocatable sorts below every real percentage.
             "%CPU" if self.node_capacity_columns() => SortKey::Num(
-                crate::columns::usage_pct(
-                    self.metrics_for(o).0,
-                    crate::columns::node_allocatable(o).0,
-                )
-                .map(|p| p as f64)
-                .unwrap_or(-1.0),
+                self.metrics_for(o)
+                    .and_then(|(cpu, _)| {
+                        crate::columns::usage_pct(cpu, crate::columns::node_allocatable(o).0)
+                    })
+                    .map(|p| p as f64)
+                    .unwrap_or(-1.0),
             ),
             "%MEM" if self.node_capacity_columns() => SortKey::Num(
-                crate::columns::usage_pct(
-                    self.metrics_for(o).1,
-                    crate::columns::node_allocatable(o).1,
-                )
-                .map(|p| p as f64)
-                .unwrap_or(-1.0),
+                self.metrics_for(o)
+                    .and_then(|(_, mem)| {
+                        crate::columns::usage_pct(mem, crate::columns::node_allocatable(o).1)
+                    })
+                    .map(|p| p as f64)
+                    .unwrap_or(-1.0),
             ),
             // Humanized time cells ("5d23h") must sort by the underlying
             // timestamp, never the rendered string. Negated epoch seconds so
@@ -953,18 +985,7 @@ impl App {
             values.push(self.node_pods_cell(obj));
         }
         if self.metrics_columns() {
-            let (cpu, mem) = self.metrics_for(obj);
-            values.push(crate::columns::fmt_cpu(cpu));
-            values.push(crate::columns::fmt_mem(mem));
-            if self.node_capacity_columns() {
-                let (alloc_cpu, alloc_mem) = crate::columns::node_allocatable(obj);
-                values.push(crate::columns::fmt_pct(crate::columns::usage_pct(
-                    cpu, alloc_cpu,
-                )));
-                values.push(crate::columns::fmt_pct(crate::columns::usage_pct(
-                    mem, alloc_mem,
-                )));
-            }
+            values.extend(self.metric_cells(obj));
         }
         self.display_headers()
             .iter()

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -50,7 +50,6 @@ impl App {
         let headers: Vec<String> = self.display_headers().to_vec();
         let show_ns = self.show_namespace_column();
         let metrics_cols = self.metrics_columns();
-        let pods_view = self.kind_plural == "pods";
 
         let objs = self.rows();
         self.ensure_table_cell_cache(&objs);
@@ -80,30 +79,7 @@ impl App {
                     cells.push(self.node_pods_cell(obj));
                 }
                 if metrics_cols {
-                    let name = obj.metadata.name.as_deref().unwrap_or_default();
-                    let key = if pods_view {
-                        format!(
-                            "{}/{}",
-                            obj.metadata.namespace.as_deref().unwrap_or_default(),
-                            name
-                        )
-                    } else {
-                        name.to_string()
-                    };
-                    let (cpu, mem) = self.metrics.get(&key).copied().unwrap_or((0, 0));
-                    cells.push(crate::columns::fmt_cpu(cpu));
-                    cells.push(crate::columns::fmt_mem(mem));
-                    // Nodes also carry %CPU/%MEM headers — the capture must
-                    // stay one cell per column.
-                    if self.node_capacity_columns() {
-                        let (alloc_cpu, alloc_mem) = crate::columns::node_allocatable(obj);
-                        cells.push(crate::columns::fmt_pct(crate::columns::usage_pct(
-                            cpu, alloc_cpu,
-                        )));
-                        cells.push(crate::columns::fmt_pct(crate::columns::usage_pct(
-                            mem, alloc_mem,
-                        )));
-                    }
+                    cells.extend(self.metric_cells(obj));
                 }
                 cells
             })

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15318,3 +15318,132 @@ async fn memory_filter_rejects_invalid_quantities() {
         assert!(app.filter_error().is_some(), "{quantity}");
     }
 }
+
+#[tokio::test]
+async fn missing_metrics_do_not_match_usage_filters() {
+    for (plural, kind) in [("pods", "Pod"), ("nodes", "Node")] {
+        for (filter, expected) in [
+            ("cpu<10m", vec!["idle"]),
+            ("memory<1Mi", vec!["idle"]),
+            ("cpu=0", vec!["idle"]),
+            ("mem=0", vec!["idle"]),
+            ("cpu!=1", vec!["busy", "idle"]),
+            ("memory!=1", vec!["busy", "idle"]),
+        ] {
+            let (mut app, _rx) = test_app();
+            app.switch_kind(plural);
+            for name in ["unknown", "idle", "busy"] {
+                let mut obj = json!({
+                    "apiVersion": "v1", "kind": kind,
+                    "metadata": {"name": name}
+                });
+                if plural == "pods" {
+                    obj["metadata"]["namespace"] = json!("default");
+                }
+                apply(&mut app, obj);
+            }
+            let key = |name: &str| {
+                if plural == "pods" {
+                    format!("default/{name}")
+                } else {
+                    name.to_string()
+                }
+            };
+            app.handle_msg(Msg::Metrics {
+                generation: app.generation,
+                data: HashMap::from([
+                    (key("idle"), (0, 0)),
+                    (key("busy"), (100, 10 * 1024 * 1024)),
+                ]),
+                containers: HashMap::new(),
+            });
+            type_filter(&mut app, filter);
+            assert_eq!(row_names(&app), expected, "{plural}: {filter}");
+            app.handle_msg(Msg::Metrics {
+                generation: app.generation,
+                data: HashMap::new(),
+                containers: HashMap::new(),
+            });
+            assert!(row_names(&app).is_empty(), "{plural}: {filter}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn missing_node_metrics_stay_distinct_in_render_capture_and_sort() {
+    use ratatui::{Terminal, backend::TestBackend};
+    for header in ["CPU", "MEM", "%CPU", "%MEM"] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("nodes");
+        for name in ["unknown", "idle", "busy"] {
+            apply(
+                &mut app,
+                json!({
+                    "apiVersion": "v1", "kind": "Node",
+                    "metadata": {"name": name},
+                    "status": {"allocatable": {"cpu": "2", "memory": "1Gi"}}
+                }),
+            );
+        }
+        app.handle_msg(Msg::Metrics {
+            generation: app.generation,
+            data: HashMap::from([
+                ("idle".into(), (0, 0)),
+                ("busy".into(), (100, 10 * 1024 * 1024)),
+            ]),
+            containers: HashMap::new(),
+        });
+        app.handle_key(press(KeyCode::Char('S'))).unwrap();
+        for c in header.chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.display_headers()[app.sort_column.unwrap()], header);
+        assert_eq!(row_names(&app), ["unknown", "idle", "busy"], "{header}");
+        app.handle_key(press(KeyCode::Char('I'))).unwrap();
+        assert_eq!(row_names(&app), ["busy", "idle", "unknown"], "{header}");
+
+        let (headers, rows) = app.snapshot_table();
+        let cell = |name: &str, header: &str| {
+            let row = rows.iter().find(|row| row[0] == name).unwrap();
+            &row[headers.iter().position(|h| h == header).unwrap()]
+        };
+        for metric in ["CPU", "MEM", "%CPU", "%MEM"] {
+            assert_eq!(cell("unknown", metric), "-");
+        }
+        for (metric, value) in [
+            ("CPU", "0m"),
+            ("MEM", "0Mi"),
+            ("%CPU", "0%"),
+            ("%MEM", "0%"),
+        ] {
+            assert_eq!(cell("idle", metric), value);
+        }
+
+        app.handle_key(press(KeyCode::End)).unwrap();
+        let fields = app.selected_row_fields();
+        for metric in ["CPU", "MEM", "%CPU", "%MEM"] {
+            assert_eq!(fields.iter().find(|(key, _)| key == metric).unwrap().1, "-");
+        }
+
+        let mut terminal = Terminal::new(TestBackend::new(200, 24)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::draw(frame, &mut app))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let lines: Vec<String> = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect()
+            })
+            .collect();
+        let unknown = lines.iter().find(|line| line.contains("unknown")).unwrap();
+        let idle = lines.iter().find(|line| line.contains("idle")).unwrap();
+        assert!(!unknown.contains("0%"), "{unknown}");
+        assert!(
+            idle.contains("0m") && idle.contains("0Mi") && idle.matches("0%").count() == 2,
+            "{idle}"
+        );
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1914,6 +1914,22 @@ pub fn node_allocatable(o: &DynamicObject) -> (Option<i64>, Option<i64>) {
     )
 }
 
+pub fn fmt_cpu_sample(milli: Option<i64>) -> String {
+    match milli {
+        Some(0) => "0m".into(),
+        Some(milli) => fmt_cpu(milli),
+        None => "-".into(),
+    }
+}
+
+pub fn fmt_mem_sample(bytes: Option<i64>) -> String {
+    match bytes {
+        Some(0) => "0Mi".into(),
+        Some(bytes) => fmt_mem(bytes),
+        None => "-".into(),
+    }
+}
+
 pub fn fmt_cpu(milli: i64) -> String {
     if milli <= 0 {
         "-".into()

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -101,6 +101,12 @@ pub enum CmpValue {
 }
 
 impl ParsedFilter {
+    pub fn uses_metrics(&self) -> bool {
+        matches!(self, Self::Structured(s) if s.terms.iter().any(|term| {
+            matches!(term, Term::Cmp(Cmp { value: CmpValue::Cpu(_) | CmpValue::Mem(_), .. }))
+        }))
+    }
+
     pub fn labels(&self) -> Option<&str> {
         match self {
             ParsedFilter::Fuzzy(_) => None,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -557,7 +557,6 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let show_ns = app.show_namespace_column();
     let metrics_cols = app.metrics_columns();
     let headers = app.display_headers();
-    let pods_view = app.kind_plural == "pods";
     let sort_col = app.sort_column;
     let sort_arrow = if app.sort_desc { " ↓" } else { " ↑" };
     // Offset from a displayed column index back to the view spec's (the spec
@@ -762,25 +761,16 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             let mut metrics_raw = None;
             let mut node_pcts: (Option<i64>, Option<i64>) = (None, None);
             if metrics_cols {
-                let name = obj.metadata.name.as_deref().unwrap_or_default();
-                let key = if pods_view {
-                    format!(
-                        "{}/{}",
-                        obj.metadata.namespace.as_deref().unwrap_or_default(),
-                        name
-                    )
-                } else {
-                    name.to_string()
-                };
-                let (cpu, mem) = app.metrics.get(&key).copied().unwrap_or((0, 0));
-                metrics_raw = Some((cpu, mem));
-                cells.push(TableCellText::Owned(columns::fmt_cpu(cpu)));
-                cells.push(TableCellText::Owned(columns::fmt_mem(mem)));
+                metrics_raw = app.metrics_for(obj);
+                let cpu = metrics_raw.map(|(cpu, _)| cpu);
+                let mem = metrics_raw.map(|(_, mem)| mem);
+                cells.push(TableCellText::Owned(columns::fmt_cpu_sample(cpu)));
+                cells.push(TableCellText::Owned(columns::fmt_mem_sample(mem)));
                 if app.node_capacity_columns() {
                     let (alloc_cpu, alloc_mem) = columns::node_allocatable(obj);
                     node_pcts = (
-                        columns::usage_pct(cpu, alloc_cpu),
-                        columns::usage_pct(mem, alloc_mem),
+                        cpu.and_then(|cpu| columns::usage_pct(cpu, alloc_cpu)),
+                        mem.and_then(|mem| columns::usage_pct(mem, alloc_mem)),
                     );
                     cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.0)));
                     cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.1)));


### PR DESCRIPTION
Missing metrics remain unknown in cells, percentages, filters, sorting, row copies, and snapshots. A measured zero remains a valid value.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #280

Depends on #301. After that pull request merges, set this pull request base to `main` before merging.
