### PR TITLE
feat: add exact and regex terms to the row filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The essentials. `?` in the app shows everything, or see the
 | Key                  | Action                                                                                            |
 | -------------------- | ------------------------------------------------------------------------------------------------- |
 | `:`                  | command palette - fuzzy over kinds, commands, bookmarks, workspaces (`:deploy social` also works) |
-| `/`                  | filter: fuzzy · `!inverse` · `-l`/`-f` selectors · `status=X` `cpu>500m` `age<2h`                 |
+| `/`                  | filter: fuzzy · `"exact"` · `/regex/` · `!inverse` · `-l`/`-f` selectors · `status=X` `age<2h`    |
 | `enter` / `esc`      | drill down / go back                                                                              |
 | `j`/`k`, `g`/`G`     | navigate                                                                                          |
 | `ctrl-f` / `ctrl-b`  | page forward / back (also `PgDn` / `PgUp`)                                                        |
@@ -127,8 +127,8 @@ The essentials. `?` in the app shows everything, or see the
 | `l` / `L`            | logs / VictoriaLogs history                                                                       |
 | `X` / `T`            | explain why it's unhealthy / state-change timeline                                                |
 | `s` / `e` / `a`      | shell or scale / edit in `$EDITOR` / attach                                                       |
-| `f`                  | port-forward — port picker from manifest, `●` marks active forwards (`:pf` manages them)         |
-| `t`                  | Flux/ArgoCD menu · CronJob trigger · pod file transfer                                                   |
+| `f`                  | port-forward — port picker from manifest, `●` marks active forwards (`:pf` manages them)          |
+| `t`                  | Flux/ArgoCD menu · CronJob trigger · pod file transfer                                            |
 | `r` / `i`            | rollout restart / set container image                                                             |
 | `ctrl-d` / `ctrl-k`  | delete / force-delete (marked rows, or current)                                                   |
 | `S` / `w` / `ctrl-e` | sort picker / wide columns / compact mode                                                         |

--- a/docs/features.md
+++ b/docs/features.md
@@ -68,10 +68,15 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `events`, `pf`, `notify`, `find`, `vlogs`, `rightsize`, `fleet`, `skin`,
   `reload`, `config`, `info`). `:` and `?` open the palette and help from every
   navigation screen, then close back to the screen where they were opened.
-- **Filtering** (`/`) with matched-character highlighting: fuzzy text, `!text`
-  inverse match, `-l`/`-f` label and field selectors (evaluated server-side on
-  ⏎), and typed column comparisons (`status=CrashLoopBackOff`, `cpu>500m`,
-  `memory>1Gi`, `restarts>=5`, `age<2h`). Space-separated terms AND together.
+- **Filtering** (`/`) with matched-character highlighting: fuzzy text, `"text"`
+  exact match, `/re/` regular expression (both case-insensitive), `!text`
+  inverse match (`!"text"` and `!/re/` too), `-l`/`-f` label and field selectors
+  (evaluated server-side on ⏎), and typed column comparisons
+  (`status=CrashLoopBackOff`, `cpu>500m`, `memory>1Gi`, `restarts>=5`,
+  `age<2h`). Space-separated terms AND together; a quoted term keeps its spaces.
+  Fuzzy matching is deliberately loose — `khc` finds `kube-httpcache-0` — so a
+  short needle like `auth` also matches names that merely contain
+  `a`…`u`…`t`…`h`. Quote it (`"auth"`) to match only a contiguous run.
 - **Toggle faults** (`Ctrl+Z`, pods only) shows pending, failed, unknown,
   terminating, and running pods that are not ready. Completed pods are hidden.
   The table title shows `[faults]` while the filter is on. It works with the

