### PR TITLE
fix: show Job execution status

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -127,6 +127,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `ScaledDown`, `Terminating`), and the whole row is tinted by it - so a
   workload whose pods are crashing or whose desired replicas aren't met reads
   red/peach in the list, like k9s, instead of looking uniformly healthy.
+- **Job execution status** distinguishes pending, running, suspended, failed,
+  completing, completed, and terminating jobs. Failed jobs use the error color even when
+  no pod is active.
 - **Explain-unhealthy view** (`X` / `:explain`) - a deterministic, evidence-based
   explanation of why the selection is unhealthy: rollout state, degraded
   conditions, blocking pods and their container failure reasons

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15447,3 +15447,72 @@ async fn missing_node_metrics_stay_distinct_in_render_capture_and_sort() {
         );
     }
 }
+
+#[tokio::test]
+async fn job_status_distinguishes_execution_states_through_navigation() {
+    for (spec, status, deleting, expected) in [
+        (
+            json!({"completions":1}),
+            json!({"active":0,"succeeded":1,"terminating":1,"conditions":[{"type":"SuccessCriteriaMet","status":"True"}]}),
+            false,
+            "Completing",
+        ),
+        (json!({}), json!({}), false, "Pending"),
+        (
+            json!({}),
+            json!({"active": 1, "failed": 2}),
+            false,
+            "Running",
+        ),
+        (
+            json!({}),
+            json!({"conditions": [{"type": "Failed", "status": "True"}]}),
+            false,
+            "Failed",
+        ),
+        (
+            json!({}),
+            json!({"active": 1, "conditions": [{"type": "FailureTarget", "status": "True"}]}),
+            false,
+            "Failed",
+        ),
+        (
+            json!({}),
+            json!({"conditions": [{"type": "Complete", "status": "True"}]}),
+            false,
+            "Completed",
+        ),
+        (json!({"suspend": true}), json!({}), false, "Suspended"),
+        (
+            json!({}),
+            json!({"conditions": [{"type": "Suspended", "status": "True"}]}),
+            false,
+            "Suspended",
+        ),
+        (
+            json!({}),
+            json!({"conditions": [{"type": "Complete", "status": "True"}]}),
+            true,
+            "Terminating",
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for ch in "jobs".chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        apply(
+            &mut app,
+            json!({"apiVersion":"batch/v1", "kind":"Job", "metadata":{"name":"job", "namespace":"default", "deletionTimestamp": deleting.then_some("2026-09-07T10:00:00Z")}, "spec":spec, "status":status}),
+        );
+        let rows = app.rows();
+        app.ensure_table_cell_cache(&rows);
+        let cache = app.table_cell_cache();
+        let (cells, status_idx) = cache.get(&row_key(rows[0])).unwrap();
+        assert_eq!(cells[status_idx.unwrap()], expected);
+        if expected == "Failed" {
+            assert_eq!(crate::theme::row_color(expected), crate::theme::red());
+        }
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -192,6 +192,7 @@ const SECRET_COLUMNS: &[Column] = &[
 
 const JOB_COLUMNS: &[Column] = &[
     column("NAME", col_name),
+    status_column("STATUS", col_job_status),
     column("COMPLETIONS", col_job_completions),
     column("DURATION", col_job_duration),
     column("AGE", col_age),
@@ -951,6 +952,27 @@ fn col_secret_type<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 
 fn col_secret_data<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     Cow::Owned(count_obj(ctx.data, &["data"]).to_string())
+}
+
+fn col_job_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    let d = ctx.data;
+    if ctx.obj.metadata.deletion_timestamp.is_some() {
+        "Terminating".into()
+    } else if condition_is(d, "Failed", "True") || condition_is(d, "FailureTarget", "True") {
+        "Failed".into()
+    } else if condition_is(d, "Complete", "True") {
+        "Completed".into()
+    } else if condition_is(d, "SuccessCriteriaMet", "True") {
+        "Completing".into()
+    } else if d.pointer("/spec/suspend").and_then(Value::as_bool) == Some(true)
+        || condition_is(d, "Suspended", "True")
+    {
+        "Suspended".into()
+    } else if iget(d, &["status", "active"]) > 0 {
+        "Running".into()
+    } else {
+        "Pending".into()
+    }
 }
 
 fn col_job_completions<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
@@ -2524,10 +2546,10 @@ mod tests {
         let (cells, _) = cells(&job, "jobs", now_secs());
         assert_eq!(
             headers("jobs"),
-            vec!["NAME", "COMPLETIONS", "DURATION", "AGE"]
+            vec!["NAME", "STATUS", "COMPLETIONS", "DURATION", "AGE"]
         );
-        assert_eq!(cells[1], "2/3");
-        assert_eq!(cells[2], "1h5m");
+        assert_eq!(cells[2], "2/3");
+        assert_eq!(cells[3], "1h5m");
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -521,8 +521,9 @@ pub fn status_color(s: &str) -> Color {
         // Faded, not "healthy green" — a finished pod isn't running, and a
         // scaled-to-zero workload isn't serving.
         "Succeeded" | "Completed" | "superseded" | "uninstalled" | "ScaledDown" => overlay0(),
-        "Pending" | "ContainerCreating" | "PodInitializing" | "SchedulingGated" | "Progressing"
-        | "pending-install" | "pending-upgrade" | "pending-rollback" => yellow(),
+        "Pending" | "Suspended" | "Completing" | "ContainerCreating" | "PodInitializing"
+        | "SchedulingGated" | "Progressing" | "pending-install" | "pending-upgrade"
+        | "pending-rollback" => yellow(),
         // Matches row_color's killColor — a distinct "on its way out" hue,
         // not the same bucket as Pending.
         "Terminating" | "uninstalling" => mauve(),
@@ -580,8 +581,9 @@ pub fn row_color(s: &str) -> Color {
     match s {
         s if failure_status(s) => red(),
         s if s.starts_with("Init:") => peach(),
-        "Pending" | "ContainerCreating" | "PodInitializing" | "SchedulingGated" | "Progressing"
-        | "pending-install" | "pending-upgrade" | "pending-rollback" => peach(),
+        "Pending" | "Suspended" | "Completing" | "ContainerCreating" | "PodInitializing"
+        | "SchedulingGated" | "Progressing" | "pending-install" | "pending-upgrade"
+        | "pending-rollback" => peach(),
         "Completed" | "Succeeded" | "superseded" | "uninstalled" | "ScaledDown" => overlay0(),
         // k9s killColor — terminating/deleting rows.
         "Terminating" | "uninstalling" => mauve(),


### PR DESCRIPTION
Job rows now show execution status and health colors. Conditions distinguish running, failed, suspended, completing, and completed Jobs, including cleanup after successful execution.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #268

Depends on #303. After that pull request merges, set this pull request base to `main` before merging.
