### PR TITLE
fix: refresh cached Helm update ages

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -198,7 +198,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   the full revision history (`helm history`); on a revision, `⏎` shows
   user-supplied values, `y` the rendered manifest, `d` the NOTES.txt. `r` rolls
   back and `ctrl-d` uninstalls - those two shell out to the real `helm` binary,
-  all the inspection is native.
+  all the inspection is native. UPDATED advances with the clock in both the
+  release list and revision history. The table keeps the deployment timestamp
+  in its row cache, so clock updates do not decode the release again.
 - **Managed-resource mutation warnings** - before you edit, delete, scale, or
   otherwise change an object Flux (or another controller) owns, sofka tells you
   the next reconcile will revert it or recreate it. Fix the source instead of

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1433,6 +1433,7 @@ struct CellCacheEntry {
     resource_version: Option<String>,
     cells: Vec<String>,
     status_idx: Option<usize>,
+    helm_updated: Option<i64>,
     /// Per-cell character-presence masks, and their union across the row.
     /// See [`subseq_mask`]: a cheap necessary condition for a fuzzy
     /// subsequence match, used to skip cells (and whole rows) without paying
@@ -1474,6 +1475,13 @@ impl TableCellCache<'_> {
             .cells
             .get(key)
             .map(|entry| (entry.cells.as_slice(), entry.status_idx))
+    }
+
+    pub(crate) fn helm_updated(&self, key: &str) -> Option<i64> {
+        self.cache
+            .cells
+            .get(key)
+            .and_then(|entry| entry.helm_updated)
     }
 }
 

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -158,7 +158,7 @@ impl App {
             .get(key)
             .is_none_or(|e| e.plural != self.kind_plural || e.resource_version != resource_version);
         if stale {
-            let (rendered, status_idx) = self.spec.cells(o, now);
+            let (rendered, status_idx, helm_updated) = self.spec.cells_with_helm_time(o, now);
             let cell_masks: Vec<u64> = rendered.iter().map(|c| subseq_mask(c)).collect();
             let row_mask = cell_masks.iter().fold(0u64, |a, m| a | m);
             cells.insert(
@@ -168,6 +168,7 @@ impl App {
                     resource_version,
                     cells: rendered,
                     status_idx,
+                    helm_updated,
                     cell_masks,
                     row_mask,
                 },
@@ -545,13 +546,15 @@ impl App {
             }
             let entry = self.cell_entry(key, obj, cells, now);
             for (i, cell) in entry.cells.iter().enumerate() {
-                let cell_width =
-                    if let Some(value) = self.spec.volatile(obj, &self.kind_plural, i, now) {
-                        // Reserve space for elapsed times as the clock advances.
-                        width(&value).max(7)
-                    } else {
-                        width(cell)
-                    };
+                let cell_width = if let Some(value) =
+                    self.spec
+                        .volatile_cached(obj, &self.kind_plural, i, now, entry.helm_updated)
+                {
+                    // Reserve space for elapsed times as the clock advances.
+                    width(&value).max(7)
+                } else {
+                    width(cell)
+                };
                 needed[i + ns_off] = needed[i + ns_off].max(cell_width);
             }
         }
@@ -562,9 +565,14 @@ impl App {
         needed
     }
 
+    #[cfg(test)]
     pub(crate) fn ensure_table_cell_cache(&self, rows: &[&DynamicObject]) {
-        let mut cache = self.rows_cache.borrow_mut();
         let now = crate::columns::now_secs();
+        self.ensure_table_cell_cache_at(rows, now);
+    }
+
+    pub(crate) fn ensure_table_cell_cache_at(&self, rows: &[&DynamicObject], now: i64) {
+        let mut cache = self.rows_cache.borrow_mut();
         for obj in rows {
             // Shares `cell_entry` with the filter pass, so a row rendered for
             // filtering is already warm for the renderer (and vice versa) and
@@ -973,11 +981,11 @@ impl App {
             values.push(obj.metadata.namespace.clone().unwrap_or_default());
         }
         let now = crate::columns::now_secs();
-        let (cells, _) = self.spec.cells(obj, now);
+        let (cells, _, helm_updated) = self.spec.cells_with_helm_time(obj, now);
         for (i, cell) in cells.into_iter().enumerate() {
             values.push(
                 self.spec
-                    .volatile(obj, &self.kind_plural, i, now)
+                    .volatile_cached(obj, &self.kind_plural, i, now, helm_updated)
                     .unwrap_or(cell),
             );
         }

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -47,17 +47,18 @@ impl App {
     /// the table renders (NAMESPACE prepended across namespaces, CPU/MEM
     /// appended for pods/nodes, volatile cells resolved), minus the coloring.
     pub(super) fn snapshot_table(&self) -> (Vec<String>, Vec<Vec<String>>) {
+        self.snapshot_table_at(crate::columns::now_secs())
+    }
+
+    pub(super) fn snapshot_table_at(&self, now: i64) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = self.display_headers().to_vec();
         let show_ns = self.show_namespace_column();
         let metrics_cols = self.metrics_columns();
 
         let objs = self.rows();
-        self.ensure_table_cell_cache(&objs);
+        self.ensure_table_cell_cache_at(&objs, now);
         let cache = self.table_cell_cache();
         let spec = self.view_spec();
-        // One clock reading for the whole snapshot, so every row's elapsed
-        // cell is measured against the same instant.
-        let now = crate::columns::now_secs();
 
         let rows = objs
             .iter()
@@ -68,8 +69,9 @@ impl App {
                     cells.push(obj.metadata.namespace.clone().unwrap_or_default());
                 }
                 if let Some((base_cells, _)) = cache.get(&rk) {
+                    let helm_updated = cache.helm_updated(&rk);
                     for (i, cell) in base_cells.iter().enumerate() {
-                        match spec.volatile(obj, &self.kind_plural, i, now) {
+                        match spec.volatile_cached(obj, &self.kind_plural, i, now, helm_updated) {
                             Some(v) => cells.push(v),
                             None => cells.push(cell.to_string()),
                         }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::store::row_key;
+use k8s_openapi::jiff::Timestamp;
 use serde_json::json;
 use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver};
@@ -15645,4 +15646,130 @@ async fn node_roles_include_legacy_labels_without_duplicates() {
             expected
         );
     }
+}
+
+fn open_helm_clock_view(app: &mut App) {
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "helm".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "helm");
+}
+
+fn helm_updated_snapshot(app: &App, now: i64) -> String {
+    let (headers, rows) = app.snapshot_table_at(now);
+    rows[0][headers.iter().position(|h| h == "UPDATED").unwrap()].clone()
+}
+
+#[tokio::test]
+async fn helm_updated_advances_without_decoding_cached_releases() {
+    let deployed = "2026-09-07T00:00:00Z";
+    let base = deployed.parse::<Timestamp>().unwrap().as_second();
+    for history in [false, true] {
+        let (mut app, _rx) = test_app();
+        open_helm_clock_view(&mut app);
+        let mut secret =
+            helm_release_secret_deployed_at("clock", "default", 1, "deployed", deployed);
+        secret["metadata"]["resourceVersion"] = json!("1");
+        apply(&mut app, secret.clone());
+        if history {
+            app.handle_key(press(KeyCode::Enter)).unwrap();
+            assert_eq!(app.kind_plural, "helmhistory");
+            apply(&mut app, secret);
+        }
+        let before = crate::helm::release_decode_count();
+        assert_eq!(helm_updated_snapshot(&app, base + 59), "59s");
+        assert_eq!(crate::helm::release_decode_count(), before + 1);
+        assert_eq!(helm_updated_snapshot(&app, base + 60), "1m");
+        assert_eq!(helm_updated_snapshot(&app, base + 3600), "1h");
+        app.table_column_widths();
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(140, 24)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::draw(frame, &mut app))
+            .unwrap();
+        terminal
+            .draw(|frame| crate::ui::draw(frame, &mut app))
+            .unwrap();
+        assert_eq!(crate::helm::release_decode_count(), before + 1);
+        let mut fresh = helm_release_secret_deployed_at(
+            "clock",
+            "default",
+            1,
+            "deployed",
+            "2026-09-07T00:01:00Z",
+        );
+        fresh["metadata"]["resourceVersion"] = json!("2");
+        apply(&mut app, fresh);
+        assert_eq!(helm_updated_snapshot(&app, base + 120), "1m");
+        assert_eq!(crate::helm::release_decode_count(), before + 2);
+    }
+}
+
+#[tokio::test]
+async fn helm_unknown_updated_stays_cached_and_future_times_clamp_to_zero() {
+    let base = "2026-09-07T00:00:00Z"
+        .parse::<Timestamp>()
+        .unwrap()
+        .as_second();
+    for deployed in ["", "invalid", "2026-09-07T01:00:00Z"] {
+        let (mut app, _rx) = test_app();
+        open_helm_clock_view(&mut app);
+        apply(
+            &mut app,
+            helm_release_secret_deployed_at("clock", "default", 1, "deployed", deployed),
+        );
+        let before = crate::helm::release_decode_count();
+        let expected = if deployed.starts_with("2026") {
+            "0s"
+        } else {
+            "<unknown>"
+        };
+        assert_eq!(helm_updated_snapshot(&app, base), expected);
+        assert_eq!(helm_updated_snapshot(&app, base + 60), expected);
+        assert_eq!(crate::helm::release_decode_count(), before + 1);
+    }
+}
+
+#[test]
+fn helm_updated_custom_columns_keep_their_own_type_and_clock() {
+    let cfg: crate::config::Config = toml::from_str(
+        r#"
+        [views.helm]
+        replace = true
+        [[views.helm.columns]]
+        name = "UPDATED"
+        path = "/metadata/creationTimestamp"
+        type = "time"
+    "#,
+    )
+    .unwrap();
+    let (views, warnings) = crate::views::compile(&cfg.views);
+    assert!(warnings.is_empty(), "{warnings:?}");
+    let view = views.get("helm").unwrap();
+    let mut secret = obj(helm_release_secret("clock", "default", 1, "deployed"));
+    let base = "2026-09-07T00:00:00Z"
+        .parse::<Timestamp>()
+        .unwrap()
+        .as_second();
+    secret.metadata.creation_timestamp = Some(
+        k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(Timestamp::from_second(base).unwrap()),
+    );
+    let spec = crate::columns::build_spec("helm", Some(view), None, false);
+    let before = crate::helm::release_decode_count();
+    let (_, _, cached) = spec.cells_with_helm_time(&secret, base + 59);
+    assert_eq!(
+        spec.volatile_cached(&secret, "helm", 0, base + 60, cached)
+            .as_deref(),
+        Some("1m")
+    );
+    assert_eq!(crate::helm::release_decode_count(), before);
+    let mut text = view.clone();
+    text.columns[0].kind = crate::views::ColumnKind::Text;
+    let spec = crate::columns::build_spec("helm", Some(&text), None, false);
+    assert!(
+        spec.volatile_cached(&secret, "helm", 0, base + 60, Some(base))
+            .is_none()
+    );
 }

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -482,6 +482,16 @@ impl ViewSpec {
     /// Cells for one object, aligned with [`Self::headers`], plus the index
     /// of the status column (if any).
     pub fn cells(&self, obj: &DynamicObject, now: i64) -> (Vec<String>, Option<usize>) {
+        let (cells, status_idx, _) = self.cells_with_helm_time(obj, now);
+        (cells, status_idx)
+    }
+
+    /// Keep the deployment timestamp from the same decode used by the row.
+    pub(crate) fn cells_with_helm_time(
+        &self,
+        obj: &DynamicObject,
+        now: i64,
+    ) -> (Vec<String>, Option<usize>, Option<i64>) {
         let ctx = CellContext::new(obj, now);
         let values = self
             .columns
@@ -491,7 +501,12 @@ impl ViewSpec {
                 SpecSource::User(uc) => crate::views::render_cell(obj, uc, now),
             })
             .collect();
-        (values, self.status_idx)
+        let helm_time = ctx
+            .helm
+            .get()
+            .and_then(Option::as_ref)
+            .and_then(|r| r.last_deployed_secs);
+        (values, self.status_idx, helm_time)
     }
 
     /// See [`volatile_cell`]. User `time` columns re-render every frame too:
@@ -510,6 +525,26 @@ impl ViewSpec {
             }
             SpecSource::User(_) => None,
             SpecSource::Curated(_) => volatile_cell(obj, plural, &col.header, now),
+        }
+    }
+
+    /// Refresh elapsed time from cached release metadata without another decode.
+    pub(crate) fn volatile_cached(
+        &self,
+        obj: &DynamicObject,
+        plural: &str,
+        idx: usize,
+        now: i64,
+        helm_time: Option<i64>,
+    ) -> Option<String> {
+        let col = self.columns.get(idx)?;
+        if matches!(plural, "helm" | "helmhistory")
+            && col.header == "UPDATED"
+            && matches!(col.source, SpecSource::Curated(_))
+        {
+            Some(helm_updated(helm_time, now))
+        } else {
+            self.volatile(obj, plural, idx, now)
         }
     }
 
@@ -628,6 +663,10 @@ pub(crate) fn parse_leading_num(s: &str) -> f64 {
 pub fn volatile_cell(obj: &DynamicObject, plural: &str, header: &str, now: i64) -> Option<String> {
     match (plural, header) {
         (_, "AGE") => Some(age(obj, now)),
+        ("helm" | "helmhistory", "UPDATED") => Some(helm_updated(
+            crate::helm::decode_summary(obj).and_then(|r| r.last_deployed_secs),
+            now,
+        )),
         ("jobs", "DURATION") if sget(&obj.data, &["status", "completionTime"]).is_none() => {
             Some(job_duration(&obj.data, now))
         }
@@ -1198,10 +1237,17 @@ fn col_helm_description<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
 }
 
 fn col_helm_updated<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
-    Cow::Owned(match ctx.helm().and_then(|r| r.last_deployed_secs) {
-        Some(secs) => humanize((Timestamp::now().as_second() - secs).max(0)),
+    Cow::Owned(helm_updated(
+        ctx.helm().and_then(|r| r.last_deployed_secs),
+        ctx.now,
+    ))
+}
+
+fn helm_updated(deployed: Option<i64>, now: i64) -> String {
+    match deployed {
+        Some(secs) => humanize(now.saturating_sub(secs).max(0)),
         None => "<unknown>".into(),
-    })
+    }
 }
 
 // ----- helpers ------------------------------------------------------------

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -146,6 +146,8 @@ pub fn parse_release_json(json: &[u8]) -> bool {
 /// The release payload as JSON: `data.release` is base64 twice over, then
 /// gzipped. Shared by [`decode`] and [`decode_summary`].
 fn release_json(secret: &DynamicObject) -> Option<Vec<u8>> {
+    #[cfg(test)]
+    RELEASE_DECODES.with(|count| count.set(count.get() + 1));
     let wire = secret.data.pointer("/data/release")?.as_str()?;
     let helm_encoded = BASE64.decode(wire).ok()?;
     let gzipped = BASE64.decode(helm_encoded).ok()?;
@@ -153,6 +155,16 @@ fn release_json(secret: &DynamicObject) -> Option<Vec<u8>> {
     let mut json = Vec::with_capacity(inflated_hint(&gzipped));
     gz.read_to_end(&mut json).ok()?;
     Some(json)
+}
+
+#[cfg(test)]
+thread_local! {
+    static RELEASE_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn release_decode_count() -> usize {
+    RELEASE_DECODES.with(std::cell::Cell::get)
 }
 
 /// Capacity to give the gunzip buffer, from gzip's ISIZE trailer — the

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -720,14 +720,14 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let col_offset = app.col_offset;
 
     let visible_objects = app.rows_window(offset, visible_rows);
-    app.ensure_table_cell_cache(&visible_objects);
-    let cell_cache = app.table_cell_cache();
     let spec = app.view_spec();
     let thresholds = app.resolved_thresholds();
     // One clock reading for the whole frame. Every visible AGE/DURATION cell
     // used to call `Timestamp::now()` for itself, so a full table took one
     // reading per volatile cell and could show two rows a second apart.
     let now = crate::columns::now_secs();
+    app.ensure_table_cell_cache_at(&visible_objects, now);
+    let cell_cache = app.table_cell_cache();
 
     let rows: Vec<Vec<Cell>> = visible_objects
         .iter()
@@ -740,6 +740,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             let (base_cells, status_idx) = cell_cache
                 .get(&row_key)
                 .expect("visible rows are warmed in the table cell cache");
+            let helm_updated = cell_cache.helm_updated(&row_key);
             let mut style_idx = status_idx;
             let mut cells = Vec::with_capacity(headers.len());
             if show_ns {
@@ -749,7 +750,9 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 style_idx = status_idx.map(|i| i + 1);
             }
             for (i, cell) in base_cells.iter().enumerate() {
-                if let Some(value) = spec.volatile(obj, &app.kind_plural, i, now) {
+                if let Some(value) =
+                    spec.volatile_cached(obj, &app.kind_plural, i, now, helm_updated)
+                {
                     cells.push(TableCellText::Owned(value));
                 } else {
                     cells.push(TableCellText::Borrowed(cell.as_str()));


### PR DESCRIPTION
Helm UPDATED now advances while the release list or history stays open. The cell cache retains the deployment timestamp, so each frame can update the age without decoding the release again.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #283

Depends on #307. After that pull request merges, set this pull request base to `main` before merging.
