### PR TITLE
fix: show the last Event occurrence time

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -21,6 +21,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   vertical scrolling does not move the columns. Node ROLES combines
   `node-role.kubernetes.io/` labels with the legacy `kubernetes.io/role` value
   and removes duplicate roles.
+- **Event timing** - LAST-SEEN shows the most recent reported occurrence for
+  core and events.k8s.io Events. It advances with time and sorts by occurrence
+  timestamp. AGE continues to show object creation age.
 - **Service endpoints** include ExternalName targets, configured external IPs,
   load balancer addresses, and NodePort values such as `80:30080/TCP`.
 - **Pod health** shows init progress and failure reasons, Pod reasons such as

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -855,6 +855,11 @@ impl App {
             // Humanized time cells ("5d23h") must sort by the underlying
             // timestamp, never the rendered string. Negated epoch seconds so
             // ascending = most recent first, matching AGE; unknowns last.
+            "LAST-SEEN" if self.kind_plural == "events" => SortKey::Num(
+                crate::columns::event_last_seen_secs(o)
+                    .map(|s| -(s as f64))
+                    .unwrap_or(f64::INFINITY),
+            ),
             "UPDATED" => SortKey::Num(
                 crate::helm::decode_summary(o)
                     .and_then(|r| r.last_deployed_secs)

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15773,3 +15773,70 @@ fn helm_updated_custom_columns_keep_their_own_type_and_clock() {
             .is_none()
     );
 }
+
+#[tokio::test]
+async fn event_last_seen_sorts_recent_occurrences_and_advances_with_time() {
+    let now = "2026-09-07T11:00:00Z"
+        .parse::<k8s_openapi::jiff::Timestamp>()
+        .unwrap()
+        .as_second();
+    for (query, api_version, recent) in [
+        (
+            "events",
+            "v1",
+            json!({"lastTimestamp":"2026-09-07T10:59:55Z", "count":20}),
+        ),
+        (
+            "events.events.k8s.io",
+            "events.k8s.io/v1",
+            json!({"eventTime":"2026-09-07T10:00:00Z", "series":{"lastObservedTime":"2026-09-07T10:59:55Z", "count":20}}),
+        ),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind(query);
+        let mut repeated = json!({"apiVersion":api_version,"kind":"Event","metadata":{"name":"repeat","namespace":"default","resourceVersion":"1","creationTimestamp":"2026-09-07T10:00:00Z"}});
+        repeated
+            .as_object_mut()
+            .unwrap()
+            .extend(recent.as_object().unwrap().clone());
+        apply(&mut app, repeated);
+        apply(
+            &mut app,
+            json!({"apiVersion":api_version,"kind":"Event","metadata":{"name":"single","namespace":"default","resourceVersion":"1","creationTimestamp":"2026-09-07T10:50:00Z"},"eventTime":"2026-09-07T10:50:00Z"}),
+        );
+        app.handle_key(press(KeyCode::Char('S'))).unwrap();
+        for ch in "lastseen".chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(row_names(&app), ["repeat", "single"]);
+        let idx = app
+            .display_headers()
+            .iter()
+            .position(|h| h == "LAST-SEEN")
+            .unwrap();
+        let age_idx = app
+            .display_headers()
+            .iter()
+            .position(|h| h == "AGE")
+            .unwrap();
+        {
+            let rows = app.rows();
+            let (cells, _) = app.spec.cells(rows[0], now);
+            assert_eq!(cells[idx], "5s");
+            assert_eq!(cells[age_idx], "1h");
+            assert_eq!(
+                app.spec.volatile(rows[0], "events", idx, now + 30),
+                Some("35s".into())
+            );
+        }
+        apply(
+            &mut app,
+            json!({"apiVersion":api_version,"kind":"Event","metadata":{"name":"single","namespace":"default","resourceVersion":"2","creationTimestamp":"2026-09-07T10:50:00Z"},"series":{"lastObservedTime":"2026-09-07T11:00:01Z","count":2}}),
+        );
+        assert_eq!(row_names(&app), ["single", "repeat"]);
+        app.handle_key(press(KeyCode::Char('S'))).unwrap();
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(row_names(&app), ["repeat", "single"]);
+    }
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -209,6 +209,7 @@ const CRONJOB_COLUMNS: &[Column] = &[
 
 const EVENT_COLUMNS: &[Column] = &[
     column("NAME", col_name),
+    column("LAST-SEEN", col_event_last_seen),
     column("TYPE", col_event_type),
     column("REASON", col_event_reason),
     column("OBJECT", col_event_object),
@@ -667,6 +668,7 @@ pub fn volatile_cell(obj: &DynamicObject, plural: &str, header: &str, now: i64) 
             crate::helm::decode_summary(obj).and_then(|r| r.last_deployed_secs),
             now,
         )),
+        ("events", "LAST-SEEN") => Some(event_last_seen(obj, now)),
         ("jobs", "DURATION") if sget(&obj.data, &["status", "completionTime"]).is_none() => {
             Some(job_duration(&obj.data, now))
         }
@@ -1062,6 +1064,10 @@ fn col_event_message<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     event_message(ctx.data)
 }
 
+fn col_event_last_seen<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(event_last_seen(ctx.obj, ctx.now))
+}
+
 fn col_event_count<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
     Cow::Owned(event_count(ctx.data).to_string())
 }
