### PR TITLE
fix: enable SOCKS5 proxies for Kubernetes clients

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ hyper = { version = "1.10.1", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "native-tokio", "ring", "tls12"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
 k8s-openapi = { version = "0.28", features = ["latest"] }
-kube = { version = "4.2.0", features = ["runtime", "client", "derive", "ws", "http-proxy", "gzip"] }
+kube = { version = "4.2.0", features = ["runtime", "client", "derive", "ws", "http-proxy", "socks5", "gzip"] }
 memchr = "2.8.3"
 nucleo-matcher = "0.3"
 ratatui = "0.30.1"

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -723,6 +723,14 @@ impl Cluster {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn client_accepts_socks5_proxy() {
+        let mut config = Config::new("https://127.0.0.1:6443".parse().unwrap());
+        config.proxy_url = Some("socks5://127.0.0.1:9090".parse().unwrap());
+
+        Client::try_from(config).expect("build client with a SOCKS5 proxy");
+    }
+
     #[test]
     fn expired_watch_errors_are_benign() {
         let expired = watcher::Error::WatchError(Box::new(kube::core::Status {


### PR DESCRIPTION
Kubeconfig entries such as `proxy-url: socks5://127.0.0.1:9090` caused client construction to fail because the `kube/socks5` feature was disabled. Enable this feature so Sofka can build a client with a SOCKS5 proxy.

Add a regression test for the reported proxy setting. The test failed with `ProxyProtocolDisabled` before the fix and passes after it. This checks client construction without a cluster or proxy connection.

Validation: `just check` passed (formatting, Clippy, 891 tests passed, 1 ignored). Commit hooks passed. Cargo confirmed that no lockfile change is needed.

Closes #294
