### PR TITLE
feat: name the cluster in the startup banner

### DIFF
--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -537,6 +537,19 @@ pub fn current_context_info() -> Option<(String, String, String)> {
     Some((context, cluster_name, server))
 }
 
+/// Name for the pre-connect startup banner. The kubeconfig context is what
+/// `kubectl config current-context` prints and what users recognise, while the
+/// cluster name is an ARN on EKS and `gke_project_zone_name` on GKE, so the
+/// context wins and the cluster name is the fallback. `None` when the
+/// kubeconfig knows neither (in-cluster config, no kubeconfig).
+pub fn connect_label(context: &str, cluster_name: &str) -> Option<String> {
+    match (context.trim(), cluster_name.trim()) {
+        ("", "") => None,
+        ("", cluster) => Some(cluster.to_string()),
+        (context, _) => Some(context.to_string()),
+    }
+}
+
 /// Public wrapper over [`cluster_name_for`] for resolving per-context config
 /// (fleet dashboard read-only policy) without a live connection.
 pub fn cluster_name_for_context(context: &str) -> String {
@@ -1147,6 +1160,25 @@ mod tests {
                 .catalog
                 .contains(&"gadgets.mixed.example.com".into())
         );
+    }
+
+    #[test]
+    fn connect_label_prefers_the_context_over_the_cluster_name() {
+        assert_eq!(
+            connect_label("prod-eu", "arn:aws:eks:eu-west-1:1234:cluster/prod"),
+            Some("prod-eu".into())
+        );
+    }
+
+    #[test]
+    fn connect_label_falls_back_to_the_cluster_name() {
+        assert_eq!(connect_label("", "kind-sofka"), Some("kind-sofka".into()));
+    }
+
+    #[test]
+    fn connect_label_is_none_without_a_kubeconfig() {
+        assert_eq!(connect_label("", ""), None);
+        assert_eq!(connect_label("  ", "\t"), None);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,16 @@ async fn run_main(args: Args) -> Result<()> {
     // unreachable current context isn't fatal for the interactive TUI: start
     // in the context picker instead (k9s behavior). Headless modes still exit
     // with the error, since there is no picker to fall back to.
-    eprintln!("Connecting to cluster…");
+    let (banner_context, banner_cluster) = match args.context.as_deref() {
+        Some(name) => (name.to_string(), k8s::cluster_name_for_context(name)),
+        None => k8s::current_context_info()
+            .map(|(context, cluster, _)| (context, cluster))
+            .unwrap_or_default(),
+    };
+    match k8s::connect_label(&banner_context, &banner_cluster) {
+        Some(label) => eprintln!("Connecting to cluster: {label}…"),
+        None => eprintln!("Connecting to cluster…"),
+    }
     let connect = match args.context.as_deref() {
         Some(name) => Cluster::connect_context(name).await,
         None => Cluster::connect().await,


### PR DESCRIPTION
## What

The pre-connect banner said only `Connecting to cluster…`. It now names the cluster it is about to contact:

```
$ sofka
Connecting to cluster: prod-eu…
```

## Why

With several kubeconfig contexts in play, a stale current-context is easy to miss, and the old banner gave no hint about which cluster was being contacted.

The banner is printed before connecting (deliberately — errors stay readable before the TUI takes over the terminal), so the name has to come from the kubeconfig rather than from the live connection. The existing offline helpers `current_context_info` and `cluster_name_for_context` already resolve both the current context and the cluster a `--context` argument points at.

## Which name

The **context** name wins over the kubeconfig cluster name: it is what `kubectl config current-context` prints and what people recognise, whereas the cluster name is a full ARN on EKS (`arn:aws:eks:eu-west-1:1234:cluster/prod`) and `gke_project_zone_name` on GKE.

Three cases:

| kubeconfig state | banner |
| --- | --- |
| context known (current, or `--context foo`) | `Connecting to cluster: foo…` |
| context unknown, cluster name known | `Connecting to cluster: <cluster>…` |
| neither (in-cluster config, no kubeconfig) | `Connecting to cluster…` (unchanged) |

## Tests

`connect_label` is a pure function over `(context, cluster_name)` with unit tests for all three cases in `src/k8s.rs`, keeping the kubeconfig I/O in `main`. `cargo fmt --check` and `cargo test` are clean (894 tests).

Note: `cargo clippy -D warnings` reports 10 `collapsible_match`/boolean-simplification warnings on `main` with the flake's current Rust 1.95 toolchain, all in `src/app/*` and none in the files this PR touches — pre-existing, not from this change.