### PR TITLE
fix: select resource columns by API group

### DIFF
--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -74,7 +74,7 @@ fn cells(c: &mut Criterion) {
     let mut g = c.benchmark_group("cells");
 
     let pods: Vec<_> = (0..256).map(bs::pod).collect();
-    let pod_spec = columns::build_spec("pods", None, None, false);
+    let pod_spec = columns::build_spec("", "pods", None, None, false);
     let now = columns::now_secs();
     g.bench_function("pods_256", |b| {
         b.iter(|| {
@@ -86,7 +86,7 @@ fn cells(c: &mut Criterion) {
 
     // Helm is two orders of magnitude slower per row, so it gets far fewer.
     let helm: Vec<_> = (0..16).map(bs::helm_secret).collect();
-    let helm_spec = columns::build_spec("helm", None, None, false);
+    let helm_spec = columns::build_spec("", "helm", None, None, false);
     g.bench_function("helm_16", |b| {
         b.iter(|| {
             for o in &helm {
@@ -320,7 +320,7 @@ fn helm_decode(c: &mut Criterion) {
 fn cell_extract(c: &mut Criterion) {
     let mut g = c.benchmark_group("cell_extract");
     let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
-    let spec = columns::build_spec("pods", None, None, true);
+    let spec = columns::build_spec("", "pods", None, None, true);
 
     g.bench_function("borrowed_ip_2000", |b| {
         b.iter(|| {
@@ -352,7 +352,7 @@ fn cell_extract(c: &mut Criterion) {
 fn frame_clock(c: &mut Criterion) {
     let mut g = c.benchmark_group("frame_clock");
     let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
-    let spec = columns::build_spec("pods", None, None, false);
+    let spec = columns::build_spec("", "pods", None, None, false);
     // AGE is the elapsed cell this measures, and it is not column 0 — that is
     // NAME, which is not volatile, so both sides would have returned `None`
     // and timed the clock call against an empty result.

--- a/docs/views.md
+++ b/docs/views.md
@@ -152,7 +152,11 @@ columns therefore doesn't hide a `node` or `drill` set under a broader key.
 
 A custom resource with no explicit view picks up its CRD
 `additionalPrinterColumns` automatically (columns with `priority > 0` become
-wide-only). A condition lookup
+wide-only). Built-in columns match both the API group and resource name.
+For example, core Services keep their network columns, while
+`services.serving.knative.dev` uses the Knative CRD columns. Printer columns
+and cached resource rows stay separate for each API group and version.
+An explicit user view with columns still takes precedence. A condition lookup
 (`.status.conditions[?(@.type=="Ready")].status` - how most CRDs express their
 READY column) becomes a `condition` column, found by type name. The same filter
 selecting another field (`.reason`, `.message`, `.lastTransitionTime`, …) keeps

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -280,6 +280,7 @@ impl App {
         let watch_labels = join_selectors(&self.labels, &self.applied_filter_labels);
         let watch_fields = join_selectors(&self.fields, &self.applied_filter_fields);
         let key = ViewKey {
+            resource: kind.resource_key(),
             kind_plural: self.kind_plural.clone(),
             namespace: self.namespace.clone(),
             labels: watch_labels.clone(),
@@ -314,10 +315,10 @@ impl App {
         );
         self.tasks.push(handle);
 
-        if matches!(self.kind_plural.as_str(), "pods" | "nodes") {
+        if self.metrics_columns() {
             self.spawn_metrics_poll();
         }
-        if self.kind_plural == "nodes" {
+        if self.node_capacity_columns() {
             self.spawn_node_pods_poll();
         }
 
@@ -382,15 +383,15 @@ impl App {
     /// For a custom resource with neither curated columns nor a user view,
     /// fetch its CRD off-thread and read `additionalPrinterColumns` for the
     /// watched version — a better automatic fallback than NAME/AGE. Results
-    /// (including "nothing usable") are cached per plural for the session.
+    /// (including "nothing usable") are cached per API resource for the session.
     fn maybe_fetch_printer_columns(&mut self, kind: &Kind) {
         let user_has_columns = self
             .active_user_view()
             .is_some_and(|v| !v.columns.is_empty());
-        if crate::columns::has_curated(&self.kind_plural)
+        if crate::columns::has_curated(&kind.ar.group, &self.kind_plural)
             || kind.ar.group.is_empty()
             || kind.ar.plural.to_lowercase() != self.kind_plural
-            || self.crd_views.contains_key(&self.kind_plural)
+            || self.crd_views.contains_key(&kind.resource_key())
             || user_has_columns
         {
             return;
@@ -401,7 +402,7 @@ impl App {
         let client = self.cluster.client.clone();
         let name = format!("{}.{}", self.kind_plural, kind.ar.group);
         let version = kind.ar.version.clone();
-        let plural = self.kind_plural.clone();
+        let resource = kind.resource_key();
         let tx = self.tx.clone();
         let genr = self.generation;
         let handle = tokio::spawn(async move {
@@ -414,7 +415,7 @@ impl App {
             let _ = tx
                 .send(Msg::PrinterColumns {
                     generation: genr,
-                    plural,
+                    resource,
                     view: Box::new(view),
                 })
                 .await;
@@ -961,11 +962,15 @@ impl App {
             }
             Msg::PrinterColumns {
                 generation,
-                plural,
+                resource,
                 view,
             } if generation == self.generation => {
-                let for_current = plural == self.kind_plural;
-                self.crd_views.insert(plural, *view);
+                let for_current = self
+                    .kind
+                    .as_ref()
+                    .is_some_and(|kind| kind.resource_key() == resource)
+                    && resource.resource == self.kind_plural;
+                self.crd_views.insert(resource, *view);
                 if for_current {
                     self.refresh_view_spec();
                     // A remembered sort on a printer column only becomes

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,7 +20,7 @@ use kube::Client;
 use kube::api::{
     Api, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams, PropagationPolicy,
 };
-use kube::core::{DynamicObject, TypeMeta};
+use kube::core::{DynamicObject, GroupVersionResource, TypeMeta};
 use kube::discovery::ApiResource;
 use kube::runtime::{utils::Backoff, watcher};
 use ratatui::widgets::{ListState, TableState};
@@ -1506,6 +1506,7 @@ const VIEW_CACHE_MAX_OBJECTS: usize = 10_000;
 /// filter terms).
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct ViewKey {
+    resource: GroupVersionResource,
     kind_plural: String,
     namespace: String,
     labels: Option<String>,
@@ -1968,9 +1969,9 @@ pub struct App {
     /// Compiled warning/critical coloring thresholds from config, re-resolved
     /// on context switch and `:reload`.
     pub thresholds: crate::thresholds::Compiled,
-    /// CRD printer-column fallbacks fetched per plural for this cluster
+    /// CRD printer-column fallbacks fetched per API resource for this cluster
     /// (`None` = fetched, nothing usable). Cleared on context switch.
-    crd_views: HashMap<String, Option<crate::views::View>>,
+    crd_views: HashMap<GroupVersionResource, Option<crate::views::View>>,
     /// Wide mode (`w`): show wide-only columns.
     pub wide: bool,
     /// Compact mode (`ctrl-e`): collapse the header to one line and hide the
@@ -2188,7 +2189,7 @@ impl App {
             crd_views: HashMap::new(),
             wide: false,
             compact: false,
-            spec: crate::columns::build_spec("", None, None, false),
+            spec: crate::columns::build_spec("", "", None, None, false),
         }
     }
 

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -252,7 +252,7 @@ impl App {
         // We already hold the CRD, so seed its printer-column fallback here
         // instead of re-fetching it when the watch starts.
         self.crd_views
-            .entry(kind.ar.plural.to_lowercase())
+            .entry(kind.resource_key())
             .or_insert_with(|| crate::views::printer_columns_view(d, &kind.ar.version));
         self.push_frame();
         self.kind_plural = kind.ar.plural.to_lowercase();

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -644,6 +644,10 @@ impl App {
     /// is opened for.
     pub fn node_capacity_columns(&self) -> bool {
         self.kind_plural == "nodes"
+            && self
+                .kind
+                .as_ref()
+                .is_some_and(|kind| kind.ar.group.is_empty())
     }
 
     pub(crate) fn view_spec(&self) -> &crate::columns::ViewSpec {
@@ -670,11 +674,14 @@ impl App {
         let sort_header = self
             .sort_column
             .and_then(|i| self.display_headers().get(i).cloned());
+        let resource = self.kind.as_ref().map(Kind::resource_key);
         let spec = crate::columns::build_spec(
+            self.kind.as_ref().map_or("", |kind| kind.ar.group.as_str()),
             &self.kind_plural,
             self.active_user_view(),
-            self.crd_views
-                .get(&self.kind_plural)
+            resource
+                .as_ref()
+                .and_then(|resource| self.crd_views.get(resource))
                 .and_then(Option::as_ref),
             self.wide,
         );
@@ -749,6 +756,10 @@ impl App {
 
     pub fn metrics_columns(&self) -> bool {
         matches!(self.kind_plural.as_str(), "pods" | "nodes")
+            && self
+                .kind
+                .as_ref()
+                .is_some_and(|kind| kind.ar.group.is_empty())
     }
 
     /// Latest (cpu_millicores, mem_bytes) for an object from the metrics map.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7830,7 +7830,7 @@ async fn helm_list_shows_only_latest_revision_per_release() {
         .expect("myapp row present");
     assert_eq!(crate::helm::revision(myapp_row), Some(2));
 
-    let (cells, _) = crate::columns::cells(myapp_row, "helm", crate::columns::now_secs());
+    let (cells, _) = crate::columns::cells(myapp_row, "", "helm", crate::columns::now_secs());
     assert_eq!(
         cells[0], "myapp",
         "NAME cell shows the release, not the secret"
@@ -9712,7 +9712,7 @@ async fn printer_columns_msg_upgrades_name_age_fallback() {
     let view = crate::views::printer_columns_view(&crd, "v1");
     app.handle_msg(Msg::PrinterColumns {
         generation: app.generation,
-        plural: "certificates".into(),
+        resource: app.cluster.resolve("certificates").unwrap().resource_key(),
         view: Box::new(view),
     });
     // Narrow mode hides the priority>0 column; wide shows it.
@@ -9727,10 +9727,14 @@ async fn printer_columns_msg_upgrades_name_age_fallback() {
     app.switch_kind("pods");
     app.handle_msg(Msg::PrinterColumns {
         generation: app.generation - 1,
-        plural: "widgets".into(),
+        resource: GroupVersionResource::gvr("example.com", "v1", "widgets"),
         view: Box::new(None),
     });
-    assert!(!app.crd_views.contains_key("widgets"));
+    assert!(!app.crd_views.contains_key(&GroupVersionResource::gvr(
+        "example.com",
+        "v1",
+        "widgets"
+    )));
 }
 
 #[tokio::test]
@@ -9747,7 +9751,7 @@ async fn user_view_wins_over_printer_columns() {
     app.switch_kind("certificates");
     app.handle_msg(Msg::PrinterColumns {
         generation: app.generation,
-        plural: "certificates".into(),
+        resource: app.cluster.resolve("certificates").unwrap().resource_key(),
         view: Box::new(Some(crate::views::View {
             columns: vec![crate::views::UserColumn {
                 header: "THEIRS".into(),
@@ -11653,7 +11657,7 @@ async fn filtering_matches_a_naive_fuzzy_pass() {
 
         // Naive expectation: name haystack, else any rendered cell.
         let matcher = crate::fuzzy::Fuzzy::new();
-        let spec = crate::columns::build_spec("pods", None, None, false);
+        let spec = crate::columns::build_spec("", "pods", None, None, false);
         let mut want: Vec<String> = Vec::new();
         for (k, o) in app.store.iter() {
             let hay = format!(
@@ -15756,7 +15760,7 @@ fn helm_updated_custom_columns_keep_their_own_type_and_clock() {
     secret.metadata.creation_timestamp = Some(
         k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(Timestamp::from_second(base).unwrap()),
     );
-    let spec = crate::columns::build_spec("helm", Some(view), None, false);
+    let spec = crate::columns::build_spec("", "helm", Some(view), None, false);
     let before = crate::helm::release_decode_count();
     let (_, _, cached) = spec.cells_with_helm_time(&secret, base + 59);
     assert_eq!(
@@ -15767,7 +15771,7 @@ fn helm_updated_custom_columns_keep_their_own_type_and_clock() {
     assert_eq!(crate::helm::release_decode_count(), before);
     let mut text = view.clone();
     text.columns[0].kind = crate::views::ColumnKind::Text;
-    let spec = crate::columns::build_spec("helm", Some(&text), None, false);
+    let spec = crate::columns::build_spec("", "helm", Some(&text), None, false);
     assert!(
         spec.volatile_cached(&secret, "helm", 0, base + 60, Some(base))
             .is_none()
@@ -15839,4 +15843,167 @@ async fn event_last_seen_sorts_recent_occurrences_and_advances_with_time() {
         app.handle_key(press(KeyCode::Enter)).unwrap();
         assert_eq!(row_names(&app), ["repeat", "single"]);
     }
+}
+
+#[tokio::test]
+async fn service_columns_and_cached_rows_follow_the_api_group() {
+    let (mut app, mut rx) = test_app();
+    for group in ["serving.knative.dev", "other.example.com"] {
+        app.cluster
+            .register_kind(group, "Service", "services", true);
+    }
+    app.cluster.register_kind("", "Service", "services", true);
+    app.cluster.register_kind(
+        "apiextensions.k8s.io",
+        "CustomResourceDefinition",
+        "customresourcedefinitions",
+        false,
+    );
+    let fetched = Arc::new(AtomicU64::new(0));
+    let requests = fetched.clone();
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            let path = request.uri().path();
+            let is_crd = path
+                .starts_with("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/services.");
+            let (status, body) = if is_crd {
+                requests.fetch_add(1, Ordering::SeqCst);
+                let columns = if path.ends_with("serving.knative.dev") {
+                    json!([
+                        {"name": "Ready", "type": "string", "jsonPath": ".status.ready"},
+                        {"name": "URL", "type": "string", "jsonPath": ".status.url"}
+                    ])
+                } else {
+                    json!([{"name": "State", "type": "string", "jsonPath": ".status.state"}])
+                };
+                (
+                    200,
+                    json!({
+                        "apiVersion": "apiextensions.k8s.io/v1",
+                        "kind": "CustomResourceDefinition",
+                        "metadata": {"name": path.rsplit('/').next().unwrap()},
+                        "spec": {"versions": [{"name": "v1", "served": true, "storage": true,
+                            "additionalPrinterColumns": columns}]}
+                    }),
+                )
+            } else {
+                (
+                    403,
+                    json!({"kind": "Status", "apiVersion": "v1", "status": "Failure",
+                    "reason": "Forbidden", "message": "unused test request", "code": 403}),
+                )
+            };
+            async move {
+                Ok::<_, std::convert::Infallible>(
+                    http::Response::builder()
+                        .status(status)
+                        .body(http_body_util::Full::new(hyper::body::Bytes::from(
+                            body.to_string(),
+                        )))
+                        .unwrap(),
+                )
+            }
+        }),
+        "default",
+    );
+    let command = |app: &mut App, name: &str| {
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for c in name.chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+    };
+    command(&mut app, "services");
+    assert_eq!(app.kind.as_ref().unwrap().ar.group, "");
+    let core_headers = app.display_headers().to_vec();
+    assert!(core_headers.contains(&"CLUSTER-IP".into()));
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Service",
+            "metadata": {"name": "shared", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"clusterIP": "10.0.0.1"}
+        }),
+    );
+    app.handle_msg(Msg::Synced {
+        generation: app.generation,
+    });
+    command(&mut app, "services.serving.knative.dev");
+    assert!(
+        app.rows().is_empty(),
+        "core rows must not enter the Knative view"
+    );
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "AGE"]);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(message @ Msg::PrinterColumns { .. }) = rx.recv().await {
+                app.handle_msg(message);
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        app.display_headers().to_vec(),
+        ["NAME", "READY", "URL", "AGE"]
+    );
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "serving.knative.dev/v1", "kind": "Service",
+            "metadata": {"name": "shared", "namespace": "default", "resourceVersion": "1"},
+            "status": {"ready": "True", "url": "https://app.example.com"}
+        }),
+    );
+    assert_eq!(app.snapshot_table().1[0][2], "https://app.example.com");
+
+    app.handle_msg(Msg::Synced {
+        generation: app.generation,
+    });
+    command(&mut app, "services.other.example.com");
+    assert!(app.rows().is_empty());
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "AGE"]);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(message @ Msg::PrinterColumns { .. }) = rx.recv().await {
+                app.handle_msg(message);
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "STATE", "AGE"]);
+    command(&mut app, "services");
+    assert_eq!(app.display_headers().to_vec(), core_headers);
+    assert_eq!(app.rows()[0].data["spec"]["clusterIP"], "10.0.0.1");
+    command(&mut app, "services.serving.knative.dev");
+    assert_eq!(
+        app.display_headers().to_vec(),
+        ["NAME", "READY", "URL", "AGE"]
+    );
+    assert_eq!(
+        app.rows()[0].data["status"]["url"],
+        "https://app.example.com"
+    );
+    assert_eq!(fetched.load(Ordering::SeqCst), 2);
+
+    install_views(
+        &mut app,
+        r#"
+        [views."serving.knative.dev/services"]
+        replace = true
+        [[views."serving.knative.dev/services".columns]]
+        name = "CUSTOM"
+        path = "/metadata/name"
+    "#,
+    );
+    command(&mut app, "services.serving.knative.dev");
+    assert_eq!(app.display_headers().to_vec(), ["CUSTOM"]);
+    command(&mut app, "services");
+    assert_eq!(app.display_headers().to_vec(), core_headers);
+    command(&mut app, "helm");
+    assert!(app.display_headers().contains(&"REVISION".to_string()));
+    assert!(!app.display_headers().contains(&"TYPE".to_string()));
 }

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -316,43 +316,44 @@ const HELM_HISTORY_COLUMNS: &[Column] = &[
     column("UPDATED", col_helm_updated),
 ];
 
-fn columns_for(plural: &str) -> &'static [Column] {
-    match plural {
-        "pods" => POD_COLUMNS,
-        "deployments" => DEPLOYMENT_COLUMNS,
-        "replicasets" => REPLICASET_COLUMNS,
-        "statefulsets" => STATEFULSET_COLUMNS,
-        "daemonsets" => DAEMONSET_COLUMNS,
-        "services" => SERVICE_COLUMNS,
-        "nodes" => NODE_COLUMNS,
-        "namespaces" => NAMESPACE_COLUMNS,
-        "configmaps" => CONFIGMAP_COLUMNS,
-        "secrets" => SECRET_COLUMNS,
-        "jobs" => JOB_COLUMNS,
-        "cronjobs" => CRONJOB_COLUMNS,
-        "events" => EVENT_COLUMNS,
-        "horizontalpodautoscalers" => HPA_COLUMNS,
-        "persistentvolumeclaims" => PVC_COLUMNS,
-        "persistentvolumes" => PV_COLUMNS,
-        "ingresses" => INGRESS_COLUMNS,
-        "httproutes" => HTTPROUTE_COLUMNS,
-        "endpoints" => ENDPOINT_COLUMNS,
-        "customresourcedefinitions" => CRD_COLUMNS,
-        "kustomizations" | "helmreleases" => FLUX_OBJECT_COLUMNS,
-        "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
-            FLUX_SOURCE_COLUMNS
-        }
-        "helm" => HELM_COLUMNS,
-        "helmhistory" => HELM_HISTORY_COLUMNS,
+fn columns_for(group: &str, plural: &str) -> &'static [Column] {
+    match (group, plural) {
+        ("", "pods") => POD_COLUMNS,
+        ("apps" | "extensions", "deployments") => DEPLOYMENT_COLUMNS,
+        ("apps" | "extensions", "replicasets") => REPLICASET_COLUMNS,
+        ("apps", "statefulsets") => STATEFULSET_COLUMNS,
+        ("apps" | "extensions", "daemonsets") => DAEMONSET_COLUMNS,
+        ("", "services") => SERVICE_COLUMNS,
+        ("", "nodes") => NODE_COLUMNS,
+        ("", "namespaces") => NAMESPACE_COLUMNS,
+        ("", "configmaps") => CONFIGMAP_COLUMNS,
+        ("", "secrets") => SECRET_COLUMNS,
+        ("batch", "jobs") => JOB_COLUMNS,
+        ("batch", "cronjobs") => CRONJOB_COLUMNS,
+        ("" | "events.k8s.io", "events") => EVENT_COLUMNS,
+        ("autoscaling", "horizontalpodautoscalers") => HPA_COLUMNS,
+        ("", "persistentvolumeclaims") => PVC_COLUMNS,
+        ("", "persistentvolumes") => PV_COLUMNS,
+        ("networking.k8s.io" | "extensions", "ingresses") => INGRESS_COLUMNS,
+        ("gateway.networking.k8s.io", "httproutes") => HTTPROUTE_COLUMNS,
+        ("", "endpoints") => ENDPOINT_COLUMNS,
+        ("apiextensions.k8s.io", "customresourcedefinitions") => CRD_COLUMNS,
+        ("kustomize.toolkit.fluxcd.io", "kustomizations")
+        | ("helm.toolkit.fluxcd.io", "helmreleases") => FLUX_OBJECT_COLUMNS,
+        (
+            "source.toolkit.fluxcd.io",
+            "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets",
+        ) => FLUX_SOURCE_COLUMNS,
+        ("", "helm") => HELM_COLUMNS,
+        ("", "helmhistory") => HELM_HISTORY_COLUMNS,
         _ => DEFAULT_COLUMNS,
     }
 }
 
-/// Whether `plural` has curated columns (anything beyond the NAME/AGE
-/// fallback). Kinds without them are candidates for the CRD printer-column
-/// fallback.
-pub fn has_curated(plural: &str) -> bool {
-    columns_for(plural).as_ptr() != DEFAULT_COLUMNS.as_ptr()
+/// Whether the API group and plural have curated columns beyond NAME/AGE.
+/// Other kinds can use the CRD printer-column fallback.
+pub fn has_curated(group: &str, plural: &str) -> bool {
+    columns_for(group, plural).as_ptr() != DEFAULT_COLUMNS.as_ptr()
 }
 
 /// The full curated headers for a kind (wide columns included), excluding the
@@ -360,16 +361,24 @@ pub fn has_curated(plural: &str) -> bool {
 /// namespaces). Live views go through [`ViewSpec`] instead, which folds in
 /// user views, printer columns, and wide-mode filtering.
 #[cfg(test)]
-pub fn headers(plural: &str) -> Vec<&'static str> {
-    columns_for(plural).iter().map(|c| c.header).collect()
+pub fn headers(group: &str, plural: &str) -> Vec<&'static str> {
+    columns_for(group, plural)
+        .iter()
+        .map(|c| c.header)
+        .collect()
 }
 
 /// Cells for one object, aligned with [`headers`]. The 2nd return value is the
 /// index of the column that should be colorized as a status (or None).
 #[cfg(test)]
-pub fn cells(obj: &DynamicObject, plural: &str, now: i64) -> (Vec<String>, Option<usize>) {
+pub fn cells(
+    obj: &DynamicObject,
+    group: &str,
+    plural: &str,
+    now: i64,
+) -> (Vec<String>, Option<usize>) {
     let ctx = CellContext::new(obj, now);
-    let columns = columns_for(plural);
+    let columns = columns_for(group, plural);
     let values = columns
         .iter()
         .map(|c| (c.extract)(&ctx).into_owned())
@@ -383,6 +392,7 @@ pub fn cells(obj: &DynamicObject, plural: &str, now: i64) -> (Vec<String>, Optio
 /// columns when the kind is unknown — then filtered by wide mode. Built once
 /// per view change, never per row.
 pub struct ViewSpec {
+    group: String,
     plural: String,
     columns: Vec<SpecColumn>,
     status_idx: Option<usize>,
@@ -423,21 +433,25 @@ fn spec_user(uc: &crate::views::UserColumn) -> SpecColumn {
 
 /// Resolve the columns for a view. `user` is the explicit view configured for
 /// the kind; `crd` is the printer-column fallback, consulted only when the
-/// user view defines no columns and `plural` has no curated ones.
+/// user view defines no columns and this API resource has no curated ones.
 pub fn build_spec(
+    group: &str,
     plural: &str,
     user: Option<&crate::views::View>,
     crd: Option<&crate::views::View>,
     wide: bool,
 ) -> ViewSpec {
-    let mut cols: Vec<SpecColumn> = columns_for(plural).iter().map(spec_curated).collect();
+    let mut cols: Vec<SpecColumn> = columns_for(group, plural)
+        .iter()
+        .map(spec_curated)
+        .collect();
     // A user view only counts as explicit column config when it has columns —
     // a sort-only view (or one whose columns all failed validation) still
     // benefits from the printer-column fallback.
     let view = match user {
         Some(v) if !v.columns.is_empty() => Some(v),
         _ => {
-            if has_curated(plural) {
+            if has_curated(group, plural) {
                 None
             } else {
                 crd
@@ -469,6 +483,7 @@ pub fn build_spec(
     cols.retain(|c| wide || !c.wide);
     let status_idx = cols.iter().position(|c| c.is_status);
     ViewSpec {
+        group: group.to_string(),
         plural: plural.to_string(),
         columns: cols,
         status_idx,
@@ -599,7 +614,7 @@ impl ViewSpec {
             SpecSource::Curated(extract) => {
                 let ctx = CellContext::new(obj, now);
                 let v = extract(&ctx);
-                if is_numeric_header(&self.plural, header) {
+                if is_numeric_header(&self.group, &self.plural, header) {
                     crate::views::SortValue::Num(parse_leading_num(&v))
                 } else {
                     crate::views::SortValue::Text(v.to_lowercase().to_string())
@@ -627,11 +642,11 @@ impl ViewSpec {
 }
 
 /// Columns whose curated cell is a count/number and should sort numerically.
-fn is_numeric_header(plural: &str, header: &str) -> bool {
+fn is_numeric_header(group: &str, plural: &str, header: &str) -> bool {
     // READY is a count ("1/2") for workloads, but flux kinds render it as
     // True/False/Unknown, which must sort as text.
     if header == "READY" {
-        let cols = columns_for(plural);
+        let cols = columns_for(group, plural);
         return cols.as_ptr() != FLUX_OBJECT_COLUMNS.as_ptr()
             && cols.as_ptr() != FLUX_SOURCE_COLUMNS.as_ptr();
     }
@@ -2275,7 +2290,7 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&p, "pods", now_secs());
+        let (cells, status_idx) = cells(&p, "", "pods", now_secs());
         assert_eq!(cells[0], "web");
         assert_eq!(cells[1], "1/2"); // ready
         assert_eq!(cells[2], "CrashLoopBackOff"); // waiting reason overrides phase
@@ -2301,7 +2316,7 @@ mod tests {
                                 "reason": "Unschedulable"}]
             }
         }));
-        let (c, _) = cells(&p, "pods", now_secs());
+        let (c, _) = cells(&p, "", "pods", now_secs());
         assert_eq!(c[1], "0/2");
         assert_eq!(c[2], "Pending");
         assert_eq!(c[3], "0");
@@ -2316,7 +2331,7 @@ mod tests {
                  "state": {"running": {}}}
             ]}
         }));
-        assert_eq!(cells(&p, "pods", now_secs()).0[1], "1/1");
+        assert_eq!(cells(&p, "", "pods", now_secs()).0[1], "1/1");
     }
 
     #[test]
@@ -2351,12 +2366,12 @@ mod tests {
         // The sidecar runs for the pod's whole life, so it is a container on
         // both sides of the fraction. `migrate` has already exited and is on
         // neither side, restarts included.
-        let (c, _) = cells(&pod(true), "pods", now_secs());
+        let (c, _) = cells(&pod(true), "", "pods", now_secs());
         assert_eq!(c[1], "2/2");
         assert_eq!(c[3], "4");
 
         // A sidecar failing its readiness probe holds the pod short of ready.
-        assert_eq!(cells(&pod(false), "pods", now_secs()).0[1], "1/2");
+        assert_eq!(cells(&pod(false), "", "pods", now_secs()).0[1], "1/2");
     }
 
     fn deploy(spec_replicas: i64, status: serde_json::Value) -> DynamicObject {
@@ -2375,7 +2390,7 @@ mod tests {
             3,
             json!({"replicas": 3, "readyReplicas": 3, "updatedReplicas": 3}),
         );
-        let (c, status_idx) = cells(&d, "deployments", now_secs());
+        let (c, status_idx) = cells(&d, "apps", "deployments", now_secs());
         assert_eq!(c[1], "3/3");
         assert_eq!(c[2], "Ready");
         assert_eq!(status_idx, Some(2));
@@ -2385,14 +2400,20 @@ mod tests {
             3,
             json!({"replicas": 3, "readyReplicas": 0, "updatedReplicas": 3}),
         );
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Unavailable");
+        assert_eq!(
+            cells(&d, "apps", "deployments", now_secs()).0[2],
+            "Unavailable"
+        );
 
         // Rollout replacing pods (updated < desired) → progressing.
         let d = deploy(
             3,
             json!({"replicas": 4, "readyReplicas": 2, "updatedReplicas": 1}),
         );
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Progressing");
+        assert_eq!(
+            cells(&d, "apps", "deployments", now_secs()).0[2],
+            "Progressing"
+        );
 
         // Fully rolled out but pods unready (crash loops, failed probes) →
         // degraded, not "progressing" — nothing is coming to fix it.
@@ -2400,14 +2421,23 @@ mod tests {
             3,
             json!({"replicas": 3, "readyReplicas": 2, "updatedReplicas": 3}),
         );
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Degraded");
+        assert_eq!(
+            cells(&d, "apps", "deployments", now_secs()).0[2],
+            "Degraded"
+        );
 
         // Scaled to zero reads faded, not broken.
         let d = deploy(0, json!({}));
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "ScaledDown");
+        assert_eq!(
+            cells(&d, "apps", "deployments", now_secs()).0[2],
+            "ScaledDown"
+        );
         // ... and still tearing down reads transitional.
         let d = deploy(0, json!({"replicas": 2, "readyReplicas": 2}));
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Progressing");
+        assert_eq!(
+            cells(&d, "apps", "deployments", now_secs()).0[2],
+            "Progressing"
+        );
     }
 
     #[test]
@@ -2421,7 +2451,7 @@ mod tests {
                                 "reason": "ProgressDeadlineExceeded"}]
             }),
         );
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Stalled");
+        assert_eq!(cells(&d, "apps", "deployments", now_secs()).0[2], "Stalled");
 
         // Available=False overrides a numerically-satisfied ready count.
         let d = deploy(
@@ -2431,7 +2461,10 @@ mod tests {
                 "conditions": [{"type": "Available", "status": "False"}]
             }),
         );
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Unavailable");
+        assert_eq!(
+            cells(&d, "apps", "deployments", now_secs()).0[2],
+            "Unavailable"
+        );
     }
 
     #[test]
@@ -2443,7 +2476,10 @@ mod tests {
             "status": {"replicas": 3, "readyReplicas": 2, "updatedReplicas": 2}
         }));
         // Rolling update in flight (updated < desired) → progressing.
-        assert_eq!(cells(&sts, "statefulsets", now_secs()).0[2], "Progressing");
+        assert_eq!(
+            cells(&sts, "apps", "statefulsets", now_secs()).0[2],
+            "Progressing"
+        );
 
         let ds = obj(json!({
             "apiVersion": "apps/v1", "kind": "DaemonSet",
@@ -2452,7 +2488,10 @@ mod tests {
                        "numberReady": 3, "updatedNumberScheduled": 5}
         }));
         // Fully rolled out, nodes unready → degraded. STATUS follows AVAILABLE.
-        assert_eq!(cells(&ds, "daemonsets", now_secs()).0[5], "Degraded");
+        assert_eq!(
+            cells(&ds, "apps", "daemonsets", now_secs()).0[5],
+            "Degraded"
+        );
 
         // An old, scaled-down ReplicaSet must read faded, not broken.
         let rs = obj(json!({
@@ -2461,7 +2500,10 @@ mod tests {
             "spec": {"replicas": 0},
             "status": {"replicas": 0}
         }));
-        assert_eq!(cells(&rs, "replicasets", now_secs()).0[4], "ScaledDown");
+        assert_eq!(
+            cells(&rs, "apps", "replicasets", now_secs()).0[4],
+            "ScaledDown"
+        );
 
         // spec.replicas unset defaults to 1 — a bare RS with one ready pod
         // is healthy, not degraded.
@@ -2470,7 +2512,7 @@ mod tests {
             "metadata": {"name": "web-abc", "namespace": "default"},
             "status": {"replicas": 1, "readyReplicas": 1}
         }));
-        assert_eq!(cells(&rs, "replicasets", now_secs()).0[4], "Ready");
+        assert_eq!(cells(&rs, "apps", "replicasets", now_secs()).0[4], "Ready");
     }
 
     #[test]
@@ -2482,7 +2524,10 @@ mod tests {
             "spec": {"replicas": 3},
             "status": {"replicas": 3, "readyReplicas": 3, "updatedReplicas": 3}
         }));
-        assert_eq!(cells(&d, "deployments", now_secs()).0[2], "Terminating");
+        assert_eq!(
+            cells(&d, "apps", "deployments", now_secs()).0[2],
+            "Terminating"
+        );
     }
 
     #[test]
@@ -2498,7 +2543,7 @@ mod tests {
             "status": {"conditions": [{"type": "Ready", "status": "True"}],
                        "nodeInfo": {"kubeletVersion": "v1.31.0"}}
         }));
-        let (node_cells, status_idx) = cells(&n, "nodes", now_secs());
+        let (node_cells, status_idx) = cells(&n, "", "nodes", now_secs());
         assert_eq!(node_cells[0], "cp-1");
         assert_eq!(node_cells[1], "Ready");
         assert_eq!(node_cells[2], "control-plane");
@@ -2507,7 +2552,7 @@ mod tests {
         assert_eq!(status_idx, Some(1));
 
         let bare = obj(json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "w-1"}}));
-        let (bare_cells, _) = cells(&bare, "nodes", now_secs());
+        let (bare_cells, _) = cells(&bare, "", "nodes", now_secs());
         assert_eq!(bare_cells[3], "0");
     }
 
@@ -2520,7 +2565,7 @@ mod tests {
                      "ports": [{"port": 80, "protocol": "TCP"}]},
             "status": {"loadBalancer": {}}
         }));
-        let (cells, _) = cells(&s, "services", now_secs());
+        let (cells, _) = cells(&s, "", "services", now_secs());
         assert_eq!(cells[1], "LoadBalancer");
         assert_eq!(cells[3], "<pending>");
         assert_eq!(cells[4], "80/TCP");
@@ -2543,10 +2588,15 @@ mod tests {
             }
         }));
         assert_eq!(
-            headers("customresourcedefinitions"),
+            headers("apiextensions.k8s.io", "customresourcedefinitions"),
             vec!["NAME", "GROUP", "KIND", "VERSIONS", "SCOPE", "AGE"]
         );
-        let (cells, _) = cells(&crd, "customresourcedefinitions", now_secs());
+        let (cells, _) = cells(
+            &crd,
+            "apiextensions.k8s.io",
+            "customresourcedefinitions",
+            now_secs(),
+        );
         assert_eq!(cells[0], "widgets.example.com");
         assert_eq!(cells[1], "example.com");
         assert_eq!(cells[2], "Widget");
@@ -2570,7 +2620,12 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&ks, "kustomizations", now_secs());
+        let (cells, status_idx) = cells(
+            &ks,
+            "kustomize.toolkit.fluxcd.io",
+            "kustomizations",
+            now_secs(),
+        );
         assert_eq!(cells[0], "apps");
         assert_eq!(cells[1], "True");
         assert_eq!(cells[2], "Applied revision: main@sha1:abc123");
@@ -2594,7 +2649,7 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&hr, "helmreleases", now_secs());
+        let (cells, status_idx) = cells(&hr, "helm.toolkit.fluxcd.io", "helmreleases", now_secs());
         assert_eq!(cells[1], "False");
         assert_eq!(cells[2], "install retries exhausted");
         assert_eq!(cells[3], "6.5.4");
@@ -2616,9 +2671,14 @@ mod tests {
                 ]
             }
         }));
-        let (cells, status_idx) = cells(&git, "gitrepositories", now_secs());
+        let (cells, status_idx) = cells(
+            &git,
+            "source.toolkit.fluxcd.io",
+            "gitrepositories",
+            now_secs(),
+        );
         assert_eq!(
-            headers("gitrepositories"),
+            headers("source.toolkit.fluxcd.io", "gitrepositories"),
             vec![
                 "NAME",
                 "READY",
@@ -2650,7 +2710,7 @@ mod tests {
                 "conditions": [{"type": "Ready", "status": "False", "message": "denied"}]
             }
         }));
-        let (cells, status_idx) = cells(&bucket, "buckets", now_secs());
+        let (cells, status_idx) = cells(&bucket, "source.toolkit.fluxcd.io", "buckets", now_secs());
         assert_eq!(cells[1], "False");
         assert_eq!(cells[2], "denied");
         assert_eq!(cells[3], "sha256:abc123");
@@ -2672,9 +2732,9 @@ mod tests {
                 "completionTime": "2024-01-01T01:05:00Z"
             }
         }));
-        let (cells, _) = cells(&job, "jobs", now_secs());
+        let (cells, _) = cells(&job, "batch", "jobs", now_secs());
         assert_eq!(
-            headers("jobs"),
+            headers("batch", "jobs"),
             vec!["NAME", "STATUS", "COMPLETIONS", "DURATION", "AGE"]
         );
         assert_eq!(cells[2], "2/3");
@@ -2690,9 +2750,9 @@ mod tests {
             "spec": {"schedule": "*/15 * * * *", "suspend": false},
             "status": {"active": [{"name": "backup-1"}]}
         }));
-        let (cells, _) = cells(&cron, "cronjobs", now_secs());
+        let (cells, _) = cells(&cron, "batch", "cronjobs", now_secs());
         assert_eq!(
-            headers("cronjobs"),
+            headers("batch", "cronjobs"),
             vec![
                 "NAME",
                 "SCHEDULE",
@@ -2720,9 +2780,9 @@ mod tests {
             "note": "Back-off restarting\nfailed container",
             "series": {"count": 7}
         }));
-        let (cells, status_idx) = cells(&event, "events", now_secs());
+        let (cells, status_idx) = cells(&event, "", "events", now_secs());
         assert_eq!(
-            headers("events"),
+            headers("", "events"),
             vec![
                 "NAME",
                 "LAST-SEEN",
@@ -2771,9 +2831,9 @@ mod tests {
                 }]
             }
         }));
-        let (cells, _) = cells(&hpa, "horizontalpodautoscalers", now_secs());
+        let (cells, _) = cells(&hpa, "autoscaling", "horizontalpodautoscalers", now_secs());
         assert_eq!(
-            headers("horizontalpodautoscalers"),
+            headers("autoscaling", "horizontalpodautoscalers"),
             vec![
                 "NAME",
                 "REFERENCE",
@@ -2798,7 +2858,12 @@ mod tests {
             "kind": "Kustomization",
             "metadata": {"name": "new"}
         }));
-        let (cells, _) = cells(&ks, "kustomizations", now_secs());
+        let (cells, _) = cells(
+            &ks,
+            "kustomize.toolkit.fluxcd.io",
+            "kustomizations",
+            now_secs(),
+        );
         assert_eq!(cells[1], "Unknown");
         assert_eq!(cells[2], "");
         assert_eq!(cells[3], "");
@@ -2816,9 +2881,9 @@ mod tests {
             },
             "status": {"loadBalancer": {"ingress": [{"ip": "203.0.113.10"}]}}
         }));
-        let (cells, _) = cells(&ing, "ingresses", now_secs());
+        let (cells, _) = cells(&ing, "networking.k8s.io", "ingresses", now_secs());
         assert_eq!(
-            headers("ingresses"),
+            headers("networking.k8s.io", "ingresses"),
             ["NAME", "CLASS", "HOSTS", "ADDRESS", "AGE"]
         );
         assert_eq!(cells[1], "nginx");
@@ -2834,7 +2899,7 @@ mod tests {
             "status": {"loadBalancer": {"ingress": [{"hostname": "abc.elb.amazonaws.com"}]}}
         }));
         assert_eq!(
-            cells(&hostname, "ingresses", now_secs()).0[3],
+            cells(&hostname, "networking.k8s.io", "ingresses", now_secs()).0[3],
             "abc.elb.amazonaws.com"
         );
 