--- a/docs/features.md
+++ b/docs/features.md
@@ -73,7 +73,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   inverse match (`!"text"` and `!/re/` too), `-l`/`-f` label and field selectors
   (evaluated server-side on ⏎), and typed column comparisons
   (`status=CrashLoopBackOff`, `cpu>500m`, `memory>1Gi`, `restarts>=5`,
-  `age<2h`). Space-separated terms AND together; a quoted term keeps its spaces.
+  `age<2h`). Space-separated terms AND together. Quoted terms and `/re/` terms keep
+  their spaces. Quotes inside `/re/` are part of the regular expression.
+  Quoted text matches Unicode lowercase equivalents in column cells.
   Fuzzy matching is deliberately loose — `khc` finds `kube-httpcache-0` — so a
   short needle like `auth` also matches names that merely contain
   `a`…`u`…`t`…`h`. Quote it (`"auth"`) to match only a contiguous run.

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -20,7 +20,7 @@ pickers keep both characters available as input.
 | `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction — remembered per kind across views and restarts                            |
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                                                      |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                                              |
-| `/`                                           | filter: fuzzy text · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                                                     |
+| `/`                                           | filter: fuzzy text · `"exact"` · `/regex/` · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |
 | `Ctrl+Z`                                      | toggle faults filter in pod views; configured actions take precedence; combine with `/`; press again to turn off                                              |
 | `n` / `0`                                     | namespace switcher / all namespaces                                                                                                                           |
 | `shift-j`                                     | jump to owner/controller                                                                                                                                      |
@@ -54,7 +54,7 @@ pickers keep both characters available as input.
 | `:find <text>`                                | global fuzzy find over object names across common kinds, all namespaces                                                                                       |
 | `i`                                           | set container image                                                                                                                                           |
 | `r`                                           | rollout restart (workloads) / force-sync (ExternalSecrets/PushSecrets) / refresh (elsewhere)                                                                  |
-| `f` / `shift-f`                               | port-forward (pods/services) — picker shows declared ports, or "Custom…" for manual entry; active forwards show `●` next to the name |
+| `f` / `shift-f`                               | port-forward (pods/services) — picker shows declared ports, or "Custom…" for manual entry; active forwards show `●` next to the name                          |
 | `t`                                           | Flux: suspend/resume/reconcile menu · ArgoCD App/AppSet: suspend/resume (App: + sync) · CronJobs: trigger/suspend/resume · pods: file transfer (`kubectl cp`) |
 | `C` / `U` / `D`                               | nodes: cordon / uncordon / drain                                                                                                                              |
 | `ctrl-d` / `ctrl-k`                           | delete / force-delete (marked rows, or current); in confirm: `f` toggles force, `c` cycles cascade (background → foreground → orphan)                         |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1318,17 +1318,19 @@ struct FilterCache {
     parsed: crate::filter::ParsedFilter,
 }
 
-/// Highlight positions per row name for the active fuzzy needle.
+/// Highlight positions per row name for the active filter's pattern.
 ///
 /// The filter pass already ran the matcher over every row; without this the
 /// renderer ran it again for every *visible* row on every redraw, which is
-/// the same fuzzy scoring work repeated at frame rate for a result that only
-/// changes when the needle or the name does.
+/// the same scoring work repeated at frame rate for a result that only
+/// changes when the filter or the name does.
 #[derive(Default)]
 struct HighlightCache {
-    /// The needle these entries were matched against. Anything else empties
-    /// the map — a new needle invalidates every entry at once.
-    needle: String,
+    /// The filter these entries were matched against — the whole string, so
+    /// that `api` and `"api"` (a fuzzy and a literal needle of the same text,
+    /// which highlight differently) cannot share entries. Anything else
+    /// empties the map, invalidating every entry at once.
+    filter: String,
     /// Match positions per name. `None` — the name did not match — is a real
     /// answer and is cached too, so a filter that excludes most rows does not
     /// re-run the matcher over them every frame.

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -92,17 +92,18 @@ impl App {
         use crate::filter::{ParsedFilter, Term};
         match parsed {
             ParsedFilter::Fuzzy(pat) => {
-                pat.is_empty() || self.fuzzy_match_row(o, pat, key, cells, now)
+                pat.text().is_empty() || self.pattern_match_row(o, pat, key, cells, now)
             }
             ParsedFilter::Structured(s) => s.terms.iter().all(|t| match t {
-                Term::Fuzzy(pat) => self.fuzzy_match_row(o, pat, key, cells, now),
-                Term::NotFuzzy(pat) => !self.fuzzy_match_row(o, pat, key, cells, now),
+                Term::Text { negate, pat } => {
+                    negate ^ self.pattern_match_row(o, pat, key, cells, now)
+                }
                 Term::Cmp(cmp) => self.eval_cmp(o, cmp, now),
             }),
         }
     }
 
-    /// Does one fuzzy pattern match this row? "namespace name" first (the
+    /// Does one text pattern match this row? "namespace name" first (the
     /// original haystack — cheap, and by far the most common hit), then each
     /// rendered column cell individually, so `/10.96` finds a Service by its
     /// CLUSTER-IP. Cells are matched one at a time rather than joined so a
@@ -115,21 +116,35 @@ impl App {
     /// a helm view that meant five gunzip+JSON-parse rounds per row per
     /// keypress. Cached by `resourceVersion`, a row is now rendered once per
     /// change instead of once per keystroke.
-    fn fuzzy_match_row(
+    fn pattern_match_row(
         &self,
         o: &DynamicObject,
-        pat: &str,
+        pat: &crate::filter::Pattern,
         key: &RowKey,
         cells: &mut crate::store::FastMap<RowKey, CellCacheEntry>,
         now: i64,
     ) -> bool {
-        let pat_mask = subseq_mask(pat);
+        // Fuzzy and literal matches both need every pattern character present
+        // in the haystack, so the mask prefilter applies to both — but only
+        // while the literal is ASCII. [`subseq_mask`] folds raw bytes with
+        // ASCII rules, and a literal folds with Unicode ones (`K` U+212A
+        // lowercases to `k`, `Ö` to `ö`), so a non-ASCII needle would be
+        // masked on bytes the matcher never compares and real matches would
+        // vanish. A regex can match text that shares no character with its
+        // source (`/a|b/`, `\d`) and never prefilters.
+        let pat_mask = match pat {
+            crate::filter::Pattern::Fuzzy(_) => subseq_mask(pat.text()),
+            crate::filter::Pattern::Literal(lit) if lit.text().is_ascii() => {
+                subseq_mask(lit.text())
+            }
+            _ => 0,
+        };
         {
             // Built into a reused buffer: this used to `format!` a fresh
             // `String` for every object on every keystroke.
             let mut hay = self.hay_buf.borrow_mut();
             self.write_fuzzy_hay(o, &mut hay);
-            if subseq_mask(&hay) & pat_mask == pat_mask && self.matcher.score(&hay, pat).is_some() {
+            if subseq_mask(&hay) & pat_mask == pat_mask && self.pattern_matches(pat, &hay) {
                 return true;
             }
         }
@@ -142,7 +157,17 @@ impl App {
             .cells
             .iter()
             .zip(&entry.cell_masks)
-            .any(|(c, &m)| m & pat_mask == pat_mask && self.matcher.score(c, pat).is_some())
+            .any(|(c, &m)| m & pat_mask == pat_mask && self.pattern_matches(pat, c))
+    }
+
+    /// One pattern against one string, with no prefiltering.
+    fn pattern_matches(&self, pat: &crate::filter::Pattern, text: &str) -> bool {
+        use crate::filter::Pattern;
+        match pat {
+            Pattern::Fuzzy(needle) => self.matcher.score(text, needle).is_some(),
+            Pattern::Literal(lit) => lit.matches(text),
+            Pattern::Regex(re) => re.is_match(text),
+        }
     }
 
     /// The cached cells for `key`, rendering them if absent or stale.
@@ -265,27 +290,27 @@ impl App {
             || parsed.fields() != self.applied_filter_fields.as_deref()
     }
 
-    /// Char indices in `name` that matched the active row filter's fuzzy
+    /// Char indices in `name` that matched the active row filter's text
     /// pattern, for highlighting them in the table. `None` when there's no
-    /// active filter or no fuzzy term (every visible row already passed
-    /// the filter pass, so this is purely a rendering aid, not a second
-    /// filter decision).
+    /// active filter or no positive text term (every visible row already
+    /// passed the filter pass, so this is purely a rendering aid, not a
+    /// second filter decision).
     ///
-    /// Memoized per name for the current needle: the renderer asks this for
-    /// every visible row on every redraw, and re-running the fuzzy matcher to
-    /// get an answer that cannot have changed is the single most expensive
-    /// thing a filtered frame used to do.
+    /// Memoized per name for the current filter: the renderer asks this for
+    /// every visible row on every redraw, and re-running the matcher to get
+    /// an answer that cannot have changed is the single most expensive thing
+    /// a filtered frame used to do.
     pub fn filter_match_indices(&self, name: &str) -> Option<Rc<[usize]>> {
         if self.filter.is_empty() {
             return None;
         }
         let parsed = self.parsed_filter();
-        let needle = parsed.fuzzy_needle()?;
+        let pat = parsed.highlight_pattern()?;
 
         let mut cache = self.highlight_cache.borrow_mut();
-        if cache.needle != needle {
-            cache.needle.clear();
-            cache.needle.push_str(needle);
+        if cache.filter != self.filter {
+            cache.filter.clear();
+            cache.filter.push_str(&self.filter);
             cache.rows.clear();
         }
         if let Some(hit) = cache.rows.get(name) {
@@ -294,12 +319,26 @@ impl App {
         if cache.rows.len() >= HIGHLIGHT_CACHE_LIMIT {
             cache.rows.clear();
         }
-        let idx = self
-            .matcher
-            .indices(name, needle)
-            .map(|idx| Rc::from(idx.as_slice()));
+        let idx = self.match_positions(pat, name).map(Rc::from);
         cache.rows.insert(Box::from(name), idx.clone());
         idx
+    }
+
+    /// Where `pat` matched in `name`, as char positions. A literal or a regex
+    /// matches one contiguous run, so both report the span they landed on;
+    /// only fuzzy scatters its positions.
+    fn match_positions(&self, pat: &crate::filter::Pattern, name: &str) -> Option<Vec<usize>> {
+        use crate::filter::Pattern;
+        match pat {
+            Pattern::Fuzzy(needle) => self.matcher.indices(name, needle),
+            Pattern::Literal(lit) => lit.match_span(name).map(Iterator::collect),
+            Pattern::Regex(re) => re.find(name).map(|m| {
+                // Byte offsets from the regex, char positions for the cell
+                // renderer, which walks `name.chars()`.
+                let start = name[..m.start()].chars().count();
+                (start..start + m.as_str().chars().count()).collect()
+            }),
+        }
     }
 
     pub(super) fn ensure_rows_cache(&self) {

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -124,19 +124,10 @@ impl App {
         cells: &mut crate::store::FastMap<RowKey, CellCacheEntry>,
         now: i64,
     ) -> bool {
-        // Fuzzy and literal matches both need every pattern character present
-        // in the haystack, so the mask prefilter applies to both — but only
-        // while the literal is ASCII. [`subseq_mask`] folds raw bytes with
-        // ASCII rules, and a literal folds with Unicode ones (`K` U+212A
-        // lowercases to `k`, `Ö` to `ö`), so a non-ASCII needle would be
-        // masked on bytes the matcher never compares and real matches would
-        // vanish. A regex can match text that shares no character with its
-        // source (`/a|b/`, `\d`) and never prefilters.
+        // Only fuzzy patterns use the byte mask. Unicode lowercase conversion
+        // can change the bytes of a literal or its cell text.
         let pat_mask = match pat {
             crate::filter::Pattern::Fuzzy(_) => subseq_mask(pat.text()),
-            crate::filter::Pattern::Literal(lit) if lit.text().is_ascii() => {
-                subseq_mask(lit.text())
-            }
             _ => 0,
         };
         {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -16297,3 +16297,49 @@ async fn service_columns_and_cached_rows_follow_the_api_group() {
     assert!(app.display_headers().contains(&"REVISION".to_string()));
     assert!(!app.display_headers().contains(&"TYPE".to_string()));
 }
+
+#[tokio::test]
+async fn regex_filter_preserves_spaces() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod", "metadata":{"name":"auth-api-0","namespace":"default"}}),
+    );
+    type_filter(&mut app, r"/default\sauth/");
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+    retype_filter(&mut app, r"/default auth/");
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+}
+
+#[tokio::test]
+async fn regex_filter_preserves_quotes_and_following_terms() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod", "metadata":{"name":"auth-api-0","namespace":"default"}}),
+    );
+    type_filter(&mut app, r#"/auth|"/ !canary"#);
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+}
+
+#[tokio::test]
+async fn quoted_filter_folds_unicode_column_text() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("events");
+    for (name, message) in [("event-1", "Kube started"), ("event-2", "other message")] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Event",
+            "metadata": {"name": name, "namespace": "default"},
+            "message": message}),
+        );
+    }
+    type_filter(&mut app, "\"kube\"");
+    assert_eq!(row_names(&app), ["event-1"]);
+    retype_filter(&mut app, "\"KUBE\"");
+    assert_eq!(row_names(&app), ["event-1"]);
+    retype_filter(&mut app, "!\"kube\"");
+    assert_eq!(row_names(&app), ["event-2"]);
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10249,6 +10249,176 @@ async fn inverse_filter_hides_fuzzy_matches() {
     assert_eq!(row_names(&app), ["api-1"]);
 }
 
+/// The noise the fuzzy filter is prone to: a subsequence match means a short
+/// needle like `auth` also drags in every name with a scattered a…u…t…h.
+/// Quoting the term keeps only what a `grep` would find.
+#[tokio::test]
+async fn quoted_filter_matches_only_contiguous_text() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["auth-api-0", "api-gateway-runtime-hash"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+
+    // Unquoted, both match: a-u-t-h occurs in "api-gateway-runtime-hash" too.
+    type_filter(&mut app, "auth");
+    assert_eq!(row_names(&app), ["api-gateway-runtime-hash", "auth-api-0"]);
+
+    retype_filter(&mut app, "\"auth\"");
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+
+    // Case-insensitive, like every other text term.
+    retype_filter(&mut app, "\"AUTH-API\"");
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+}
+
+#[tokio::test]
+async fn regex_filter_terms_match_names_and_cells() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["auth-api-0", "auth-api-canary", "web-1"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+
+    type_filter(&mut app, "/auth-api-\\d/");
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+
+    // Cells are matched one at a time, so `^` anchors to the NAME cell rather
+    // than to the "namespace name" haystack.
+    retype_filter(&mut app, "/^web/");
+    assert_eq!(row_names(&app), ["web-1"]);
+}
+
+#[tokio::test]
+async fn quoted_and_regex_terms_invert_and_combine() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["auth-api-0", "auth-api-canary", "web-1"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+
+    type_filter(&mut app, "!\"canary\"");
+    assert_eq!(row_names(&app), ["auth-api-0", "web-1"]);
+
+    // AND-ed with a positive literal term, and with an inverse regex.
+    retype_filter(&mut app, "\"auth\" !/canary/");
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+}
+
+/// Literals see the rendered columns like fuzzy terms do — and, unlike fuzzy,
+/// an IP fragment can't match a cell that merely contains its digits in order.
+#[tokio::test]
+async fn quoted_filter_matches_column_cells_without_gaps() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    for (n, ip) in [("api", "10.96.13.5"), ("web", "10.9.61.35")] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Service",
+                   "metadata": {"name": n, "namespace": "default"},
+                   "spec": {"type": "ClusterIP", "clusterIP": ip,
+                            "ports": [{"port": 80, "protocol": "TCP"}]}}),
+        );
+    }
+
+    type_filter(&mut app, "10.96");
+    assert_eq!(row_names(&app), ["api", "web"]);
+
+    retype_filter(&mut app, "\"10.96\"");
+    assert_eq!(row_names(&app), ["api"]);
+}
+
+/// The row filter prefilters on a byte mask that folds with ASCII rules,
+/// while a literal folds with Unicode ones. A needle whose case mapping
+/// changes its bytes must still reach the matcher instead of being masked out.
+#[tokio::test]
+async fn unicode_literals_survive_the_mask_prefilter() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["kube-httpcache-0", "öresund-api", "web-1"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+
+    // U+212A KELVIN SIGN lowercases to a plain ASCII `k`.
+    type_filter(&mut app, "\"\u{212a}ube\"");
+    assert_eq!(row_names(&app), ["kube-httpcache-0"]);
+
+    // A needle whose folded form is itself non-ASCII.
+    retype_filter(&mut app, "\"Öresund\"");
+    assert_eq!(row_names(&app), ["öresund-api"]);
+}
+
+/// A term that cannot be compiled is skipped and reported, like every other
+/// malformed term — the rest of the filter still narrows the table.
+#[tokio::test]
+async fn malformed_regex_filter_reports_and_keeps_filtering() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in ["auth-api-0", "web-1"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+                   "metadata": {"name": n, "namespace": "default"}}),
+        );
+    }
+
+    type_filter(&mut app, "/[unclosed/ auth");
+    assert!(
+        app.filter_error().is_some_and(|e| e.contains("bad regex")),
+        "{:?}",
+        app.filter_error()
+    );
+    assert_eq!(row_names(&app), ["auth-api-0"]);
+    assert!(!app.filter_server_side());
+}
+
+/// The NAME highlight follows the term that matched: a literal or a regex
+/// marks the contiguous run it landed on, not fuzzy's scattered positions.
+#[tokio::test]
+async fn quoted_and_regex_filters_highlight_the_matched_run() {
+    let (mut app, _rx) = test_app();
+
+    retype_filter(&mut app, "khc");
+    let scattered = app.filter_match_indices("kube-httpcache-0").unwrap();
+    assert_eq!(scattered.len(), 3);
+
+    retype_filter(&mut app, "\"httpcache\"");
+    assert_eq!(
+        app.filter_match_indices("kube-httpcache-0")
+            .unwrap()
+            .to_vec(),
+        (5..14).collect::<Vec<usize>>()
+    );
+
+    retype_filter(&mut app, "/cache-\\d/");
+    assert_eq!(
+        app.filter_match_indices("kube-httpcache-0")
+            .unwrap()
+            .to_vec(),
+        (9..16).collect::<Vec<usize>>()
+    );
+
+    // A name the pattern doesn't occur in highlights nothing, even though the
+    // row may have matched on one of its other cells.
+    assert_eq!(app.filter_match_indices("web-1"), None);
+}
+
 #[tokio::test]
 async fn fuzzy_filter_matches_any_column_cell() {
     let (mut app, _rx) = test_app();

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -137,7 +137,11 @@ impl Literal {
     }
 
     pub fn matches(&self, haystack: &str) -> bool {
-        self.substring.matches(haystack)
+        if haystack.is_ascii() {
+            self.substring.matches(haystack)
+        } else {
+            self.substring.matches(&haystack.to_lowercase())
+        }
     }
 
     /// Char positions of the first occurrence in `haystack`, for highlighting
@@ -362,24 +366,60 @@ fn is_structured(input: &str) -> bool {
 /// narrowing the table while it is still being typed.
 fn tokenize(input: &str) -> Vec<&str> {
     let mut tokens = Vec::new();
-    let mut start: Option<usize> = None;
-    let mut quoted = false;
-    for (i, c) in input.char_indices() {
-        if c == '"' {
-            quoted = !quoted;
+    let mut rest = input.trim_start();
+    while !rest.is_empty() {
+        let regex_start = if rest.starts_with("!/") { 2 } else { 1 };
+        if (rest.starts_with('/') || rest.starts_with("!/"))
+            && let Some(end) = regex_end(rest, regex_start)
+        {
+            tokens.push(&rest[..end]);
+            rest = rest[end..].trim_start();
+            continue;
         }
-        if c.is_whitespace() && !quoted {
-            if let Some(s) = start.take() {
-                tokens.push(&input[s..i]);
-            }
-        } else if start.is_none() {
-            start = Some(i);
-        }
-    }
-    if let Some(s) = start {
-        tokens.push(&input[s..]);
+        let mut quoted = false;
+        let end = rest
+            .char_indices()
+            .find_map(|(i, c)| {
+                if c == '"' {
+                    quoted = !quoted;
+                }
+                (c.is_whitespace() && !quoted).then_some(i)
+            })
+            .unwrap_or(rest.len());
+        tokens.push(&rest[..end]);
+        rest = rest[end..].trim_start();
     }
     tokens
+}
+
+// Find a closing slash at a term boundary. Keep escapes and character classes
+// inside the regex. Keep an invalid class available for the compiler to report.
+fn regex_end(input: &str, start: usize) -> Option<usize> {
+    let mut escaped = false;
+    let mut classes = 0usize;
+    let mut fallback = None;
+    for (offset, c) in input[start..].char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => escaped = true,
+            '[' => classes += 1,
+            ']' => classes = classes.saturating_sub(1),
+            '/' => {
+                let end = start + offset + 1;
+                if input[end..].chars().next().is_none_or(char::is_whitespace) {
+                    if classes == 0 {
+                        return Some(end);
+                    }
+                    fallback.get_or_insert(end);
+                }
+            }
+            _ => {}
+        }
+    }
+    fallback
 }
 
 /// Classify one text term: `"quoted"` is a literal, `/re/` a regex, anything
@@ -736,18 +776,35 @@ mod tests {
         assert!(tokenize("   ").is_empty());
     }
 
-    /// Where case folding stops: the substring matcher folds the *needle*
-    /// with full Unicode rules and then reads the haystack's raw bytes. So a
-    /// needle that folds onto ASCII finds ASCII text, but an ASCII needle
-    /// does not find a haystack character that merely folds to it. Folding
-    /// every cell of every row to close that gap is the cost the log filter
-    /// and the document search — the same matcher — already decided against,
-    /// and a Kubernetes name cannot hold such a character anyway.
     #[test]
-    fn literals_fold_the_needle_not_the_haystack() {
-        // U+212A KELVIN SIGN folds to a plain `k`.
+    fn tokenizer_keeps_regex_contents_in_one_term() {
+        for input in [
+            r#"/a b/ !canary"#,
+            r#"/a"b/ !canary"#,
+            r"/a\/ b/ !canary",
+            r"/[a/ ]/ !canary",
+            r"!/a b/ !canary",
+        ] {
+            let tokens = tokenize(input);
+            assert_eq!(tokens.len(), 2, "{input}");
+            assert_eq!(tokens[1], "!canary");
+            let parsed = structured(input);
+            assert_eq!(parsed.error, None, "{input}");
+            assert!(matches!(
+                &parsed.terms[0],
+                Term::Text {
+                    pat: Pattern::Regex(_),
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn literals_fold_both_the_needle_and_the_haystack() {
         assert!(Literal::new("\u{212a}ube").matches("kube-httpcache-0"));
-        assert!(!Literal::new("kube").matches("\u{212a}ube-httpcache-0"));
+        assert!(Literal::new("kube").matches("\u{212a}ube-httpcache-0"));
+        assert!(Literal::new("KUBE").matches("\u{212a}ube-httpcache-0"));
     }
 
     /// Highlight positions are char indices into the name, so a multibyte

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,15 +3,24 @@
 //! Plain text with no structured markers stays what it always was: one fuzzy
 //! pattern over "namespace name", falling back to each rendered column cell
 //! (so `/10.96` finds a Service by its CLUSTER-IP). Once any structured marker
-//! appears, the input is split on whitespace and every term must match
-//! (terms are AND-ed; there is no OR/grouping — deliberately small):
+//! appears, the input is split into terms on whitespace (a `"quoted"` term
+//! keeps its spaces) and every term must match (terms are AND-ed; there is no
+//! OR/grouping — deliberately small):
 //!
 //! - `text`                   fuzzy match (namespace + name + any column cell)
-//! - `!text`                  inverse fuzzy match
+//! - `"text"`                 literal match: contiguous, case-insensitive
+//! - `/re/`                   regular expression (case-insensitive)
+//! - `!text`                  inverse match (`!"text"` and `!/re/` too)
 //! - `-l app=api,env=prod`    Kubernetes label selector (sent server-side)
 //! - `-f spec.nodeName=n1`    Kubernetes field selector (sent server-side)
 //! - `status=CrashLoopBackOff` column equality (case-insensitive)
 //! - `cpu>500m` `memory>1Gi` `restarts>=5` `age<2h` typed comparisons
+//!
+//! Fuzzy is deliberately loose — `khc` finds `kube-httpcache-0` — which in a
+//! namespace with hundreds of pods makes a short needle like `auth` match
+//! every name with a scattered `a`…`u`…`t`…`h` in it. Quoting the term
+//! (`"auth"`) drops the gaps and matches only what a `grep` would; `/re/`
+//! covers the rest.
 //!
 //! Comparison operators: `=` (or `==`), `!=`, `>`, `>=`, `<`, `<=`. The
 //! value's type follows the key: `cpu` parses CPU quantities (millicores),
@@ -24,9 +33,11 @@
 /// The parsed form of the filter input.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParsedFilter {
-    /// The whole input is one fuzzy pattern (no structured markers) — the
-    /// original `/text` behavior, kept byte-for-byte compatible.
-    Fuzzy(String),
+    /// The whole input is one pattern (no structured markers) — the original
+    /// `/text` behavior, kept byte-for-byte compatible. Always
+    /// [`Pattern::Fuzzy`]: a `"literal"` or `/re/` is a marker, so it parses
+    /// as a one-term [`Structured`] filter instead.
+    Fuzzy(Pattern),
     Structured(Structured),
 }
 
@@ -44,9 +55,112 @@ pub struct Structured {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Term {
-    Fuzzy(String),
-    NotFuzzy(String),
+    /// One text pattern, inverted when the term was written `!pat`.
+    Text {
+        negate: bool,
+        pat: Pattern,
+    },
     Cmp(Cmp),
+}
+
+/// How a text term matches a row.
+#[derive(Clone)]
+pub enum Pattern {
+    /// Plain text: a fuzzy subsequence match, gaps allowed (`khc` finds
+    /// `kube-httpcache-0`).
+    Fuzzy(String),
+    /// `"text"`: a contiguous case-insensitive substring — what `grep` would
+    /// find, for when fuzzy is too loose to name one thing.
+    Literal(Literal),
+    /// `/re/`: a case-insensitive regular expression.
+    Regex(Box<regex::Regex>),
+}
+
+impl Pattern {
+    /// The text the user typed inside the markers — the fuzzy needle, the
+    /// quoted text, or the regex source.
+    pub fn text(&self) -> &str {
+        match self {
+            Pattern::Fuzzy(pat) => pat,
+            Pattern::Literal(lit) => lit.text(),
+            Pattern::Regex(re) => re.as_str(),
+        }
+    }
+}
+
+/// Compared by source text: two patterns built from the same term are equal,
+/// and a compiled automaton has no meaningful equality of its own.
+impl PartialEq for Pattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Pattern::Fuzzy(a), Pattern::Fuzzy(b)) => a == b,
+            (Pattern::Literal(a), Pattern::Literal(b)) => a.text() == b.text(),
+            (Pattern::Regex(a), Pattern::Regex(b)) => a.as_str() == b.as_str(),
+            _ => false,
+        }
+    }
+}
+
+/// The text, not the automaton behind it — a `{:?}` of a filter should read
+/// like the filter.
+impl std::fmt::Debug for Pattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Pattern::Fuzzy(pat) => write!(f, "Fuzzy({pat:?})"),
+            Pattern::Literal(lit) => write!(f, "Literal({:?})", lit.text()),
+            Pattern::Regex(re) => write!(f, "Regex({:?})", re.as_str()),
+        }
+    }
+}
+
+/// A compiled `"text"` term: the text as typed, for highlighting, alongside
+/// the case-insensitive substring automaton that tests it. Built once per
+/// filter change — a filter pass runs it against every row in the store.
+#[derive(Clone)]
+pub struct Literal {
+    text: String,
+    substring: crate::logfilter::Substring,
+}
+
+impl Literal {
+    /// `text` must not be empty; the parser rejects `""` before this.
+    fn new(text: &str) -> Self {
+        Literal {
+            text: text.to_string(),
+            substring: crate::logfilter::Substring::new(text),
+        }
+    }
+
+    /// The text as typed, without the quotes.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn matches(&self, haystack: &str) -> bool {
+        self.substring.matches(haystack)
+    }
+
+    /// Char positions of the first occurrence in `haystack`, for highlighting
+    /// it in the NAME cell. `None` when the text does not occur there — a row
+    /// can match on a column cell instead, and then its name highlights
+    /// nothing.
+    ///
+    /// Folds one character at a time rather than through `str::to_lowercase`:
+    /// the mappings that change length (`İ` → `i̇`) are exactly the ones that
+    /// would put the reported position on the wrong character. This is a
+    /// highlight, not the match decision — [`matches`](Self::matches) already
+    /// made that with full folding.
+    pub fn match_span(&self, haystack: &str) -> Option<std::ops::Range<usize>> {
+        let fold = |c: char| c.to_lowercase().next().unwrap_or(c);
+        let hay: Vec<char> = haystack.chars().map(fold).collect();
+        let needle: Vec<char> = self.text.chars().map(fold).collect();
+        if needle.is_empty() || needle.len() > hay.len() {
+            return None;
+        }
+        (0..=hay.len() - needle.len())
+            .find(|&i| hay[i..i + needle.len()] == needle[..])
+            .map(|i| i..i + needle.len())
+    }
 }
 
 /// One `key<op>value` column comparison.
@@ -129,12 +243,12 @@ impl ParsedFilter {
     }
 
     /// The pattern NAME-cell highlighting should mark: the legacy fuzzy
-    /// pattern, or the first positive fuzzy term of a structured filter.
-    pub fn fuzzy_needle(&self) -> Option<&str> {
+    /// pattern, or the first positive text term of a structured filter.
+    pub fn highlight_pattern(&self) -> Option<&Pattern> {
         match self {
-            ParsedFilter::Fuzzy(pat) => (!pat.is_empty()).then_some(pat.as_str()),
+            ParsedFilter::Fuzzy(pat) => (!pat.text().is_empty()).then_some(pat),
             ParsedFilter::Structured(s) => s.terms.iter().find_map(|t| match t {
-                Term::Fuzzy(pat) => Some(pat.as_str()),
+                Term::Text { negate: false, pat } => Some(pat),
                 _ => None,
             }),
         }
@@ -144,7 +258,7 @@ impl ParsedFilter {
 pub fn parse(input: &str) -> ParsedFilter {
     let trimmed = input.trim();
     if trimmed.is_empty() || !is_structured(trimmed) {
-        return ParsedFilter::Fuzzy(trimmed.to_string());
+        return ParsedFilter::Fuzzy(Pattern::Fuzzy(trimmed.to_string()));
     }
 
     let mut terms = Vec::new();
@@ -157,7 +271,7 @@ pub fn parse(input: &str) -> ParsedFilter {
         }
     };
 
-    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    let tokens = tokenize(trimmed);
     let mut i = 0;
     while i < tokens.len() {
         let tok = tokens[i];
@@ -201,15 +315,19 @@ pub fn parse(input: &str) -> ParsedFilter {
             }
             continue;
         }
-        if let Some(pat) = tok.strip_prefix('!') {
-            if pat.is_empty() {
-                fail(&mut error, "expected text after '!'".into());
-            } else {
-                terms.push(Term::NotFuzzy(pat.to_string()));
-            }
+        // Text: `!` inverts, then the term's own markers pick the matcher.
+        let (negate, rest) = match tok.strip_prefix('!') {
+            Some(rest) => (true, rest),
+            None => (false, tok),
+        };
+        if rest.is_empty() {
+            fail(&mut error, "expected text after '!'".into());
             continue;
         }
-        terms.push(Term::Fuzzy(tok.to_string()));
+        match pattern(rest) {
+            Ok(pat) => terms.push(Term::Text { negate, pat }),
+            Err(e) => fail(&mut error, e),
+        }
     }
 
     ParsedFilter::Structured(Structured {
@@ -223,14 +341,76 @@ pub fn parse(input: &str) -> ParsedFilter {
 /// Whether any token flips the input from a single legacy fuzzy pattern into
 /// the structured grammar. Mirrors the markers `parse` acts on.
 fn is_structured(input: &str) -> bool {
-    input.split_whitespace().any(|tok| {
+    tokenize(input).into_iter().any(|tok| {
+        let text = tok.strip_prefix('!').unwrap_or(tok);
         tok == "-l"
             || tok == "-f"
             || attached_selector(tok, "-l").is_some()
             || attached_selector(tok, "-f").is_some()
             || tok.starts_with('!')
+            || text.starts_with('"')
+            || is_regex(text)
             || split_cmp(tok).is_some()
     })
+}
+
+/// Split the input into terms on whitespace, keeping a double-quoted run
+/// together so `"my pod"` is one term.
+///
+/// An unterminated quote runs to the end of the input rather than being
+/// dropped: the filter is re-parsed on every keystroke, and a term must keep
+/// narrowing the table while it is still being typed.
+fn tokenize(input: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut start: Option<usize> = None;
+    let mut quoted = false;
+    for (i, c) in input.char_indices() {
+        if c == '"' {
+            quoted = !quoted;
+        }
+        if c.is_whitespace() && !quoted {
+            if let Some(s) = start.take() {
+                tokens.push(&input[s..i]);
+            }
+        } else if start.is_none() {
+            start = Some(i);
+        }
+    }
+    if let Some(s) = start {
+        tokens.push(&input[s..]);
+    }
+    tokens
+}
+
+/// Classify one text term: `"quoted"` is a literal, `/re/` a regex, anything
+/// else the fuzzy text the filter has always taken.
+fn pattern(tok: &str) -> Result<Pattern, String> {
+    if let Some(rest) = tok.strip_prefix('"') {
+        // The closing quote is optional — the term may still be being typed.
+        let text = rest.strip_suffix('"').unwrap_or(rest);
+        if text.is_empty() {
+            return Err("expected text between the quotes".into());
+        }
+        return Ok(Pattern::Literal(Literal::new(text)));
+    }
+    if is_regex(tok) {
+        let source = &tok[1..tok.len() - 1];
+        if source.is_empty() {
+            return Err("expected a pattern between the slashes".into());
+        }
+        return regex::RegexBuilder::new(source)
+            .case_insensitive(true)
+            .build()
+            .map(|re| Pattern::Regex(Box::new(re)))
+            .map_err(|_| format!("bad regex '{source}'"));
+    }
+    Ok(Pattern::Fuzzy(tok.to_string()))
+}
+
+/// A `/re/` term. Both slashes are required, so a lone `/` and text like
+/// `/healthz` stay fuzzy — the same rule the log filter uses.
+fn is_regex(tok: &str) -> bool {
+    tok.len() >= 2 && tok.starts_with('/') && tok.ends_with('/')
 }
 
 /// The selector of an attached `-l`/`-f` form (`-lapp=api`). Requires an `=`
@@ -384,26 +564,203 @@ mod tests {
         }
     }
 
+    fn fuzzy(pat: &str) -> Term {
+        Term::Text {
+            negate: false,
+            pat: Pattern::Fuzzy(pat.into()),
+        }
+    }
+
+    fn not_fuzzy(pat: &str) -> Term {
+        Term::Text {
+            negate: true,
+            pat: Pattern::Fuzzy(pat.into()),
+        }
+    }
+
+    /// The single text pattern of a one-term filter.
+    fn only_pattern(input: &str) -> Pattern {
+        let s = structured(input);
+        assert_eq!(s.terms.len(), 1, "expected one term in '{input}'");
+        match s.terms.into_iter().next() {
+            Some(Term::Text { negate: false, pat }) => pat,
+            other => panic!("expected a positive text term in '{input}', got {other:?}"),
+        }
+    }
+
     #[test]
     fn plain_text_stays_one_legacy_fuzzy_pattern() {
-        assert_eq!(parse(""), ParsedFilter::Fuzzy(String::new()));
-        assert_eq!(parse("api"), ParsedFilter::Fuzzy("api".into()));
+        assert_eq!(
+            parse(""),
+            ParsedFilter::Fuzzy(Pattern::Fuzzy(String::new()))
+        );
+        assert_eq!(
+            parse("api"),
+            ParsedFilter::Fuzzy(Pattern::Fuzzy("api".into()))
+        );
         // Spaces included: the whole string is the pattern, as before.
         assert_eq!(
             parse("kube system dns"),
-            ParsedFilter::Fuzzy("kube system dns".into())
+            ParsedFilter::Fuzzy(Pattern::Fuzzy("kube system dns".into()))
         );
         // Leading/trailing whitespace is not part of the pattern.
-        assert_eq!(parse("  api "), ParsedFilter::Fuzzy("api".into()));
+        assert_eq!(
+            parse("  api "),
+            ParsedFilter::Fuzzy(Pattern::Fuzzy("api".into()))
+        );
         // A lone dash or dashed name is still fuzzy text, not a flag.
-        assert_eq!(parse("-longname"), ParsedFilter::Fuzzy("-longname".into()));
+        assert_eq!(
+            parse("-longname"),
+            ParsedFilter::Fuzzy(Pattern::Fuzzy("-longname".into()))
+        );
     }
 
     #[test]
     fn inverse_term() {
         let s = structured("!canary");
-        assert_eq!(s.terms, vec![Term::NotFuzzy("canary".into())]);
+        assert_eq!(s.terms, vec![not_fuzzy("canary")]);
         assert_eq!(s.error, None);
+    }
+
+    /// The fix for noisy fuzzy hits: a quoted term matches a contiguous run,
+    /// so it no longer drags in every name with the characters scattered
+    /// through it.
+    #[test]
+    fn quoted_terms_match_contiguously() {
+        let Pattern::Literal(lit) = only_pattern("\"auth\"") else {
+            panic!("expected a literal term");
+        };
+        assert!(lit.matches("default auth-api-0"));
+        assert!(lit.matches("AUTH-API"), "literals fold case");
+        // Fuzzy's subsequence match, which is what the quotes rule out.
+        assert!(!lit.matches("api-gateway-runtime-hash"));
+    }
+
+    /// A quoted term keeps its spaces: the tokenizer splits terms on
+    /// whitespace, but not inside quotes.
+    #[test]
+    fn quoted_terms_keep_their_spaces() {
+        let Pattern::Literal(lit) = only_pattern("\"kube system\"") else {
+            panic!("expected a literal term");
+        };
+        assert_eq!(lit.text(), "kube system");
+        // Still one term when other terms surround it.
+        let s = structured("\"kube system\" status=Running");
+        assert_eq!(s.terms.len(), 2);
+    }
+
+    /// The filter is reparsed on every keystroke, so a term that is still
+    /// being typed has to keep working before its closing quote arrives.
+    #[test]
+    fn an_unterminated_quote_still_narrows() {
+        let Pattern::Literal(lit) = only_pattern("\"auth") else {
+            panic!("expected a literal term");
+        };
+        assert_eq!(lit.text(), "auth");
+    }
+
+    #[test]
+    fn regex_terms_compile_case_insensitively() {
+        let Pattern::Regex(re) = only_pattern("/auth-\\d+/") else {
+            panic!("expected a regex term");
+        };
+        assert!(re.is_match("auth-12"));
+        assert!(re.is_match("AUTH-12"));
+        assert!(!re.is_match("auth-api"));
+    }
+
+    /// Both slashes are required, so the paths and image tags people filter
+    /// on are still plain fuzzy text.
+    #[test]
+    fn a_single_slash_is_not_a_regex() {
+        assert_eq!(
+            parse("/healthz"),
+            ParsedFilter::Fuzzy(Pattern::Fuzzy("/healthz".into()))
+        );
+        assert_eq!(parse("/"), ParsedFilter::Fuzzy(Pattern::Fuzzy("/".into())));
+        assert_eq!(
+            parse("nginx/nginx:1.2"),
+            ParsedFilter::Fuzzy(Pattern::Fuzzy("nginx/nginx:1.2".into()))
+        );
+    }
+
+    #[test]
+    fn quoted_and_regex_terms_invert() {
+        let s = structured("!\"canary\"");
+        assert_eq!(
+            s.terms,
+            vec![Term::Text {
+                negate: true,
+                pat: Pattern::Literal(Literal::new("canary")),
+            }]
+        );
+        assert_eq!(s.error, None);
+
+        let s = structured("!/canary|debug/");
+        let Term::Text { negate, pat } = &s.terms[0] else {
+            panic!("expected a text term");
+        };
+        assert!(negate);
+        assert!(matches!(pat, Pattern::Regex(_)));
+    }
+
+    /// Same contract as the rest of the grammar: a term that cannot be built
+    /// is skipped and reported, never a blank table.
+    #[test]
+    fn malformed_quoted_and_regex_terms_report_without_blanking() {
+        let s = structured("\"\" api");
+        assert_eq!(s.terms, vec![fuzzy("api")]);
+        assert!(s.error.as_deref().is_some_and(|e| e.contains("quotes")));
+
+        let s = structured("// api");
+        assert_eq!(s.terms, vec![fuzzy("api")]);
+        assert!(s.error.as_deref().is_some_and(|e| e.contains("slashes")));
+
+        let s = structured("/[unclosed/ api");
+        assert_eq!(s.terms, vec![fuzzy("api")]);
+        assert!(s.error.as_deref().is_some_and(|e| e.contains("bad regex")));
+    }
+
+    #[test]
+    fn tokenizer_splits_on_whitespace_outside_quotes() {
+        assert_eq!(
+            tokenize("api !canary -l app=api"),
+            ["api", "!canary", "-l", "app=api"]
+        );
+        assert_eq!(
+            tokenize("  \"kube system\"  api "),
+            ["\"kube system\"", "api"]
+        );
+        assert_eq!(tokenize("!\"a b\""), ["!\"a b\""]);
+        assert_eq!(tokenize("\"unterminated api"), ["\"unterminated api"]);
+        assert!(tokenize("   ").is_empty());
+    }
+
+    /// Where case folding stops: the substring matcher folds the *needle*
+    /// with full Unicode rules and then reads the haystack's raw bytes. So a
+    /// needle that folds onto ASCII finds ASCII text, but an ASCII needle
+    /// does not find a haystack character that merely folds to it. Folding
+    /// every cell of every row to close that gap is the cost the log filter
+    /// and the document search — the same matcher — already decided against,
+    /// and a Kubernetes name cannot hold such a character anyway.
+    #[test]
+    fn literals_fold_the_needle_not_the_haystack() {
+        // U+212A KELVIN SIGN folds to a plain `k`.
+        assert!(Literal::new("\u{212a}ube").matches("kube-httpcache-0"));
+        assert!(!Literal::new("kube").matches("\u{212a}ube-httpcache-0"));
+    }
+
+    /// Highlight positions are char indices into the name, so a multibyte
+    /// name marks the characters the user sees.
+    #[test]
+    fn literal_match_spans_are_char_indices() {
+        let lit = Literal::new("world");
+        assert_eq!(lit.match_span("héllo-world"), Some(6..11));
+        let chars: Vec<char> = "héllo-world".chars().collect();
+        assert_eq!(chars[6], 'w');
+        // Case-insensitive, and absent text has no span to highlight.
+        assert_eq!(Literal::new("AUTH").match_span("auth-api"), Some(0..4));
+        assert_eq!(lit.match_span("héllo"), None);
     }
 
     #[test]
@@ -565,8 +922,8 @@ mod tests {
         assert_eq!(
             s.terms,
             vec![
-                Term::Fuzzy("api".into()),
-                Term::NotFuzzy("canary".into()),
+                fuzzy("api"),
+                not_fuzzy("canary"),
                 Term::Cmp(Cmp {
                     key: "status".into(),
                     op: Op::Eq,
@@ -596,16 +953,26 @@ mod tests {
         assert!(s.error.as_deref().is_some_and(|e| e.contains("soon")));
 
         let s = structured("! api");
-        assert_eq!(s.terms, vec![Term::Fuzzy("api".into())]);
+        assert_eq!(s.terms, vec![fuzzy("api")]);
         assert!(s.error.is_some());
     }
 
     #[test]
-    fn fuzzy_needle_prefers_first_positive_term() {
-        assert_eq!(parse("khc").fuzzy_needle(), Some("khc"));
-        assert_eq!(parse("").fuzzy_needle(), None);
-        assert_eq!(parse("!x khc status=Running").fuzzy_needle(), Some("khc"));
-        assert_eq!(parse("-l app=api").fuzzy_needle(), None);
+    fn highlight_pattern_prefers_first_positive_term() {
+        let needle = |input: &str| {
+            parse(input)
+                .highlight_pattern()
+                .map(|p| p.text().to_string())
+        };
+        assert_eq!(needle("khc").as_deref(), Some("khc"));
+        assert_eq!(needle(""), None);
+        assert_eq!(needle("!x khc status=Running").as_deref(), Some("khc"));
+        assert_eq!(needle("-l app=api"), None);
+        // A quoted or regex term highlights too — it is a positive text term.
+        assert_eq!(needle("\"auth\"").as_deref(), Some("auth"));
+        assert_eq!(needle("/auth-\\d/").as_deref(), Some("auth-\\d"));
+        // Negated terms are not what the row matched on, so they never mark it.
+        assert_eq!(needle("!\"canary\""), None);
     }
 
     #[test]

--- a/src/logfilter.rs
+++ b/src/logfilter.rs
@@ -22,7 +22,9 @@ pub struct LogMatcher {
 ///
 /// Built once per filter change and queried per line. Also used on its own by
 /// the document search (`/` in a YAML/describe/events view), which wants plain
-/// substring semantics without the `!`/`/re/` grammar [`LogMatcher`] adds.
+/// substring semantics without the `!`/`/re/` grammar [`LogMatcher`] adds, and
+/// by the row filter's `"quoted"` terms.
+#[derive(Clone)]
 pub enum Substring {
     /// ASCII pattern, matched by an Aho-Corasick automaton. For a single
     /// pattern the crate picks its `memmem`/Teddy prefilter, which is

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -368,7 +368,7 @@ fn table(title: &str, columns: &[&str], rows: Vec<Vec<String>>) -> Value {
 /// The label and field selectors the view filter implies.
 ///
 /// `-l` and `-f` terms are already Kubernetes selectors, so they are sent with
-/// the list and narrow the scan exactly. The rest of the grammar — fuzzy text
+/// the list and narrow the scan exactly. The rest of the grammar — text terms
 /// and typed comparisons like `restarts>=5` — is evaluated against rendered
 /// table cells inside the app, and this adapter cannot reproduce it. Rather
 /// than silently sanitize a wider set than the table is showing, refuse: for a

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2186,7 +2186,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         ),
         bind(
             "/",
-            "filter: fuzzy · !inverse · -l/-f selectors (server-side on ⏎) · col=val cpu>500m age<2h",
+            "filter: fuzzy · \"exact\" · /regex/ · !inverse · -l/-f selectors (server-side on ⏎) · col=val cpu>500m age<2h",
         ),
         bind(
             "ctrl-u · ctrl-w",


### PR DESCRIPTION
## What this is

A feature, not a bug fix. Nothing was broken: `/` did fuzzy matching, and every doc said fuzzy. Fuzzy is a subsequence match by design — `khc` finds `kube-httpcache-0` — so in a namespace with hundreds of pods a short needle like `auth` also matches `api-gateway-runtime-hash` (a…u…t…h). #339 asks for a way out of that looseness.

Ranking contiguous hits first, the issue's other suggestion, isn't available here: the table's row order belongs to the sort column, not to a match score. So this adds the opt-in modifiers the reporter proposed instead.

**The alternative I did not take** is tightening the default so plain `auth` only matches contiguously. That changes documented, intentional behaviour for every existing filter, so it's a maintainer call rather than mine. Happy to swap this for that if you'd rather.

## Grammar

| Term | Meaning |
| --- | --- |
| `"auth"` | contiguous, case-insensitive substring — what `grep` would find |
| `/auth-\d+/` | case-insensitive regular expression |
| `!"auth"`, `!/re/` | inverse, like `!text` |

Both AND with the rest of the grammar (`"auth" !/canary/ status=Running`), and a quoted term keeps its spaces (`"kube system"`). A term that can't be compiled is skipped and reported in the prompt like every other malformed term — never a blank table. Regexes use the same `/re/` shape the logs filter already has, and both slashes are required, so `/healthz` and `nginx/nginx:1.2` stay plain fuzzy text.

### Compatibility

Existing filters keep meaning what they did, with one edge worth naming: a token starting with `"`, or wrapped in `/…/`, now parses as a literal or a regex, and one such token puts the whole input into structured mode where whitespace splits terms. Kubernetes names can contain neither character; rendered cells can (an ingress `PATHS` cell like `/api/` was fuzzy text before and is a regex now — it still matches, more broadly).

