### PR TITLE
feat: add namespace-specific view layouts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ Each of these is documented where the feature itself is:
 
 | Section               | What it does                                | Docs                                                       |
 | --------------------- | ------------------------------------------- | ---------------------------------------------------------- |
-| `[views]`             | custom table columns per resource           | [Views and thresholds](views.md)                           |
+| `[views]`             | custom columns per resource and namespace   | [Views and thresholds](views.md)                           |
 | `[thresholds]`        | RESTARTS/CPU/MEM/utilization coloring bands | [Views and thresholds](views.md#thresholds)                |
 | `[[plugins]]`         | shell-out commands bound to key chords      | [Plugins](plugins.md)                                      |
 | `[[bookmarks]]`       | saved navigation commands                   | [Plugins](plugins.md#bookmarks)                            |

--- a/docs/features.md
+++ b/docs/features.md
@@ -51,7 +51,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Custom views** - define columns for any resource in the config file. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
   automatically. `w` toggles wide-only columns (kubectl `-o wide`), including
-  node labels. See
+  node labels. Add `@<namespace>` to a view key to select columns for one
+  namespace. See
   [Views and thresholds](views.md).
 - **Drill-down navigation** with a breadcrumb stack: workload/service → pods,
   cronjob → its jobs, node → its pods, pod → containers, namespace → re-scope,

--- a/docs/views.md
+++ b/docs/views.md
@@ -47,6 +47,55 @@ the layout. By default columns overlay the curated ones: a matching header
 replaces it in place, new columns go before AGE. Invalid entries are skipped with
 a warning in the app - they never take down the TUI.
 
+### Namespace-specific views
+
+Add `@<namespace>` to a view key to select a layout for one namespace:
+
+```toml
+[[views."v1/pods".columns]]
+name = "OWNERKIND"
+path = "/metadata/ownerReferences/0/kind"
+
+[[views."v1/pods@matlab".columns]]
+name = "TENANT"
+path = "/metadata/annotations/ops.example.com~1tenant"
+
+[[views."v1/pods@matlab".columns]]
+name = "MODEL"
+path = "/metadata/annotations/ops.example.com~1model"
+```
+
+When a namespaced resource view is set to one namespace, sofka tries these
+keys in order:
+
+1. `apiVersion/plural@namespace`
+2. `group/plural@namespace`
+3. `plural@namespace`
+4. `kind@namespace`
+5. The same resource keys without a namespace, in the same order.
+
+For example, `pods@matlab` has priority over `v1/pods`.
+All-namespaces mode and cluster-scoped resources use only unqualified keys.
+A row filter does not change the namespace used for this lookup.
+
+The selected layout does not inherit columns, `replace`, or `sort` from
+another view key. Columns still overlay the built-in layout unless
+`replace = true`. In this example, the `matlab` view adds TENANT and MODEL,
+but does not add OWNERKIND. Wide mode works as usual. An active sort stays
+on its column if that column is still present. A saved user sort has priority
+over the configured initial sort.
+
+The `node` and `drill` settings use the same key order, but each setting
+falls back separately. A view that sets only columns does not hide a
+`node` or `drill` setting on a less specific key. Built-in navigation rules
+still apply.
+
+Namespace selection works with `sofka pods -n matlab`, the namespace picker,
+resource commands, bookmarks, and view history. The namespace suffix must
+be a valid namespace name: 1 to 63 lowercase letters, digits, or hyphens,
+with a letter or digit at each end. Invalid suffixes produce a configuration
+warning and the view is ignored.
+
 ### Pods and nodes
 
 Custom columns also overlay sofka's curated core-resource views. Pods already

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -75,13 +75,13 @@ impl App {
     /// The JSON Pointer holding the current kind's node name, if it has one.
     pub(super) fn node_pointer(&self) -> Option<String> {
         let ar = &self.kind.as_ref()?.ar;
-        crate::views::node_pointer(&self.user_views, ar).map(str::to_string)
+        crate::views::node_pointer(&self.user_views, ar, self.view_namespace()).map(str::to_string)
     }
 
     /// The `[views."…"].drill` for the current kind, if one is configured.
     fn configured_drill(&self) -> Option<crate::views::Drill> {
         let ar = &self.kind.as_ref()?.ar;
-        crate::views::drill_for(&self.user_views, ar).cloned()
+        crate::views::drill_for(&self.user_views, ar, self.view_namespace()).cloned()
     }
 
     /// Drill from a row into the kind its view's `drill` names, scoped by the

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -838,6 +838,11 @@ impl App {
         self.col_scroll_max = 0;
     }
 
+    pub(super) fn view_namespace(&self) -> Option<&str> {
+        self.kind.as_ref().filter(|kind| kind.namespaced)?;
+        (!self.all_namespaces()).then_some(self.namespace.as_str())
+    }
+
     /// The user-configured view matching the current kind, if any. Synthetic
     /// views (helm/helmhistory) are backed by an unrelated kind (`secrets`),
     /// so they never match.
@@ -846,7 +851,7 @@ impl App {
         if kind.ar.plural.to_lowercase() != self.kind_plural {
             return None;
         }
-        crate::views::lookup(&self.user_views, &kind.ar)
+        crate::views::lookup(&self.user_views, &kind.ar, self.view_namespace())
     }
 
     /// Apply a view's configured initial sort, unless a sort is already

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -17291,3 +17291,171 @@ async fn refresh_key_reads_pods_through_a_configured_ca_server_certificate() {
     app.handle_key(press(KeyCode::Char('q'))).unwrap();
     server.abort();
 }
+
+#[tokio::test]
+async fn namespace_views_follow_navigation_bookmarks_and_wide_mode() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [[views."v1/pods".columns]]
+        name = "OWNER"
+        path = "/metadata/ownerReferences/0/kind"
+
+        [views."pods@matlab"]
+        sort = "TENANT:desc"
+        [[views."pods@matlab".columns]]
+        name = "TENANT"
+        path = "/metadata/annotations/ops.example.com~1tenant"
+        [[views."pods@matlab".columns]]
+        name = "MODEL"
+        path = "/metadata/annotations/ops.example.com~1model"
+        wide = true
+
+        [views."pods@python"]
+        replace = true
+        [[views."pods@python".columns]]
+        name = "NAME"
+        path = "/metadata/name"
+
+        [[views."nodes@matlab".columns]]
+        name = "WRONG"
+        path = "/metadata/name"
+    "#,
+    );
+    // Startup sets the CLI namespace before it opens the resource.
+    app.namespace = "matlab".into();
+    app.switch_kind("pods");
+    assert!(app.display_headers().contains(&"TENANT".to_string()));
+    assert!(!app.display_headers().contains(&"OWNER".to_string()));
+    assert_eq!(app.display_headers()[app.sort_column.unwrap()], "TENANT");
+    assert!(app.sort_desc);
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "job", "namespace": "matlab",
+                "annotations": {"ops.example.com/tenant": "team-a"}}
+        }),
+    );
+    let rows = app.rows();
+    app.ensure_table_cell_cache(&rows);
+    let index = app
+        .display_headers()
+        .iter()
+        .position(|h| h == "TENANT")
+        .unwrap();
+    assert_eq!(
+        app.table_cell_cache().get(&row_key(rows[0])).unwrap().0[index],
+        "team-a"
+    );
+    drop(rows);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert!(app.display_headers().contains(&"MODEL".to_string()));
+    assert_eq!(app.display_headers()[app.sort_column.unwrap()], "TENANT");
+
+    palette(&mut app, "pods all");
+    assert!(app.all_namespaces());
+    assert!(app.display_headers().contains(&"OWNER".to_string()));
+    assert!(!app.display_headers().contains(&"TENANT".to_string()));
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(app.namespace, "matlab");
+    assert!(app.display_headers().contains(&"TENANT".to_string()));
+
+    app.bookmarks = vec![crate::config::Bookmark {
+        key: Some("z".into()),
+        name: "batch".into(),
+        resource: "pods".into(),
+        namespace: Some("python".into()),
+        ..Default::default()
+    }];
+    app.handle_key(press(KeyCode::Char('z'))).unwrap();
+    assert_eq!(app.namespace, "python");
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "CPU", "MEM"]);
+    assert!(app.sort_column.is_none());
+    palette(&mut app, "pods other");
+    assert!(app.display_headers().contains(&"OWNER".to_string()));
+    palette(&mut app, "nodes matlab");
+    assert!(!app.display_headers().contains(&"WRONG".to_string()));
+}
+
+#[tokio::test]
+async fn namespace_view_picker_keeps_the_user_sort() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."pods@matlab"]
+        sort = "TENANT:desc"
+        [[views."pods@matlab".columns]]
+        name = "TENANT"
+        path = "/metadata/name"
+    "#,
+    );
+    palette(&mut app, "pods other");
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    let header = app.display_headers()[app.sort_column.unwrap()].clone();
+    let desc = app.sort_desc;
+    app.ns_list = vec!["<all>".into(), "matlab".into(), "other".into()];
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    for c in "matlab".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.namespace, "matlab");
+    assert!(app.display_headers().contains(&"TENANT".to_string()));
+    assert_eq!(app.display_headers()[app.sort_column.unwrap()], header);
+    assert_eq!(app.sort_desc, desc);
+}
+
+#[tokio::test]
+async fn namespace_view_navigation_settings_fall_back_separately() {
+    for (namespace, expected_node, expected_target) in [
+        ("matlab", "batch-node", "secrets"),
+        ("other", "base-node", "pods"),
+        ("all", "base-node", "pods"),
+    ] {
+        let (mut app, _rx) = test_app();
+        install_views(
+            &mut app,
+            r#"
+            [views.certificates]
+            node = "/status/baseNode"
+            drill = { kind = "pods", labels = "cert={name}" }
+            [views."certificates@matlab"]
+            node = "/status/batchNode"
+            drill = { kind = "secrets", labels = "cert={name}" }
+            [[views."cert-manager.io/v1/certificates@matlab".columns]]
+            name = "EXTRA"
+            path = "/metadata/name"
+        "#,
+        );
+        palette(&mut app, &format!("certificates {namespace}"));
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "cert-manager.io/v1", "kind": "Certificate",
+                "metadata": {"name": "tls", "namespace": "matlab"},
+                "status": {"baseNode": "base-node", "batchNode": "batch-node"}
+            }),
+        );
+        app.table_state.select(Some(0));
+        app.handle_key(press(KeyCode::Char('o'))).unwrap();
+        assert_eq!(app.kind_plural, "nodes");
+        assert_eq!(app.fields, Some(format!("metadata.name={expected_node}")));
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "cert-manager.io/v1", "kind": "Certificate",
+                "metadata": {"name": "tls", "namespace": "matlab"}
+            }),
+        );
+        app.table_state.select(Some(0));
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.kind_plural, expected_target);
+        assert_eq!(app.labels.as_deref(), Some("cert=tls"));
+    }
+}

