### PR TITLE
fix: count StatefulSet partition updates correctly

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -13936,7 +13936,7 @@ async fn workload_table_reports_rollout_generation_and_desired_readiness() {
         (
             "statefulsets",
             "StatefulSet",
-            json!({"replicas": 3, "ordinals": {"start": 5}, "updateStrategy": {"rollingUpdate": {"partition": 6}}}),
+            json!({"replicas": 3, "ordinals": {"start": 5}, "updateStrategy": {"rollingUpdate": {"partition": 1}}}),
             json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 2, "observedGeneration": 2}),
             2,
             "3/3",

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -786,8 +786,7 @@ impl WorkloadCounts {
             counts.updated = counts.desired;
         } else {
             let partition = iget(d, &["spec", "updateStrategy", "rollingUpdate", "partition"]);
-            let start = iget(d, &["spec", "ordinals", "start"]);
-            counts.updated += (partition - start).clamp(0, counts.desired.max(0));
+            counts.updated += partition.clamp(0, counts.desired.max(0));
         }
         counts
     }


### PR DESCRIPTION
StatefulSet rollout status now treats the rolling update partition as a count of Pods that retain the old revision. A nonzero start ordinal no longer changes the update target.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Follow-up to #292. Refs #267.

Depends on #302. After that pull request merges, set this pull request base to `main` before merging.
