### PR TITLE
feat: extend GitOps view and columns to Argo CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ architecture. The short version:
   patches. No `flux` binary. Plus a native Helm inspector that decodes release
   Secrets itself.
 - **Argo CD built in** - `t` suspends, resumes, and syncs ArgoCD Applications
-  and ApplicationSets through native API patches. No `argocd` binary.
+  and ApplicationSets through native API patches, `:argo` walks the
+  Application → source → revision chain behind any object it applied, and
+  Applications get sync/health columns. No `argocd` binary.
 - **It tells you why something is broken** - `X` opens a deterministic,
   evidence-based incident view. No AI, no external service.
 - **Bulk actions** - `space` marks rows for delete, kill, or Flux actions across

--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -74,7 +74,7 @@ fn cells(c: &mut Criterion) {
     let mut g = c.benchmark_group("cells");
 
     let pods: Vec<_> = (0..256).map(bs::pod).collect();
-    let pod_spec = columns::build_spec("pods", None, None, false);
+    let pod_spec = columns::build_spec("pods", "", None, None, false);
     let now = columns::now_secs();
     g.bench_function("pods_256", |b| {
         b.iter(|| {
@@ -86,7 +86,7 @@ fn cells(c: &mut Criterion) {
 
     // Helm is two orders of magnitude slower per row, so it gets far fewer.
     let helm: Vec<_> = (0..16).map(bs::helm_secret).collect();
-    let helm_spec = columns::build_spec("helm", None, None, false);
+    let helm_spec = columns::build_spec("helm", "", None, None, false);
     g.bench_function("helm_16", |b| {
         b.iter(|| {
             for o in &helm {
@@ -320,7 +320,7 @@ fn helm_decode(c: &mut Criterion) {
 fn cell_extract(c: &mut Criterion) {
     let mut g = c.benchmark_group("cell_extract");
     let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
-    let spec = columns::build_spec("pods", None, None, true);
+    let spec = columns::build_spec("pods", "", None, None, true);
 
     g.bench_function("borrowed_ip_2000", |b| {
         b.iter(|| {
@@ -352,7 +352,7 @@ fn cell_extract(c: &mut Criterion) {
 fn frame_clock(c: &mut Criterion) {
     let mut g = c.benchmark_group("frame_clock");
     let pods: Vec<_> = (0..2_000).map(bs::pod).collect();
-    let spec = columns::build_spec("pods", None, None, false);
+    let spec = columns::build_spec("pods", "", None, None, false);
     // AGE is the elapsed cell this measures, and it is not column 0 — that is
     // NAME, which is not volatile, so both sides would have returned `None`
     // and timed the clock call against an empty result.

--- a/docs/features.md
+++ b/docs/features.md
@@ -135,12 +135,24 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   base64 annotation so resume restores it exactly; ApplicationSet suspend sets
   `applicationsSync` to `create-only` (no `none` mode exists) and stashes the
   original value the same way. Sync-now patches the top-level `operation`
-  field. No `argocd` binary needed. Works with bulk multiselect.
-- **GitOps view** (`:gitops` / `:flux`) - the Flux ownership and reconciliation
-  chain for the selection: the owning Kustomization/HelmRelease, its source
+  field. No `argocd` binary needed. Works with bulk multiselect. Applications,
+  ApplicationSets, and AppProjects get curated columns too - sync and health
+  (health colors the row), the synced revision abbreviated like git shows it,
+  the project, destination, and repository; an ApplicationSet shows its
+  generators and the condition holding it back. `app`, `appset`, and `appproj`
+  are aliases for the three kinds.
+- **GitOps view** (`:gitops` / `:flux` / `:argo`) - the ownership and
+  reconciliation chain for the selection, whichever controller applied it. For
+  Flux: the owning Kustomization/HelmRelease, its source
   (GitRepository/OCIRepository/HelmRepository) with applied and latest revision,
-  the `dependsOn` edges, and ready status. Each item is a finding you can `⏎`
-  into.
+  the `dependsOn` edges, and ready status. For Argo CD: the Application named by
+  the object's `argocd.argoproj.io/tracking-id` annotation or instance label,
+  its sync and health status, the revision synced, whether its sync policy is
+  automated, the repositories and paths it syncs from, and the AppProject and
+  generating ApplicationSet beside it. Either way the last block says what is
+  blocking - a suspended owner, an unready source, drift ("OutOfSync - 1 of 3
+  resources differ"), degraded health, a failed sync - or that it reconciled.
+  Each item is a finding you can `⏎` into.
 - **Native Helm inspector** (`:helm` / `:hm`) - sofka decodes Helm's release
   storage Secrets directly (double base64 → gunzip → JSON, same as Helm) and
   lists one row per release at its latest revision, like `helm list`. `⏎` opens

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -29,7 +29,7 @@ pickers keep both characters available as input.
 | `y` / `d` / `E`                               | view YAML / describe (`kubectl`) / live events                                                                                                                |
 | `x`                                           | secrets: show `data` base64-decoded (as `stringData`)                                                                                                         |
 | `X` / `T`                                     | explain why the selection is unhealthy / session-local state-change timeline                                                                                  |
-| `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                                          |
+| `:gitops` / `:flux` / `:argo`                 | Flux/Argo CD owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                                  |
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                                                      |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                                        |
 | `:rightsize`                                  | historical right-sizing: P50/P95/P99 usage → suggested requests + patch preview (needs a metrics backend)                                                     |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,13 +32,14 @@ Milestone status. Longer-form thinking on direction lives in
 
 ## Milestone 4: GitOps and safety
 
-- [x] Flux ownership and dependency navigation.
+- [x] Flux and Argo CD ownership and dependency navigation.
 - [x] Revision and reconciliation-chain visibility.
 - [x] Managed-resource mutation warnings.
 - [x] Action-aware authorization checks.
 - [x] Declarative guardrails.
 - [x] Local action journal.
 - [x] ArgoCD Application suspend/resume/sync controls.
+- [x] ArgoCD Application/ApplicationSet/AppProject columns and sync chain.
 
 ## Milestone 5: debugging and collaboration
 

--- a/docs/vs-k9s.md
+++ b/docs/vs-k9s.md
@@ -24,7 +24,10 @@ For measured start time, memory use, command start time, and binary size, see th
   and the ArgoCD `operation` field through the Kubernetes API - no `flux` or
   `argocd` binary. ArgoCD suspend/resume stashes the original sync policy as a
   base64 annotation so `prune`, `selfHeal`, and `allowEmpty` survive the
-  round-trip. Works with bulk multiselect too.
+  round-trip. Works with bulk multiselect too. `:gitops` goes the other way for
+  either controller: from any object, to the Kustomization or Application that
+  applied it, the source and revision behind it, and what is blocking the
+  reconcile.
 - **Port-forwards run in the background.** Starting one doesn't freeze the TUI
   for its lifetime. `:pf` lists the active forwards and stops them individually
   while the others keep running. sofka tears all of them down on quit instead of

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -825,16 +825,16 @@ impl App {
         } else {
             format!("{name} in {ns}")
         };
-        // A Flux-managed object gets its spec reverted on the next reconcile —
-        // warn (and confirm) before opening the editor.
-        let flux = flux_managed_by(obj);
+        // A GitOps-managed object gets its spec reverted on the next
+        // reconcile — warn (and confirm) before opening the editor.
+        let managed = gitops_managed_by(obj);
         let mut argv = self.kubectl_base();
         argv.extend(["edit".into(), self.kind_plural.clone(), name]);
         if !ns.is_empty() {
             argv.push("-n".into());
             argv.push(ns);
         }
-        match flux {
+        match managed {
             Some(owner) => {
                 self.confirm_label = format!(
                     "⚠ Managed by {owner} — your edit will be reverted on the next reconcile. Edit anyway?"

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -1,16 +1,16 @@
 use super::*;
 
-use crate::gitops::{self, FluxRef, Node};
+use crate::gitops::{self, Engine, Managed, Node, ObjRef};
 
-/// Flux kinds resolved up front so the off-thread gather can map a
-/// `sourceRef.kind` / `dependsOn` to an API resource without the cluster
-/// registry (which isn't available in the spawned task).
-type FluxKinds = HashMap<String, (ApiResource, bool, String)>;
+/// GitOps kinds resolved up front so the off-thread gather can map a
+/// `sourceRef.kind` / `dependsOn` / Argo reference to an API resource without
+/// the cluster registry (which isn't available in the spawned task).
+type GitopsKinds = HashMap<String, (ApiResource, bool, String)>;
 
 impl App {
-    /// Open the GitOps view for the selection: its Flux owner, source, the
-    /// dependsOn chain, and reconciliation state. Gathered off-thread; the
-    /// findings arrive as [`Msg::Gitops`].
+    /// Open the GitOps view for the selection: its Flux or Argo CD owner, the
+    /// source it reconciles from, the objects that gate it, and reconciliation
+    /// state. Gathered off-thread; the findings arrive as [`Msg::Gitops`].
     pub(super) fn open_gitops(&mut self) {
         if self.kind.is_none() {
             self.flash_warn("select a resource first");
@@ -55,22 +55,27 @@ impl App {
         let subject = format!("{}/{name}", kind.ar.kind);
         let title = self.gitops_title.clone();
 
-        // The selection is itself the owner (a Kustomization/HelmRelease), or
-        // it's a managed object naming its owner via toolkit labels.
-        let self_is_owner = gitops::is_owner_plural(&plural);
-        let owner_ref = if self_is_owner {
-            Some(FluxRef {
-                kind: kind.ar.kind.clone(),
-                name,
-                namespace: ns,
-            })
-        } else {
-            gitops::owner_ref(&obj)
+        // The selection is itself the owner (a Kustomization/HelmRelease, an
+        // Application/ApplicationSet), or it's a managed object naming its
+        // owner through the toolkit labels / Argo tracking stamp.
+        let self_engine = gitops::owner_engine(&plural, &kind.ar.group);
+        let owner_ref = match self_engine {
+            Some(engine) => Some(gitops::Owner {
+                engine,
+                reference: ObjRef {
+                    kind: kind.ar.kind.clone(),
+                    name,
+                    namespace: ns,
+                },
+                inferred: false,
+            }),
+            None => gitops::owner_ref(&obj),
         };
+        let self_is_owner = self_engine.is_some();
         let owner_inline = self_is_owner.then(|| obj.clone());
         let owner_plural_inline = self_is_owner.then(|| plural.clone());
 
-        let flux = self.flux_kind_map();
+        let kinds = self.gitops_kind_map();
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.generation;
@@ -78,41 +83,70 @@ impl App {
 
         tokio::spawn(async move {
             let mut warn = None;
-            // Owner: the selection itself, or fetched from its label reference.
+            // Owner: the selection itself, or fetched from its reference.
             let owner = match owner_ref {
                 None => None,
                 Some(r) => {
                     let (plural, obj) = match (owner_inline, owner_plural_inline) {
                         (Some(o), Some(p)) => (p, Some(o)),
-                        _ => fetch_flux(&client, &flux, &r, &mut warn).await,
+                        _ => fetch_ref(&client, &kinds, &r.reference, &mut warn).await,
                     };
-                    Some(Node {
-                        reference: r,
-                        plural,
-                        obj,
+                    let mut reference = r.reference;
+                    // A namespace-less Argo stamp resolves to wherever the
+                    // Application actually lives, so the jump target works.
+                    if let Some(found) = obj.as_ref().and_then(|o| o.metadata.namespace.clone()) {
+                        reference.namespace = found;
+                    }
+                    Some(Managed {
+                        engine: r.engine,
+                        node: Node {
+                            reference,
+                            plural,
+                            obj,
+                        },
+                        inferred: r.inferred,
                     })
                 }
             };
 
-            // Source + dependencies, read from the owner object.
+            // The rest of the chain, read from the owner object.
             let mut source = None;
             let mut deps = Vec::new();
-            if let Some(owner_obj) = owner.as_ref().and_then(|n| n.obj.as_ref()) {
-                if let Some(sr) = gitops::source_ref(owner_obj) {
-                    let (plural, obj) = fetch_flux(&client, &flux, &sr, &mut warn).await;
-                    source = Some(Node {
-                        reference: sr,
-                        plural,
-                        obj,
-                    });
-                }
-                for dr in gitops::depends_on(owner_obj) {
-                    let (plural, obj) = fetch_flux(&client, &flux, &dr, &mut warn).await;
-                    deps.push(Node {
-                        reference: dr,
-                        plural,
-                        obj,
-                    });
+            if let Some(m) = owner.as_ref()
+                && let Some(owner_obj) = m.node.obj.as_ref()
+            {
+                match m.engine {
+                    Engine::Flux => {
+                        if let Some(sr) = gitops::source_ref(owner_obj) {
+                            let (plural, obj) = fetch_ref(&client, &kinds, &sr, &mut warn).await;
+                            source = Some(Node {
+                                reference: sr,
+                                plural,
+                                obj,
+                            });
+                        }
+                        for dr in gitops::depends_on(owner_obj) {
+                            let (plural, obj) = fetch_ref(&client, &kinds, &dr, &mut warn).await;
+                            deps.push(Node {
+                                reference: dr,
+                                plural,
+                                obj,
+                            });
+                        }
+                    }
+                    Engine::Argo => {
+                        let refs = gitops::argo_project_ref(owner_obj)
+                            .into_iter()
+                            .chain(gitops::argo_parent_ref(owner_obj));
+                        for r in refs {
+                            let (plural, obj) = fetch_ref(&client, &kinds, &r, &mut warn).await;
+                            deps.push(Node {
+                                reference: r,
+                                plural,
+                                obj,
+                            });
+                        }
+                    }
                 }
             }
 
@@ -136,11 +170,11 @@ impl App {
         });
     }
 
-    /// Resolve the Flux kinds the chain can reference (owner, sources,
-    /// dependencies) into API resources, keyed by both lowercased kind and
-    /// plural so a `sourceRef.kind` or plural both look up.
-    fn flux_kind_map(&self) -> FluxKinds {
-        let mut m = FluxKinds::new();
+    /// Resolve the kinds a chain can reference (owners, sources, dependencies,
+    /// Argo projects and generators) into API resources, keyed by both
+    /// lowercased kind and plural so a `sourceRef.kind` or plural both look up.
+    fn gitops_kind_map(&self) -> GitopsKinds {
+        let mut m = GitopsKinds::new();
         for k in [
             "kustomizations",
             "helmreleases",
@@ -149,6 +183,11 @@ impl App {
             "buckets",
             "helmrepositories",
             "helmcharts",
+            // Argo's plurals are generic, so its kinds are looked up by their
+            // group-qualified names.
+            "applications.argoproj.io",
+            "applicationsets.argoproj.io",
+            "appprojects.argoproj.io",
         ] {
             if let Some(kind) = self.cluster.resolve(k) {
                 let plural = kind.ar.plural.to_lowercase();
@@ -191,20 +230,28 @@ impl App {
     }
 }
 
-/// Fetch one Flux object by reference, returning its resolved plural (empty if
-/// the kind is unknown to the cluster) and the object (`None` if not found).
-/// A read *failure* (a 403, a timeout) is recorded in `warn` — folding it into
-/// `None` would make the chain view assert the object doesn't exist.
-async fn fetch_flux(
+/// Fetch one GitOps object by reference, returning its resolved plural (empty
+/// if the kind is unknown to the cluster) and the object (`None` if not
+/// found). A reference with no namespace — an Argo instance stamp naming an
+/// Application in the controller's own namespace — is searched for across all
+/// of them. A read *failure* (a 403, a timeout) is recorded in `warn`; folding
+/// it into `None` would make the chain view assert the object doesn't exist.
+async fn fetch_ref(
     client: &Client,
-    flux: &FluxKinds,
-    r: &FluxRef,
+    kinds: &GitopsKinds,
+    r: &ObjRef,
     warn: &mut Option<String>,
 ) -> (String, Option<DynamicObject>) {
-    let Some((ar, namespaced, plural)) = flux.get(&r.kind.to_lowercase()) else {
+    let Some((ar, namespaced, plural)) = kinds.get(&r.kind.to_lowercase()) else {
         return (String::new(), None);
     };
-    let api: Api<DynamicObject> = if *namespaced && !r.namespace.is_empty() {
+    if *namespaced && r.namespace.is_empty() {
+        return (
+            plural.clone(),
+            search_all(client, ar, plural, r, warn).await,
+        );
+    }
+    let api: Api<DynamicObject> = if *namespaced {
         Api::namespaced_with(client.clone(), &r.namespace, ar)
     } else {
         Api::all_with(client.clone(), ar)
@@ -218,4 +265,25 @@ async fn fetch_flux(
         }
     };
     (plural.clone(), obj)
+}
+
+/// Find a namespaced object by name across every namespace. The apiserver
+/// supports `metadata.name` as a field selector for any kind, so this stays
+/// one request instead of a full list plus a client-side scan.
+async fn search_all(
+    client: &Client,
+    ar: &ApiResource,
+    plural: &str,
+    r: &ObjRef,
+    warn: &mut Option<String>,
+) -> Option<DynamicObject> {
+    let api: Api<DynamicObject> = Api::all_with(client.clone(), ar);
+    let lp = ListParams::default().fields(&format!("metadata.name={}", r.name));
+    match api.list(&lp).await {
+        Ok(list) => list.items.into_iter().next(),
+        Err(e) => {
+            warn.get_or_insert(format!("searching {plural} for {}: {e}", r.name));
+            None
+        }
+    }
 }

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -237,11 +237,11 @@ pub(super) fn node_targets_label(targets: &[String]) -> String {
     }
 }
 
-/// What manages `obj`, if anything: its Flux owner (from the toolkit labels)
-/// preferred, else its controller/owner reference. Used to warn that a delete
-/// will be recreated.
+/// What manages `obj`, if anything: its GitOps owner (from the Flux toolkit
+/// labels or the Argo CD tracking stamp) preferred, else its controller/owner
+/// reference. Used to warn that a delete will be recreated.
 pub(super) fn managed_by(obj: &DynamicObject) -> Option<String> {
-    if let Some(f) = flux_managed_by(obj) {
+    if let Some(f) = gitops_managed_by(obj) {
         return Some(f);
     }
     let owners = obj.metadata.owner_references.as_ref()?;
@@ -252,10 +252,21 @@ pub(super) fn managed_by(obj: &DynamicObject) -> Option<String> {
     Some(format!("{}/{}", owner.kind, owner.name))
 }
 
-/// The Flux Kustomization/HelmRelease managing `obj`, from its toolkit labels.
-/// Used to warn that an edit will be reverted on the next reconcile.
-pub(super) fn flux_managed_by(obj: &DynamicObject) -> Option<String> {
-    crate::gitops::owner_ref(obj).map(|r| format!("Flux {}/{}", r.kind, r.name))
+/// The GitOps owner managing `obj` — a Flux Kustomization/HelmRelease from the
+/// toolkit labels, or an Argo CD Application from its tracking stamp. Used to
+/// warn that an edit will be reverted on the next reconcile.
+///
+/// An owner only *inferred* from the generic `app.kubernetes.io/instance`
+/// label is ignored: Helm and hand-written manifests set it too, and a warning
+/// that names an Application which may not exist is worse than none.
+pub(super) fn gitops_managed_by(obj: &DynamicObject) -> Option<String> {
+    let owner = crate::gitops::owner_ref(obj).filter(|o| !o.inferred)?;
+    Some(format!(
+        "{} {}/{}",
+        owner.engine.label(),
+        owner.reference.kind,
+        owner.reference.name
+    ))
 }
 
 pub(super) fn delete_confirm_label(

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -387,7 +387,7 @@ impl App {
         let user_has_columns = self
             .active_user_view()
             .is_some_and(|v| !v.columns.is_empty());
-        if crate::columns::has_curated(&self.kind_plural)
+        if crate::columns::has_curated(&self.kind_plural, &kind.ar.group)
             || kind.ar.group.is_empty()
             || kind.ar.plural.to_lowercase() != self.kind_plural
             || self.crd_views.contains_key(&self.kind_plural)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -85,7 +85,7 @@ const FLUX_SUSPENDABLE_KINDS: &[&str] = &[
 
 /// The ArgoCD CRD group. Used to disambiguate the very generic `applications`
 /// and `applicationsets` plurals — only `argoproj.io` kinds get the `t` menu.
-const ARGOCD_GROUP: &str = "argoproj.io";
+const ARGOCD_GROUP: &str = crate::gitops::ARGO_GROUP;
 
 /// Items in the Flux action menu (`t`), in display order. Deliberately a menu
 /// — not a single-key toggle — so suspending something always takes an
@@ -573,7 +573,7 @@ const PALETTE_COMMANDS: &[PaletteCommand] = &[
     },
     PaletteCommand {
         action: PaletteAction::Gitops,
-        names: &["gitops", "flux", "reconcile", "recon"],
+        names: &["gitops", "flux", "argocd", "argo", "reconcile", "recon"],
     },
     PaletteCommand {
         action: PaletteAction::CanI,
@@ -2084,7 +2084,7 @@ impl App {
             crd_views: HashMap::new(),
             wide: false,
             compact: false,
-            spec: crate::columns::build_spec("", None, None, false),
+            spec: crate::columns::build_spec("", "", None, None, false),
         }
     }
 

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -660,6 +660,7 @@ impl App {
             .and_then(|i| self.display_headers().get(i).cloned());
         let spec = crate::columns::build_spec(
             &self.kind_plural,
+            self.kind.as_ref().map_or("", |k| k.ar.group.as_str()),
             self.active_user_view(),
             self.crd_views
                 .get(&self.kind_plural)

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4331,6 +4331,36 @@ async fn argocd_menu_requires_explicit_choice_not_a_single_key() {
     assert!(!app.flash.contains("suspending"));
 }
 
+#[tokio::test]
+async fn argocd_applications_get_sync_and_health_columns() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+
+    let headers: Vec<String> = app.display_headers().to_vec();
+    assert!(
+        headers.contains(&"SYNC".to_string()) && headers.contains(&"HEALTH".to_string()),
+        "{headers:?}"
+    );
+    assert!(headers.contains(&"PROJECT".to_string()), "{headers:?}");
+}
+
+#[tokio::test]
+async fn gitops_view_opens_for_an_argocd_application() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("applications");
+    apply(&mut app, argocd_app("guestbook"));
+
+    // `:argo` and `:argocd` are the Argo-flavored names of the GitOps view.
+    assert!(app.run_palette_command("argocd"));
+    assert_eq!(app.mode, Mode::Gitops);
+    assert_eq!(app.gitops_title, "guestbook — GitOps");
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.run_palette_command("argo"));
+    assert_eq!(app.mode, Mode::Gitops);
+}
+
 #[test]
 fn argocd_suspend_stashes_automated_and_removes_field() {
     let o = obj(argocd_app("guestbook"));
@@ -7479,6 +7509,48 @@ async fn editing_unmanaged_object_skips_the_warning() {
     let (mut app, _rx) = app_with_pod(); // plain pod, no toolkit labels
     app.request_edit();
     assert_ne!(app.mode, Mode::Confirm, "unmanaged edit needs no confirm");
+    assert!(matches!(app.pending, Some(Suspend::Shell(_))));
+}
+
+#[tokio::test]
+async fn editing_argocd_managed_object_confirms_with_revert_warning() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1","kind":"Pod","metadata":{
+            "name":"a","namespace":"default","annotations":{
+                "argocd.argoproj.io/tracking-id":"guestbook:/Pod:default/a"}}}),
+    );
+    app.table_state.select(Some(0));
+
+    app.request_edit();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(app.pending.is_none(), "must not edit before confirming");
+    assert!(
+        app.confirm_label
+            .contains("Managed by Argo CD Application/guestbook"),
+        "{}",
+        app.confirm_label
+    );
+}
+
+#[tokio::test]
+async fn a_bare_instance_label_is_too_weak_to_warn_on() {
+    // Helm sets `app.kubernetes.io/instance` on everything it installs —
+    // warning about an Argo Application that may not exist would cry wolf.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1","kind":"Pod","metadata":{
+            "name":"a","namespace":"default","labels":{
+                "app.kubernetes.io/instance":"guestbook"}}}),
+    );
+    app.table_state.select(Some(0));
+
+    app.request_edit();
+    assert_ne!(app.mode, Mode::Confirm, "{}", app.confirm_label);
     assert!(matches!(app.pending, Some(Suspend::Shell(_))));
 }
 
@@ -10801,7 +10873,7 @@ async fn filtering_matches_a_naive_fuzzy_pass() {
 
         // Naive expectation: name haystack, else any rendered cell.
         let matcher = crate::fuzzy::Fuzzy::new();
-        let spec = crate::columns::build_spec("pods", None, None, false);
+        let spec = crate::columns::build_spec("pods", "", None, None, false);
         let mut want: Vec<String> = Vec::new();
         for (k, o) in app.store.iter() {
             let hay = format!(

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -11,6 +11,8 @@ use k8s_openapi::jiff::Timestamp;
 use kube::core::DynamicObject;
 use serde_json::Value;
 
+use crate::gitops::ARGO_GROUP;
+
 /// Curated extractors borrow values that already live in the Kubernetes
 /// object and own only derived/formatted values. Cached full rows convert the
 /// result once; one-column filter/sort probes can consume borrowed text.
@@ -290,6 +292,41 @@ const FLUX_SOURCE_COLUMNS: &[Column] = &[
     column("AGE", col_age),
 ];
 
+/// Argo CD Applications. HEALTH is the status column rather than SYNC: an
+/// OutOfSync app that still serves traffic is a warning, a Degraded one is the
+/// broken row an operator is scanning for.
+const ARGOCD_APP_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("SYNC", col_argo_sync),
+    status_column("HEALTH", col_argo_health),
+    column("REVISION", col_argo_revision),
+    column("PROJECT", col_argo_project),
+    wide_column("DESTINATION", col_argo_destination),
+    wide_column("REPO", col_argo_repo),
+    column("AGE", col_age),
+];
+
+/// Argo CD ApplicationSets. They have no sync/health of their own — their
+/// status is whether the generators produced Applications.
+const ARGOCD_APPSET_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    status_column("STATUS", col_argo_appset_status),
+    column("GENERATORS", col_argo_generators),
+    column("MESSAGE", col_argo_appset_message),
+    column("PROJECT", col_argo_project),
+    wide_column("REPO", col_argo_repo),
+    column("AGE", col_age),
+];
+
+/// Argo CD AppProjects — the guardrails an Application is allowed to sync
+/// within.
+const ARGOCD_APPPROJECT_COLUMNS: &[Column] = &[
+    column("NAME", col_name),
+    column("DESTINATIONS", col_argo_allowed_destinations),
+    column("SOURCE REPOS", col_argo_allowed_repos),
+    column("AGE", col_age),
+];
+
 const DEFAULT_COLUMNS: &[Column] = &[column("NAME", col_name), column("AGE", col_age)];
 
 /// One row per release, at its latest revision — like `helm list`. Backed by
@@ -314,7 +351,9 @@ const HELM_HISTORY_COLUMNS: &[Column] = &[
     column("UPDATED", col_helm_updated),
 ];
 
-fn columns_for(plural: &str) -> &'static [Column] {
+/// The curated columns for a kind. `group` disambiguates plurals that aren't
+/// unique across API groups — `applications` alone says nothing about Argo CD.
+fn columns_for(plural: &str, group: &str) -> &'static [Column] {
     match plural {
         "pods" => POD_COLUMNS,
         "deployments" => DEPLOYMENT_COLUMNS,
@@ -340,6 +379,9 @@ fn columns_for(plural: &str) -> &'static [Column] {
         "gitrepositories" | "helmrepositories" | "ocirepositories" | "buckets" => {
             FLUX_SOURCE_COLUMNS
         }
+        "applications" if group == ARGO_GROUP => ARGOCD_APP_COLUMNS,
+        "applicationsets" if group == ARGO_GROUP => ARGOCD_APPSET_COLUMNS,
+        "appprojects" if group == ARGO_GROUP => ARGOCD_APPPROJECT_COLUMNS,
         "helm" => HELM_COLUMNS,
         "helmhistory" => HELM_HISTORY_COLUMNS,
         _ => DEFAULT_COLUMNS,
@@ -349,8 +391,8 @@ fn columns_for(plural: &str) -> &'static [Column] {
 /// Whether `plural` has curated columns (anything beyond the NAME/AGE
 /// fallback). Kinds without them are candidates for the CRD printer-column
 /// fallback.
-pub fn has_curated(plural: &str) -> bool {
-    columns_for(plural).as_ptr() != DEFAULT_COLUMNS.as_ptr()
+pub fn has_curated(plural: &str, group: &str) -> bool {
+    columns_for(plural, group).as_ptr() != DEFAULT_COLUMNS.as_ptr()
 }
 
 /// The full curated headers for a kind (wide columns included), excluding the
@@ -359,15 +401,36 @@ pub fn has_curated(plural: &str) -> bool {
 /// user views, printer columns, and wide-mode filtering.
 #[cfg(test)]
 pub fn headers(plural: &str) -> Vec<&'static str> {
-    columns_for(plural).iter().map(|c| c.header).collect()
+    headers_in(plural, "")
+}
+
+/// As [`headers`], for a kind whose plural needs its API group to
+/// disambiguate.
+#[cfg(test)]
+pub fn headers_in(plural: &str, group: &str) -> Vec<&'static str> {
+    columns_for(plural, group)
+        .iter()
+        .map(|c| c.header)
+        .collect()
 }
 
 /// Cells for one object, aligned with [`headers`]. The 2nd return value is the
 /// index of the column that should be colorized as a status (or None).
 #[cfg(test)]
 pub fn cells(obj: &DynamicObject, plural: &str, now: i64) -> (Vec<String>, Option<usize>) {
+    cells_in(obj, plural, "", now)
+}
+
+/// As [`cells`], for a kind whose plural needs its API group to disambiguate.
+#[cfg(test)]
+pub fn cells_in(
+    obj: &DynamicObject,
+    plural: &str,
+    group: &str,
+    now: i64,
+) -> (Vec<String>, Option<usize>) {
     let ctx = CellContext::new(obj, now);
-    let columns = columns_for(plural);
+    let columns = columns_for(plural, group);
     let values = columns
         .iter()
         .map(|c| (c.extract)(&ctx).into_owned())
@@ -382,6 +445,7 @@ pub fn cells(obj: &DynamicObject, plural: &str, now: i64) -> (Vec<String>, Optio
 /// per view change, never per row.
 pub struct ViewSpec {
     plural: String,
+    group: String,
     columns: Vec<SpecColumn>,
     status_idx: Option<usize>,
 }
@@ -424,18 +488,22 @@ fn spec_user(uc: &crate::views::UserColumn) -> SpecColumn {
 /// user view defines no columns and `plural` has no curated ones.
 pub fn build_spec(
     plural: &str,
+    group: &str,
     user: Option<&crate::views::View>,
     crd: Option<&crate::views::View>,
     wide: bool,
 ) -> ViewSpec {
-    let mut cols: Vec<SpecColumn> = columns_for(plural).iter().map(spec_curated).collect();
+    let mut cols: Vec<SpecColumn> = columns_for(plural, group)
+        .iter()
+        .map(spec_curated)
+        .collect();
     // A user view only counts as explicit column config when it has columns —
     // a sort-only view (or one whose columns all failed validation) still
     // benefits from the printer-column fallback.
     let view = match user {
         Some(v) if !v.columns.is_empty() => Some(v),
         _ => {
-            if has_curated(plural) {
+            if has_curated(plural, group) {
                 None
             } else {
                 crd
@@ -468,6 +536,7 @@ pub fn build_spec(
     let status_idx = cols.iter().position(|c| c.is_status);
     ViewSpec {
         plural: plural.to_string(),
+        group: group.to_string(),
         columns: cols,
         status_idx,
     }
@@ -562,7 +631,7 @@ impl ViewSpec {
             SpecSource::Curated(extract) => {
                 let ctx = CellContext::new(obj, now);
                 let v = extract(&ctx);
-                if is_numeric_header(&self.plural, header) {
+                if is_numeric_header(&self.plural, &self.group, header) {
                     crate::views::SortValue::Num(parse_leading_num(&v))
                 } else {
                     crate::views::SortValue::Text(v.to_lowercase().to_string())
@@ -590,11 +659,11 @@ impl ViewSpec {
 }
 
 /// Columns whose curated cell is a count/number and should sort numerically.
-fn is_numeric_header(plural: &str, header: &str) -> bool {
+fn is_numeric_header(plural: &str, group: &str, header: &str) -> bool {
     // READY is a count ("1/2") for workloads, but flux kinds render it as
     // True/False/Unknown, which must sort as text.
     if header == "READY" {
-        let cols = columns_for(plural);
+        let cols = columns_for(plural, group);
         return cols.as_ptr() != FLUX_OBJECT_COLUMNS.as_ptr()
             && cols.as_ptr() != FLUX_SOURCE_COLUMNS.as_ptr();
     }
@@ -1237,6 +1306,185 @@ fn flux_source_url(d: &Value) -> Cow<'_, str> {
         (Some(endpoint), None) => Cow::Borrowed(endpoint),
         (None, Some(bucket)) => Cow::Borrowed(bucket),
         (None, None) => Cow::Borrowed(""),
+    }
+}
+
+/// Argo CD sync state: `Synced` / `OutOfSync`, `Unknown` until the controller
+/// has compared the live objects with the source.
+fn col_argo_sync<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "sync", "status"]).unwrap_or("Unknown"))
+}
+
+/// Argo CD health: `Healthy` / `Progressing` / `Degraded` / `Missing` /
+/// `Suspended`.
+fn col_argo_health<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(sget(ctx.data, &["status", "health", "status"]).unwrap_or("Unknown"))
+}
+
+/// The revision Argo last synced, abbreviated the way git does when it's a
+/// commit SHA (a chart version or branch is left alone).
+fn col_argo_revision<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    let rev = sget(ctx.data, &["status", "sync", "revision"]).unwrap_or_default();
+    if rev.len() == 40 && rev.chars().all(|c| c.is_ascii_hexdigit()) {
+        Cow::Borrowed(&rev[..7])
+    } else {
+        Cow::Borrowed(rev)
+    }
+}
+
+/// The AppProject an Application (or an ApplicationSet's template) syncs under.
+fn col_argo_project<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(
+        sget(ctx.data, &["spec", "project"])
+            .or_else(|| sget(ctx.data, &["spec", "template", "spec", "project"]))
+            .unwrap_or_default(),
+    )
+}
+
+/// Where the Application deploys: `<cluster>/<namespace>`, with the cluster
+/// left off when it's the local one Argo runs in.
+fn col_argo_destination<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    let dest = |k: &str| {
+        sget(ctx.data, &["spec", "destination", k])
+            .or_else(|| sget(ctx.data, &["spec", "template", "spec", "destination", k]))
+            .unwrap_or_default()
+    };
+    let namespace = dest("namespace");
+    let cluster = match (dest("name"), dest("server")) {
+        ("", server) if server.contains("kubernetes.default.svc") => "",
+        ("", server) => server,
+        (name, _) => name,
+    };
+    match (cluster, namespace) {
+        ("", ns) => Cow::Borrowed(ns),
+        (c, "") => Cow::Borrowed(c),
+        (c, ns) => Cow::Owned(format!("{c}/{ns}")),
+    }
+}
+
+/// The repository the Application syncs from — the first one for a
+/// multi-source app.
+fn col_argo_repo<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Borrowed(
+        argo_first_source(ctx.data)
+            .and_then(|s| s.get("repoURL")?.as_str())
+            .unwrap_or_default(),
+    )
+}
+
+/// The first `source`/`sources[0]` of an Application or of an
+/// ApplicationSet's template.
+fn argo_first_source(d: &Value) -> Option<&Value> {
+    for base in ["/spec", "/spec/template/spec"] {
+        if let Some(one) = d.pointer(&format!("{base}/source")) {
+            return Some(one);
+        }
+        if let Some(first) = d
+            .pointer(&format!("{base}/sources"))
+            .and_then(Value::as_array)
+            .and_then(|a| a.first())
+        {
+            return Some(first);
+        }
+    }
+    None
+}
+
+/// The generator kinds an ApplicationSet is built from (`git`, `list`,
+/// `matrix`, …) — what to read before wondering where its Applications came
+/// from.
+fn col_argo_generators<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    let names: Vec<&str> = ctx
+        .data
+        .pointer("/spec/generators")
+        .and_then(Value::as_array)
+        .map(|gens| {
+            gens.iter()
+                .filter_map(|g| g.as_object()?.keys().next().map(String::as_str))
+                .collect()
+        })
+        .unwrap_or_default();
+    if names.is_empty() {
+        Cow::Borrowed("")
+    } else {
+        Cow::Owned(names.join(","))
+    }
+}
+
+/// An ApplicationSet reports through conditions, not a phase: `ErrorOccurred`
+/// inverts (True is the failure), `ResourcesUpToDate` is the healthy one.
+fn col_argo_appset_status<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    if condition_is(ctx.data, "ErrorOccurred", "True") {
+        return Cow::Borrowed("Error");
+    }
+    if condition_is(ctx.data, "ResourcesUpToDate", "True") {
+        return Cow::Borrowed("Ready");
+    }
+    if ctx.data.pointer("/status/conditions").is_none() {
+        return Cow::Borrowed("Unknown");
+    }
+    Cow::Borrowed("Progressing")
+}
+
+/// The message behind an ApplicationSet's status: the error when it has one,
+/// otherwise whatever is keeping it from being up to date.
+fn col_argo_appset_message<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    let conds = ctx
+        .data
+        .pointer("/status/conditions")
+        .and_then(Value::as_array);
+    let Some(conds) = conds else {
+        return Cow::Borrowed("");
+    };
+    let pick = |ty: &str, status: &str| {
+        conds
+            .iter()
+            .find(|c| {
+                c.get("type").and_then(Value::as_str) == Some(ty)
+                    && c.get("status").and_then(Value::as_str) == Some(status)
+            })
+            .and_then(|c| c.get("message")?.as_str())
+    };
+    Cow::Borrowed(
+        pick("ErrorOccurred", "True")
+            .or_else(|| pick("ResourcesUpToDate", "False"))
+            .unwrap_or_default(),
+    )
+}
+
+/// The namespaces an AppProject allows syncing into, deduplicated.
+fn col_argo_allowed_destinations<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(join_unique(ctx.data.pointer("/spec/destinations"), |d| {
+        d.get("namespace").and_then(Value::as_str)
+    }))
+}
+
+/// The repositories an AppProject allows syncing from.
+fn col_argo_allowed_repos<'a>(ctx: &CellContext<'a>) -> Cow<'a, str> {
+    Cow::Owned(join_unique(
+        ctx.data.pointer("/spec/sourceRepos"),
+        Value::as_str,
+    ))
+}
+
+/// Comma-join the extracted strings of a JSON array, dropping repeats and
+/// empties. `<none>` when nothing is allowed at all.
+fn join_unique<'a>(
+    list: Option<&'a Value>,
+    extract: impl Fn(&'a Value) -> Option<&'a str>,
+) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for v in list.and_then(Value::as_array).into_iter().flatten() {
+        if let Some(s) = extract(v).filter(|s| !s.is_empty())
+            && !out.contains(&s)
+        {
+            out.push(s);
+        }
+    }
+    if out.is_empty() {
+        "<none>".to_string()
+    } else {
+        out.join(",")
     }
 }
 
@@ -2523,6 +2771,162 @@ mod tests {
                 assert!(idx < cells.len(), "{kind} status index");
             }
         }
+        // The kinds whose columns only apply inside their own API group.
+        for kind in ["applications", "applicationsets", "appprojects"] {
+            let headers = headers_in(kind, ARGO_GROUP);
+            let (cells, status_idx) = cells_in(&o, kind, ARGO_GROUP, now_secs());
+            assert_eq!(headers.len(), cells.len(), "{kind} column count");
+            if let Some(idx) = status_idx {
+                assert!(idx < cells.len(), "{kind} status index");
+            }
+        }
+    }
+
+    #[test]
+    fn argocd_application_cells_show_sync_health_and_revision() {
+        let app = obj(json!({
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Application",
+            "metadata": {"name": "api", "namespace": "argocd"},
+            "spec": {
+                "project": "prod",
+                "destination": {"server": "https://kubernetes.default.svc",
+                                "namespace": "prod"},
+                "source": {"repoURL": "https://github.com/acme/gitops",
+                           "path": "apps/api", "targetRevision": "main"}
+            },
+            "status": {
+                "sync": {"status": "OutOfSync",
+                         "revision": "0123456789abcdef0123456789abcdef01234567"},
+                "health": {"status": "Degraded"}
+            }
+        }));
+        assert_eq!(
+            headers_in("applications", ARGO_GROUP),
+            vec![
+                "NAME",
+                "SYNC",
+                "HEALTH",
+                "REVISION",
+                "PROJECT",
+                "DESTINATION",
+                "REPO",
+                "AGE"
+            ]
+        );
+        let (cells, status_idx) = cells_in(&app, "applications", ARGO_GROUP, now_secs());
+        assert_eq!(cells[1], "OutOfSync");
+        assert_eq!(cells[2], "Degraded");
+        // A commit SHA is abbreviated; the local cluster is left off the
+        // destination.
+        assert_eq!(cells[3], "0123456");
+        assert_eq!(cells[4], "prod");
+        assert_eq!(cells[5], "prod");
+        assert_eq!(cells[6], "https://github.com/acme/gitops");
+        // HEALTH is what colors the row.
+        assert_eq!(status_idx, Some(2));
+
+        // A chart version is not a SHA and stays whole, and a named cluster
+        // shows up next to the namespace.
+        let remote = obj(json!({
+            "apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
+            "metadata": {"name": "redis"},
+            "spec": {"destination": {"name": "eu-west", "namespace": "cache"}},
+            "status": {"sync": {"status": "Synced", "revision": "18.1.2"},
+                       "health": {"status": "Healthy"}}
+        }));
+        let (cells, _) = cells_in(&remote, "applications", ARGO_GROUP, now_secs());
+        assert_eq!(cells[3], "18.1.2");
+        assert_eq!(cells[5], "eu-west/cache");
+    }
+
+    #[test]
+    fn argocd_application_before_the_controller_looks_reads_unknown() {
+        let app = obj(json!({
+            "apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
+            "metadata": {"name": "api"}, "spec": {}
+        }));
+        let (cells, _) = cells_in(&app, "applications", ARGO_GROUP, now_secs());
+        assert_eq!(cells[1], "Unknown");
+        assert_eq!(cells[2], "Unknown");
+    }
+
+    #[test]
+    fn argocd_applicationset_cells_come_from_conditions() {
+        let appset = obj(json!({
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "ApplicationSet",
+            "metadata": {"name": "prod-apps"},
+            "spec": {
+                "generators": [{"git": {}}, {"clusters": {}}],
+                "template": {"spec": {"project": "prod",
+                    "source": {"repoURL": "https://github.com/acme/gitops"}}}
+            },
+            "status": {"conditions": [
+                {"type": "ErrorOccurred", "status": "True",
+                 "message": "error generating params"},
+                {"type": "ResourcesUpToDate", "status": "False"}
+            ]}
+        }));
+        let (cells, status_idx) = cells_in(&appset, "applicationsets", ARGO_GROUP, now_secs());
+        assert_eq!(cells[1], "Error");
+        assert_eq!(cells[2], "git,clusters");
+        assert_eq!(cells[3], "error generating params");
+        assert_eq!(cells[4], "prod");
+        assert_eq!(status_idx, Some(1));
+
+        // ErrorOccurred=False with everything generated is the healthy shape.
+        let ok = obj(json!({
+            "apiVersion": "argoproj.io/v1alpha1", "kind": "ApplicationSet",
+            "metadata": {"name": "prod-apps"},
+            "status": {"conditions": [
+                {"type": "ErrorOccurred", "status": "False"},
+                {"type": "ResourcesUpToDate", "status": "True"}
+            ]}
+        }));
+        let (cells, _) = cells_in(&ok, "applicationsets", ARGO_GROUP, now_secs());
+        assert_eq!(cells[1], "Ready");
+        assert_eq!(cells[3], "");
+    }
+
+    #[test]
+    fn argocd_appproject_cells_list_what_it_allows() {
+        let project = obj(json!({
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "AppProject",
+            "metadata": {"name": "prod"},
+            "spec": {
+                "sourceRepos": ["https://github.com/acme/gitops"],
+                "destinations": [
+                    {"server": "https://kubernetes.default.svc", "namespace": "prod"},
+                    {"server": "https://kubernetes.default.svc", "namespace": "prod"},
+                    {"server": "https://kubernetes.default.svc", "namespace": "staging"}
+                ]
+            }
+        }));
+        let (cells, _) = cells_in(&project, "appprojects", ARGO_GROUP, now_secs());
+        assert_eq!(cells[1], "prod,staging");
+        assert_eq!(cells[2], "https://github.com/acme/gitops");
+
+        let empty = obj(json!({
+            "apiVersion": "argoproj.io/v1alpha1", "kind": "AppProject",
+            "metadata": {"name": "locked"}, "spec": {}
+        }));
+        let (cells, _) = cells_in(&empty, "appprojects", ARGO_GROUP, now_secs());
+        assert_eq!(cells[1], "<none>");
+    }
+
+    #[test]
+    fn a_foreign_applications_crd_keeps_the_printer_column_fallback() {
+        // `applications` is a generic plural — only Argo's own kind gets the
+        // sync/health columns, everything else stays a fallback candidate so
+        // its CRD printer columns are used instead.
+        assert!(has_curated("applications", ARGO_GROUP));
+        assert!(!has_curated("applications", "app.k8s.io"));
+        assert_eq!(
+            headers_in("applications", "app.k8s.io"),
+            vec!["NAME", "AGE"]
+        );
     }
 
     // ----- view specs (curated + user/printer columns + wide) --------------
@@ -2563,7 +2967,7 @@ mod tests {
             ],
             false,
         );
-        let spec = build_spec("pods", Some(&v), None, false);
+        let spec = build_spec("pods", "", Some(&v), None, false);
         assert_eq!(
             spec.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "NODE-IP", "AGE"]
@@ -2589,18 +2993,18 @@ mod tests {
             ],
             true,
         );
-        let spec = build_spec("pods", Some(&v), None, true);
+        let spec = build_spec("pods", "", Some(&v), None, true);
         assert_eq!(spec.headers(), vec!["NAME", "PHASE"]);
     }
 
     #[test]
     fn spec_wide_mode_gates_wide_only_columns() {
-        let narrow = build_spec("pods", None, None, false);
+        let narrow = build_spec("pods", "", None, None, false);
         assert_eq!(
             narrow.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
         );
-        let wide = build_spec("pods", None, None, true);
+        let wide = build_spec("pods", "", None, None, true);
         assert_eq!(
             wide.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE"]
@@ -2615,10 +3019,10 @@ mod tests {
             false,
         );
         // Unknown kind: printer columns upgrade the NAME/AGE fallback.
-        let spec = build_spec("widgets", None, Some(&crd), false);
+        let spec = build_spec("widgets", "", None, Some(&crd), false);
         assert_eq!(spec.headers(), vec!["NAME", "PHASE", "AGE"]);
         // Curated kind: printer columns never apply.
-        let spec = build_spec("pods", None, Some(&crd), false);
+        let spec = build_spec("pods", "", None, Some(&crd), false);
         assert_eq!(
             spec.headers(),
             vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
@@ -2628,14 +3032,14 @@ mod tests {
             vec![user_col("MINE", "/status/mine", ColumnKind::Text)],
             false,
         );
-        let spec = build_spec("widgets", Some(&user), Some(&crd), false);
+        let spec = build_spec("widgets", "", Some(&user), Some(&crd), false);
         assert_eq!(spec.headers(), vec!["NAME", "MINE", "AGE"]);
         // A sort-only user view (no columns) still gets printer columns.
         let sort_only = crate::views::View {
             sort: Some(("PHASE".into(), false)),
             ..Default::default()
         };
-        let spec = build_spec("widgets", Some(&sort_only), Some(&crd), false);
+        let spec = build_spec("widgets", "", Some(&sort_only), Some(&crd), false);
         assert_eq!(spec.headers(), vec!["NAME", "PHASE", "AGE"]);
     }
 
@@ -2646,7 +3050,7 @@ mod tests {
             vec![user_col("CPU", "/spec/cpu", ColumnKind::Quantity)],
             false,
         );
-        let spec = build_spec("widgets", Some(&v), None, false);
+        let spec = build_spec("widgets", "", Some(&v), None, false);
         let o = obj(json!({
             "apiVersion": "example.com/v1", "kind": "Widget",
             "metadata": {"name": "w"},
@@ -2671,7 +3075,7 @@ mod tests {
                 "containerStatuses": []
             }
         }));
-        let spec = build_spec("pods", None, None, true);
+        let spec = build_spec("pods", "", None, None, true);
 
         assert!(matches!(
             spec.cell_at(&pod, 0, now_secs()),
@@ -2698,7 +3102,7 @@ mod tests {
                 "status": {"conditions": [{"type": "Ready", "status": status}]}
             }))
         };
-        let spec = build_spec("kustomizations", None, None, false);
+        let spec = build_spec("kustomizations", "", None, None, false);
         let ready =
             |status: &str| match spec.sort_value(&flux(status), "READY", now_secs()).unwrap() {
                 SortValue::Text(t) => t,
@@ -2715,7 +3119,7 @@ mod tests {
                 {"ready": false, "restartCount": 0, "state": {"running": {}}}
             ]}
         }));
-        let spec = build_spec("pods", None, None, false);
+        let spec = build_spec("pods", "", None, None, false);
         match spec.sort_value(&pod, "READY", now_secs()).unwrap() {
             SortValue::Num(n) => assert_eq!(n, 1.0),
             SortValue::Text(t) => panic!("pod READY must sort numerically, got '{t}'"),

--- a/src/gitops.rs
+++ b/src/gitops.rs
@@ -1,10 +1,16 @@
-//! Flux GitOps ownership and reconciliation analysis.
+//! GitOps ownership and reconciliation analysis for Flux and Argo CD.
 //!
 //! Every object Flux applies is stamped with `kustomize.toolkit.fluxcd.io/name`
 //! (+`/namespace`) or `helm.toolkit.fluxcd.io/name` labels naming the
 //! Kustomization / HelmRelease that manages it. From there the chain runs
 //! owner → source (GitRepository/OCIRepository/HelmChart/…) → the revision
 //! actually applied, plus any `dependsOn` Kustomizations that gate it.
+//!
+//! Argo CD stamps its own with an `argocd.argoproj.io/tracking-id` annotation
+//! or an instance label naming the Application. That chain runs Application →
+//! the repo/chart sources it syncs from → the revision actually synced, with
+//! the AppProject that constrains it and the ApplicationSet that generated it
+//! alongside.
 //!
 //! This module is pure: it extracts the references to follow (so the app knows
 //! what to fetch) and, given the fetched objects, formats the chain into
@@ -16,9 +22,28 @@ use serde_json::Value;
 
 use crate::explain::{Finding, Level, Target};
 
-/// A reference to a Flux object: its kind, name, and namespace.
+/// The GitOps controller a chain belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Engine {
+    Flux,
+    Argo,
+}
+
+impl Engine {
+    /// How the engine is named in findings.
+    pub fn label(self) -> &'static str {
+        match self {
+            Engine::Flux => "Flux",
+            Engine::Argo => "Argo CD",
+        }
+    }
+}
+
+/// A reference to a GitOps object: its kind, name, and namespace. The
+/// namespace is empty when the stamp doesn't carry one — Argo's instance label
+/// only spells one out for Applications outside the controller's namespace.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FluxRef {
+pub struct ObjRef {
     pub kind: String,
     pub name: String,
     pub namespace: String,
@@ -29,7 +54,7 @@ pub struct FluxRef {
 /// object (`None` when missing or unfetched).
 #[derive(Debug, Clone)]
 pub struct Node {
-    pub reference: FluxRef,
+    pub reference: ObjRef,
     pub plural: String,
     pub obj: Option<DynamicObject>,
 }
@@ -44,56 +69,152 @@ impl Node {
     }
 }
 
+/// The owner named by an object's stamps, before it has been fetched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Owner {
+    pub engine: Engine,
+    pub reference: ObjRef,
+    /// The reference came from the generic `app.kubernetes.io/instance` label,
+    /// which Helm and hand-written manifests set too. A chain that can't find
+    /// the named Application reads as unmanaged rather than as broken.
+    pub inferred: bool,
+}
+
+/// The owner once fetched: which engine manages the subject, and the node.
+#[derive(Debug, Clone)]
+pub struct Managed {
+    pub engine: Engine,
+    pub node: Node,
+    pub inferred: bool,
+}
+
 /// The gathered reconciliation picture for one selected object.
 pub struct Evidence {
     /// e.g. `Deployment/api`.
     pub subject: String,
-    /// The selected object is itself the Kustomization/HelmRelease.
+    /// The selected object is itself the owner (Kustomization, HelmRelease,
+    /// Application, ApplicationSet).
     pub self_is_owner: bool,
-    /// The managing Kustomization/HelmRelease (or the object itself).
-    pub owner: Option<Node>,
-    /// The source the owner reconciles from.
+    /// The managing owner (or the object itself), and its engine.
+    pub owner: Option<Managed>,
+    /// Flux only: the source the owner reconciles from.
     pub source: Option<Node>,
-    /// `dependsOn` Kustomizations that gate the owner.
+    /// Flux: the `dependsOn` Kustomizations that gate the owner. Argo: the
+    /// AppProject constraining the Application and the ApplicationSet that
+    /// generated it.
     pub deps: Vec<Node>,
 }
 
 // ----- reference extraction (used by the app to know what to fetch) --------
 
-/// The Flux owner named by a managed object's toolkit labels, if any.
-pub fn owner_ref(obj: &DynamicObject) -> Option<FluxRef> {
+/// Argo CD's API group. Its CRD plurals (`applications`, `applicationsets`)
+/// are generic enough that another CRD can own the bare name, so anything
+/// keyed on one of them checks the group too.
+pub const ARGO_GROUP: &str = "argoproj.io";
+
+/// Argo CD's own annotation naming the Application that applied an object.
+const ARGO_TRACKING_ID: &str = "argocd.argoproj.io/tracking-id";
+/// Argo CD's instance label, when `application.instanceLabelKey` is set to it.
+const ARGO_INSTANCE_LABEL: &str = "argocd.argoproj.io/instance";
+/// The default instance label — set by Helm and hand-written manifests too, so
+/// a reference read from it is only [`Owner::inferred`].
+const APP_INSTANCE_LABEL: &str = "app.kubernetes.io/instance";
+
+/// The GitOps owner named by a managed object's stamps: Flux's toolkit labels
+/// first (they are unambiguous), then Argo CD's tracking annotation and
+/// instance labels.
+pub fn owner_ref(obj: &DynamicObject) -> Option<Owner> {
+    flux_owner_ref(obj).or_else(|| argo_owner_ref(obj))
+}
+
+/// The Flux Kustomization/HelmRelease named by an object's toolkit labels.
+pub fn flux_owner_ref(obj: &DynamicObject) -> Option<Owner> {
     let labels = obj.metadata.labels.as_ref()?;
     let get = |k: &str| labels.get(k).cloned();
+    let flux = |kind: &str, name: String, namespace: String| {
+        Some(Owner {
+            engine: Engine::Flux,
+            reference: ObjRef {
+                kind: kind.into(),
+                name,
+                namespace,
+            },
+            inferred: false,
+        })
+    };
     if let Some(name) = get("kustomize.toolkit.fluxcd.io/name") {
-        return Some(FluxRef {
-            kind: "Kustomization".into(),
-            name,
-            namespace: get("kustomize.toolkit.fluxcd.io/namespace").unwrap_or_default(),
-        });
+        let ns = get("kustomize.toolkit.fluxcd.io/namespace").unwrap_or_default();
+        return flux("Kustomization", name, ns);
     }
     if let Some(name) = get("helm.toolkit.fluxcd.io/name") {
-        return Some(FluxRef {
-            kind: "HelmRelease".into(),
-            name,
-            namespace: get("helm.toolkit.fluxcd.io/namespace").unwrap_or_default(),
-        });
+        let ns = get("helm.toolkit.fluxcd.io/namespace").unwrap_or_default();
+        return flux("HelmRelease", name, ns);
     }
     None
 }
 
-/// Whether `plural` is a Flux Kustomization/HelmRelease (an owner kind).
-pub fn is_owner_plural(plural: &str) -> bool {
-    matches!(plural, "kustomizations" | "helmreleases")
+/// The Argo CD Application named by an object's tracking annotation or
+/// instance label.
+///
+/// The tracking annotation is `<instance>:<group>/<Kind>:<ns>/<name>`; both it
+/// and the labels carry the Application's *instance name*, which is
+/// `<namespace>_<name>` for an Application outside the controller's namespace
+/// and a bare name inside it (a bare name leaves the namespace to the caller
+/// to find — Kubernetes names can't contain `_`, so the split is unambiguous).
+pub fn argo_owner_ref(obj: &DynamicObject) -> Option<Owner> {
+    let annotations = obj.metadata.annotations.as_ref();
+    let labels = obj.metadata.labels.as_ref();
+    let tracked = annotations
+        .and_then(|a| a.get(ARGO_TRACKING_ID))
+        .and_then(|v| v.split(':').next())
+        .filter(|s| !s.is_empty());
+    if let Some(instance) = tracked {
+        return Some(argo_owner(instance, false));
+    }
+    if let Some(instance) = labels.and_then(|l| l.get(ARGO_INSTANCE_LABEL)) {
+        return Some(argo_owner(instance, false));
+    }
+    // The generic instance label is a weak signal — Helm sets it to the
+    // release name — so it only counts when the Application turns up.
+    let instance = labels.and_then(|l| l.get(APP_INSTANCE_LABEL))?;
+    Some(argo_owner(instance, true))
+}
+
+fn argo_owner(instance: &str, inferred: bool) -> Owner {
+    let (namespace, name) = match instance.split_once('_') {
+        Some((ns, name)) => (ns.to_string(), name.to_string()),
+        None => (String::new(), instance.to_string()),
+    };
+    Owner {
+        engine: Engine::Argo,
+        reference: ObjRef {
+            kind: "Application".into(),
+            name,
+            namespace,
+        },
+        inferred,
+    }
+}
+
+/// The engine whose owner kind `plural` is, when the selection is itself an
+/// owner. `applications`/`applicationsets` are generic plurals, so the Argo
+/// kinds are only recognized in their own API group.
+pub fn owner_engine(plural: &str, group: &str) -> Option<Engine> {
+    match plural {
+        "kustomizations" | "helmreleases" => Some(Engine::Flux),
+        "applications" | "applicationsets" if group == ARGO_GROUP => Some(Engine::Argo),
+        _ => None,
+    }
 }
 
 /// The source a Kustomization/HelmRelease reconciles from. Kustomizations use
 /// `spec.sourceRef`; HelmRelease v2 GA uses `spec.chartRef`, older ones
 /// `spec.chart.spec.sourceRef` (a HelmChart the controller creates).
-pub fn source_ref(owner: &DynamicObject) -> Option<FluxRef> {
+pub fn source_ref(owner: &DynamicObject) -> Option<ObjRef> {
     let d = &owner.data;
     let owner_ns = owner.metadata.namespace.clone().unwrap_or_default();
-    let from = |v: &Value| -> Option<FluxRef> {
-        Some(FluxRef {
+    let from = |v: &Value| -> Option<ObjRef> {
+        Some(ObjRef {
             kind: v.get("kind").and_then(Value::as_str)?.to_string(),
             name: v.get("name").and_then(Value::as_str)?.to_string(),
             namespace: v
@@ -111,7 +232,7 @@ pub fn source_ref(owner: &DynamicObject) -> Option<FluxRef> {
 
 /// The `dependsOn` Kustomizations gating `owner` (namespace defaults to the
 /// owner's).
-pub fn depends_on(owner: &DynamicObject) -> Vec<FluxRef> {
+pub fn depends_on(owner: &DynamicObject) -> Vec<ObjRef> {
     let owner_ns = owner.metadata.namespace.clone().unwrap_or_default();
     owner
         .data
@@ -120,7 +241,7 @@ pub fn depends_on(owner: &DynamicObject) -> Vec<FluxRef> {
         .map(|deps| {
             deps.iter()
                 .filter_map(|d| {
-                    Some(FluxRef {
+                    Some(ObjRef {
                         kind: "Kustomization".into(),
                         name: d.get("name").and_then(Value::as_str)?.to_string(),
                         namespace: d
@@ -135,16 +256,49 @@ pub fn depends_on(owner: &DynamicObject) -> Vec<FluxRef> {
         .unwrap_or_default()
 }
 
+/// The AppProject an Application (or an ApplicationSet's template) names.
+/// Projects live beside the Application, in the controller's namespace.
+pub fn argo_project_ref(owner: &DynamicObject) -> Option<ObjRef> {
+    let name = str_at(owner, "/spec/project")
+        .or_else(|| str_at(owner, "/spec/template/spec/project"))
+        .filter(|p| !p.is_empty())?;
+    Some(ObjRef {
+        kind: "AppProject".into(),
+        name,
+        namespace: owner.metadata.namespace.clone().unwrap_or_default(),
+    })
+}
+
+/// The ApplicationSet that generated an Application, from its owner reference.
+pub fn argo_parent_ref(owner: &DynamicObject) -> Option<ObjRef> {
+    let parent = owner
+        .metadata
+        .owner_references
+        .as_ref()?
+        .iter()
+        .find(|o| o.kind == "ApplicationSet")?;
+    Some(ObjRef {
+        kind: "ApplicationSet".into(),
+        name: parent.name.clone(),
+        namespace: owner.metadata.namespace.clone().unwrap_or_default(),
+    })
+}
+
 // ----- object state accessors ----------------------------------------------
 
 /// `(status, reason, message)` of the object's `Ready` condition.
 pub fn ready(obj: &DynamicObject) -> Option<(String, String, String)> {
+    condition(obj, "Ready")
+}
+
+/// `(status, reason, message)` of one of the object's conditions.
+fn condition(obj: &DynamicObject, ty: &str) -> Option<(String, String, String)> {
     let cond = obj
         .data
         .pointer("/status/conditions")
         .and_then(Value::as_array)?
         .iter()
-        .find(|c| c.get("type").and_then(Value::as_str) == Some("Ready"))?;
+        .find(|c| c.get("type").and_then(Value::as_str) == Some(ty))?;
     let s = |k: &str| {
         cond.get(k)
             .and_then(Value::as_str)
@@ -178,47 +332,147 @@ fn source_revision(obj: &DynamicObject) -> Option<String> {
     str_at(obj, "/status/artifact/revision")
 }
 
+/// Whether the object is an Argo ApplicationSet rather than an Application.
+fn is_appset(node: &Node) -> bool {
+    node.reference.kind == "ApplicationSet"
+}
+
+/// Argo sync state: `(status, revision)` — `Synced`/`OutOfSync`/`Unknown`.
+fn argo_sync(obj: &DynamicObject) -> (String, String) {
+    (
+        str_at(obj, "/status/sync/status").unwrap_or_else(|| "Unknown".into()),
+        str_at(obj, "/status/sync/revision").unwrap_or_default(),
+    )
+}
+
+/// Argo health state: `(status, message)` — `Healthy`/`Degraded`/`Missing`/…
+fn argo_health(obj: &DynamicObject) -> (String, String) {
+    (
+        str_at(obj, "/status/health/status").unwrap_or_else(|| "Unknown".into()),
+        str_at(obj, "/status/health/message").unwrap_or_default(),
+    )
+}
+
+/// The last sync operation's `(phase, message)`, when one has run.
+fn argo_operation(obj: &DynamicObject) -> Option<(String, String)> {
+    let phase = str_at(obj, "/status/operationState/phase")?;
+    let msg = str_at(obj, "/status/operationState/message").unwrap_or_default();
+    Some((phase, msg))
+}
+
+/// Whether the Application syncs itself (`spec.syncPolicy.automated`). Sofka's
+/// own suspend removes that block, so a manual Application is one nothing will
+/// reconcile until someone syncs it.
+fn argo_automated(obj: &DynamicObject) -> bool {
+    obj.data.pointer("/spec/syncPolicy/automated").is_some()
+}
+
+/// `(out-of-sync, total)` resources the Application last reported.
+fn argo_resource_drift(obj: &DynamicObject) -> (usize, usize) {
+    let Some(resources) = obj
+        .data
+        .pointer("/status/resources")
+        .and_then(Value::as_array)
+    else {
+        return (0, 0);
+    };
+    let drifted = resources
+        .iter()
+        .filter(|r| {
+            r.get("status")
+                .and_then(Value::as_str)
+                .is_some_and(|s| s != "Synced")
+        })
+        .count();
+    (drifted, resources.len())
+}
+
+/// One line per Argo source: the repo, the revision asked for, and the path or
+/// chart inside it. Reads an Application's `spec.source`/`spec.sources` or an
+/// ApplicationSet's `spec.template.spec` equivalents.
+pub fn argo_sources(obj: &DynamicObject) -> Vec<String> {
+    let d = &obj.data;
+    let mut out = Vec::new();
+    for base in ["/spec", "/spec/template/spec"] {
+        if let Some(list) = d
+            .pointer(&format!("{base}/sources"))
+            .and_then(Value::as_array)
+        {
+            out.extend(list.iter().filter_map(argo_source_line));
+        }
+        if let Some(line) = d
+            .pointer(&format!("{base}/source"))
+            .and_then(argo_source_line)
+        {
+            out.push(line);
+        }
+        if !out.is_empty() {
+            break;
+        }
+    }
+    out
+}
+
+fn argo_source_line(src: &Value) -> Option<String> {
+    let s = |k: &str| src.get(k).and_then(Value::as_str).unwrap_or_default();
+    let repo = s("repoURL");
+    if repo.is_empty() {
+        return None;
+    }
+    let mut line = repo.to_string();
+    let rev = s("targetRevision");
+    if !rev.is_empty() {
+        line.push_str(&format!(" @ {rev}"));
+    }
+    let inner = match (s("chart"), s("path")) {
+        ("", "") | ("", ".") => String::new(),
+        ("", path) => format!(" ({path})"),
+        (chart, _) => format!(" (chart {chart})"),
+    };
+    line.push_str(&inner);
+    Some(line)
+}
+
 // ----- findings -------------------------------------------------------------
 
 /// Render the reconciliation chain into ranked findings with jump targets.
 pub fn describe(ev: &Evidence) -> Vec<Finding> {
-    let mut out = Vec::new();
+    // An owner only guessed at from `app.kubernetes.io/instance` and not
+    // actually in the cluster was never an owner — Helm sets that label too.
+    let owner = match &ev.owner {
+        Some(o) if !(o.inferred && o.node.obj.is_none()) => o,
+        _ => return unmanaged(ev),
+    };
+    match owner.engine {
+        Engine::Flux => describe_flux(ev, owner),
+        Engine::Argo => describe_argo(ev, owner),
+    }
+}
 
-    let Some(owner) = &ev.owner else {
-        out.push(finding(
+fn unmanaged(ev: &Evidence) -> Vec<Finding> {
+    vec![
+        finding(
             0,
             Level::Info,
-            format!("{} is not managed by Flux", ev.subject),
-        ));
-        out.push(finding(
+            format!("{} is not managed by Flux or Argo CD", ev.subject),
+        ),
+        finding(
             1,
             Level::Info,
-            "no kustomize/helm toolkit labels found",
-        ));
-        return out;
-    };
+            "no Flux toolkit labels and no Argo CD tracking stamp found",
+        ),
+    ]
+}
 
-    // Headline.
-    if ev.self_is_owner {
-        out.push(finding(
-            0,
-            owner_health_level(owner),
-            format!("{} — Flux {}", ev.subject, owner.reference.kind),
-        ));
-    } else {
-        out.push(finding(
-            0,
-            owner_health_level(owner),
-            format!(
-                "{} is managed by {}/{}",
-                ev.subject, owner.reference.kind, owner.reference.name
-            ),
-        ));
-    }
+fn describe_flux(ev: &Evidence, owner: &Managed) -> Vec<Finding> {
+    let mut out = Vec::new();
+    let node = &owner.node;
+
+    out.push(headline(ev, owner));
 
     // Owner block.
     out.push(finding(0, Level::Heading, "Owner"));
-    push_flux_object(&mut out, owner, ev.self_is_owner);
+    push_flux_object(&mut out, node, ev.self_is_owner);
 
     // Source block.
     out.push(finding(0, Level::Heading, "Source"));
@@ -250,15 +504,89 @@ pub fn describe(ev: &Evidence) -> Vec<Finding> {
 
     // Reconciliation summary: what, if anything, is blocking.
     out.push(finding(0, Level::Heading, "Reconciliation"));
-    for line in reconciliation_summary(ev, owner) {
+    for line in flux_reconciliation_summary(ev, node) {
         out.push(finding(1, line.0, line.1));
     }
 
     out
 }
 
-/// The owner's health, for the headline and its own line.
-fn owner_health_level(owner: &Node) -> Level {
+fn describe_argo(ev: &Evidence, owner: &Managed) -> Vec<Finding> {
+    let mut out = Vec::new();
+    let node = &owner.node;
+
+    out.push(headline(ev, owner));
+
+    // Owner block.
+    out.push(finding(0, Level::Heading, "Owner"));
+    push_argo_object(&mut out, node, ev.self_is_owner);
+
+    // Sources are fields on the Application, not objects of their own.
+    out.push(finding(0, Level::Heading, "Source"));
+    let sources = node.obj.as_ref().map(argo_sources).unwrap_or_default();
+    if sources.is_empty() {
+        out.push(finding(1, Level::Info, "no source resolved"));
+    } else {
+        for line in sources {
+            out.push(finding(1, Level::Info, short(&line)));
+        }
+    }
+
+    // The AppProject constraining it and the ApplicationSet that generated it.
+    if !ev.deps.is_empty() {
+        out.push(finding(0, Level::Heading, "Related"));
+        for dep in &ev.deps {
+            let mut f = finding(1, related_level(dep), related_line(dep));
+            if let Some(t) = dep.target() {
+                f = f.with_target(t);
+            }
+            out.push(f);
+        }
+    }
+
+    out.push(finding(0, Level::Heading, "Reconciliation"));
+    for (level, text) in argo_reconciliation_summary(node) {
+        out.push(finding(1, level, text));
+    }
+
+    out
+}
+
+/// The first line: what the subject is, or who manages it.
+fn headline(ev: &Evidence, owner: &Managed) -> Finding {
+    let node = &owner.node;
+    let level = match owner.engine {
+        Engine::Flux => flux_owner_level(node),
+        Engine::Argo => argo_owner_level(node),
+    };
+    if ev.self_is_owner {
+        finding(
+            0,
+            level,
+            format!(
+                "{} — {} {}",
+                ev.subject,
+                owner.engine.label(),
+                node.reference.kind
+            ),
+        )
+    } else {
+        finding(
+            0,
+            level,
+            format!(
+                "{} is managed by {} {}/{}",
+                ev.subject,
+                owner.engine.label(),
+                node.reference.kind,
+                node.reference.name
+            ),
+        )
+    }
+}
+
+/// The Flux owner's health, for the headline and its own line.
+fn flux_owner_level(owner: &Node) -> Level {
     match owner.obj.as_ref() {
         None => Level::Warn,
         Some(o) if suspended(o) => Level::Warn,
@@ -270,18 +598,34 @@ fn owner_health_level(owner: &Node) -> Level {
     }
 }
 
-/// Append the owner's own detail lines (state, suspend, revisions).
-fn push_flux_object(out: &mut Vec<Finding>, owner: &Node, self_is_owner: bool) {
-    // The owner's identity line (with a jump target unless it's the selection).
-    let mut head = finding(
-        1,
-        owner_health_level(owner),
-        format!("{}/{}", owner.reference.kind, owner.reference.name),
-    );
-    if !self_is_owner && let Some(t) = owner.target() {
-        head = head.with_target(t);
+/// The Argo owner's health: degraded/missing health or a failed sync is
+/// critical, drift or a manual sync policy is a warning.
+fn argo_owner_level(owner: &Node) -> Level {
+    let Some(o) = owner.obj.as_ref() else {
+        return Level::Warn;
+    };
+    if is_appset(owner) {
+        return match condition(o, "ErrorOccurred") {
+            Some((s, _, _)) if s == "True" => Level::Critical,
+            _ => Level::Good,
+        };
     }
-    out.push(head);
+    let (sync, _) = argo_sync(o);
+    match argo_health(o).0.as_str() {
+        "Degraded" | "Missing" => Level::Critical,
+        "Progressing" | "Suspended" | "Unknown" => Level::Warn,
+        _ if sync != "Synced" => Level::Warn,
+        _ => Level::Good,
+    }
+}
+
+/// Append the Flux owner's own detail lines (state, suspend, revisions).
+fn push_flux_object(out: &mut Vec<Finding>, owner: &Node, self_is_owner: bool) {
+    out.push(owner_identity(
+        owner,
+        self_is_owner,
+        flux_owner_level(owner),
+    ));
 
     let Some(o) = owner.obj.as_ref() else {
         out.push(finding(2, Level::Warn, "owner not found in cluster"));
@@ -323,6 +667,118 @@ fn push_flux_object(out: &mut Vec<Finding>, owner: &Node, self_is_owner: bool) {
     }
 }
 
+/// Append the Argo owner's own detail lines (sync, health, revision, policy).
+fn push_argo_object(out: &mut Vec<Finding>, owner: &Node, self_is_owner: bool) {
+    out.push(owner_identity(
+        owner,
+        self_is_owner,
+        argo_owner_level(owner),
+    ));
+
+    let Some(o) = owner.obj.as_ref() else {
+        out.push(finding(2, Level::Warn, "owner not found in cluster"));
+        return;
+    };
+    if is_appset(owner) {
+        push_appset_conditions(out, o);
+        return;
+    }
+    let (sync, revision) = argo_sync(o);
+    out.push(finding(
+        2,
+        match sync.as_str() {
+            "Synced" => Level::Good,
+            "OutOfSync" => Level::Warn,
+            _ => Level::Info,
+        },
+        format!("Sync: {sync}"),
+    ));
+    let (health, health_msg) = argo_health(o);
+    out.push(finding(
+        2,
+        argo_health_level(&health),
+        format!("Health: {}", join(&health, "", &health_msg)),
+    ));
+    if !revision.is_empty() {
+        out.push(finding(
+            2,
+            Level::Info,
+            format!("synced revision {}", short_rev(&revision)),
+        ));
+    }
+    let (policy_level, policy) = if argo_automated(o) {
+        (Level::Info, "sync policy: automated")
+    } else {
+        (Level::Warn, "sync policy: manual (no automated sync)")
+    };
+    out.push(finding(2, policy_level, policy));
+    if let Some((phase, msg)) = argo_operation(o)
+        && phase != "Succeeded"
+    {
+        out.push(finding(
+            2,
+            argo_phase_level(&phase),
+            format!("last sync {}", join(&phase, "", &msg)),
+        ));
+    }
+}
+
+/// An ApplicationSet has no sync/health — it reports on generating its
+/// Applications through conditions instead.
+fn push_appset_conditions(out: &mut Vec<Finding>, o: &DynamicObject) {
+    let mut reported = false;
+    for ty in ["ErrorOccurred", "ParametersGenerated", "ResourcesUpToDate"] {
+        let Some((status, reason, msg)) = condition(o, ty) else {
+            continue;
+        };
+        reported = true;
+        // ErrorOccurred inverts: True is the bad one.
+        let bad = if ty == "ErrorOccurred" {
+            status == "True"
+        } else {
+            status != "True"
+        };
+        let level = if bad { Level::Critical } else { Level::Good };
+        out.push(finding(
+            2,
+            level,
+            format!("{ty}: {}", join(&status, &reason, &msg)),
+        ));
+    }
+    if !reported {
+        out.push(finding(2, Level::Warn, "no conditions reported yet"));
+    }
+}
+
+/// The owner's identity line, with a jump target unless it's the selection.
+fn owner_identity(owner: &Node, self_is_owner: bool, level: Level) -> Finding {
+    let mut head = finding(
+        1,
+        level,
+        format!("{}/{}", owner.reference.kind, owner.reference.name),
+    );
+    if !self_is_owner && let Some(t) = owner.target() {
+        head = head.with_target(t);
+    }
+    head
+}
+
+fn argo_health_level(health: &str) -> Level {
+    match health {
+        "Healthy" => Level::Good,
+        "Degraded" | "Missing" => Level::Critical,
+        _ => Level::Warn,
+    }
+}
+
+fn argo_phase_level(phase: &str) -> Level {
+    match phase {
+        "Succeeded" => Level::Good,
+        "Failed" | "Error" => Level::Critical,
+        _ => Level::Warn,
+    }
+}
+
 fn source_level(src: &Node) -> Level {
     match src.obj.as_ref().and_then(ready) {
         Some((s, _, _)) if s == "True" => Level::Good,
@@ -357,8 +813,27 @@ fn dep_line(dep: &Node) -> String {
     format!("{} — {state}", dep.reference.name)
 }
 
-/// What's blocking reconciliation, or that it's healthy.
-fn reconciliation_summary(ev: &Evidence, owner: &Node) -> Vec<(Level, String)> {
+/// Argo's related objects (AppProject, ApplicationSet) carry no Ready
+/// condition — the only thing to report is whether they exist.
+fn related_level(dep: &Node) -> Level {
+    if dep.obj.is_some() {
+        Level::Info
+    } else {
+        Level::Warn
+    }
+}
+
+fn related_line(dep: &Node) -> String {
+    let suffix = if dep.obj.is_some() {
+        ""
+    } else {
+        " (not found)"
+    };
+    format!("{}/{}{suffix}", dep.reference.kind, dep.reference.name)
+}
+
+/// What's blocking Flux reconciliation, or that it's healthy.
+fn flux_reconciliation_summary(ev: &Evidence, owner: &Node) -> Vec<(Level, String)> {
     let mut out = Vec::new();
     if let Some(o) = owner.obj.as_ref()
         && suspended(o)
@@ -401,6 +876,60 @@ fn reconciliation_summary(ev: &Evidence, owner: &Node) -> Vec<(Level, String)> {
     out
 }
 
+/// What's blocking the Argo Application, or that it's synced and healthy.
+fn argo_reconciliation_summary(owner: &Node) -> Vec<(Level, String)> {
+    let Some(o) = owner.obj.as_ref() else {
+        return vec![(Level::Warn, "owner not found — cannot say".into())];
+    };
+    if is_appset(owner) {
+        return match condition(o, "ErrorOccurred") {
+            Some((s, reason, msg)) if s == "True" => {
+                vec![(Level::Critical, join("generation failed", &reason, &msg))]
+            }
+            _ => vec![(Level::Good, "generating applications".into())],
+        };
+    }
+
+    let mut out = Vec::new();
+    if !argo_automated(o) {
+        out.push((
+            Level::Warn,
+            "sync policy is manual — nothing will reconcile drift".into(),
+        ));
+    }
+    let (sync, revision) = argo_sync(o);
+    if sync != "Synced" {
+        let (drifted, total) = argo_resource_drift(o);
+        let detail = if total > 0 {
+            format!(" — {drifted} of {total} resources differ")
+        } else {
+            String::new()
+        };
+        out.push((Level::Warn, format!("{sync} with the source{detail}")));
+    }
+    let (health, health_msg) = argo_health(o);
+    if health != "Healthy" {
+        out.push((
+            argo_health_level(&health),
+            join(&format!("health is {health}"), "", &health_msg),
+        ));
+    }
+    if let Some((phase, msg)) = argo_operation(o)
+        && matches!(phase.as_str(), "Failed" | "Error")
+    {
+        out.push((Level::Critical, join("last sync failed", "", &msg)));
+    }
+    if out.is_empty() {
+        let rev = if revision.is_empty() {
+            String::new()
+        } else {
+            format!(" at {}", short_rev(&revision))
+        };
+        out.push((Level::Good, format!("synced and healthy{rev}")));
+    }
+    out
+}
+
 fn is_ready(node: &Node) -> bool {
     matches!(node.obj.as_ref().and_then(ready), Some((s, _, _)) if s == "True")
 }
@@ -431,6 +960,16 @@ fn short(s: &str) -> String {
     crate::text::ellipsize(s.trim(), 80)
 }
 
+/// Argo records the full 40-character commit SHA; show it the way git does.
+/// Anything else (a chart version, a branch) is left alone.
+fn short_rev(s: &str) -> String {
+    let s = s.trim();
+    if s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        return s[..7].to_string();
+    }
+    short(s)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -440,16 +979,32 @@ mod tests {
         serde_json::from_value(v).unwrap()
     }
 
-    fn node(kind: &str, name: &str, plural: &str, o: Option<Value>) -> Node {
+    fn node(kind: &str, name: &str, plural: &str, ns: &str, o: Option<Value>) -> Node {
         Node {
-            reference: FluxRef {
+            reference: ObjRef {
                 kind: kind.into(),
                 name: name.into(),
-                namespace: "flux-system".into(),
+                namespace: ns.into(),
             },
             plural: plural.into(),
             obj: o.map(obj),
         }
+    }
+
+    fn managed(engine: Engine, node: Node) -> Managed {
+        Managed {
+            engine,
+            node,
+            inferred: false,
+        }
+    }
+
+    fn lines(findings: &[Finding]) -> String {
+        findings
+            .iter()
+            .map(|f| f.text.clone())
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     #[test]
@@ -460,20 +1015,82 @@ mod tests {
                 "kustomize.toolkit.fluxcd.io/name":"apps",
                 "kustomize.toolkit.fluxcd.io/namespace":"flux-system"}}
         }));
-        let r = owner_ref(&d).unwrap();
-        assert_eq!(r.kind, "Kustomization");
-        assert_eq!(r.name, "apps");
-        assert_eq!(r.namespace, "flux-system");
+        let o = owner_ref(&d).unwrap();
+        assert_eq!(o.engine, Engine::Flux);
+        assert_eq!(o.reference.kind, "Kustomization");
+        assert_eq!(o.reference.name, "apps");
+        assert_eq!(o.reference.namespace, "flux-system");
 
         let helm = obj(json!({
             "apiVersion":"v1","kind":"ConfigMap",
             "metadata":{"name":"c","labels":{"helm.toolkit.fluxcd.io/name":"podinfo",
                 "helm.toolkit.fluxcd.io/namespace":"default"}}
         }));
-        assert_eq!(owner_ref(&helm).unwrap().kind, "HelmRelease");
+        assert_eq!(owner_ref(&helm).unwrap().reference.kind, "HelmRelease");
 
         // No labels → not managed.
         assert!(owner_ref(&obj(json!({"metadata":{"name":"x"}}))).is_none());
+    }
+
+    #[test]
+    fn argo_owner_ref_prefers_the_tracking_annotation() {
+        // The annotation wins over both labels, and carries the app name in
+        // its first field.
+        let d = obj(json!({
+            "apiVersion":"apps/v1","kind":"Deployment",
+            "metadata":{"name":"api","namespace":"prod",
+                "annotations":{"argocd.argoproj.io/tracking-id":
+                    "api:apps/Deployment:prod/api"},
+                "labels":{"app.kubernetes.io/instance":"something-else"}}
+        }));
+        let o = owner_ref(&d).unwrap();
+        assert_eq!(o.engine, Engine::Argo);
+        assert_eq!(o.reference.kind, "Application");
+        assert_eq!(o.reference.name, "api");
+        // No namespace in the stamp — the app layer searches for it.
+        assert_eq!(o.reference.namespace, "");
+        assert!(!o.inferred);
+
+        // An app outside the controller's namespace is stamped `<ns>_<name>`.
+        let elsewhere = obj(json!({
+            "metadata":{"name":"api","labels":{
+                "argocd.argoproj.io/instance":"team-a_api"}}
+        }));
+        let o = owner_ref(&elsewhere).unwrap();
+        assert_eq!(o.reference.namespace, "team-a");
+        assert_eq!(o.reference.name, "api");
+        assert!(!o.inferred);
+
+        // The generic label is only a guess — Helm sets it too.
+        let weak = obj(json!({
+            "metadata":{"name":"api","labels":{"app.kubernetes.io/instance":"api"}}
+        }));
+        assert!(owner_ref(&weak).unwrap().inferred);
+    }
+
+    #[test]
+    fn flux_labels_win_over_an_argo_instance_label() {
+        // Flux applying a chart that sets `app.kubernetes.io/instance` must
+        // not read as Argo-managed.
+        let d = obj(json!({
+            "metadata":{"name":"api","labels":{
+                "helm.toolkit.fluxcd.io/name":"podinfo",
+                "app.kubernetes.io/instance":"podinfo"}}
+        }));
+        let o = owner_ref(&d).unwrap();
+        assert_eq!(o.engine, Engine::Flux);
+    }
+
+    #[test]
+    fn owner_kinds_are_group_checked_for_argo() {
+        assert_eq!(owner_engine("kustomizations", ""), Some(Engine::Flux));
+        assert_eq!(
+            owner_engine("applications", "argoproj.io"),
+            Some(Engine::Argo)
+        );
+        // Some other CRD that happens to be called `applications`.
+        assert_eq!(owner_engine("applications", "app.k8s.io"), None);
+        assert_eq!(owner_engine("pods", ""), None);
     }
 
     #[test]
@@ -497,6 +1114,48 @@ mod tests {
     }
 
     #[test]
+    fn extracts_argo_project_parent_and_sources() {
+        let app = obj(json!({
+            "apiVersion":"argoproj.io/v1alpha1","kind":"Application",
+            "metadata":{"name":"api","namespace":"argocd","ownerReferences":[
+                {"apiVersion":"argoproj.io/v1alpha1","kind":"ApplicationSet",
+                 "name":"prod-apps","uid":"1"}]},
+            "spec":{"project":"prod",
+                "sources":[
+                    {"repoURL":"https://github.com/acme/gitops","path":"apps/api",
+                     "targetRevision":"main"},
+                    {"repoURL":"https://charts.acme.io","chart":"redis",
+                     "targetRevision":"18.1.2"}]}
+        }));
+        let project = argo_project_ref(&app).unwrap();
+        assert_eq!(project.kind, "AppProject");
+        assert_eq!(project.name, "prod");
+        assert_eq!(project.namespace, "argocd");
+        let parent = argo_parent_ref(&app).unwrap();
+        assert_eq!(parent.name, "prod-apps");
+        assert_eq!(
+            argo_sources(&app),
+            vec![
+                "https://github.com/acme/gitops @ main (apps/api)".to_string(),
+                "https://charts.acme.io @ 18.1.2 (chart redis)".to_string(),
+            ]
+        );
+
+        // An ApplicationSet keeps all of that under its template.
+        let appset = obj(json!({
+            "apiVersion":"argoproj.io/v1alpha1","kind":"ApplicationSet",
+            "metadata":{"name":"prod-apps","namespace":"argocd"},
+            "spec":{"template":{"spec":{"project":"prod",
+                "source":{"repoURL":"https://github.com/acme/gitops","path":"apps"}}}}
+        }));
+        assert_eq!(argo_project_ref(&appset).unwrap().name, "prod");
+        assert_eq!(
+            argo_sources(&appset),
+            vec!["https://github.com/acme/gitops (apps)".to_string()]
+        );
+    }
+
+    #[test]
     fn unmanaged_object_says_so() {
         let ev = Evidence {
             subject: "Deployment/api".into(),
@@ -506,7 +1165,25 @@ mod tests {
             deps: vec![],
         };
         let f = describe(&ev);
-        assert!(f[0].text.contains("not managed by Flux"));
+        assert!(f[0].text.contains("not managed by Flux or Argo CD"));
+    }
+
+    #[test]
+    fn an_inferred_owner_that_is_not_there_reads_as_unmanaged() {
+        // `app.kubernetes.io/instance` on a Helm-installed object names no
+        // Application — saying "owner not found" would be a false alarm.
+        let ev = Evidence {
+            subject: "Deployment/api".into(),
+            self_is_owner: false,
+            owner: Some(Managed {
+                engine: Engine::Argo,
+                node: node("Application", "api", "applications", "", None),
+                inferred: true,
+            }),
+            source: None,
+            deps: vec![],
+        };
+        assert!(describe(&ev)[0].text.contains("not managed by"));
     }
 
     #[test]
@@ -515,6 +1192,7 @@ mod tests {
             "Kustomization",
             "apps",
             "kustomizations",
+            "flux-system",
             Some(json!({
                 "metadata":{"name":"apps","namespace":"flux-system"},
                 "status":{"lastAppliedRevision":"main@sha1:abcdef",
@@ -525,6 +1203,7 @@ mod tests {
             "GitRepository",
             "flux-system",
             "gitrepositories",
+            "flux-system",
             Some(json!({
                 "metadata":{"name":"flux-system","namespace":"flux-system"},
                 "status":{"artifact":{"revision":"main@sha1:abcdef"},
@@ -534,14 +1213,16 @@ mod tests {
         let ev = Evidence {
             subject: "Deployment/api".into(),
             self_is_owner: false,
-            owner: Some(owner),
+            owner: Some(managed(Engine::Flux, owner)),
             source: Some(source),
             deps: vec![],
         };
         let f = describe(&ev);
-        let all: Vec<&str> = f.iter().map(|x| x.text.as_str()).collect();
-        let joined = all.join("\n");
-        assert!(joined.contains("managed by Kustomization/apps"), "{joined}");
+        let joined = lines(&f);
+        assert!(
+            joined.contains("managed by Flux Kustomization/apps"),
+            "{joined}"
+        );
         assert!(
             joined.contains("applied revision main@sha1:abcdef"),
             "{joined}"
@@ -558,6 +1239,7 @@ mod tests {
             "Kustomization",
             "apps",
             "kustomizations",
+            "flux-system",
             Some(json!({
                 "metadata":{"name":"apps","namespace":"flux-system"},
                 "status":{"conditions":[{"type":"Ready","status":"False","reason":"DependencyNotReady"}]}
@@ -567,6 +1249,7 @@ mod tests {
             "GitRepository",
             "flux-system",
             "gitrepositories",
+            "flux-system",
             Some(json!({
                 "metadata":{"name":"flux-system"},
                 "status":{"conditions":[{"type":"Ready","status":"False","reason":"GitOperationFailed"}]}
@@ -576,6 +1259,7 @@ mod tests {
             "Kustomization",
             "infra",
             "kustomizations",
+            "flux-system",
             Some(json!({
                 "metadata":{"name":"infra"},
                 "status":{"conditions":[{"type":"Ready","status":"False"}]}
@@ -584,16 +1268,11 @@ mod tests {
         let ev = Evidence {
             subject: "Kustomization/apps".into(),
             self_is_owner: true,
-            owner: Some(owner),
+            owner: Some(managed(Engine::Flux, owner)),
             source: Some(source),
             deps: vec![dep],
         };
-        let f = describe(&ev);
-        let joined: String = f
-            .iter()
-            .map(|x| x.text.clone())
-            .collect::<Vec<_>>()
-            .join("\n");
+        let joined = lines(&describe(&ev));
         assert!(
             joined.contains("blocked: source flux-system is not ready"),
             "{joined}"
@@ -607,6 +1286,7 @@ mod tests {
             "Kustomization",
             "apps",
             "kustomizations",
+            "flux-system",
             Some(json!({
                 "metadata":{"name":"apps"},
                 "spec":{"suspend":true},
@@ -616,15 +1296,196 @@ mod tests {
         let ev = Evidence {
             subject: "Kustomization/apps".into(),
             self_is_owner: true,
-            owner: Some(owner),
+            owner: Some(managed(Engine::Flux, owner)),
             source: None,
             deps: vec![],
         };
-        let joined: String = describe(&ev)
-            .iter()
-            .map(|x| x.text.clone())
-            .collect::<Vec<_>>()
-            .join("\n");
+        let joined = lines(&describe(&ev));
         assert!(joined.contains("suspended"), "{joined}");
+    }
+
+    fn argo_app(status: Value) -> Value {
+        json!({
+            "apiVersion":"argoproj.io/v1alpha1","kind":"Application",
+            "metadata":{"name":"api","namespace":"argocd"},
+            "spec":{"project":"prod",
+                "syncPolicy":{"automated":{"prune":true,"selfHeal":true}},
+                "source":{"repoURL":"https://github.com/acme/gitops","path":"apps/api",
+                    "targetRevision":"main"}},
+            "status": status
+        })
+    }
+
+    #[test]
+    fn argo_chain_reports_synced_and_healthy_with_targets() {
+        let owner = node(
+            "Application",
+            "api",
+            "applications",
+            "argocd",
+            Some(argo_app(json!({
+                "sync":{"status":"Synced",
+                    "revision":"0123456789abcdef0123456789abcdef01234567"},
+                "health":{"status":"Healthy"},
+                "operationState":{"phase":"Succeeded"}
+            }))),
+        );
+        let project = node(
+            "AppProject",
+            "prod",
+            "appprojects",
+            "argocd",
+            Some(json!({"metadata":{"name":"prod"}})),
+        );
+        let ev = Evidence {
+            subject: "Deployment/api".into(),
+            self_is_owner: false,
+            owner: Some(managed(Engine::Argo, owner)),
+            source: None,
+            deps: vec![project],
+        };
+        let f = describe(&ev);
+        let joined = lines(&f);
+        assert!(
+            joined.contains("managed by Argo CD Application/api"),
+            "{joined}"
+        );
+        assert!(joined.contains("Sync: Synced"), "{joined}");
+        assert!(joined.contains("Health: Healthy"), "{joined}");
+        // The 40-char SHA is abbreviated the way git shows it.
+        assert!(joined.contains("synced revision 0123456"), "{joined}");
+        assert!(joined.contains("sync policy: automated"), "{joined}");
+        assert!(
+            joined.contains("https://github.com/acme/gitops @ main (apps/api)"),
+            "{joined}"
+        );
+        assert!(joined.contains("synced and healthy at 0123456"), "{joined}");
+        // Both the Application and its project are jumpable.
+        let app_line = f.iter().find(|x| x.text == "Application/api").unwrap();
+        assert_eq!(app_line.target.as_ref().unwrap().plural, "applications");
+        let project_line = f.iter().find(|x| x.text == "AppProject/prod").unwrap();
+        assert_eq!(project_line.target.as_ref().unwrap().plural, "appprojects");
+    }
+
+    #[test]
+    fn argo_drift_degraded_health_and_failed_sync_are_flagged() {
+        let owner = node(
+            "Application",
+            "api",
+            "applications",
+            "argocd",
+            Some(argo_app(json!({
+                "sync":{"status":"OutOfSync","revision":"main"},
+                "health":{"status":"Degraded","message":"pod api-0 is in CrashLoopBackOff"},
+                "operationState":{"phase":"Failed","message":"one or more objects failed"},
+                "resources":[
+                    {"kind":"Deployment","name":"api","status":"OutOfSync"},
+                    {"kind":"Service","name":"api","status":"Synced"},
+                    {"kind":"ConfigMap","name":"api","status":"Synced"}]
+            }))),
+        );
+        let ev = Evidence {
+            subject: "Application/api".into(),
+            self_is_owner: true,
+            owner: Some(managed(Engine::Argo, owner)),
+            source: None,
+            deps: vec![],
+        };
+        let f = describe(&ev);
+        let joined = lines(&f);
+        assert!(
+            joined.contains("Application/api — Argo CD Application"),
+            "{joined}"
+        );
+        assert!(
+            joined.contains("OutOfSync with the source — 1 of 3 resources differ"),
+            "{joined}"
+        );
+        assert!(
+            joined.contains("health is Degraded — pod api-0 is in CrashLoopBackOff"),
+            "{joined}"
+        );
+        assert!(
+            joined.contains("last sync failed — one or more objects failed"),
+            "{joined}"
+        );
+        // The headline reads critical, not merely "not ready".
+        assert_eq!(f[0].level, Level::Critical);
+    }
+
+    #[test]
+    fn argo_manual_sync_policy_is_flagged() {
+        // What sofka's own `t` → Suspend leaves behind: no automation.
+        let mut app = argo_app(json!({
+            "sync":{"status":"OutOfSync"},"health":{"status":"Healthy"}
+        }));
+        app["spec"].as_object_mut().unwrap().remove("syncPolicy");
+        let owner = node("Application", "api", "applications", "argocd", Some(app));
+        let ev = Evidence {
+            subject: "Application/api".into(),
+            self_is_owner: true,
+            owner: Some(managed(Engine::Argo, owner)),
+            source: None,
+            deps: vec![],
+        };
+        let joined = lines(&describe(&ev));
+        assert!(
+            joined.contains("sync policy: manual (no automated sync)"),
+            "{joined}"
+        );
+        assert!(
+            joined.contains("sync policy is manual — nothing will reconcile drift"),
+            "{joined}"
+        );
+    }
+
+    #[test]
+    fn argo_applicationset_reports_its_conditions() {
+        let owner = node(
+            "ApplicationSet",
+            "prod-apps",
+            "applicationsets",
+            "argocd",
+            Some(json!({
+                "apiVersion":"argoproj.io/v1alpha1","kind":"ApplicationSet",
+                "metadata":{"name":"prod-apps","namespace":"argocd"},
+                "spec":{"template":{"spec":{"project":"prod"}}},
+                "status":{"conditions":[
+                    {"type":"ErrorOccurred","status":"True","reason":"ApplicationGenerationFromParamsError",
+                     "message":"error generating params"},
+                    {"type":"ResourcesUpToDate","status":"False"}]}
+            })),
+        );
+        let ev = Evidence {
+            subject: "ApplicationSet/prod-apps".into(),
+            self_is_owner: true,
+            owner: Some(managed(Engine::Argo, owner)),
+            source: None,
+            deps: vec![],
+        };
+        let f = describe(&ev);
+        let joined = lines(&f);
+        assert!(
+            joined.contains("ErrorOccurred: True (ApplicationGenerationFromParamsError)"),
+            "{joined}"
+        );
+        assert!(joined.contains("generation failed"), "{joined}");
+        assert_eq!(f[0].level, Level::Critical);
+    }
+
+    #[test]
+    fn a_missing_argo_owner_is_reported_not_swallowed() {
+        let ev = Evidence {
+            subject: "Deployment/api".into(),
+            self_is_owner: false,
+            owner: Some(managed(
+                Engine::Argo,
+                node("Application", "api", "applications", "argocd", None),
+            )),
+            source: None,
+            deps: vec![],
+        };
+        let joined = lines(&describe(&ev));
+        assert!(joined.contains("owner not found in cluster"), "{joined}");
     }
 }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -589,6 +589,10 @@ pub const ALIASES: &[(&str, &str)] = &[
     // Flux CD — the CRDs' own `shortNames`.
     ("ks", "kustomizations"),
     ("hr", "helmreleases"),
+    // Argo CD — the CRDs' own `shortNames`.
+    ("app", "applications"),
+    ("appset", "applicationsets"),
+    ("appproj", "appprojects"),
 ];
 
 #[cfg(any(test, feature = "bench"))]
@@ -658,9 +662,11 @@ impl Cluster {
         // A CRD whose plural collides with the `:snapshots` built-in command,
         // for palette-priority tests (CRD names outrank built-ins).
         cluster.register_kind("kopiur.home-operations.com", "Snapshot", "snapshots", true);
-        // ArgoCD CRDs, for the `t` suspend/resume/sync menu.
+        // ArgoCD CRDs, for the `t` suspend/resume/sync menu and the GitOps
+        // view's Application chain.
         cluster.register_kind("argoproj.io", "Application", "applications", true);
         cluster.register_kind("argoproj.io", "ApplicationSet", "applicationsets", true);
+        cluster.register_kind("argoproj.io", "AppProject", "appprojects", true);
         // A second `events` kind, reachable only by its qualified name — the
         // bare plural stays with core, as `discover` would leave it.
         let events_k8s_io = Kind {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -515,18 +515,24 @@ pub fn accent() -> Style {
 /// against the row tint.
 pub fn status_color(s: &str) -> Color {
     match s {
-        "Running" | "Ready" | "Active" | "Bound" | "True" | "deployed" => green(),
+        // Argo CD's Healthy/Synced read like Running: the app is where it
+        // should be.
+        "Running" | "Ready" | "Active" | "Bound" | "True" | "deployed" | "Healthy" | "Synced" => {
+            green()
+        }
         // Faded, not "healthy green" — a finished pod isn't running, and a
         // scaled-to-zero workload isn't serving.
-        "Succeeded" | "Completed" | "superseded" | "uninstalled" | "ScaledDown" => overlay0(),
+        "Succeeded" | "Completed" | "superseded" | "uninstalled" | "ScaledDown" | "Suspended" => {
+            overlay0()
+        }
         "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" | "pending-install"
-        | "pending-upgrade" | "pending-rollback" => yellow(),
+        | "pending-upgrade" | "pending-rollback" | "OutOfSync" => yellow(),
         // Matches row_color's killColor — a distinct "on its way out" hue,
         // not the same bucket as Pending.
         "Terminating" | "uninstalling" => mauve(),
         "Failed" | "Error" | "CrashLoopBackOff" | "ImagePullBackOff" | "ErrImagePull"
         | "Evicted" | "OOMKilled" | "NotReady" | "False" | "failed" | "Degraded"
-        | "Unavailable" | "Stalled" => red(),
+        | "Unavailable" | "Stalled" | "Missing" => red(),
         "Unknown" | "" | "unknown" => overlay1(),
         _ => text(),
     }
@@ -546,10 +552,12 @@ pub fn row_color(s: &str) -> Color {
     match s {
         "Failed" | "Error" | "CrashLoopBackOff" | "ImagePullBackOff" | "ErrImagePull"
         | "Evicted" | "OOMKilled" | "NotReady" | "Unhealthy" | "False" | "failed" | "Degraded"
-        | "Unavailable" | "Stalled" => red(),
+        | "Unavailable" | "Stalled" | "Missing" => red(),
         "Pending" | "ContainerCreating" | "PodInitializing" | "Progressing" | "pending-install"
-        | "pending-upgrade" | "pending-rollback" => peach(),
-        "Completed" | "Succeeded" | "superseded" | "uninstalled" | "ScaledDown" => overlay0(),
+        | "pending-upgrade" | "pending-rollback" | "OutOfSync" => peach(),
+        "Completed" | "Succeeded" | "superseded" | "uninstalled" | "ScaledDown" | "Suspended" => {
+            overlay0()
+        }
         // k9s killColor — terminating/deleting rows.
         "Terminating" | "uninstalling" => mauve(),
         _ => blue(),
@@ -677,6 +685,26 @@ mod tests {
         // Pending pops distinct from the row's peach.
         assert_eq!(status_color("Pending"), yellow());
         assert_ne!(status_color("Pending"), row_color("Pending"));
+    }
+
+    #[test]
+    fn argocd_sync_and_health_statuses_are_colored() {
+        // Argo's own status vocabulary, which no k8s phase covers.
+        assert_eq!(status_color("Healthy"), green());
+        assert_eq!(status_color("Synced"), green());
+        assert_eq!(row_color("Healthy"), blue());
+        // Drift is a warning, not a failure.
+        assert_eq!(status_color("OutOfSync"), yellow());
+        assert_eq!(row_color("OutOfSync"), peach());
+        // A Missing app is as broken as a failed one.
+        assert_eq!(status_color("Missing"), red());
+        assert_eq!(row_color("Missing"), red());
+        // Suspended fades — nothing is wrong, nothing is happening.
+        assert_eq!(status_color("Suspended"), row_color("Suspended"));
+        assert_eq!(row_color("Suspended"), overlay0());
+        // Degraded/Progressing already had the right colors.
+        assert_eq!(status_color("Degraded"), red());
+        assert_eq!(row_color("Progressing"), peach());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2066,8 +2066,8 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
             "historical right-sizing: P50/P95/P99 usage → suggested requests + patch (needs [providers.metrics])",
         ),
         bind(
-            ":gitops · :flux",
-            "Flux owner, source, revisions & reconciliation chain (⏎ to jump)",
+            ":gitops · :flux · :argo",
+            "Flux/Argo CD owner, source, revisions & reconciliation chain (⏎ to jump)",
         ),
         bind(
             ":journal · :audit",

--- a/src/views.rs
+++ b/src/views.rs
@@ -1807,7 +1807,7 @@ mod tests {
             SortValue::Num(_) => panic!("reason sorts as text"),
         }
 
-        let spec = crate::columns::build_spec("widgets", None, Some(&view), false);
+        let spec = crate::columns::build_spec("widgets", "", None, Some(&view), false);
         assert_eq!(spec.headers(), vec!["NAME", "A", "B", "C", "AGE"]);
         let (cells, status_idx) = spec.cells(&obj, crate::columns::now_secs());
         assert_eq!(


### PR DESCRIPTION
The GitOps view only understood Flux: an object Argo CD applied reported "not managed by Flux", and Applications listed as bare NAME/AGE rows even though `t` could already suspend, resume, and sync them. Half the feature was there — the actions — with none of the navigation or reading.

`gitops.rs` now resolves an owner for either controller. Argo's stamps are the `argocd.argoproj.io/tracking-id` annotation and the instance labels, which carry the Application's instance name (`<ns>_<name>` outside the controller's namespace, a bare name inside it, so a stamp without a namespace is searched for by name across all of them). The generic `app.kubernetes.io/instance` label is treated as a weak signal: Helm sets it too, so an Application it names that isn't in the cluster reads as unmanaged rather than as a broken chain, and the edit warning stays quiet for it.

From the Application the chain runs to its sources, sync and health status, the revision synced, its sync policy, and the AppProject and generating ApplicationSet beside it — with the same "what is blocking" summary the Flux chain ends on, spelling out drift, degraded health, a failed sync, or a manual policy that will reconcile nothing.

Applications, ApplicationSets, and AppProjects get curated columns. Their plurals are generic, so `columns_for` takes the API group and only claims them inside `argoproj.io`; another `applications` CRD keeps the printer-column fallback. Health colors the row, which needed Argo's status vocabulary (Healthy, Synced, OutOfSync, Missing, Suspended) in the theme.