### PR TITLE
fix: include legacy Node role labels

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -18,7 +18,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   a NAME/AGE fallback for everything else. STATUS columns use a fixed width of
   26 characters so status changes do not move adjacent columns. A configured
   column width takes priority. Column widths use the full filtered list so
-  vertical scrolling does not move the columns.
+  vertical scrolling does not move the columns. Node ROLES combines
+  `node-role.kubernetes.io/` labels with the legacy `kubernetes.io/role` value
+  and removes duplicate roles.
 - **Service endpoints** include ExternalName targets, configured external IPs,
   load balancer addresses, and NodePort values such as `80:30080/TCP`.
 - **Pod health** shows init progress and failure reasons, Pod reasons such as

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15611,3 +15611,38 @@ async fn service_endpoint_columns_include_names_addresses_and_node_ports() {
         );
     }
 }
+
+#[tokio::test]
+async fn node_roles_include_legacy_labels_without_duplicates() {
+    for (labels, expected) in [
+        (json!({"kubernetes.io/role":"worker"}), "worker"),
+        (
+            json!({"kubernetes.io/role":"worker", "node-role.kubernetes.io/worker":"", "node-role.kubernetes.io/control-plane":""}),
+            "control-plane,worker",
+        ),
+        (
+            json!({"kubernetes.io/role":"", "node-role.kubernetes.io/":""}),
+            "<none>",
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for ch in "nodes".chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        apply(
+            &mut app,
+            json!({"apiVersion":"v1", "kind":"Node", "metadata":{"name":"worker","labels":labels}}),
+        );
+        let headers = app.display_headers().to_vec();
+        let rows = app.rows();
+        app.ensure_table_cell_cache(&rows);
+        let cache = app.table_cell_cache();
+        let (cells, _) = cache.get(&row_key(rows[0])).unwrap();
+        assert_eq!(
+            cells[headers.iter().position(|h| h == "ROLES").unwrap()],
+            expected
+        );
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -1716,7 +1716,17 @@ fn node_roles(obj: &DynamicObject) -> String {
                 .collect()
         })
         .unwrap_or_default();
+    if let Some(role) = obj
+        .metadata
+        .labels
+        .as_ref()
+        .and_then(|labels| labels.get("kubernetes.io/role"))
+        .filter(|role| !role.is_empty())
+    {
+        roles.push(role.clone());
+    }
     roles.sort();
+    roles.dedup();
     if roles.is_empty() {
         "<none>".into()
     } else {


### PR DESCRIPTION
Node ROLES now includes kubernetes.io/role with the current role labels. Repeated roles appear once.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #273

Depends on #306. After that pull request merges, set this pull request base to `main` before merging.
