### PR TITLE
fix: ctrl-n/p navigate sort and copy pickers

### DIFF
--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -267,6 +267,12 @@ impl App {
             }
             KeyCode::Down => list_step(&mut self.sort_picker_state, len, true),
             KeyCode::Up => list_step(&mut self.sort_picker_state, len, false),
+            KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                list_step(&mut self.sort_picker_state, len, true)
+            }
+            KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                list_step(&mut self.sort_picker_state, len, false)
+            }
             KeyCode::Enter => {
                 if let Some(entry) = self
                     .sort_picker_state
@@ -404,6 +410,12 @@ impl App {
             }
             KeyCode::Down => list_step(&mut self.copy_picker_state, len, true),
             KeyCode::Up => list_step(&mut self.copy_picker_state, len, false),
+            KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                list_step(&mut self.copy_picker_state, len, true)
+            }
+            KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                list_step(&mut self.copy_picker_state, len, false)
+            }
             KeyCode::Enter => {
                 if let Some((header, value)) = self
                     .copy_picker_state

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -267,10 +267,10 @@ impl App {
             }
             KeyCode::Down => list_step(&mut self.sort_picker_state, len, true),
             KeyCode::Up => list_step(&mut self.sort_picker_state, len, false),
-            KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
                 list_step(&mut self.sort_picker_state, len, true)
             }
-            KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char('p') if key.modifiers == KeyModifiers::CONTROL => {
                 list_step(&mut self.sort_picker_state, len, false)
             }
             KeyCode::Enter => {
@@ -410,10 +410,10 @@ impl App {
             }
             KeyCode::Down => list_step(&mut self.copy_picker_state, len, true),
             KeyCode::Up => list_step(&mut self.copy_picker_state, len, false),
-            KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
                 list_step(&mut self.copy_picker_state, len, true)
             }
-            KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char('p') if key.modifiers == KeyModifiers::CONTROL => {
                 list_step(&mut self.copy_picker_state, len, false)
             }
             KeyCode::Enter => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6121,6 +6121,23 @@ async fn sort_picker_esc_clears_filter_then_closes() {
 }
 
 #[tokio::test]
+async fn sort_picker_ctrl_n_p_navigate_without_touching_filter() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    assert_eq!(app.sort_picker_state.selected(), Some(0));
+
+    app.handle_key(ctrl(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.sort_picker_state.selected(), Some(1));
+    app.handle_key(ctrl(KeyCode::Char('p'))).unwrap();
+    assert_eq!(app.sort_picker_state.selected(), Some(0));
+    assert!(
+        app.sort_picker_filter.is_empty(),
+        "ctrl-n/p must not fall through to the type-to-filter buffer"
+    );
+}
+
+#[tokio::test]
 async fn copy_picker_lists_full_row_fields_and_filters_on_values() {
     let (mut app, _rx) = test_app();
     app.switch_kind("services");
@@ -6162,6 +6179,31 @@ async fn copy_picker_lists_full_row_fields_and_filters_on_values() {
     assert!(app.copy_picker_filter.is_empty());
     app.handle_key(press(KeyCode::Esc)).unwrap();
     assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn copy_picker_ctrl_n_p_navigate_without_touching_filter() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Service",
+               "metadata": {"name": "web", "namespace": "default"},
+               "spec": {"type": "ClusterIP", "clusterIP": "10.96.13.5",
+                        "ports": [{"port": 80, "protocol": "TCP"}]}}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('Y'))).unwrap();
+    assert_eq!(app.copy_picker_state.selected(), Some(0));
+
+    app.handle_key(ctrl(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.copy_picker_state.selected(), Some(1));
+    app.handle_key(ctrl(KeyCode::Char('p'))).unwrap();
+    assert_eq!(app.copy_picker_state.selected(), Some(0));
+    assert!(
+        app.copy_picker_filter.is_empty(),
+        "ctrl-n/p must not fall through to the type-to-filter buffer"
+    );
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6135,6 +6135,15 @@ async fn sort_picker_ctrl_n_p_navigate_without_touching_filter() {
         app.sort_picker_filter.is_empty(),
         "ctrl-n/p must not fall through to the type-to-filter buffer"
     );
+
+    // ctrl-alt-n is a distinct chord, left to typing "n" into the filter —
+    // not a nav move (see ctrl_alt_f leaves paging alone).
+    let ctrl_alt_n = KeyEvent::new(
+        KeyCode::Char('n'),
+        KeyModifiers::CONTROL | KeyModifiers::ALT,
+    );
+    app.handle_key(ctrl_alt_n).unwrap();
+    assert_eq!(app.sort_picker_filter, "n");
 }
 
 #[tokio::test]
@@ -6204,6 +6213,15 @@ async fn copy_picker_ctrl_n_p_navigate_without_touching_filter() {
         app.copy_picker_filter.is_empty(),
         "ctrl-n/p must not fall through to the type-to-filter buffer"
     );
+
+    // ctrl-alt-n is a distinct chord, left to typing "n" into the filter —
+    // not a nav move (see ctrl_alt_f leaves paging alone).
+    let ctrl_alt_n = KeyEvent::new(
+        KeyCode::Char('n'),
+        KeyModifiers::CONTROL | KeyModifiers::ALT,
+    );
+    app.handle_key(ctrl_alt_n).unwrap();
+    assert_eq!(app.copy_picker_filter, "n");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `S` (sort picker) and `Y` (copy picker) now accept `ctrl-n`/`ctrl-p` as vim/readline-style aliases for `Down`/`Up`
- Previously these keys fell through to the type-to-filter buffer (ctrl-n typed a literal "n" into the filter)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked` (890 passed)
- [x] Ran the built binary against a live cluster (tmux), exercised ctrl-n/ctrl-p in both pickers and confirmed the filter buffer stayed empty

Closes https://github.com/nklmilojevic/sofka/issues/311