@@ -2842,7 +2907,10 @@ mod tests {
             "apiVersion": "networking.k8s.io/v1", "kind": "Ingress",
             "metadata": {"name": "pending"}
         }));
-        assert_eq!(cells(&pending, "ingresses", now_secs()).0[3], "<none>");
+        assert_eq!(
+            cells(&pending, "networking.k8s.io", "ingresses", now_secs()).0[3],
+            "<none>"
+        );
     }
 
     #[test]
@@ -2853,8 +2921,16 @@ mod tests {
             "metadata": {"name": "web"},
             "spec": {"hostnames": ["app.example.com", "www.example.com"]}
         }));
-        let (row, idx) = cells(&route, "httproutes", now_secs());
-        assert_eq!(headers("httproutes"), ["NAME", "HOSTNAMES", "AGE"]);
+        let (row, idx) = cells(
+            &route,
+            "gateway.networking.k8s.io",
+            "httproutes",
+            now_secs(),
+        );
+        assert_eq!(
+            headers("gateway.networking.k8s.io", "httproutes"),
+            ["NAME", "HOSTNAMES", "AGE"]
+        );
         assert_eq!(row[1], "app.example.com,www.example.com");
         assert_eq!(idx, None);
 
@@ -2862,7 +2938,16 @@ mod tests {
             "apiVersion": "gateway.networking.k8s.io/v1", "kind": "HTTPRoute",
             "metadata": {"name": "any"}
         }));
