### PR TITLE
fix: show storage deletion status

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -130,6 +130,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Job execution status** distinguishes pending, running, suspended, failed,
   completing, completed, and terminating jobs. Failed jobs use the error color even when
   no pod is active.
+- **Storage deletion status** shows `Terminating` for PVs and PVCs after
+  deletion starts, including when a storage protection finalizer keeps the
+  object in the API.
 - **Explain-unhealthy view** (`X` / `:explain`) - a deterministic, evidence-based
   explanation of why the selection is unhealthy: rollout state, degraded
   conditions, blocking pods and their container failure reasons

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15516,3 +15516,32 @@ async fn job_status_distinguishes_execution_states_through_navigation() {
         }
     }
 }
+
+#[tokio::test]
+async fn storage_table_shows_deletion_before_bound_phase() {
+    for (kind, plural, namespaced) in [
+        ("PersistentVolume", "persistentvolumes", false),
+        ("PersistentVolumeClaim", "persistentvolumeclaims", true),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.cluster.register_kind("", kind, plural, namespaced);
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for ch in plural.chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        for (version, deleting, expected) in [("1", false, "Bound"), ("2", true, "Terminating")] {
+            apply(
+                &mut app,
+                json!({"apiVersion":"v1", "kind":kind,
+                "metadata":{"name":"data", "namespace":namespaced.then_some("default"), "resourceVersion":version,
+                "deletionTimestamp":deleting.then_some("2026-09-07T10:00:00Z")}, "status":{"phase":"Bound"}}),
+            );
+            let rows = app.rows();
+            app.ensure_table_cell_cache(&rows);
+            let cache = app.table_cell_cache();
+            let (cells, status_idx) = cache.get(&row_key(rows[0])).unwrap();
+            assert_eq!(cells[status_idx.unwrap()], expected, "{kind}");
+        }
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1060,6 +1060,9 @@ fn col_hpa_replicas<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 }
 
 fn col_pvc_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    if ctx.obj.metadata.deletion_timestamp.is_some() {
+        return "Terminating".into();
+    }
     Cow::Borrowed(sget(ctx.data, &["status", "phase"]).unwrap_or_default())
 }
 
@@ -1076,6 +1079,9 @@ fn col_pv_capacity<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 }
 
 fn col_pv_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    if ctx.obj.metadata.deletion_timestamp.is_some() {
+        return "Terminating".into();
+    }
     Cow::Borrowed(sget(ctx.data, &["status", "phase"]).unwrap_or_default())
 }
 


### PR DESCRIPTION
PersistentVolume and PersistentVolumeClaim rows now show Terminating when deletion has started, instead of retaining Bound.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #270

Depends on #304. After that pull request merges, set this pull request base to `main` before merging.
