### PR TITLE
feat: let a drill read the row by JSON Pointer and filter client-side

### DIFF
--- a/docs/views.md
+++ b/docs/views.md
@@ -118,8 +118,10 @@ list; a pointer that lands on something other than a string warns that the
 pointer is wrong.
 
 **A row selects other objects** - `drill` names the kind `enter` should open and
-how to scope it: a label selector (`labels`), a field selector (`fields`), or
-both, with `{name}` and `{namespace}` filled in from the row:
+how to scope it: a label selector (`labels`), a field selector (`fields`), a
+client-side row filter (`filter`, the `/` key's syntax), or any mix. Templates
+take `{name}` and `{namespace}` from the row's metadata and `{/json/pointer}`
+from anywhere in the object:
 
 ```toml
 # children carry the parent's name in a label
@@ -129,15 +131,28 @@ drill = { kind = "nodeclaims", labels = "karpenter.sh/nodepool={name}" }
 # the target is a single object with a known name and nothing labelling it back
 [views.externalsecrets]
 drill = { kind = "secrets", fields = "metadata.name={name}" }
+
+# the target's name sits in the row's spec
+[views.persistentvolumeclaims]
+drill = { kind = "volumeattributesclasses", fields = "metadata.name={/spec/volumeAttributesClassName}" }
+
+# nothing server-side expresses the relationship: filter the rows after landing
+[views.volumeattributesclasses]
+drill = { kind = "persistentvolumeclaims", filter = "{name}" }
 ```
 
 Prefer `labels` when the target carries a label pointing back at the row -
 that's how most operators mark what they own. Use `fields` when it doesn't:
 `metadata.name` and `metadata.namespace` are selectable on every kind, other
-fields only where the apiserver indexes them. `kind` is anything `:` accepts
-(alias, plural, or kind) and is resolved when you press `enter`, so an unknown
-kind warns and stays put. A namespaced target opens in the row's namespace; a
-cluster-scoped one ignores it.
+fields only where the apiserver indexes them. When neither applies, `filter`
+narrows the list in the TUI instead, matching text in the visible columns
+(give the target view a column for the field if it has none); as with any
+filter, the first `esc` clears it to show the whole list and the second comes
+back. A pointer placeholder must land on a non-empty string; a row where it
+doesn't warns and stays put. `kind` is anything `:` accepts (alias, plural, or kind) and is
+resolved when you press `enter`, so an unknown kind warns and stays put. A
+namespaced target opens in the row's namespace; a cluster-scoped one ignores
+it.
 
 Kinds with a built-in drill-down keep it - a `drill` on pods won't replace the
 container picker, and `:config` warns that the stanza is ignored. When a view

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -75,16 +75,34 @@ impl App {
     /// Drill from a row into the kind its view's `drill` names, scoped by the
     /// selector the row fills in — a NodePool into its NodeClaims, say.
     fn drill_configured(&mut self, obj: &DynamicObject, drill: &crate::views::Drill) {
+        let target = match drill.resolve(obj) {
+            Ok(target) => target,
+            Err(why) => {
+                self.flash_warn(&why);
+                return;
+            }
+        };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
-        let scope = format!("{}/{name}", trim_s(&self.kind_plural));
-        self.drill_to(
-            &drill.kind,
-            ns,
-            drill.labels_for(obj),
-            drill.fields_for(obj),
-            scope,
-        );
+        // The kind name is the singular; `trim_s` would leave `-es` plurals
+        // (volumeattributesclasses, ingresses) one letter off.
+        let singular = self
+            .kind
+            .as_ref()
+            .map(|k| k.ar.kind.to_lowercase())
+            .unwrap_or_else(|| trim_s(&self.kind_plural).to_string());
+        let scope = format!("{singular}/{name}");
+        if !self.drill_to(&drill.kind, ns, target.labels, target.fields, scope) {
+            return;
+        }
+        // The client-side filter goes on after landing, the way a bookmark's
+        // does: `drill_to` cleared the filter along with the rest of the view.
+        if let Some(filter) = target.filter {
+            self.filter = filter;
+            self.sync_filter_selectors();
+            self.invalidate_rows();
+            self.table_state.select(Some(0));
+        }
     }
 
     pub(super) fn drop_owner_scope(&mut self) {
@@ -282,7 +300,8 @@ impl App {
 
     /// Push the current view and open `kind` (alias, plural, or kind name)
     /// under the given selectors — the shared tail of every drill that lands
-    /// on a list. A cluster-scoped target ignores `ns`.
+    /// on a list. A cluster-scoped target ignores `ns`. False when the kind
+    /// doesn't resolve; the view is then untouched and a warning is up.
     pub(super) fn drill_to(
         &mut self,
         kind: &str,
@@ -290,10 +309,10 @@ impl App {
         labels: Option<String>,
         fields: Option<String>,
         scope: String,
-    ) {
+    ) -> bool {
         let Some(target) = self.cluster.resolve(kind) else {
             self.flash_warn(&format!("{kind} kind unavailable"));
-            return;
+            return false;
         };
         let plural = target.ar.plural.to_lowercase();
         self.push_frame();
@@ -310,6 +329,7 @@ impl App {
         self.flash = format!("↳ drilled into {plural}");
         self.flash_err = false;
         self.start_watch();
+        true
     }
 
     /// Scope the nodes list to one node by name — the shared tail of every

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3300,7 +3300,7 @@ fn views_with_drill(key: &str, kind: &str, labels: &str) -> HashMap<String, crat
             drill: Some(crate::config::DrillConfig {
                 kind: kind.to_string(),
                 labels: Some(labels.to_string()),
-                fields: None,
+                ..Default::default()
             }),
             ..Default::default()
         },
@@ -3504,8 +3504,8 @@ async fn enter_on_externalsecret_opens_the_secret_it_writes() {
         crate::config::ViewConfig {
             drill: Some(crate::config::DrillConfig {
                 kind: "secrets".to_string(),
-                labels: None,
                 fields: Some("metadata.name={name}".to_string()),
+                ..Default::default()
             }),
             ..Default::default()
         },
@@ -3544,6 +3544,7 @@ async fn builtin_drill_list_matches_the_enter_arms() {
                     kind: "secrets".to_string(),
                     labels: None,
                     fields: None,
+                    filter: None,
                 }),
                 ..Default::default()
             },
@@ -3562,6 +3563,137 @@ async fn builtin_drill_list_matches_the_enter_arms() {
             "{plural} honoured a configured drill"
         );
     }
+}
+
+/// A PVC names its VolumeAttributesClass in `spec`, not in metadata, and a
+/// class knows nothing about its claims: the pair needs a pointer placeholder
+/// one way and a client-side filter the other.
+fn register_pvc_and_vac(app: &mut App) {
+    app.cluster
+        .register_kind("", "PersistentVolumeClaim", "persistentvolumeclaims", true);
+    app.cluster.register_kind(
+        "storage.k8s.io",
+        "VolumeAttributesClass",
+        "volumeattributesclasses",
+        false,
+    );
+}
+
+fn pvc_to_vac_views() -> HashMap<String, crate::views::View> {
+    views_for(
+        "persistentvolumeclaims",
+        crate::config::ViewConfig {
+            drill: Some(crate::config::DrillConfig {
+                kind: "volumeattributesclasses".to_string(),
+                fields: Some("metadata.name={/spec/volumeAttributesClassName}".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )
+}
+
+#[tokio::test]
+async fn enter_on_pvc_opens_its_volume_attributes_class() {
+    let (mut app, _rx) = test_app();
+    register_pvc_and_vac(&mut app);
+    app.user_views = pvc_to_vac_views();
+    app.switch_kind("persistentvolumeclaims");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "PersistentVolumeClaim",
+               "metadata": {"name": "data-db-0", "namespace": "db"},
+               "spec": {"volumeAttributesClassName": "gold"}}),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "volumeattributesclasses");
+    assert_eq!(app.fields.as_deref(), Some("metadata.name=gold"));
+    assert_eq!(
+        app.namespace, "",
+        "cluster-scoped target ignores the row's namespace"
+    );
+    assert_eq!(
+        app.scope_label.as_deref(),
+        Some("persistentvolumeclaim/data-db-0")
+    );
+    assert!(!app.flash_err);
+
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "persistentvolumeclaims");
+}
+
+#[tokio::test]
+async fn pvc_without_a_class_warns_instead_of_drilling() {
+    let (mut app, _rx) = test_app();
+    register_pvc_and_vac(&mut app);
+    app.user_views = pvc_to_vac_views();
+    app.switch_kind("persistentvolumeclaims");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "PersistentVolumeClaim",
+               "metadata": {"name": "scratch", "namespace": "db"},
+               "spec": {"storageClassName": "standard"}}),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "persistentvolumeclaims");
+    assert!(app.stack.is_empty());
+    assert!(app.flash_err);
+    assert_eq!(
+        app.flash,
+        "/spec/volumeAttributesClassName is empty on scratch"
+    );
+}
+
+#[tokio::test]
+async fn enter_on_volume_attributes_class_filters_its_claims() {
+    let (mut app, _rx) = test_app();
+    register_pvc_and_vac(&mut app);
+    app.user_views = views_for(
+        "volumeattributesclasses",
+        crate::config::ViewConfig {
+            drill: Some(crate::config::DrillConfig {
+                kind: "persistentvolumeclaims".to_string(),
+                // No label points back and the apiserver indexes no PVC
+                // field but name/namespace: filter client-side by the name.
+                filter: Some("{name}".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+    app.switch_kind("volumeattributesclasses");
+    apply(
+        &mut app,
+        json!({"apiVersion": "storage.k8s.io/v1", "kind": "VolumeAttributesClass",
+               "metadata": {"name": "gold"}, "driverName": "ebs.csi.aws.com"}),
+    );
+    app.table_state.select(Some(0));
+
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "persistentvolumeclaims");
+    assert_eq!(
+        app.namespace, "",
+        "a cluster-scoped row opens the target across namespaces"
+    );
+    assert_eq!((app.labels.as_deref(), app.fields.as_deref()), (None, None));
+    assert_eq!(app.filter, "gold");
+    assert_eq!(
+        app.scope_label.as_deref(),
+        Some("volumeattributesclass/gold")
+    );
+    assert!(!app.flash_err);
+
+    // `esc` behaves as it does for any filter: the first press clears it,
+    // widening to every claim; the second pops back to the classes.
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "persistentvolumeclaims");
+    assert_eq!(app.filter, "");
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.kind_plural, "volumeattributesclasses");
 }
 
 #[tokio::test]
@@ -3597,7 +3729,7 @@ async fn configured_drill_wins_over_node_on_enter_but_o_still_jumps() {
             drill: Some(crate::config::DrillConfig {
                 kind: "secrets".to_string(),
                 labels: Some("cert={name}".to_string()),
-                fields: None,
+                ..Default::default()
             }),
             ..Default::default()
         },

--- a/src/config.rs
+++ b/src/config.rs
@@ -740,8 +740,8 @@ pub struct ViewConfig {
 }
 
 /// The `drill` of a [`ViewConfig`]: `enter` on a row of this kind opens
-/// `kind`, filtered by `labels` and/or `fields` with `{name}` and
-/// `{namespace}` filled in from the row.
+/// `kind`, scoped by `labels`, `fields`, and/or `filter`, with `{name}`,
+/// `{namespace}`, and any `{/json/pointer}` filled in from the row.
 ///
 /// ```toml
 /// [views."karpenter.sh/v1/nodepools"]
@@ -749,6 +749,9 @@ pub struct ViewConfig {
 ///
 /// [views.externalsecrets]
 /// drill = { kind = "secrets", fields = "metadata.name={name}" }
+///
+/// [views.persistentvolumeclaims]
+/// drill = { kind = "volumeattributesclasses", fields = "metadata.name={/spec/volumeAttributesClassName}" }
 /// ```
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
@@ -759,6 +762,9 @@ pub struct DrillConfig {
     pub labels: Option<String>,
     /// Field selector template, same placeholders (e.g. `metadata.name={name}`).
     pub fields: Option<String>,
+    /// Row filter applied after landing, in the `/` key's syntax, same
+    /// placeholders — for a target no server-side selector can express.
+    pub filter: Option<String>,
 }
 
 /// One column of a [`ViewConfig`]. Everything is optional at parse time so a

--- a/src/views.rs
+++ b/src/views.rs
@@ -85,40 +85,77 @@ pub struct View {
     pub drill: Option<Drill>,
 }
 
-/// A configured drill-down: `enter` on a row opens `kind`, scoped by the
-/// selectors `labels` and `fields` yield for that row.
+/// A configured drill-down: `enter` on a row opens `kind`, scoped by what
+/// `labels`, `fields`, and `filter` yield for that row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Drill {
     /// Target kind as the user named it (alias, plural, or kind); resolved
     /// against the cluster when the drill happens.
     pub kind: String,
-    /// Label selector template with `{name}` / `{namespace}` placeholders.
+    /// Label selector template — see [`fill_placeholders`] for the tokens.
     pub labels: Option<String>,
     /// Field selector template, same placeholders.
     pub fields: Option<String>,
+    /// Row filter applied after landing (the `/` key's syntax), same
+    /// placeholders. For a target no server-side selector can express — the
+    /// apiserver indexes few fields, and not every relationship is labelled.
+    pub filter: Option<String>,
+}
+
+/// A [`Drill`]'s templates filled in for one row.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DrillTarget {
+    pub labels: Option<String>,
+    pub fields: Option<String>,
+    pub filter: Option<String>,
 }
 
 impl Drill {
-    /// The label selector for one row: placeholders filled from its metadata.
-    pub fn labels_for(&self, obj: &DynamicObject) -> Option<String> {
-        self.labels.as_deref().map(|t| fill_placeholders(t, obj))
-    }
-
-    /// The field selector for one row, likewise.
-    pub fn fields_for(&self, obj: &DynamicObject) -> Option<String> {
-        self.fields.as_deref().map(|t| fill_placeholders(t, obj))
+    /// Fill every template from the row. Fails, with a message fit for the
+    /// status line, when a pointer placeholder finds nothing usable — the row
+    /// then has nowhere to drill to, and saying why beats an empty list.
+    pub fn resolve(&self, obj: &DynamicObject) -> Result<DrillTarget, String> {
+        let fill = |t: &Option<String>| t.as_deref().map(|t| fill_placeholders(t, obj)).transpose();
+        Ok(DrillTarget {
+            labels: fill(&self.labels)?,
+            fields: fill(&self.fields)?,
+            filter: fill(&self.filter)?,
+        })
     }
 }
 
-fn fill_placeholders(template: &str, obj: &DynamicObject) -> String {
+/// Fill a drill template's `{…}` tokens from a row: `{name}` and
+/// `{namespace}` from its metadata, and `{/json/pointer}` from anywhere in
+/// the object via [`extract`] — which must land on a non-empty string, since
+/// a selector or filter has nowhere to put anything else.
+fn fill_placeholders(template: &str, obj: &DynamicObject) -> Result<String, String> {
     let name = obj.metadata.name.as_deref().unwrap_or_default();
     let namespace = obj.metadata.namespace.as_deref().unwrap_or_default();
-    template
-        .replace("{name}", name)
-        .replace("{namespace}", namespace)
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        let after = &rest[start + 1..];
+        let Some(end) = after.find('}') else { break };
+        out.push_str(&rest[..start]);
+        match &after[..end] {
+            "name" => out.push_str(name),
+            "namespace" => out.push_str(namespace),
+            pointer => match extract(obj, pointer) {
+                Some(Value::String(s)) if !s.is_empty() => out.push_str(&s),
+                Some(Value::String(_)) | None => {
+                    return Err(format!("{pointer} is empty on {name}"));
+                }
+                Some(_) => return Err(format!("{pointer} on {name} is not a string")),
+            },
+        }
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
 }
 
-/// The placeholders a drill's `labels` template may use.
+/// The named placeholders a drill template may use; any `{/…}` token is a
+/// JSON Pointer into the row and is accepted too.
 const DRILL_PLACEHOLDERS: &[&str] = &["name", "namespace"];
 
 /// Kinds whose `enter` has a built-in drill-down (the arms of `App::drill`),
@@ -149,7 +186,8 @@ fn key_plural(key: &str) -> &str {
     key.rsplit('/').next().unwrap_or(key)
 }
 
-/// The `{…}` tokens in a template that aren't in [`DRILL_PLACEHOLDERS`].
+/// The `{…}` tokens in a template that are neither in [`DRILL_PLACEHOLDERS`]
+/// nor a JSON Pointer.
 fn unknown_placeholders(template: &str) -> Vec<String> {
     let mut unknown = Vec::new();
     let mut rest = template;
@@ -157,7 +195,7 @@ fn unknown_placeholders(template: &str) -> Vec<String> {
         let after = &rest[start + 1..];
         let Some(end) = after.find('}') else { break };
         let token = &after[..end];
-        if !DRILL_PLACEHOLDERS.contains(&token) {
+        if !DRILL_PLACEHOLDERS.contains(&token) && !token.starts_with('/') {
             unknown.push(token.to_string());
         }
         rest = &after[end + 1..];
@@ -331,14 +369,26 @@ pub fn compile(
                 warnings.push(format!("views.\"{key}\": drill.kind is empty; ignored"));
                 return None;
             }
-            let labels = d.labels.as_deref().map(str::trim).filter(|l| !l.is_empty());
-            let fields = d.fields.as_deref().map(str::trim).filter(|f| !f.is_empty());
-            for (what, template) in [("labels", labels), ("fields", fields)] {
-                let unknown = template.map(unknown_placeholders).unwrap_or_default();
+            let clean = |t: &Option<String>| {
+                t.as_deref()
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                    .map(str::to_string)
+            };
+            let (labels, fields, filter) = (clean(&d.labels), clean(&d.fields), clean(&d.filter));
+            for (what, template) in [
+                ("labels", &labels),
+                ("fields", &fields),
+                ("filter", &filter),
+            ] {
+                let unknown = template
+                    .as_deref()
+                    .map(unknown_placeholders)
+                    .unwrap_or_default();
                 if !unknown.is_empty() {
                     warnings.push(format!(
                         "views.\"{key}\": drill.{what} has unknown placeholder(s) {} \
-                         (only {{name}} and {{namespace}}); ignored",
+                         (only {{name}}, {{namespace}}, and {{/json/pointer}}); ignored",
                         unknown.join(", ")
                     ));
                     return None;
@@ -346,8 +396,9 @@ pub fn compile(
             }
             Some(Drill {
                 kind: kind.to_string(),
-                labels: labels.map(str::to_string),
-                fields: fields.map(str::to_string),
+                labels,
+                fields,
+                filter,
             })
         });
         views.insert(
@@ -1216,11 +1267,12 @@ mod tests {
         let drill = drill_for(&views, &pools).expect("drill configured");
         assert_eq!(drill.kind, "nodeclaims");
         let pool = obj(json!({"metadata": {"name": "default"}}));
+        let target = drill.resolve(&pool).unwrap();
         assert_eq!(
-            drill.labels_for(&pool).as_deref(),
+            target.labels.as_deref(),
             Some("karpenter.sh/nodepool=default")
         );
-        assert_eq!(drill.fields_for(&pool), None);
+        assert_eq!((target.fields, target.filter), (None, None));
         // A target that needs no selector is allowed.
         let (views, warnings) = compile_toml(
             r#"
@@ -1229,7 +1281,69 @@ mod tests {
             "#,
         );
         assert!(warnings.is_empty(), "{warnings:?}");
-        assert_eq!(drill_for(&views, &pools).unwrap().labels_for(&pool), None);
+        assert_eq!(
+            drill_for(&views, &pools).unwrap().resolve(&pool).unwrap(),
+            DrillTarget::default()
+        );
+    }
+
+    #[test]
+    fn drill_pointer_placeholders_read_the_row() {
+        let (views, warnings) = compile_toml(
+            r#"
+            [views.persistentvolumeclaims]
+            drill = { kind = "volumeattributesclasses", fields = "metadata.name={/spec/volumeAttributesClassName}" }
+
+            [views.volumeattributesclasses]
+            drill = { kind = "persistentvolumeclaims", filter = "{name}" }
+            "#,
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+        let pvc_drill = views["persistentvolumeclaims"].drill.as_ref().unwrap();
+        let pvc = obj(json!({
+            "metadata": {"name": "data", "namespace": "db"},
+            "spec": {"volumeAttributesClassName": "gold", "resources": {}}
+        }));
+        assert_eq!(
+            pvc_drill.resolve(&pvc).unwrap().fields.as_deref(),
+            Some("metadata.name=gold")
+        );
+        // A pointer that finds nothing, or something other than a string, is
+        // a message for the status line — not an empty or bogus selector.
+        let unset = obj(json!({"metadata": {"name": "scratch"}, "spec": {}}));
+        assert_eq!(
+            pvc_drill.resolve(&unset).unwrap_err(),
+            "/spec/volumeAttributesClassName is empty on scratch"
+        );
+        let (views, _) = compile_toml(
+            r#"
+            [views.persistentvolumeclaims]
+            drill = { kind = "volumeattributesclasses", fields = "metadata.name={/spec/resources}" }
+            "#,
+        );
+        assert_eq!(
+            views["persistentvolumeclaims"]
+                .drill
+                .as_ref()
+                .unwrap()
+                .resolve(&pvc)
+                .unwrap_err(),
+            "/spec/resources on data is not a string"
+        );
+        // `filter` fills the same way, and metadata pointers work like `path`.
+        let (views, warnings) = compile_toml(
+            r#"
+            [views.volumeattributesclasses]
+            drill = { kind = "persistentvolumeclaims", filter = "{name} {/metadata/name}" }
+            "#,
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+        let vac_drill = views["volumeattributesclasses"].drill.as_ref().unwrap();
+        let vac = obj(json!({"metadata": {"name": "gold"}}));
+        assert_eq!(
+            vac_drill.resolve(&vac).unwrap().filter.as_deref(),
+            Some("gold gold")
+        );
     }
 
     #[test]
@@ -1277,14 +1391,16 @@ mod tests {
         );
         let drill = views["externalsecrets"].drill.as_ref().unwrap();
         let es = obj(json!({"metadata": {"name": "db-creds", "namespace": "shop"}}));
+        let target = drill.resolve(&es).unwrap();
         assert_eq!(
-            drill.fields_for(&es).as_deref(),
+            target.fields.as_deref(),
             Some("metadata.name=db-creds,metadata.namespace=shop")
         );
-        assert_eq!(drill.labels_for(&es), None);
+        assert_eq!(target.labels, None);
         assert_eq!(views["widgets"].drill, None);
         assert_eq!(warnings.len(), 1, "{warnings:?}");
         assert!(warnings[0].contains("drill.fields"), "{}", warnings[0]);
+        assert!(warnings[0].contains("{/json/pointer}"), "{}", warnings[0]);
     }
 
     #[test]


### PR DESCRIPTION
## What problem this solves

`[views."…"].drill` (#189) covers relationships a label or an indexed field can express, with `{name}` and `{namespace}` from the row's metadata. Two common shapes fall outside that:

- **The target's name sits in the row's `spec`.** A PersistentVolumeClaim names its VolumeAttributesClass in `spec.volumeAttributesClassName`; nothing in metadata carries it, so no template could reach it.
- **Nothing server-side expresses the relationship.** Going the other way, a VolumeAttributesClass's claims carry no label naming it, and the apiserver indexes no PVC field but `metadata.name`/`metadata.namespace`, so a `fields` selector on `spec.volumeAttributesClassName` is rejected by the watch.

## What this does

Two small extensions to `drill`, both generic:

**`{/json/pointer}` placeholders.** Any `{/…}` token in `labels`, `fields`, or `filter` is a JSON Pointer into the row, resolved through the same `extract` that custom columns use. It must land on a non-empty string; a row where it doesn't warns (`/spec/volumeAttributesClassName is empty on scratch`, or `… is not a string`) and stays put, instead of opening a list scoped to nothing.

**`filter`.** A client-side row filter applied after landing, in the `/` key's syntax, filled from the same placeholders — for a target no selector can express. It goes through the same path a bookmark's `filter` does, so `-l`/`-f` terms still reach the server and `esc` behaves as for any filter: first press clears it, second pops back.

```toml
[views.persistentvolumeclaims]
drill = { kind = "volumeattributesclasses", fields = "metadata.name={/spec/volumeAttributesClassName}" }

[views.volumeattributesclasses]
drill = { kind = "persistentvolumeclaims", filter = "{name}" }
```

Nothing about PVCs or VACs is built in; they are the documented example.

## Shape of the change

- `Drill` gains `filter`; `labels_for`/`fields_for` become one `resolve(&obj) -> Result<DrillTarget, String>`, so a bad pointer is one message rather than three silent empties.
- `fill_placeholders` walks `{…}` tokens: `name`, `namespace`, or a pointer via `extract`. `unknown_placeholders` accepts `/`-prefixed tokens, so `compile` still warns on typos like `{node}`.
- `drill_to` returns whether it landed, and `drill_configured` applies the filter only then.
- The drill scope label takes its singular from the kind name rather than `trim_s`, which left `-es` plurals one letter off (`volumeattributesclasse/gold`).

## Tests and docs

- `src/app/tests.rs`, through `handle_key`: PVC → its class by pointer (cluster-scoped target drops the namespace), a PVC without a class warns and stays, VAC → its claims by filter across all namespaces with the two-step `esc`.
- `src/views.rs`: pointer placeholders in `fields` and `filter`, empty and non-string pointers as errors, `filter` compiles, the unknown-placeholder warning names the pointer form.
- `docs/views.md`: the two new stanzas and a paragraph on `filter` and pointer placeholders.

`cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --locked` (895 passing) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