-        assert_eq!(cells(&wildcard, "httproutes", now_secs()).0[1], "*");
+        assert_eq!(
+            cells(
+                &wildcard,
+                "gateway.networking.k8s.io",
+                "httproutes",
+                now_secs()
+            )
+            .0[1],
+            "*"
+        );
     }
 
     #[test]
@@ -2871,7 +2956,7 @@ mod tests {
             "apiVersion": "example.com/v1", "kind": "Widget",
             "metadata": {"name": "thingy"}
         }));
-        let (cells, idx) = cells(&o, "widgets", now_secs());
+        let (cells, idx) = cells(&o, "example.com", "widgets", now_secs());
         assert_eq!(cells[0], "thingy");
         assert_eq!(cells.len(), 2);
         assert_eq!(idx, None);
@@ -2885,38 +2970,38 @@ mod tests {
             "metadata": {"name": "sample"}
         }));
         let kinds = [
-            "pods",
-            "deployments",
-            "replicasets",
-            "statefulsets",
-            "daemonsets",
-            "services",
-            "nodes",
-            "namespaces",
-            "configmaps",
-            "secrets",
-            "jobs",
-            "cronjobs",
-            "events",
-            "horizontalpodautoscalers",
-            "persistentvolumeclaims",
-            "persistentvolumes",
-            "ingresses",
-            "httproutes",
-            "endpoints",
-            "customresourcedefinitions",
-            "kustomizations",
-            "helmreleases",
-            "gitrepositories",
-            "helmrepositories",
-            "ocirepositories",
-            "buckets",
-            "widgets",
+            ("", "pods"),
+            ("apps", "deployments"),
+            ("apps", "replicasets"),
+            ("apps", "statefulsets"),
+            ("apps", "daemonsets"),
+            ("", "services"),
+            ("", "nodes"),
+            ("", "namespaces"),
+            ("", "configmaps"),
+            ("", "secrets"),
+            ("batch", "jobs"),
+            ("batch", "cronjobs"),
+            ("", "events"),
+            ("autoscaling", "horizontalpodautoscalers"),
+            ("", "persistentvolumeclaims"),
+            ("", "persistentvolumes"),
+            ("networking.k8s.io", "ingresses"),
+            ("gateway.networking.k8s.io", "httproutes"),
+            ("", "endpoints"),
+            ("apiextensions.k8s.io", "customresourcedefinitions"),
+            ("kustomize.toolkit.fluxcd.io", "kustomizations"),
+            ("helm.toolkit.fluxcd.io", "helmreleases"),
+            ("source.toolkit.fluxcd.io", "gitrepositories"),
+            ("source.toolkit.fluxcd.io", "helmrepositories"),
+            ("source.toolkit.fluxcd.io", "ocirepositories"),
+            ("source.toolkit.fluxcd.io", "buckets"),
+            ("example.com", "widgets"),
         ];
 