--- a/src/views.rs
+++ b/src/views.rs
@@ -187,9 +187,10 @@ const NODE_REFS: &[(&str, &str)] = &[
 fn setting<'a, T: ?Sized>(
     views: &'a HashMap<String, View>,
     ar: &ApiResource,
+    namespace: Option<&str>,
     pick: impl Fn(&'a View) -> Option<&'a T>,
 ) -> Option<&'a T> {
-    lookup_keys(ar)
+    lookup_keys(ar, namespace)
         .into_iter()
         .find_map(|k| views.get(&k).and_then(&pick))
 }
@@ -197,17 +198,25 @@ fn setting<'a, T: ?Sized>(
 /// Where `enter` drills for a kind, per `[views."…"].drill`. Kinds with a
 /// built-in drill-down (workloads to pods, CRDs to their resources, …) never
 /// consult this.
-pub fn drill_for<'a>(views: &'a HashMap<String, View>, ar: &ApiResource) -> Option<&'a Drill> {
-    setting(views, ar, |v| v.drill.as_ref())
+pub fn drill_for<'a>(
+    views: &'a HashMap<String, View>,
+    ar: &ApiResource,
+    namespace: Option<&str>,
+) -> Option<&'a Drill> {
+    setting(views, ar, namespace, |v| v.drill.as_ref())
 }
 
 /// The pointer to a kind's node name: an explicit `[views."…"].node` wins over
 /// the built-in table.