## Implementation notes

- `Term::Fuzzy`/`NotFuzzy` collapse into `Term::Text { negate, pat }` over a new `Pattern` enum, so there's one text-matching path rather than a variant per kind.
- Literals compile to the existing `logfilter::Substring` automaton once per filter change, not once per row.
- The character-mask prefilter still applies to **ASCII** literals, where the folded needle is the same bytes Aho-Corasick compares. Non-ASCII literals opt out: `Substring` folds with full Unicode rules (`K` U+212A → `k`, `Ö` → `ö`) and a byte mask built with ASCII folding would drop real matches. Caught in review; regression test included. A regex never prefilters — `\d` shares no character with what it matches.
- Input is tokenized rather than `split_whitespace`, so a quoted run stays one term. An unterminated quote runs to the end of the input, because the filter is reparsed on every keystroke and a half-typed term still has to narrow.
- NAME highlighting marks the contiguous run a literal or regex landed on instead of fuzzy's scattered positions; the highlight memo is keyed on the whole filter string so `api` and `"api"` can't share entries.

## Overlaps with #248

#248 rewrites the same tokenizer, parse loop and eval path, and gives the same syntax a different meaning: `"api server"` is a fuzzy pattern containing a space there, an exact literal here. It also hard-errors on an unterminated quote where this keeps narrowing. #248 does not cover #339 — its quotes preserve spaces and matching stays fuzzy, and it has no regex terms.

If #248 lands first this needs more than a rebase, and the reconciliation is straightforward: quoting a **value** (`name='api server'`, `-l '…'`) keeps #248's meaning, quoting a **bare term** means exact, and `/re/` collides with nothing. Say the word and I'll fold these terms into #248 instead of carrying a second grammar.

## Tests

16 new tests — 9 in `src/filter.rs` for the grammar, 7 in `src/app/tests.rs` driven through `handle_key`: the issue's repro (unquoted `auth` returns both pods, `"auth"` returns one), regex anchoring to a single cell, inverse and combined terms, literals over column cells, a malformed regex still filtering on the remaining term, the highlight spans, and the Unicode prefilter regression (verified failing without the fix: `left: []  right: ["kube-httpcache-0"]`).

`just check` green: `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, 907 tests.

Docs ship with it: `docs/features.md`, `docs/keys.md`, `README.md`, and the `?` help line in `src/ui.rs`.

Closes #339