-        for kind in kinds {
-            let headers = headers(kind);
-            let (cells, status_idx) = cells(&o, kind, now_secs());
+        for (group, kind) in kinds {
+            let headers = headers(group, kind);
+            let (cells, status_idx) = cells(&o, group, kind, now_secs());
             assert_eq!(headers.len(), cells.len(), "{kind} column count");
             if let Some(idx) = status_idx {
                 assert!(idx < cells.len(), "{kind} status index");
@@ -2962,7 +3047,7 @@ mod tests {
             ],
             false,
         );
-        let spec = build_spec("pods", Some(&v), None, false);
+        let spec = build_spec("", "pods", Some(&v), None, false);
         assert_eq!(
             spec.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "NODE-IP", "AGE"]
@@ -2988,18 +3073,18 @@ mod tests {
             ],
             true,
         );
-        let spec = build_spec("pods", Some(&v), None, true);
+        let spec = build_spec("", "pods", Some(&v), None, true);
         assert_eq!(spec.headers(), vec!["NAME", "PHASE"]);
     }
 
     #[test]
     fn spec_wide_mode_gates_wide_only_columns() {
-        let narrow = build_spec("pods", None, None, false);
+        let narrow = build_spec("", "pods", None, None, false);
         assert_eq!(
             narrow.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
         );
-        let wide = build_spec("pods", None, None, true);
+        let wide = build_spec("", "pods", None, None, true);
         assert_eq!(
             wide.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE"]
@@ -3014,10 +3099,10 @@ mod tests {
             false,
         );
         // Unknown kind: printer columns upgrade the NAME/AGE fallback.
-        let spec = build_spec("widgets", None, Some(&crd), false);
+        let spec = build_spec("example.com", "widgets", None, Some(&crd), false);
         assert_eq!(spec.headers(), vec!["NAME", "PHASE", "AGE"]);
         // Curated kind: printer columns never apply.
-        let spec = build_spec("pods", None, Some(&crd), false);
+        let spec = build_spec("", "pods", None, Some(&crd), false);
         assert_eq!(
             spec.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
@@ -3027,14 +3112,20 @@ mod tests {
             vec![user_col("MINE", "/status/mine", ColumnKind::Text)],
             false,
         );
-        let spec = build_spec("widgets", Some(&user), Some(&crd), false);
+        let spec = build_spec("example.com", "widgets", Some(&user), Some(&crd), false);
         assert_eq!(spec.headers(), vec!["NAME", "MINE", "AGE"]);
         // A sort-only user view (no columns) still gets printer columns.
         let sort_only = crate::views::View {
             sort: Some(("PHASE".into(), false)),
             ..Default::default()
         };
-        let spec = build_spec("widgets", Some(&sort_only), Some(&crd), false);
+        let spec = build_spec(
+            "example.com",
+            "widgets",
+            Some(&sort_only),
+            Some(&crd),
+            false,
+        );
         assert_eq!(spec.headers(), vec!["NAME", "PHASE", "AGE"]);
     }
 
@@ -3045,7 +3136,7 @@ mod tests {
             vec![user_col("CPU", "/spec/cpu", ColumnKind::Quantity)],
             false,
         );
-        let spec = build_spec("widgets", Some(&v), None, false);
+        let spec = build_spec("example.com", "widgets", Some(&v), None, false);
         let o = obj(json!({
             "apiVersion": "example.com/v1", "kind": "Widget",
             "metadata": {"name": "w"},
@@ -3070,7 +3161,7 @@ mod tests {
                 "containerStatuses": []
             }
         }));
-        let spec = build_spec("pods", None, None, true);
+        let spec = build_spec("", "pods", None, None, true);
 
         assert!(matches!(
             spec.cell_at(&pod, 0, now_secs()),
@@ -3097,7 +3188,13 @@ mod tests {
                 "status": {"conditions": [{"type": "Ready", "status": status}]}
             }))
         };
-        let spec = build_spec("kustomizations", None, None, false);
+        let spec = build_spec(
+            "kustomize.toolkit.fluxcd.io",
+            "kustomizations",
+            None,
+            None,
+            false,
+        );
         let ready =
             |status: &str| match spec.sort_value(&flux(status), "READY", now_secs()).unwrap() {
                 SortValue::Text(t) => t,
@@ -3114,7 +3211,7 @@ mod tests {
                 {"ready": false, "restartCount": 0, "state": {"running": {}}}
             ]}
         }));
