### PR TITLE
feat: drill from MachineDeployment into its Machines

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -13,7 +13,7 @@ pickers keep both characters available as input.
 | `:<resource> <ns>`                            | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                                                 |
 | `[` / `]`                                     | view history - back / forward through visited kind+namespace views                                                                                            |
 | `Tab` / `shift-Tab`                           | next / previous common resource in the current namespace; cycle workspace views when one is open                                                              |
-| `enter`                                       | drill down (workload/svc → pods, cronjob → jobs, node → pods, pod → containers, ns → re-scope, CRD → resources, or [views](views.md))                         |
+| `enter`                                       | drill down (workload/svc → pods, machinedeployment → machines, cronjob → jobs, node → pods, pod → containers, ns → re-scope, CRD → resources, or [views](views.md))  |
 | `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                                                     |
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                                                      |
 | `ctrl-f` / `ctrl-b`, `PgDn` / `PgUp`          | page forward / back - one screenful at a time                                                                                                                 |

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -35,10 +35,11 @@ impl App {
                 None => self.flash_warn("service has no selector"),
             },
             // Cluster API: MachineDeployment → Machines, same selector
-            // pattern as workload → pods.
+            // pattern as workload → pods. Use the qualified name so a
+            // bare `machines` registered by an unrelated CRD can't hijack it.
             "machinedeployments" => match label_selector(&obj, "matchLabels") {
                 Some(sel) => self.drill_to(
-                    "machines",
+                    "machines.cluster.x-k8s.io",
                     ns,
                     Some(sel),
                     None,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -34,19 +34,6 @@ impl App {
                 Some(sel) => self.drill_to_pods(ns, Some(sel), None, format!("svc/{name}")),
                 None => self.flash_warn("service has no selector"),
             },
-            // Cluster API: MachineDeployment → Machines, same selector
-            // pattern as workload → pods. Use the qualified name so a
-            // bare `machines` registered by an unrelated CRD can't hijack it.
-            "machinedeployments" => match label_selector(&obj, "matchLabels") {
-                Some(sel) => self.drill_to(
-                    "machines.cluster.x-k8s.io",
-                    ns,
-                    Some(sel),
-                    None,
-                    format!("machinedeployment/{name}"),
-                ),
-                None => self.flash_warn("no machine selector on this object"),
-            },
             "pods" => self.open_containers(&obj),
             "cronjobs" => self.drill_into_cronjob_jobs(&obj),
             // enter on a CRD lists its custom resources, not its YAML.
@@ -62,7 +49,28 @@ impl App {
             // names a node (`[views."…"].node`) drills into it. Pods name one
             // too, but they drill into containers above.
             _ => {
-                if let Some(drill) = self.configured_drill() {
+                // Cluster API: MachineDeployment → Machines, same selector
+                // pattern as workload → pods. Guarded by the API group so a
+                // non-CAPI kind that happens to share the plural
+                // `machinedeployments` falls through to its configured drill
+                // or YAML instead of trying to open Cluster API Machines.
+                if self.kind_plural == "machinedeployments"
+                    && self
+                        .kind
+                        .as_ref()
+                        .is_some_and(|k| k.ar.group == "cluster.x-k8s.io")
+                {
+                    match label_selector(&obj, "matchLabels") {
+                        Some(sel) => self.drill_to(
+                            "machines.cluster.x-k8s.io",
+                            ns,
+                            Some(sel),
+                            None,
+                            format!("machinedeployment/{name}"),
+                        ),
+                        None => self.flash_warn("no machine selector on this object"),
+                    }
+                } else if let Some(drill) = self.configured_drill() {
                     self.drill_configured(&obj, &drill);
                 } else if let Some(pointer) = self.node_pointer() {
                     self.show_node_at(&pointer);

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -34,6 +34,18 @@ impl App {
                 Some(sel) => self.drill_to_pods(ns, Some(sel), None, format!("svc/{name}")),
                 None => self.flash_warn("service has no selector"),
             },
+            // Cluster API: MachineDeployment → Machines, same selector
+            // pattern as workload → pods.
+            "machinedeployments" => match label_selector(&obj, "matchLabels") {
+                Some(sel) => self.drill_to(
+                    "machines",
+                    ns,
+                    Some(sel),
+                    None,
+                    format!("machinedeployment/{name}"),
+                ),
+                None => self.flash_warn("no machine selector on this object"),
+            },
             "pods" => self.open_containers(&obj),
             "cronjobs" => self.drill_into_cronjob_jobs(&obj),
             // enter on a CRD lists its custom resources, not its YAML.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3358,6 +3358,36 @@ async fn machinedeployment_drill_resolves_qualified_machine_group() {
 }
 
 #[tokio::test]
+async fn non_capi_machinedeployments_falls_through_to_yaml() {
+    let (mut app, _rx) = test_app();
+    app.cluster.register_kind(
+        "other.example.com",
+        "MachineDeployment",
+        "machinedeployments",
+        true,
+    );
+    app.switch_kind("machinedeployments");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "other.example.com/v1", "kind": "MachineDeployment",
+            "metadata": {"name": "md-1", "namespace": "default"},
+            "spec": {"selector": {"matchLabels": {"app": "web"}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+
+    // Enter on a non-CAPI machinedeployments opens YAML, not Cluster API
+    // Machines — the group guard prevents the CAPI drill from firing.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Detail, "opens YAML, not machines");
+    assert_eq!(
+        app.kind_plural, "machinedeployments",
+        "stays on machinedeployments"
+    );
+}
+
+#[tokio::test]
 async fn o_on_pod_scopes_to_its_host_node() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3250,6 +3250,77 @@ async fn drill_into_workload_then_esc_restores() {
 }
 
 #[tokio::test]
+async fn drill_into_machinedeployment_shows_machines() {
+    let (mut app, _rx) = test_app();
+    app.cluster.register_kind(
+        "cluster.x-k8s.io",
+        "MachineDeployment",
+        "machinedeployments",
+        true,
+    );
+    app.cluster
+        .register_kind("cluster.x-k8s.io", "Machine", "machines", true);
+    app.switch_kind("machinedeployments");
+    assert_eq!(app.kind_plural, "machinedeployments");
+
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "cluster.x-k8s.io/v1", "kind": "MachineDeployment",
+            "metadata": {"name": "md-1", "namespace": "default"},
+            "spec": {"selector": {"matchLabels": {"cluster.x-k8s.io/cluster-name": "my-cluster"}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+    assert_eq!(app.rows().len(), 1);
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "machines");
+    assert_eq!(
+        app.labels.as_deref(),
+        Some("cluster.x-k8s.io/cluster-name=my-cluster")
+    );
+    assert_eq!(app.scope_label.as_deref(), Some("machinedeployment/md-1"));
+    assert_eq!(app.stack.len(), 1);
+
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "machinedeployments");
+    assert_eq!(app.labels, None);
+    assert!(app.stack.is_empty());
+}
+
+#[tokio::test]
+async fn machinedeployment_without_selector_warns() {
+    let (mut app, _rx) = test_app();
+    app.cluster.register_kind(
+        "cluster.x-k8s.io",
+        "MachineDeployment",
+        "machinedeployments",
+        true,
+    );
+    app.cluster
+        .register_kind("cluster.x-k8s.io", "Machine", "machines", true);
+    app.switch_kind("machinedeployments");
+
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "cluster.x-k8s.io/v1", "kind": "MachineDeployment",
+            "metadata": {"name": "md-1", "namespace": "default"},
+            "spec": {"selector": {}}
+        }),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(
+        app.kind_plural, "machinedeployments",
+        "stays on machinedeployments"
+    );
+    assert!(app.flash.contains("no machine selector"));
+}
+
+#[tokio::test]
 async fn o_on_pod_scopes_to_its_host_node() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3321,6 +3321,43 @@ async fn machinedeployment_without_selector_warns() {
 }
 
 #[tokio::test]
+async fn machinedeployment_drill_resolves_qualified_machine_group() {
+    let (mut app, _rx) = test_app();
+    app.cluster.register_kind(
+        "cluster.x-k8s.io",
+        "MachineDeployment",
+        "machinedeployments",
+        true,
+    );
+    app.cluster
+        .register_kind("cluster.x-k8s.io", "Machine", "machines", true);
+    // A competing CRD with the same plural but a different group. The bare
+    // `machines` key in the registry is last-write-wins, so it now resolves
+    // to the wrong kind. The drill must use the qualified name to avoid this.
+    app.cluster
+        .register_kind("other.example.com", "Machine", "machines", true);
+
+    app.switch_kind("machinedeployments");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "cluster.x-k8s.io/v1", "kind": "MachineDeployment",
+            "metadata": {"name": "md-1", "namespace": "default"},
+            "spec": {"selector": {"matchLabels": {"app": "web"}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "machines");
+    assert_eq!(
+        app.kind.as_ref().unwrap().ar.group,
+        "cluster.x-k8s.io",
+        "qualified name resolves to Cluster API, not the competing CRD"
+    );
+}
+
+#[tokio::test]
 async fn o_on_pod_scopes_to_its_host_node() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -495,10 +495,6 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
             hint_line(&[("Y", "copy cell"), ("^d", "delete")]),
         ],
-        "machinedeployments" => vec![
-            hint_line(&[("⏎", "machines"), ("y", "yaml"), ("d", "describe")]),
-            hint_line(&[("e", "edit"), ("^d", "delete")]),
-        ],
         "nodes" => vec![
             hint_line(&[("⏎", "pods"), ("y", "yaml"), ("d", "describe")]),
             hint_line(&[("C", "cordon"), ("U", "uncordon"), ("D", "drain")]),
@@ -537,6 +533,17 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             hint_line(&[("^d", "delete")]),
         ],
     };
+    if app.kind_plural == "machinedeployments"
+        && app
+            .kind
+            .as_ref()
+            .is_some_and(|k| k.ar.group == "cluster.x-k8s.io")
+    {
+        lines = vec![
+            hint_line(&[("⏎", "machines"), ("y", "yaml"), ("d", "describe")]),
+            hint_line(&[("e", "edit"), ("^d", "delete")]),
+        ];
+    }
     if app.flux_suspendable() {
         lines.push(hint_line(&[("t", "flux menu")]));
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -495,6 +495,10 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
             hint_line(&[("Y", "copy cell"), ("^d", "delete")]),
         ],
+        "machinedeployments" => vec![
+            hint_line(&[("⏎", "machines"), ("y", "yaml"), ("d", "describe")]),
+            hint_line(&[("e", "edit"), ("^d", "delete")]),
+        ],
         "nodes" => vec![
             hint_line(&[("⏎", "pods"), ("y", "yaml"), ("d", "describe")]),
             hint_line(&[("C", "cordon"), ("U", "uncordon"), ("D", "drain")]),

--- a/src/views.rs
+++ b/src/views.rs
@@ -136,6 +136,7 @@ pub const BUILTIN_DRILLS: &[&str] = &[
     "cronjobs",
     "services",
     "pods",
+    "machinedeployments",
     "customresourcedefinitions",
     "helm",
     "helmhistory",

--- a/src/views.rs
+++ b/src/views.rs
@@ -136,7 +136,6 @@ pub const BUILTIN_DRILLS: &[&str] = &[
     "cronjobs",
     "services",
     "pods",
-    "machinedeployments",
     "customresourcedefinitions",
     "helm",
     "helmhistory",


### PR DESCRIPTION
Pressing enter on a MachineDeployment now lists the Machines it manages, using the same `spec.selector.matchLabels` mechanism as Deployment → Pods. Previously enter fell through to the YAML view, making it hard to navigate the Cluster API hierarchy.

`y` continues to open the YAML view as before.