### PR TITLE
fix: show Service addresses and node ports

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -19,6 +19,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   26 characters so status changes do not move adjacent columns. A configured
   column width takes priority. Column widths use the full filtered list so
   vertical scrolling does not move the columns.
+- **Service endpoints** include ExternalName targets, configured external IPs,
+  load balancer addresses, and NodePort values such as `80:30080/TCP`.
 - **Pod health** shows init progress and failure reasons, Pod reasons such as
   `Evicted`, scheduling gates, and termination signals or exit codes.
   Init progress appears after the kubelet reports init state. Until then, the

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15545,3 +15545,69 @@ async fn storage_table_shows_deletion_before_bound_phase() {
         }
     }
 }
+
+#[tokio::test]
+async fn service_endpoint_columns_include_names_addresses_and_node_ports() {
+    for (spec, status, expected_ip, expected_ports) in [
+        (
+            json!({"type":"ExternalName", "externalName":"db.example.com"}),
+            json!({}),
+            "db.example.com",
+            "<none>",
+        ),
+        (
+            json!({"type":"ClusterIP", "externalIPs":["192.0.2.10"], "ports":[{"port":80,"protocol":"TCP"}]}),
+            json!({}),
+            "192.0.2.10",
+            "80/TCP",
+        ),
+        (
+            json!({"type":"NodePort", "ports":[{"port":80,"nodePort":30080,"protocol":"TCP"},{"port":53,"nodePort":30053,"protocol":"UDP"}]}),
+            json!({}),
+            "<none>",
+            "80:30080/TCP,53:30053/UDP",
+        ),
+        (
+            json!({"type":"LoadBalancer", "externalIPs":["192.0.2.10"], "ports":[]}),
+            json!({"loadBalancer":{"ingress":[{"hostname":"lb.example.com"}]}}),
+            "lb.example.com,192.0.2.10",
+            "<none>",
+        ),
+        (
+            json!({"type":"LoadBalancer"}),
+            json!({}),
+            "<pending>",
+            "<none>",
+        ),
+        (
+            json!({"type":"LoadBalancer", "externalIPs":["192.0.2.10"]}),
+            json!({}),
+            "192.0.2.10",
+            "<none>",
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for ch in "services".chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        apply(
+            &mut app,
+            json!({"apiVersion":"v1", "kind":"Service", "metadata":{"name":"svc","namespace":"default"}, "spec":spec, "status":status}),
+        );
+        let headers = app.display_headers().to_vec();
+        let rows = app.rows();
+        app.ensure_table_cell_cache(&rows);
+        let cache = app.table_cell_cache();
+        let (cells, _) = cache.get(&row_key(rows[0])).unwrap();
+        assert_eq!(
+            cells[headers.iter().position(|h| h == "EXTERNAL-IP").unwrap()],
+            expected_ip
+        );
+        assert_eq!(
+            cells[headers.iter().position(|h| h == "PORTS").unwrap()],
+            expected_ports
+        );
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1616,24 +1616,48 @@ pub fn pod_status(obj: &DynamicObject) -> String {
 }
 
 fn external_ip(d: &Value, typ: &str) -> String {
-    if let Some(ing) = d
-        .pointer("/status/loadBalancer/ingress")
-        .and_then(Value::as_array)
+    if typ == "ExternalName" {
+        return sget(d, &["spec", "externalName"])
+            .unwrap_or("<none>")
+            .to_string();
+    }
+    let mut ips = Vec::new();
+    if typ == "LoadBalancer"
+        && let Some(ingress) = d
+            .pointer("/status/loadBalancer/ingress")
+            .and_then(Value::as_array)
     {
-        let ips: Vec<String> = ing
-            .iter()
-            .filter_map(|i| {
-                i.get("ip")
-                    .or_else(|| i.get("hostname"))
-                    .and_then(Value::as_str)
-                    .map(String::from)
-            })
-            .collect();
-        if !ips.is_empty() {
-            return ips.join(",");
+        for address in ingress {
+            if let Some(value) = address
+                .get("ip")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .or_else(|| {
+                    address
+                        .get("hostname")
+                        .and_then(Value::as_str)
+                        .filter(|s| !s.is_empty())
+                })
+                && !ips.contains(&value)
+            {
+                ips.push(value);
+            }
         }
     }
-    if typ == "LoadBalancer" {
+    if let Some(external) = d.pointer("/spec/externalIPs").and_then(Value::as_array) {
+        for address in external
+            .iter()
+            .filter_map(Value::as_str)
+            .filter(|s| !s.is_empty())
+        {
+            if !ips.contains(&address) {
+                ips.push(address);
+            }
+        }
+    }
+    if !ips.is_empty() {
+        ips.join(",")
+    } else if typ == "LoadBalancer" {
         "<pending>".into()
     } else {
         "<none>".into()
@@ -1649,11 +1673,15 @@ fn svc_ports(d: &Value) -> String {
                 .map(|p| {
                     let port = p.get("port").and_then(Value::as_i64).unwrap_or(0);
                     let proto = p.get("protocol").and_then(Value::as_str).unwrap_or("TCP");
-                    format!("{port}/{proto}")
+                    match p.get("nodePort").and_then(Value::as_i64).filter(|p| *p > 0) {
+                        Some(node_port) => format!("{port}:{node_port}/{proto}"),
+                        None => format!("{port}/{proto}"),
+                    }
                 })
                 .collect::<Vec<_>>()
                 .join(",")
         })
+        .filter(|ports| !ports.is_empty())
         .unwrap_or_else(|| "<none>".into())
 }
 


### PR DESCRIPTION
Service rows now include external names, configured external IPs, load balancer addresses, and node ports. Repeated addresses appear once.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #272

Depends on #305. After that pull request merges, set this pull request base to `main` before merging.