-        let spec = build_spec("pods", None, None, false);
+        let spec = build_spec("", "pods", None, None, false);
         match spec.sort_value(&pod, "READY", now_secs()).unwrap() {
             SortValue::Num(n) => assert_eq!(n, 1.0),
             SortValue::Text(t) => panic!("pod READY must sort numerically, got '{t}'"),

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use kube::api::{Api, ListParams};
 use kube::config::{KubeConfigOptions, Kubeconfig};
-use kube::core::DynamicObject;
+use kube::core::{DynamicObject, GroupVersionResource};
 use kube::discovery::{ApiResource, Discovery, Scope};
 use kube::runtime::{WatchStreamExt, watcher};
 use kube::{Client, Config, ResourceExt};
@@ -48,6 +48,10 @@ pub struct Kind {
 }
 
 impl Kind {
+    pub fn resource_key(&self) -> GroupVersionResource {
+        GroupVersionResource::gvr(&self.ar.group, &self.ar.version, &self.ar.plural)
+    }
+
     pub fn title(&self) -> String {
         if self.ar.group.is_empty() {
             self.ar.plural.clone()

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use kube::core::DynamicObject;
+use kube::core::{DynamicObject, GroupVersionResource};
 
 /// Identity of an asynchronous operation's claim on the shared status bar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -51,11 +51,11 @@ pub enum Msg {
         generation: u64,
         counts: HashMap<String, usize>,
     },
-    /// CRD `additionalPrinterColumns` fallback for a custom-resource plural,
+    /// CRD `additionalPrinterColumns` fallback for an API resource,
     /// fetched off-thread (`None` = CRD had nothing usable for the version).
     PrinterColumns {
         generation: u64,
-        plural: String,
+        resource: GroupVersionResource,
         view: Box<Option<crate::views::View>>,
     },
     PulseData {

--- a/src/views.rs
+++ b/src/views.rs
@@ -1807,7 +1807,7 @@ mod tests {
             SortValue::Num(_) => panic!("reason sorts as text"),
         }
 
-        let spec = crate::columns::build_spec("widgets", None, Some(&view), false);
+        let spec = crate::columns::build_spec("example.com", "widgets", None, Some(&view), false);
         assert_eq!(spec.headers(), vec!["NAME", "A", "B", "C", "AGE"]);
         let (cells, status_idx) = spec.cells(&obj, crate::columns::now_secs());
         assert_eq!(


### PR DESCRIPTION
Built-in columns now match the API group and resource name. Custom resources with built-in names use their own printer columns. Printer replies and row caches retain the full resource identity.

Validation: formatting, Clippy with warnings denied, and tests pass on this branch. Regression tests cover the changed behavior. `cargo check --locked --features bench --bench hot_paths` also passes.

Closes #278

Depends on #309. After that pull request merges, set this pull request base to `main` before merging.
