### PR TITLE
feat: add automatic refresh to describe view

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -275,6 +275,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   watch saw, so "what just changed?" has an answer. The last revision of up to
   256 changed objects is kept in memory.
 
+In the describe view, `r` turns automatic refresh on or off. Refresh is off
+when the view opens. When on, it runs `kubectl describe` immediately and then
+5 seconds after each result. This updates the full document, including events.
+The resource, scroll position, and search stay the same. Refresh stops when
+you leave the view or a request fails. A failed request keeps the last result.
+
 ## PVC explore
 
 A PersistentVolumeClaim has no API that returns its contents: the only way to

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -105,6 +105,12 @@ highlighted. `n` / `N` go to the next or previous match. `w` wraps. `c` copies
 the document. `esc` backs out - the first press clears an active search. In the
 `?` help panel, `/` filters instead and narrows to matching keybinds.
 
+In the describe view, `r` turns automatic refresh on or off. Refresh is off
+when the view opens. When on, it runs `kubectl describe` immediately and then
+5 seconds after each result. This updates the full document, including events.
+The resource, scroll position, and search stay the same. Refresh stops when
+you leave the view or a request fails. A failed request keeps the last result.
+
 ## Explain view (`X`)
 
 `j` / `k` move, `⏎` goes to the resource behind a finding (a blocking pod), `E`

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -6,6 +6,8 @@ impl App {
     /// Remember which view a transient sub-view (logs/detail/diff) was opened
     /// from, so `esc` returns there (e.g. back to the xray tree, not the table).
     pub(super) fn set_return_mode(&mut self) {
+        self.stop_describe_refresh();
+        self.describe_source = None;
         self.stop_plugins();
         // A transient sub-view (logs/detail/events) opened from a list-style
         // view returns to that view, not the table underneath it.
@@ -71,6 +73,8 @@ impl App {
     /// in-document `x` binding lands here, so esc still returns to wherever
     /// the describe/YAML view was opened from.
     pub(super) fn show_decoded_secret(&mut self) {
+        self.stop_describe_refresh();
+        self.describe_source = None;
         let Some(obj) = self.selected_ref() else {
             return;
         };
@@ -143,6 +147,7 @@ impl App {
             argv.push(ns.clone());
         }
         let claim = self.claim_status(format!("describing {name}…"));
+        self.describe_source = Some((claim, argv.clone()));
         tokio::spawn(async move {
             let msg = match tokio::process::Command::new(&argv[0])
                 .args(&argv[1..])
@@ -182,6 +187,70 @@ impl App {
             };
             let _ = tx.send(msg).await;
         });
+    }
+
+    pub(super) fn stop_describe_refresh(&mut self) {
+        self.describe_refresh_generation += 1;
+        if let Some(task) = self.describe_refresh_task.take() {
+            task.abort();
+        }
+    }
+
+    pub(super) fn check_describe_refresh(&mut self) {
+        if self.should_quit
+            || (self.mode != Mode::Detail
+                && !(self.mode == Mode::DocFilter && self.doc_filter_return == Mode::Detail))
+        {
+            self.stop_describe_refresh();
+        }
+    }
+
+    pub(super) fn toggle_describe_refresh(&mut self) {
+        if self.describe_refresh_task.is_some() {
+            self.stop_describe_refresh();
+            self.flash = "describe refresh: off".into();
+            self.flash_err = false;
+            return;
+        }
+        let Some((_, argv)) = &self.describe_source else {
+            return;
+        };
+        let argv = argv.clone();
+        let tx = self.tx.clone();
+        let generation = self.describe_refresh_generation;
+        self.describe_refresh_task = Some(tokio::spawn(async move {
+            loop {
+                let result = match tokio::process::Command::new(&argv[0])
+                    .args(&argv[1..])
+                    .kill_on_drop(true)
+                    .output()
+                    .await
+                {
+                    Ok(out) if out.status.success() => Ok(String::from_utf8_lossy(&out.stdout)
+                        .lines()
+                        .map(String::from)
+                        .collect()),
+                    Ok(out) => Err(format!(
+                        "describe refresh failed: {}",
+                        String::from_utf8_lossy(&out.stderr)
+                            .lines()
+                            .next()
+                            .unwrap_or("error")
+                    )),
+                    Err(e) => Err(format!("describe refresh failed: {e}")),
+                };
+                if tx
+                    .send(Msg::DescribeRefresh { generation, result })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }));
+        self.flash = "describe refresh: on (5s)".into();
+        self.flash_err = false;
     }
 
     /// Render an object as YAML lines, stamping its type if missing.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -16,6 +16,7 @@ impl App {
         };
         let run = self.plugin_run;
         let result = self.handle_key_inner(key);
+        self.check_describe_refresh();
         let overlay = matches!(
             self.mode,
             Mode::Command
@@ -28,6 +29,9 @@ impl App {
                 | Mode::SortPicker
                 | Mode::CopyPicker
         );
+        if before == Mode::Detail && self.mode != Mode::Detail && !overlay {
+            self.describe_source = None;
+        }
         if self.should_quit || (self.plugin_run == run && self.mode != before && !overlay) {
             self.stop_plugins();
         }
@@ -959,6 +963,8 @@ impl App {
                 } else if self.mode == Mode::Events {
                     self.stop_event_stream();
                 }
+                self.stop_describe_refresh();
+                self.describe_source = None;
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
                     self.restore_selection();
@@ -975,6 +981,7 @@ impl App {
             // when no search is active.
             KeyCode::Char('n') if detail => target.step_match(true),
             KeyCode::Char('N') if detail => target.step_match(false),
+            KeyCode::Char('r') if self.mode == Mode::Detail => self.toggle_describe_refresh(),
             // Copy the document to the clipboard (k9s `c`), same as the logs
             // view: an active search copies only the matching lines.
             KeyCode::Char('c') if detail => {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -838,6 +838,8 @@ impl App {
     }
 
     pub(super) fn bump_generation(&mut self) {
+        self.stop_describe_refresh();
+        self.describe_source = None;
         self.stop_event_stream();
         self.clear_progress_flash();
         self.stop_plugins();
@@ -855,6 +857,7 @@ impl App {
     /// being involved at all.
     pub fn handle_msg(&mut self, msg: Msg) {
         self.handle_msg_inner(msg);
+        self.check_describe_refresh();
         let overlay = matches!(
             self.mode,
             Mode::PvcExplore
@@ -1144,6 +1147,8 @@ impl App {
                 lines,
                 warn,
             } if generation == self.generation && run == self.plugin_run => {
+                self.stop_describe_refresh();
+                self.describe_source = None;
                 self.plugin_task = None;
                 self.plugin_claim = None;
                 self.detail = Scrollable {
@@ -1266,6 +1271,15 @@ impl App {
                 lines,
                 warn,
             } if generation == self.generation => {
+                self.stop_describe_refresh();
+                if warn.is_some()
+                    || self
+                        .describe_source
+                        .as_ref()
+                        .is_none_or(|(id, _)| *id != claim)
+                {
+                    self.describe_source = None;
+                }
                 self.detail = Scrollable {
                     title,
                     lines: lines.into(),
@@ -1277,6 +1291,21 @@ impl App {
                     // The "describing X…" progress flash has served its
                     // purpose once the document arrives.
                     None => self.clear_claimed_status(claim),
+                }
+            }
+            Msg::DescribeRefresh { generation, result }
+                if generation == self.describe_refresh_generation
+                    && self.describe_refresh_task.is_some()
+                    && (self.mode == Mode::Detail
+                        || (self.mode == Mode::DocFilter
+                            && self.doc_filter_return == Mode::Detail)) =>
+            {
+                match result {
+                    Ok(lines) => self.detail.replace_lines(lines.into()),
+                    Err(error) => {
+                        self.stop_describe_refresh();
+                        self.flash_warn(&error);
+                    }
                 }
             }
             Msg::Events {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -897,6 +897,7 @@ impl Scrollable {
             .as_ref()
             .map(|viewport| (viewport.width, viewport.height));
         self.lines = lines;
+        self.scroll_h(0);
         self.revision = self.revision.wrapping_add(1);
         self.viewport = None;
         if let Some((width, height)) = dimensions {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1676,6 +1676,9 @@ pub struct App {
     pub last_action_error: Option<String>,
 
     pub detail: Scrollable,
+    pub(super) describe_source: Option<(crate::store::StatusClaim, Vec<String>)>,
+    pub describe_refresh_task: Option<tokio::task::JoinHandle<()>>,
+    pub(super) describe_refresh_generation: u64,
     /// Search query for the help view (`?`), which has no backing
     /// [`Scrollable`] — its lines are built at render time.
     pub help_filter: String,
@@ -2055,6 +2058,9 @@ impl App {
             status_claim: None,
             last_action_error: None,
             detail: Scrollable::empty(),
+            describe_source: None,
+            describe_refresh_task: None,
+            describe_refresh_generation: 0,
             help_filter: String::new(),
             help_return: Mode::Table,
             doc_filter_return: Mode::Detail,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -17502,3 +17502,172 @@ async fn namespace_view_navigation_settings_fall_back_separately() {
         assert_eq!(app.labels.as_deref(), Some("cert=tls"));
     }
 }
+
+fn describe_refresh_app() -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"web", "namespace":"default"}}),
+    );
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    let claim = app.claim_status("describing web");
+    app.describe_source = Some((
+        claim,
+        vec![
+            "/bin/sh".into(),
+            "-c".into(),
+            "printf 'Events:\nnew event\n'".into(),
+        ],
+    ));
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        claim,
+        title: "web describe".into(),
+        lines: vec!["Events:".into(), "old event".into()],
+        warn: None,
+    });
+    (app, rx)
+}
+
+#[tokio::test]
+async fn describe_refresh_toggle_updates_and_rejects_stopped_results() {
+    let (mut app, mut rx) = describe_refresh_app();
+    assert!(app.describe_refresh_task.is_none());
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "event".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    let scroll = app.detail.scroll;
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert!(app.describe_refresh_task.is_some());
+    let generation = app.describe_refresh_generation;
+    let msg = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    app.handle_msg(msg);
+    assert_eq!(app.detail.lines[1], "new event");
+    assert_eq!(app.detail.filter, "event");
+    assert_eq!(app.detail.scroll, scroll);
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert!(app.describe_refresh_task.is_none());
+    app.handle_msg(Msg::DescribeRefresh {
+        generation,
+        result: Ok(vec!["late".into()]),
+    });
+    assert_eq!(app.detail.lines[1], "new event");
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    app.handle_key(press(KeyCode::Char('q'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.describe_refresh_task.is_none());
+    assert!(app.describe_source.is_none());
+}
+
+#[tokio::test]
+async fn describe_refresh_failure_keeps_document_and_search_accepts_updates() {
+    let (mut app, _rx) = describe_refresh_app();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    let generation = app.describe_refresh_generation;
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    app.handle_msg(Msg::DescribeRefresh {
+        generation,
+        result: Ok(vec!["updated".into()]),
+    });
+    assert_eq!(app.mode, Mode::DocFilter);
+    assert_eq!(app.detail.lines[0], "updated");
+    app.handle_msg(Msg::DescribeRefresh {
+        generation,
+        result: Err("request failed".into()),
+    });
+    assert_eq!(app.detail.lines[0], "updated");
+    assert!(app.describe_refresh_task.is_none());
+    assert!(app.flash.contains("request failed"));
+}
+
+#[tokio::test]
+async fn describe_refresh_is_unavailable_in_yaml_and_stops_on_palette_navigation() {
+    let (mut app, _rx) = describe_refresh_app();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert!(app.describe_refresh_task.is_none());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Char('q'))).unwrap();
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert!(app.describe_source.is_none());
+    assert!(app.describe_refresh_task.is_none());
+}
+
+#[tokio::test]
+async fn describe_refresh_repeats_for_the_original_resource() {
+    let (mut app, mut rx) = describe_refresh_app();
+    let (_, argv) = app.describe_source.as_mut().unwrap();
+    *argv = vec![
+        "/bin/sh".into(),
+        "-c".into(),
+        "printf '%s' \"$1\"".into(),
+        "describe".into(),
+        "web".into(),
+    ];
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"another", "namespace":"default"}}),
+    );
+    app.table_state.select(Some(0));
+    assert_eq!(
+        app.selected_ref().unwrap().metadata.name.as_deref(),
+        Some("another")
+    );
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    for _ in 0..2 {
+        let msg = tokio::time::timeout(Duration::from_secs(8), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        app.handle_msg(msg);
+        assert_eq!(app.detail.lines[0], "web");
+    }
+    app.handle_key(press(KeyCode::Char('q'))).unwrap();
+}
+
+#[tokio::test]
+async fn describe_refresh_does_not_replace_plugin_output_or_yaml_fallback() {
+    let (mut app, _rx) = describe_refresh_app();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    let generation = app.describe_refresh_generation;
+    let claim = app.claim_status("plugin");
+    app.handle_msg(Msg::PluginOutput {
+        run: app.plugin_run,
+        generation: app.generation,
+        claim,
+        title: "plugin".into(),
+        lines: vec!["report".into()],
+        warn: None,
+    });
+    app.handle_msg(Msg::DescribeRefresh {
+        generation,
+        result: Ok(vec!["late".into()]),
+    });
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert_eq!(app.detail.lines[0], "report");
+    assert!(app.describe_refresh_task.is_none());
+    assert!(app.describe_source.is_none());
+
+    let (mut app, _rx) = describe_refresh_app();
+    let claim = app.describe_source.as_ref().unwrap().0;
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        claim,
+        title: "web YAML".into(),
+        lines: vec!["fallback".into()],
+        warn: Some("describe failed".into()),
+    });
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    assert!(app.describe_refresh_task.is_none());
+    assert!(app.describe_source.is_none());
+    assert_eq!(app.detail.lines[0], "fallback");
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -17671,3 +17671,36 @@ async fn describe_refresh_does_not_replace_plugin_output_or_yaml_fallback() {
     assert!(app.describe_source.is_none());
     assert_eq!(app.detail.lines[0], "fallback");
 }
+
+#[tokio::test]
+async fn describe_refresh_clamps_horizontal_scroll_when_content_shrinks() {
+    for viewport in [false, true] {
+        let (mut app, _rx) = describe_refresh_app();
+        if viewport {
+            app.detail.set_viewport(4, 2);
+        }
+        app.handle_key(press(KeyCode::Right)).unwrap();
+        assert_eq!(app.detail.hscroll, 5);
+        app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        let generation = app.describe_refresh_generation;
+
+        app.handle_msg(Msg::DescribeRefresh {
+            generation,
+            result: Ok(vec!["another wide event".into()]),
+        });
+        assert_eq!(app.detail.hscroll, 5);
+
+        app.handle_msg(Msg::DescribeRefresh {
+            generation,
+            result: Ok(vec!["ok".into()]),
+        });
+        assert_eq!(app.detail.hscroll, 1);
+
+        app.handle_msg(Msg::DescribeRefresh {
+            generation,
+            result: Ok(vec![]),
+        });
+        assert_eq!(app.detail.hscroll, 0);
+        app.handle_key(press(KeyCode::Char('q'))).unwrap();
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -124,6 +124,10 @@ pub enum Msg {
         /// Set when describe failed and we fell back to YAML.
         warn: Option<String>,
     },
+    DescribeRefresh {
+        generation: u64,
+        result: Result<Vec<String>, String>,
+    },
     /// Live Event rows for the selected object.
     Events {
         generation: u64,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -402,7 +402,11 @@ fn draw_compact_header(frame: &mut Frame, app: &App, area: Rect) {
         spans.push(Span::styled(app.flash.clone(), style));
     }
 
-    let (synced, sync_color) = sync_indicator(app.mode, app.doc_filter_return, app.store.synced);
+    let (synced, sync_color) = if app.describe_refresh_task.is_some() {
+        ("● refresh", theme::sky())
+    } else {
+        sync_indicator(app.mode, app.doc_filter_return, app.store.synced)
+    };
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Min(10), Constraint::Length(10)])
@@ -2195,6 +2199,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(Span::styled("  Inspect", theme::title())),
         bind("y · d", "view YAML · describe (kubectl)"),
+        bind("r (describe)", "turn automatic refresh on/off (5s)"),
         bind("l · p", "logs (workload = all pods) · previous logs"),
         bind(
             "shift-l · :vlogs",
@@ -3806,6 +3811,18 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 "  j/k:scroll  ^f/^b:page  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  esc:back"
             };
+            let hint = if app.mode == Mode::Detail && app.describe_source.is_some() {
+                format!(
+                    "{hint}  r:refresh {}",
+                    if app.describe_refresh_task.is_some() {
+                        "on"
+                    } else {
+                        "off"
+                    }
+                )
+            } else {
+                hint.to_string()
+            };
             Line::from(Span::styled(hint, theme::dim()))
         }
         Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),
@@ -3903,7 +3920,11 @@ fn draw_status(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         Style::default().fg(theme::subtext0())
     };
-    let (synced, sync_color) = sync_indicator(app.mode, app.doc_filter_return, app.store.synced);
+    let (synced, sync_color) = if app.describe_refresh_task.is_some() {
+        ("● refresh", theme::sky())
+    } else {
+        sync_indicator(app.mode, app.doc_filter_return, app.store.synced)
+    };
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Min(10), Constraint::Length(12)])


### PR DESCRIPTION
The describe view shows one `kubectl describe` result, so its events become stale. Press `r` to turn automatic refresh on or off. Refresh is off when the view opens. When on, it runs immediately and then 5 seconds after each result.

Refresh uses the original resource and keeps the search and scroll position. It stops when the user leaves the view or a request fails. Failed requests keep the last result, and late results cannot replace another document. The view shows the refresh state. Help and key documentation include the new control.

Validation: `just check` and all pre-commit hooks passed. Five new tests cover the key control, repeated requests for the original resource, search, failures, navigation, and rejection of late results. Tests use local commands and need no cluster.

Closes #332