-pub fn node_pointer<'a>(views: &'a HashMap<String, View>, ar: &ApiResource) -> Option<&'a str> {
-    if let Some(pointer) = setting(views, ar, |v| v.node.as_deref()) {
+pub fn node_pointer<'a>(
+    views: &'a HashMap<String, View>,
+    ar: &ApiResource,
+    namespace: Option<&str>,
+) -> Option<&'a str> {
+    if let Some(pointer) = setting(views, ar, namespace, |v| v.node.as_deref()) {
         return Some(pointer);
     }
-    lookup_keys(ar).into_iter().find_map(|key| {
+    lookup_keys(ar, None).into_iter().find_map(|key| {
         NODE_REFS
             .iter()
             .find(|(row, _)| *row == key)
@@ -230,6 +239,21 @@ pub fn compile(
     let mut views = HashMap::new();
     let mut warnings = Vec::new();
     for (key, cfg) in raw {
+        if let Some((resource, namespace)) = key.split_once('@')
+            && (resource.is_empty()
+                || namespace.is_empty()
+                || namespace.len() > 63
+                || !namespace.starts_with(|c: char| c.is_ascii_lowercase() || c.is_ascii_digit())
+                || !namespace.ends_with(|c: char| c.is_ascii_lowercase() || c.is_ascii_digit())
+                || !namespace
+                    .bytes()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == b'-'))
+        {
+            warnings.push(format!(
+                "views.\"{key}\": invalid namespace suffix; view ignored"
+            ));
+            continue;
+        }
         let mut columns = Vec::new();
         for c in &cfg.columns {
             let header = c.name.trim().to_uppercase();
@@ -317,7 +341,10 @@ pub fn compile(
             None => None,
         };
         let drill = cfg.drill.as_ref().and_then(|d| {
-            let key_lc = key.to_lowercase();
+            let key_lc = key
+                .split_once('@')
+                .map_or(key.as_str(), |(resource, _)| resource)
+                .to_lowercase();
             let plural = key_plural(&key_lc);
             if BUILTIN_DRILLS.contains(&plural) {
                 warnings.push(format!(
@@ -390,7 +417,8 @@ fn parse_sort(key: &str, s: &str, warnings: &mut Vec<String>) -> Option<(String,
 
 /// The keys a resource's view can be configured under, most specific first:
 /// `apiVersion/plural`, `group/plural`, plural, then lowercased kind.
-fn lookup_keys(ar: &ApiResource) -> Vec<String> {
+/// Try all namespace-qualified keys before the unqualified keys.
+fn lookup_keys(ar: &ApiResource, namespace: Option<&str>) -> Vec<String> {
     let plural = ar.plural.to_lowercase();
     let mut keys = vec![format!("{}/{plural}", ar.api_version.to_lowercase())];
     if !ar.group.is_empty() {
@@ -398,12 +426,26 @@ fn lookup_keys(ar: &ApiResource) -> Vec<String> {
     }
     keys.push(plural);
     keys.push(ar.kind.to_lowercase());
+    if let Some(namespace) = namespace.filter(|ns| !ns.is_empty()) {
+        let mut qualified: Vec<_> = keys
+            .iter()
+            .map(|key| format!("{key}@{namespace}"))
+            .collect();
+        qualified.extend(keys);
+        return qualified;
+    }
     keys
 }
 
 /// Find the view for a resource, most specific key first.
-pub fn lookup<'a>(views: &'a HashMap<String, View>, ar: &ApiResource) -> Option<&'a View> {
-    lookup_keys(ar).into_iter().find_map(|k| views.get(&k))
+pub fn lookup<'a>(
+    views: &'a HashMap<String, View>,
+    ar: &ApiResource,
+    namespace: Option<&str>,
+) -> Option<&'a View> {
+    lookup_keys(ar, namespace)
+        .into_iter()
+        .find_map(|k| views.get(&k))
 }
 
 /// Resolve a JSON Pointer against the object as served by the API:
@@ -1060,6 +1102,101 @@ mod tests {
     }
 
     #[test]
+    fn namespace_view_keys_use_two_precedence_groups() {
+        let ar = ApiResource {
+            group: "example.com".into(),
+            version: "v1".into(),
+            api_version: "example.com/v1".into(),
+            kind: "Widget".into(),
+            plural: "widgets".into(),
+        };
+        let keys = [
+            "example.com/v1/widgets@batch",
+            "example.com/widgets@batch",
+            "widgets@batch",
+            "widget@batch",
+            "example.com/v1/widgets",
+            "example.com/widgets",
+            "widgets",
+            "widget",
+        ];
+        let mut views: HashMap<_, _> = keys
+            .iter()
+            .map(|key| {
+                (
+                    key.to_string(),
+                    View {
+                        sort: Some((key.to_string(), false)),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        for key in keys {
+            assert_eq!(
+                lookup(&views, &ar, Some("batch"))
+                    .unwrap()
+                    .sort
+                    .as_ref()
+                    .unwrap()
+                    .0,
+                key
+            );
+            views.remove(key);
+        }
+        assert!(lookup(&views, &ar, Some("batch")).is_none());
+        let (views, warnings) = compile_toml(
+            r#"
+            [views."widgets@batch"]
+            sort = "NAME"
+            [views.widgets]
+            sort = "AGE"
+        "#,
+        );
+        assert!(warnings.is_empty());
+        for namespace in [None, Some(""), Some("other")] {
+            assert_eq!(
+                lookup(&views, &ar, namespace).unwrap().sort,
+                Some(("AGE".into(), false))
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_namespace_suffixes_warn_and_skip_the_view() {
+        for key in [
+            "pods@",
+            "@batch",
+            "pods@a@b",
+            "pods@Batch",
+            "pods@-batch",
+            "pods@batch-",
+            "pods@a.b",
+            "pods@a_b",
+            "pods@all namespaces",
+        ] {
+            let (views, warnings) = compile_toml(&format!("[views.\"{key}\"]"));
+            assert!(views.is_empty(), "{key}");
+            assert_eq!(warnings.len(), 1, "{key}");
+            assert!(warnings[0].contains("invalid namespace suffix"));
+        }
+        let key = format!("pods@{}", "a".repeat(64));
+        let (views, warnings) = compile_toml(&format!("[views.\"{key}\"]"));
+        assert!(views.is_empty());
+        assert_eq!(warnings.len(), 1);
+        let (_, warnings) = compile_toml(
+            r#"[views."pods@batch"]
+            drill = { kind = "secrets" }
+        "#,
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("drill is ignored"))
+        );
+    }
+
+    #[test]
     fn lookup_prefers_most_specific_key() {
         let ar = ApiResource {
             group: "cert-manager.io".into(),
@@ -1075,22 +1212,22 @@ mod tests {
         let mut views = HashMap::new();
         views.insert("certificate".to_string(), mk("by-kind"));
         assert_eq!(
-            lookup(&views, &ar).unwrap().sort,
+            lookup(&views, &ar, None).unwrap().sort,
             Some(("BY-KIND".into(), false))
         );
         views.insert("certificates".to_string(), mk("by-plural"));
         assert_eq!(
-            lookup(&views, &ar).unwrap().sort,
+            lookup(&views, &ar, None).unwrap().sort,
             Some(("BY-PLURAL".into(), false))
         );
         views.insert("cert-manager.io/certificates".to_string(), mk("by-group"));
         assert_eq!(
-            lookup(&views, &ar).unwrap().sort,
+            lookup(&views, &ar, None).unwrap().sort,
             Some(("BY-GROUP".into(), false))
         );
         views.insert("cert-manager.io/v1/certificates".to_string(), mk("by-gvr"));
         assert_eq!(
-            lookup(&views, &ar).unwrap().sort,
+            lookup(&views, &ar, None).unwrap().sort,
             Some(("BY-GVR".into(), false))
         );
     }
@@ -1110,20 +1247,23 @@ mod tests {
         };
         let views = HashMap::new();
         assert_eq!(
-            node_pointer(&views, &ar("", "Pod", "pods")),
+            node_pointer(&views, &ar("", "Pod", "pods"), None),
             Some("/spec/nodeName")
         );
         let claims = ar("karpenter.sh", "NodeClaim", "nodeclaims");
-        assert_eq!(node_pointer(&views, &claims), Some("/status/nodeName"));
+        assert_eq!(
+            node_pointer(&views, &claims, None),
+            Some("/status/nodeName")
+        );
         // A kind the table doesn't list names no node until config says where.
         let pools = ar("karpenter.sh", "NodePool", "nodepools");
-        assert_eq!(node_pointer(&views, &pools), None);
+        assert_eq!(node_pointer(&views, &pools, None), None);
         // Rows are scoped to their group: a same-named plural elsewhere
         // (or PodMetrics, whose plural is also `pods`) gets nothing.
         let other_claims = ar("example.com", "NodeClaim", "nodeclaims");
-        assert_eq!(node_pointer(&views, &other_claims), None);
+        assert_eq!(node_pointer(&views, &other_claims, None), None);
         let pod_metrics = ar("metrics.k8s.io", "PodMetrics", "pods");
-        assert_eq!(node_pointer(&views, &pod_metrics), None);
+        assert_eq!(node_pointer(&views, &pod_metrics, None), None);
 
         let (configured, warnings) = compile_toml(
             r#"
@@ -1137,10 +1277,13 @@ mod tests {
         assert!(warnings.is_empty(), "{warnings:?}");
         // Config overrides a shipped row and adds a kind without one.
         assert_eq!(
-            node_pointer(&configured, &claims),
+            node_pointer(&configured, &claims, None),
             Some("/status/providerID")
         );
-        assert_eq!(node_pointer(&configured, &pools), Some("/status/host"));
+        assert_eq!(
+            node_pointer(&configured, &pools, None),
+            Some("/status/host")
+        );
     }
 
     #[test]
@@ -1164,8 +1307,8 @@ mod tests {
             "#,
         );
         assert!(warnings.is_empty(), "{warnings:?}");
-        assert_eq!(lookup(&views, &widgets).unwrap().node, None);
-        assert_eq!(node_pointer(&views, &widgets), Some("/status/host"));
+        assert_eq!(lookup(&views, &widgets, None).unwrap().node, None);
+        assert_eq!(node_pointer(&views, &widgets, None), Some("/status/host"));
     }
 
     #[test]
@@ -1186,7 +1329,7 @@ mod tests {
             node = "status.host"
             "#,
         );
-        assert_eq!(node_pointer(&views, &pods), Some("/status/hostName"));
+        assert_eq!(node_pointer(&views, &pods, None), Some("/status/hostName"));
         // A path that isn't a pointer is dropped with a warning, like columns.
         assert_eq!(views["widgets"].node, None);
         assert_eq!(warnings.len(), 1, "{warnings:?}");
@@ -1213,7 +1356,7 @@ mod tests {
         );
         assert!(warnings.is_empty(), "{warnings:?}");
         // Found on the broader key even though the narrower one matches first.
-        let drill = drill_for(&views, &pools).expect("drill configured");
+        let drill = drill_for(&views, &pools, None).expect("drill configured");
         assert_eq!(drill.kind, "nodeclaims");
         let pool = obj(json!({"metadata": {"name": "default"}}));
         assert_eq!(
@@ -1229,7 +1372,10 @@ mod tests {
             "#,
         );
         assert!(warnings.is_empty(), "{warnings:?}");
-        assert_eq!(drill_for(&views, &pools).unwrap().labels_for(&pool), None);
+        assert_eq!(
+            drill_for(&views, &pools, None).unwrap().labels_for(&pool),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Custom annotation columns currently appear in every namespace. Add an optional `@<namespace>` suffix to view keys so a layout such as `v1/pods@matlab` applies only when the view is set to that namespace.

Namespace-qualified keys take priority over unqualified keys. The selected layout does not inherit columns or sort settings from another view. All-namespaces mode and cluster-scoped resources use unqualified layouts. The `node` and `drill` settings follow the same key order with separate fallback for each setting. Invalid namespace suffixes produce configuration warnings.

Tests cover key priority, namespace selection, startup scope, bookmarks, history, wide mode, saved sorting, and navigation settings. Documentation includes an annotation-column example and the fallback rules.

Validation: `just check` and all pre-commit hooks passed. 965 tests passed; one test was ignored.

Closes #348