@@ -1403,6 +1409,39 @@ pub fn age(obj: &DynamicObject, now: i64) -> String {
 pub fn age_secs(obj: &DynamicObject, now: i64) -> Option<i64> {
     let ts = obj.metadata.creation_timestamp.as_ref()?;
     Some((now - ts.0.as_second()).max(0))
+}
+
+/// Last event occurrence, with creation time as the fallback.
+pub fn event_last_seen_secs(obj: &DynamicObject) -> Option<i64> {
+    [
+        "/series/lastObservedTime",
+        "/lastTimestamp",
+        "/deprecatedLastTimestamp",
+        "/eventTime",
+        "/firstTimestamp",
+        "/deprecatedFirstTimestamp",
+    ]
+    .iter()
+    .find_map(|path| {
+        obj.data
+            .pointer(path)?
+            .as_str()?
+            .parse::<Timestamp>()
+            .ok()
+            .map(|ts| ts.as_second())
+    })
+    .or_else(|| {
+        obj.metadata
+            .creation_timestamp
+            .as_ref()
+            .map(|ts| ts.0.as_second())
+    })
+}
+
+fn event_last_seen(obj: &DynamicObject, now: i64) -> String {
+    event_last_seen_secs(obj)
+        .map(|secs| humanize((now - secs).max(0)))
+        .unwrap_or_else(|| "<unknown>".into())
 }
 
 /// One reading of the wall clock, in epoch seconds, for a whole frame or
@@ -2685,14 +2724,21 @@ mod tests {
         assert_eq!(
             headers("events"),
             vec![
-                "NAME", "TYPE", "REASON", "OBJECT", "MESSAGE", "COUNT", "AGE"
+                "NAME",
+                "LAST-SEEN",
+                "TYPE",
+                "REASON",
+                "OBJECT",
+                "MESSAGE",
+                "COUNT",
+                "AGE"
             ]
         );
-        assert_eq!(cells[1], "Warning");
-        assert_eq!(cells[2], "BackOff");
-        assert_eq!(cells[3], "Pod/nginx");
-        assert_eq!(cells[4], "Back-off restarting failed container");
-        assert_eq!(cells[5], "7");
+        assert_eq!(cells[2], "Warning");
+        assert_eq!(cells[3], "BackOff");
+        assert_eq!(cells[4], "Pod/nginx");
+        assert_eq!(cells[5], "Back-off restarting failed container");
+        assert_eq!(cells[6], "7");
         assert_eq!(status_idx, None);
     }
 
@@ -3219,5 +3265,37 @@ mod tests {
             pod_summary(&pod),
             ("1/2".into(), "Running".into(), "2".into())
         );
+    }
+
+    #[test]
+    fn event_last_seen_uses_series_and_legacy_fallbacks() {
+        let mut event = obj(json!({"apiVersion":"v1","kind":"Event",
+            "metadata":{"name":"event","creationTimestamp":"2026-09-07T10:00:00Z"}}));
+        let created = "2026-09-07T10:00:00Z"
+            .parse::<Timestamp>()
+            .unwrap()
+            .as_second();
+        let recent = "2026-09-07T10:59:55Z";
+        for field in [
+            "lastTimestamp",
+            "deprecatedLastTimestamp",
+            "eventTime",
+            "firstTimestamp",
+            "deprecatedFirstTimestamp",
+        ] {
+            event.data = json!({field:recent});
+            assert_eq!(
+                event_last_seen_secs(&event),
+                Some(created + 3595),
+                "{field}"
+            );
+        }
+        event.data =
+            json!({"lastTimestamp":"2026-09-07T10:30:00Z", "series":{"lastObservedTime":recent}});
+        assert_eq!(event_last_seen_secs(&event), Some(created + 3595));
+        event.data = json!({"lastTimestamp":"invalid"});
+        assert_eq!(event_last_seen_secs(&event), Some(created));
+        event.metadata.creation_timestamp = None;
+        assert_eq!(event_last_seen_secs(&event), None);
     }
 }


### PR DESCRIPTION
Event tables now show LAST-SEEN from the latest event timestamp, including repeated events and both Event API groups. Sorting uses the timestamp and the displayed age advances with time.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior.

Closes #285

Depends on #308. After that pull request merges, set this pull request base to `main` before merging.
