### PR TITLE
feat: make built-in metric columns configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,7 @@ Each of these is documented where the feature itself is:
 
 | Section               | What it does                                | Docs                                                       |
 | --------------------- | ------------------------------------------- | ---------------------------------------------------------- |
-| `[views]`             | custom columns per resource and namespace   | [Views and thresholds](views.md)                           |
+| `[views]`             | path, built-in, and metric columns per view | [Views and thresholds](views.md)                           |
 | `[thresholds]`        | RESTARTS/CPU/MEM/utilization coloring bands | [Views and thresholds](views.md#thresholds)                |
 | `[[plugins]]`         | shell-out commands bound to key chords      | [Plugins](plugins.md)                                      |
 | `[[bookmarks]]`       | saved navigation commands                   | [Plugins](plugins.md#bookmarks)                            |

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,7 +53,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   NAME and NAMESPACE stay fixed. Other columns keep their widths while you
   scroll. Arrows in the title show where more content is available. When all
   columns fit, Left and Right do nothing.
-- **Custom views** - define columns for any resource in the config file. An
+- **Custom views** - define columns for any resource in the config file.
+  Select and order built-in columns, live CPU/MEM usage, pod request and limit
+  totals, and utilization percentages. Metric columns support numeric sorting,
+  structured filters, and threshold colors. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
   automatically. `w` toggles wide-only columns (kubectl `-o wide`), including
   node labels. Add `@<namespace>` to a view key to select columns for one

--- a/docs/views.md
+++ b/docs/views.md
@@ -47,6 +47,86 @@ the layout. By default columns overlay the curated ones: a matching header
 replaces it in place, new columns go before AGE. Invalid entries are skipped with
 a warning in the app - they never take down the TUI.
 
+### Built-in and metric columns
+
+Set exactly one source for each column: `path`, `builtin`, or `metric`.
+Use `builtin` to retain an existing computed column, such as `READY` or `AGE`.
+Its value comes from the selected resource's built-in view. Use `metric` for
+live usage, resource totals, or percentages. `name` sets the displayed header.
+`type` applies only to `path` columns. All sources support `wide`, `width`,
+and `align`.
+
+This example puts CPU usage and request utilization before memory usage and AGE:
+
+```toml
+[views."v1/pods"]
+replace = true
+columns = [
+  { name = "NAME", builtin = "NAME" },
+  { name = "READY", builtin = "READY" },
+  { name = "STATUS", builtin = "STATUS" },
+  { name = "RESTARTS", builtin = "RESTARTS" },
+  { name = "CPU", metric = "cpu" },
+  { name = "CPU/R", metric = "cpu-request" },
+  { name = "%CPU/R", metric = "cpu-request-utilization" },
+  { name = "%CPU/L", metric = "cpu-limit-utilization", wide = true },
+  { name = "MEM", metric = "memory" },
+  { name = "%MEM/R", metric = "memory-request-utilization" },
+  { name = "%MEM/L", metric = "memory-limit-utilization", wide = true },
+  { name = "AGE", builtin = "AGE" },
+]
+```
+
+With `replace = true` and at least one valid `builtin` or `metric` column,
+only the declared columns are used, in declaration order. A namespace column
+is still added in all-namespaces mode. Without `replace`, columns overlay
+the built-in view. Default metrics remain unless their source or header is
+already declared, including a declaration with `wide = true`.
+Existing configurations that use only `path` retain their default metric
+columns. A custom CPU or MEM header prevents a duplicate default header.
+
+Available metric sources:
+
+| Sources                                                 | Resources   | Value                                          |
+| ------------------------------------------------------- | ----------- | ---------------------------------------------- |
+| `cpu`, `memory`                                         | Pods, nodes | Live usage                                     |
+| `cpu-request`, `memory-request`                         | Pods        | Request totals                                 |
+| `cpu-limit`, `memory-limit`                             | Pods        | Limit totals                                   |
+| `cpu-request-utilization`, `memory-request-utilization` | Pods        | Usage as a percentage of the request           |
+| `cpu-limit-utilization`, `memory-limit-utilization`     | Pods        | Usage as a percentage of the limit             |
+| `node-pods`                                             | Nodes       | Pod count                                      |
+| `node-cpu-utilization`, `node-memory-utilization`       | Nodes       | Usage as a percentage of allocatable resources |
+
+Pod totals sum application containers and native sidecars
+(`initContainers` with `restartPolicy = "Always"`). A declaration in
+`spec.resources` takes priority for that resource and request or limit.
+Regular init containers and pod overhead are excluded. These are workload
+totals after startup, not the effective values used for scheduling.
+Pod percentages can hide a container that is near its own limit. Open the
+container picker to check individual containers.
+
+For requests, unset container values contribute zero. If all values are
+unset, the total is `-`. For limits, the total is `-` if any included
+container has no limit, unless a pod-level limit is set. A percentage is
+`-` when its request or limit is missing or zero, or usage is unavailable.
+A measured zero usage is `0m`, `0Mi`, or `0%`. Request and limit totals
+remain available without Metrics Server.
+
+Sorting uses numeric values. Missing values sort first in ascending order,
+as in the default CPU and MEM columns. Structured filters use the displayed
+header, without regard to letter case: `cpu/r>4`, `%cpu/r>=75`,
+`%mem/l>=90%`, or `mem/r>=1Gi`. CPU quantities without a suffix are cores.
+Memory quantities without a suffix are bytes. Percentage values are points
+from zero, with an optional `%` suffix. Metric filters and sorts update
+when a new sample arrives. Use structured filters to search metric values.
+The existing `cpu`, `mem`, and `memory` usage filters remain available when
+those default columns are hidden.
+
+CPU and memory values use the existing resource threshold bands.
+Percentages use `[thresholds].utilization`, including per-resource overrides.
+Duplicate headers, invalid source combinations, and sources that are not
+available for a resource produce configuration warnings.
+
 ### Namespace-specific views
 
 Add `@<namespace>` to a view key to select a layout for one namespace:

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -994,14 +994,18 @@ impl App {
                         let headers = self.display_headers();
                         headers.get(i).cloned()
                     })
-                    .is_some_and(|h| matches!(h.as_str(), "CPU" | "MEM" | "%CPU" | "%MEM"));
+                    .is_some_and(|h| self.spec.metric(&h).is_some());
                 if !data.is_empty() || !containers.is_empty() {
                     self.metrics_seen = true;
                 }
                 self.metrics_error = None;
                 self.metrics = data;
                 self.container_metrics = containers;
-                if sort_uses_metrics || self.parsed_filter().uses_metrics() {
+                if sort_uses_metrics
+                    || self
+                        .parsed_filter()
+                        .uses_metrics(&|key| self.spec.metric(key).is_some())
+                {
                     self.invalidate_rows();
                 }
             }
@@ -1009,9 +1013,15 @@ impl App {
                 let sort_uses_pods = self
                     .sort_column
                     .and_then(|i| self.display_headers().get(i).cloned())
-                    .is_some_and(|h| h == "PODS");
+                    .is_some_and(|h| {
+                        self.spec.metric(&h) == Some(crate::columns::MetricColumn::NodePods)
+                    });
                 self.node_pods = Some(counts);
-                if sort_uses_pods {
+                if sort_uses_pods
+                    || self.parsed_filter().uses_metrics(&|key| {
+                        self.spec.metric(key) == Some(crate::columns::MetricColumn::NodePods)
+                    })
+                {
                     self.invalidate_rows();
                 }
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1351,9 +1351,8 @@ struct HighlightCache {
 /// times per frame, and each call used to build a fresh `Vec<String>` of owned
 /// headers only to read one entry out of it.
 struct HeaderCache {
-    /// `(namespace column, node capacity columns, metrics columns)` — the
-    /// toggles that add columns around the spec's own.
-    shape: (bool, bool, bool),
+    /// Whether the namespace column is added before the view columns.
+    namespace: bool,
     /// Bumped whenever the view spec is rebuilt.
     spec_rev: u64,
     headers: Rc<[String]>,

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -262,10 +262,32 @@ impl App {
         now: i64,
     ) -> Option<bool> {
         use crate::filter::CmpValue;
+        if let Some(metric) = self.spec.metric(&cmp.key) {
+            let actual = self.metric_value(o, metric)? as f64;
+            let wanted = match &cmp.value {
+                CmpValue::Cpu(v) | CmpValue::Mem(v) => *v as f64,
+                CmpValue::Num(v) | CmpValue::Quantity { value: v, .. } => {
+                    if metric.cpu() && !metric.percentage() {
+                        v * 1000.0
+                    } else {
+                        *v
+                    }
+                }
+                CmpValue::Str(v) if metric.percentage() => v.strip_suffix('%')?.parse().ok()?,
+                _ => return None,
+            };
+            return wanted
+                .is_finite()
+                .then(|| cmp.op.eval(actual.total_cmp(&wanted)));
+        }
         let ordering = match &cmp.value {
             CmpValue::Cpu(want) => self.row_metrics(o, key)?.0.cmp(want),
             CmpValue::Mem(want) => self.row_metrics(o, key)?.1.cmp(want),
             CmpValue::Duration(want) => crate::columns::age_secs(o, now)?.cmp(want),
+            CmpValue::Quantity { text, .. } => {
+                let cell = self.column_cell(o, key, &cmp.key, cells, now)?;
+                crate::filter::cmp_folded_lower(&cell, text)
+            }
             CmpValue::Num(want) => {
                 let cell = self.column_cell(o, key, &cmp.key, cells, now)?;
                 crate::filter::cell_number(&cell)?.total_cmp(want)
@@ -328,6 +350,9 @@ impl App {
             _ => {}
         }
         if let Some(i) = self.spec.header_index(key) {
+            if let Some(value) = self.live_cell(o, i) {
+                return Some(Cow::Owned(value));
+            }
             // Time-derived cells (AGE, a running Job's DURATION, a CronJob's
             // LAST-SCHEDULE, user `time` columns) drift without a new
             // resourceVersion, so the row cache cannot answer for them.
@@ -458,7 +483,7 @@ impl App {
         // CPU/MEM (and the node capacity percentages and pod counts) sort by
         // live poll snapshots, which move without a new resourceVersion, so
         // those keys can never be cached.
-        let volatile_sort = matches!(sort_header, Some("CPU" | "MEM" | "%CPU" | "%MEM" | "PODS"));
+        let volatile_sort = sort_header.is_some_and(|h| self.spec.metric(h).is_some());
         // The aggregated Helm release list (`helm list` semantics) shows only
         // the latest revision per release; `helmhistory` (one release's full
         // history) shows every revision, so it skips this.
@@ -741,38 +766,22 @@ impl App {
     /// for from a dozen places, several times per frame, and each answer used
     /// to be a freshly built list of owned header strings.
     pub fn display_headers(&self) -> Rc<[String]> {
-        let shape = (
-            self.show_namespace_column(),
-            self.node_capacity_columns(),
-            self.metrics_columns(),
-        );
+        let namespace = self.show_namespace_column();
         if let Some(c) = self.header_cache.borrow().as_ref()
-            && c.shape == shape
+            && c.namespace == namespace
             && c.spec_rev == self.spec_rev
         {
             return Rc::clone(&c.headers);
         }
 
-        let (ns, caps, metrics) = shape;
         let mut h = self.spec.headers();
-        if ns {
+        if namespace {
             h.insert(0, "NAMESPACE".into());
-        }
-        if caps {
-            h.push("PODS".into());
-        }
-        if metrics {
-            h.push("CPU".into());
-            h.push("MEM".into());
-        }
-        if caps {
-            h.push("%CPU".into());
-            h.push("%MEM".into());
         }
 
         let headers: Rc<[String]> = Rc::from(h);
         *self.header_cache.borrow_mut() = Some(HeaderCache {
-            shape,
+            namespace,
             spec_rev: self.spec_rev,
             headers: Rc::clone(&headers),
         });
@@ -815,6 +824,16 @@ impl App {
             .sort_column
             .and_then(|i| self.display_headers().get(i).cloned());
         let resource = self.kind.as_ref().map(Kind::resource_key);
+        let warnings = crate::columns::view_warnings(
+            self.kind.as_ref().map_or("", |kind| kind.ar.group.as_str()),
+            &self.kind_plural,
+            self.active_user_view(),
+        );
+        for warning in warnings {
+            if !self.config_warnings.contains(&warning) {
+                self.config_warnings.push(warning);
+            }
+        }
         let spec = crate::columns::build_spec(
             self.kind.as_ref().map_or("", |kind| kind.ar.group.as_str()),
             &self.kind_plural,
@@ -918,24 +937,21 @@ impl App {
         self.metrics.get(&key).copied()
     }
 
-    pub(super) fn metric_cells(&self, obj: &DynamicObject) -> Vec<String> {
-        let metrics = self.metrics_for(obj);
-        let cpu = metrics.map(|(cpu, _)| cpu);
-        let mem = metrics.map(|(_, mem)| mem);
-        let mut cells = vec![
-            crate::columns::fmt_cpu_sample(cpu),
-            crate::columns::fmt_mem_sample(mem),
-        ];
-        if self.node_capacity_columns() {
-            let (alloc_cpu, alloc_mem) = crate::columns::node_allocatable(obj);
-            cells.push(crate::columns::fmt_pct(
-                cpu.and_then(|cpu| crate::columns::usage_pct(cpu, alloc_cpu)),
-            ));
-            cells.push(crate::columns::fmt_pct(
-                mem.and_then(|mem| crate::columns::usage_pct(mem, alloc_mem)),
-            ));
+    pub(crate) fn metric_value(
+        &self,
+        obj: &DynamicObject,
+        metric: crate::columns::MetricColumn,
+    ) -> Option<i64> {
+        let group = self.kind.as_ref().map_or("", |k| k.ar.group.as_str());
+        if !metric.supported(group, &self.kind_plural) {
+            return None;
         }
-        cells
+        metric.value(obj, self.metrics_for(obj), self.node_pods_for(obj))
+    }
+
+    pub(crate) fn live_cell(&self, obj: &DynamicObject, idx: usize) -> Option<String> {
+        let metric = self.spec.metric_at(idx)?;
+        Some(metric.format(self.metric_value(obj, metric)))
     }
 
     /// Latest pod count for a node from the pods poll; `None` before the
@@ -958,6 +974,18 @@ impl App {
 
     /// Comparable value of `header`'s cell for object `o`.
     pub(super) fn column_sort_key(&self, o: &DynamicObject, header: &str, now: i64) -> SortKey {
+        if let Some(metric) = self.spec.metric(header) {
+            return SortKey::Num(
+                self.metric_value(o, metric)
+                    .map(|v| v as f64)
+                    .unwrap_or(-1.0),
+            );
+        }
+        let source_header = self
+            .spec
+            .header_index(header)
+            .and_then(|i| self.spec.canonical_header(i))
+            .unwrap_or(header);
         // User/printer columns sort by their declared type (quantity, number,
         // time…), and win over the curated special cases so an overlay that
         // redefines a header sorts by its own values.
@@ -966,7 +994,7 @@ impl App {
         {
             return SortKey::from(v);
         }
-        match header {
+        match source_header {
             "NAMESPACE" => SortKey::Text(
                 o.metadata
                     .namespace
@@ -977,37 +1005,6 @@ impl App {
             ),
             // Unknown timestamps sort last (oldest-unknown) in ascending order.
             "AGE" => SortKey::Num(crate::columns::age_secs(o, now).unwrap_or(i64::MAX) as f64),
-            "CPU" => SortKey::Num(
-                self.metrics_for(o)
-                    .map(|(cpu, _)| cpu as f64)
-                    .unwrap_or(-1.0),
-            ),
-            "MEM" => SortKey::Num(
-                self.metrics_for(o)
-                    .map(|(_, mem)| mem as f64)
-                    .unwrap_or(-1.0),
-            ),
-            // Unknown counts (poll hasn't landed) sort below every real count.
-            "PODS" if self.node_capacity_columns() => {
-                SortKey::Num(self.node_pods_for(o).map(|c| c as f64).unwrap_or(-1.0))
-            }
-            // Unknown allocatable sorts below every real percentage.
-            "%CPU" if self.node_capacity_columns() => SortKey::Num(
-                self.metrics_for(o)
-                    .and_then(|(cpu, _)| {
-                        crate::columns::usage_pct(cpu, crate::columns::node_allocatable(o).0)
-                    })
-                    .map(|p| p as f64)
-                    .unwrap_or(-1.0),
-            ),
-            "%MEM" if self.node_capacity_columns() => SortKey::Num(
-                self.metrics_for(o)
-                    .and_then(|(_, mem)| {
-                        crate::columns::usage_pct(mem, crate::columns::node_allocatable(o).1)
-                    })
-                    .map(|p| p as f64)
-                    .unwrap_or(-1.0),
-            ),
             // Humanized time cells ("5d23h") must sort by the underlying
             // timestamp, never the rendered string. Negated epoch seconds so
             // ascending = most recent first, matching AGE; unknowns last.
@@ -1128,11 +1125,8 @@ impl App {
         self.selected_ref().cloned()
     }
 
-    /// `(header, value)` pairs for the selected row, mirroring the table's
-    /// displayed columns (NAMESPACE prefix, view-spec cells with volatile
-    /// overrides, PODS/CPU/MEM suffixes) — but with the full cell values,
-    /// never the width-truncated text the renderer shows. Empty cells are
-    /// dropped: there is nothing to copy from them.
+    /// Full `(header, value)` pairs for the selected row, in display order.
+    /// Live values replace cached cells. Empty cells are excluded.
     pub fn selected_row_fields(&self) -> Vec<(String, String)> {
         let Some(obj) = self.selected_ref() else {
             return Vec::new();
@@ -1145,16 +1139,13 @@ impl App {
         let (cells, _, helm_updated) = self.spec.cells_with_helm_time(obj, now);
         for (i, cell) in cells.into_iter().enumerate() {
             values.push(
-                self.spec
-                    .volatile_cached(obj, &self.kind_plural, i, now, helm_updated)
+                self.live_cell(obj, i)
+                    .or_else(|| {
+                        self.spec
+                            .volatile_cached(obj, &self.kind_plural, i, now, helm_updated)
+                    })
                     .unwrap_or(cell),
             );
-        }
-        if self.node_capacity_columns() {
-            values.push(self.node_pods_cell(obj));
-        }
-        if self.metrics_columns() {
-            values.extend(self.metric_cells(obj));
         }
         self.display_headers()
             .iter()

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -43,9 +43,7 @@ impl App {
         });
     }
 
-    /// The current table as plain (unstyled) columns + rows — the same layout
-    /// the table renders (NAMESPACE prepended across namespaces, CPU/MEM
-    /// appended for pods/nodes, volatile cells resolved), minus the coloring.
+    /// The current table as plain columns and rows, with live values.
     pub(super) fn snapshot_table(&self) -> (Vec<String>, Vec<Vec<String>>) {
         self.snapshot_table_at(crate::columns::now_secs())
     }
@@ -53,7 +51,6 @@ impl App {
     pub(super) fn snapshot_table_at(&self, now: i64) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = self.display_headers().to_vec();
         let show_ns = self.show_namespace_column();
-        let metrics_cols = self.metrics_columns();
 
         let objs = self.rows();
         self.ensure_table_cell_cache_at(&objs, now);
@@ -71,17 +68,13 @@ impl App {
                 if let Some((base_cells, _)) = cache.get(&rk) {
                     let helm_updated = cache.helm_updated(&rk);
                     for (i, cell) in base_cells.iter().enumerate() {
-                        match spec.volatile_cached(obj, &self.kind_plural, i, now, helm_updated) {
+                        match self.live_cell(obj, i).or_else(|| {
+                            spec.volatile_cached(obj, &self.kind_plural, i, now, helm_updated)
+                        }) {
                             Some(v) => cells.push(v),
                             None => cells.push(cell.to_string()),
                         }
                     }
-                }
-                if self.node_capacity_columns() {
-                    cells.push(self.node_pods_cell(obj));
-                }
-                if metrics_cols {
-                    cells.extend(self.metric_cells(obj));
                 }
                 cells
             })

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -17704,3 +17704,295 @@ async fn describe_refresh_clamps_horizontal_scroll_when_content_shrinks() {
         app.handle_key(press(KeyCode::Char('q'))).unwrap();
     }
 }
+
+#[tokio::test]
+async fn configured_metric_columns_keep_order_values_and_live_filters() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/pods"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "READY", builtin = "READY" },
+            { name = "CPU", metric = "cpu" },
+            { name = "CPU/R", metric = "cpu-request" },
+            { name = "LOAD", metric = "cpu-request-utilization" },
+            { name = "MEM/R", metric = "memory-request" },
+            { name = "LIMIT", metric = "memory-limit-utilization", wide = true },
+            { name = "AGE", builtin = "AGE" },
+        ]
+    "#,
+    );
+    palette(&mut app, "pods");
+    for name in ["api", "worker"] {
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": name, "namespace": "default"},
+                "spec": {
+                    "containers": [
+                        {"name": "app", "resources": {"requests": {"cpu": "4", "memory": "1Gi"}, "limits": {"memory": "2Gi"}}},
+                        {"name": "reloader", "resources": {"requests": {"cpu": "100m"}}}
+                    ],
+                    "initContainers": [
+                        {"name": "proxy", "restartPolicy": "Always", "resources": {"requests": {"cpu": "100m", "memory": "128Mi"}}},
+                        {"name": "setup", "resources": {"requests": {"cpu": "20", "memory": "8Gi"}}}
+                    ]
+                },
+                "status": {"phase": "Running", "containerStatuses": [
+                    {"name": "app", "ready": true, "restartCount": 0},
+                    {"name": "reloader", "ready": true, "restartCount": 0}
+                ], "initContainerStatuses": [{"name": "proxy", "ready": true, "restartCount": 0}]}
+            }),
+        );
+    }
+    let metrics = |app: &mut App, api| {
+        app.handle_msg(Msg::Metrics {
+            generation: app.generation,
+            data: HashMap::from([
+                ("default/api".into(), (api, 0)),
+                ("default/worker".into(), (420, 0)),
+            ]),
+            containers: HashMap::new(),
+        });
+    };
+    metrics(&mut app, 4200);
+    let (headers, rows) = app.snapshot_table();
+    assert_eq!(
+        headers,
+        ["NAME", "READY", "CPU", "CPU/R", "LOAD", "MEM/R", "AGE"]
+    );
+    assert_eq!(
+        &rows[0][..6],
+        ["api", "3/3", "4200m", "4200m", "100%", "1.1Gi"]
+    );
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    let (headers, rows) = app.snapshot_table();
+    assert_eq!(headers[6], "LIMIT");
+    assert_eq!(rows[0][6], "-");
+    let fields = app.selected_row_fields();
+    assert!(fields.contains(&("LOAD".into(), "100%".into())));
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    let mut terminal = Terminal::new(TestBackend::new(180, 24)).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let buffer = terminal.backend().buffer();
+    let mut found_red = false;
+    for y in 0..buffer.area.height {
+        let line: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, y)].symbol())
+            .collect();
+        if line.contains("api")
+            && let Some(x) = line.find("100%")
+        {
+            // The table prefix can contain a multi-byte border or marker.
+            let x = line[..x].chars().count() as u16;
+            found_red = buffer[(x, y)].fg == crate::theme::red();
+        }
+    }
+    assert!(found_red);
+    type_filter(&mut app, "load>=75%");
+    assert_eq!(row_names(&app), ["api"]);
+    metrics(&mut app, 0);
+    assert!(row_names(&app).is_empty());
+    retype_filter(&mut app, "cpu/r>4 mem/r>=1Gi");
+    assert_eq!(row_names(&app), ["api", "worker"]);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    for c in "LOAD".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(row_names(&app), ["api", "worker"]);
+    metrics(&mut app, 4200);
+    assert_eq!(row_names(&app), ["worker", "api"]);
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::new(),
+        containers: HashMap::new(),
+    });
+    let (_, rows) = app.snapshot_table();
+    assert_eq!(rows[0][2], "-");
+    assert_eq!(rows[0][3], "4200m");
+    assert_eq!(rows[0][4], "-");
+}
+
+#[tokio::test]
+async fn configured_node_metrics_filter_and_refresh_by_source() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/nodes"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "COUNT", metric = "node-pods" },
+            { name = "LOAD", metric = "node-cpu-utilization" },
+            { name = "USED", metric = "memory" },
+        ]
+    "#,
+    );
+    palette(&mut app, "nodes");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "node"}, "status": {"allocatable": {"cpu": "2"}}}),
+    );
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::from([("node".into(), (1000, 1024 * 1024 * 1024))]),
+        containers: HashMap::new(),
+    });
+    type_filter(&mut app, "count>0 load>=50 used>=1Gi");
+    assert!(row_names(&app).is_empty());
+    app.handle_msg(Msg::NodePods {
+        generation: app.generation,
+        counts: HashMap::from([("node".into(), 3)]),
+    });
+    assert_eq!(row_names(&app), ["node"]);
+    let (headers, rows) = app.snapshot_table();
+    assert_eq!(headers, ["NAME", "COUNT", "LOAD", "USED"]);
+    assert_eq!(rows[0], ["node", "3", "50%", "1.0Gi"]);
+    app.handle_msg(Msg::NodePods {
+        generation: app.generation,
+        counts: HashMap::new(),
+    });
+    assert!(row_names(&app).is_empty());
+}
+
+#[tokio::test]
+async fn metric_layout_keeps_hidden_columns_hidden_and_avoids_duplicate_defaults() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/pods"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "CPU", metric = "cpu", wide = true },
+        ]
+    "#,
+    );
+    palette(&mut app, "pods");
+    assert_eq!(app.display_headers().to_vec(), ["NAME"]);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "CPU"]);
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/pods"]
+        columns = [{ name = "CPU", path = "/spec/containers/0/resources/requests/cpu", type = "quantity" }]
+    "#,
+    );
+    palette(&mut app, "nodes");
+    palette(&mut app, "pods");
+    assert_eq!(
+        app.display_headers()
+            .iter()
+            .filter(|h| h.as_str() == "CPU")
+            .count(),
+        1
+    );
+    assert!(app.display_headers().contains(&"MEM".into()));
+}
+
+#[tokio::test]
+async fn metric_overlay_retains_defaults_and_filters_percent_headers() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/pods"]
+        columns = [{ name = "%CPU/R", metric = "cpu-request-utilization" }]
+    "#,
+    );
+    palette(&mut app, "pods");
+    assert_eq!(
+        app.display_headers().to_vec(),
+        [
+            "NAME", "READY", "STATUS", "RESTARTS", "%CPU/R", "AGE", "CPU", "MEM"
+        ]
+    );
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "api", "namespace": "default"}, "spec": {"containers": [{"resources": {"requests": {"cpu": "1"}}}]}}),
+    );
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::from([("default/api".into(), (900, 0))]),
+        containers: HashMap::new(),
+    });
+    type_filter(&mut app, "%cpu/r>=90%");
+    assert_eq!(row_names(&app), ["api"]);
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::from([("default/api".into(), (800, 0))]),
+        containers: HashMap::new(),
+    });
+    assert!(row_names(&app).is_empty());
+}
+
+#[tokio::test]
+async fn unsupported_column_sources_warn_and_keep_a_usable_view() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/nodes"]
+        replace = true
+        columns = [
+            { name = "READY", builtin = "READY" },
+            { name = "CPU/R", metric = "cpu-request" },
+        ]
+    "#,
+    );
+    palette(&mut app, "nodes");
+    assert!(app.display_headers().contains(&"NAME".into()));
+    assert!(!app.display_headers().contains(&"CPU/R".into()));
+    assert_eq!(app.config_warnings.len(), 2);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.config_warnings.len(), 2);
+}
+
+#[tokio::test]
+async fn builtin_aliases_keep_numeric_sort_and_elapsed_values() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/pods"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "RETRY", builtin = "RESTARTS" },
+            { name = "CREATED", builtin = "AGE" },
+        ]
+    "#,
+    );
+    palette(&mut app, "pods");
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "RETRY", "CREATED"]);
+    for (name, restarts) in [("api", 10), ("worker", 2)] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod", "metadata": {"name": name, "namespace": "default", "creationTimestamp": "2025-01-01T00:00:00Z"}, "status": {"containerStatuses": [{"name": "app", "restartCount": restarts}]}}),
+        );
+    }
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    for c in "RETRY".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(row_names(&app), ["worker", "api"]);
+    let now = "2025-01-01T00:01:00Z"
+        .parse::<Timestamp>()
+        .unwrap()
+        .as_second();
+    assert_eq!(app.snapshot_table_at(now).1[0][2], "1m");
+    assert_eq!(app.snapshot_table_at(now + 60).1[0][2], "2m");
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -4,6 +4,10 @@
 //! hand-written renderer per resource, known kinds get curated columns and
 //! everything else falls back to NAME/AGE pulled from metadata.
 
+#[path = "columns_metrics.rs"]
+mod metrics;
+pub use metrics::MetricColumn;
+
 use std::borrow::Cow;
 use std::cell::OnceCell;
 
@@ -401,6 +405,9 @@ pub struct ViewSpec {
 struct SpecColumn {
     header: String,
     source: SpecSource,
+    original_header: String,
+    width: Option<u16>,
+    align: Option<crate::views::Align>,
     is_status: bool,
     wide: bool,
 }
@@ -414,6 +421,9 @@ fn spec_curated(c: &Column) -> SpecColumn {
     SpecColumn {
         header: c.header.to_string(),
         source: SpecSource::Curated(c.extract),
+        original_header: c.header.into(),
+        width: None,
+        align: None,
         is_status: c.is_status,
         wide: c.wide,
     }
@@ -428,7 +438,27 @@ fn spec_user(uc: &crate::views::UserColumn) -> SpecColumn {
         ),
         wide: uc.wide,
         source: SpecSource::User(uc.clone()),
+        original_header: uc.header.clone(),
+        width: uc.width,
+        align: uc.align,
     }
+}
+
+fn column_supported(group: &str, plural: &str, column: &crate::views::UserColumn) -> bool {
+    match column.kind {
+        crate::views::ColumnKind::Metric(metric) => metric.supported(group, plural),
+        crate::views::ColumnKind::Builtin => columns_for(group, plural)
+            .iter()
+            .any(|c| c.header == column.pointer),
+        _ => true,
+    }
+}
+
+pub fn view_warnings(group: &str, plural: &str, user: Option<&crate::views::View>) -> Vec<String> {
+    user.into_iter().flat_map(|v| &v.columns)
+        .filter(|c| !column_supported(group, plural, c))
+        .map(|c| format!("view {group}/{plural}: column {} is not available for this resource; column skipped", c.header))
+        .collect()
 }
 
 /// Resolve the columns for a view. `user` is the explicit view configured for
@@ -458,12 +488,41 @@ pub fn build_spec(
             }
         }
     };
+    let explicit_layout = view.is_some_and(|v| {
+        v.columns.iter().any(|c| {
+            column_supported(group, plural, c)
+                && matches!(
+                    c.kind,
+                    crate::views::ColumnKind::Metric(_) | crate::views::ColumnKind::Builtin
+                )
+        })
+    });
+    let user_column = |uc: &crate::views::UserColumn| {
+        if !column_supported(group, plural, uc) {
+            return None;
+        }
+        if uc.kind == crate::views::ColumnKind::Builtin {
+            let c = columns_for(group, plural)
+                .iter()
+                .find(|c| c.header == uc.pointer)?;
+            let mut sc = spec_curated(c);
+            sc.header = uc.header.clone();
+            sc.wide = uc.wide;
+            sc.width = uc.width;
+            sc.align = uc.align;
+            Some(sc)
+        } else {
+            Some(spec_user(uc))
+        }
+    };
     if let Some(v) = view {
-        if v.replace && !v.columns.is_empty() {
-            cols = v.columns.iter().map(spec_user).collect();
+        if v.replace && v.columns.iter().any(|c| column_supported(group, plural, c)) {
+            cols = v.columns.iter().filter_map(user_column).collect();
         } else {
             for uc in &v.columns {
-                let sc = spec_user(uc);
+                let Some(sc) = user_column(uc) else {
+                    continue;
+                };
                 match cols.iter().position(|c| c.header == sc.header) {
                     // A matching header replaces the curated column in place.
                     Some(i) => cols[i] = sc,
@@ -480,6 +539,36 @@ pub fn build_spec(
             }
         }
     }
+    if (!explicit_layout || !view.is_some_and(|v| v.replace))
+        && group.is_empty()
+        && matches!(plural, "pods" | "nodes")
+    {
+        let mut defaults = Vec::new();
+        if plural == "nodes" {
+            defaults.push(("PODS", MetricColumn::NodePods));
+        }
+        defaults.extend([("CPU", MetricColumn::Cpu), ("MEM", MetricColumn::Memory)]);
+        if plural == "nodes" {
+            defaults.extend([
+                ("%CPU", MetricColumn::NodeCpuUtilization),
+                ("%MEM", MetricColumn::NodeMemoryUtilization),
+            ]);
+        }
+        for (header, metric) in defaults {
+            if cols.iter().any(|c| c.header == header || matches!(&c.source, SpecSource::User(uc) if uc.kind == crate::views::ColumnKind::Metric(metric))) {
+                continue;
+            }
+            cols.push(spec_user(&crate::views::UserColumn {
+                header: header.into(),
+                pointer: String::new(),
+                kind: crate::views::ColumnKind::Metric(metric),
+                wide: false,
+                width: None,
+                align: None,
+                condition_field: None,
+            }));
+        }
+    }
     cols.retain(|c| wide || !c.wide);
     let status_idx = cols.iter().position(|c| c.is_status);
     ViewSpec {
@@ -491,6 +580,27 @@ pub fn build_spec(
 }
 
 impl ViewSpec {
+    pub fn metric_at(&self, idx: usize) -> Option<MetricColumn> {
+        match &self.columns.get(idx)?.source {
+            SpecSource::User(uc) => match uc.kind {
+                crate::views::ColumnKind::Metric(metric) => Some(metric),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub fn metric(&self, header: &str) -> Option<MetricColumn> {
+        self.metric_at(self.header_index(header)?)
+    }
+
+    pub fn canonical_header(&self, idx: usize) -> Option<&str> {
+        if self.metric_at(idx).is_some() {
+            return None;
+        }
+        Some(&self.columns.get(idx)?.original_header)
+    }
+
     pub fn headers(&self) -> Vec<String> {
         self.columns.iter().map(|c| c.header.clone()).collect()
     }
@@ -540,7 +650,7 @@ impl ViewSpec {
                 Some(crate::views::render_cell(obj, uc, now))
             }
             SpecSource::User(_) => None,
-            SpecSource::Curated(_) => volatile_cell(obj, plural, &col.header, now),
+            SpecSource::Curated(_) => volatile_cell(obj, plural, &col.original_header, now),
         }
     }
 
@@ -555,7 +665,7 @@ impl ViewSpec {
     ) -> Option<String> {
         let col = self.columns.get(idx)?;
         if matches!(plural, "helm" | "helmhistory")
-            && col.header == "UPDATED"
+            && col.original_header == "UPDATED"
             && matches!(col.source, SpecSource::Curated(_))
         {
             Some(helm_updated(helm_time, now))
@@ -613,7 +723,7 @@ impl ViewSpec {
             SpecSource::Curated(extract) => {
                 let ctx = CellContext::new(obj, now);
                 let v = extract(&ctx);
-                if is_numeric_header(&self.group, &self.plural, header) {
+                if is_numeric_header(&self.group, &self.plural, &col.original_header) {
                     crate::views::SortValue::Num(parse_leading_num(&v))
                 } else {
                     crate::views::SortValue::Text(v.to_lowercase().to_string())
@@ -625,18 +735,12 @@ impl ViewSpec {
     /// Configured fixed width for the column at `idx`, when it's a user
     /// column that set one.
     pub fn width_at(&self, idx: usize) -> Option<u16> {
-        match &self.columns.get(idx)?.source {
-            SpecSource::User(uc) => uc.width,
-            SpecSource::Curated(_) => None,
-        }
+        self.columns.get(idx)?.width
     }
 
     /// Configured alignment for the column at `idx`.
     pub fn align_at(&self, idx: usize) -> Option<crate::views::Align> {
-        match &self.columns.get(idx)?.source {
-            SpecSource::User(uc) => uc.align,
-            SpecSource::Curated(_) => None,
-        }
+        self.columns.get(idx)?.align
     }
 }
 
@@ -3089,7 +3193,9 @@ mod tests {
         let spec = build_spec("", "pods", Some(&v), None, false);
         assert_eq!(
             spec.headers(),
-            vec!["NAME", "READY", "STATUS", "RESTARTS", "NODE-IP", "AGE"]
+            vec![
+                "NAME", "READY", "STATUS", "RESTARTS", "NODE-IP", "AGE", "CPU", "MEM"
+            ]
         );
         let o = obj(json!({
             "apiVersion": "v1", "kind": "Pod",
@@ -3113,7 +3219,7 @@ mod tests {
             true,
         );
         let spec = build_spec("", "pods", Some(&v), None, true);
-        assert_eq!(spec.headers(), vec!["NAME", "PHASE"]);
+        assert_eq!(spec.headers(), vec!["NAME", "PHASE", "CPU", "MEM"]);
     }
 
     #[test]
@@ -3121,12 +3227,14 @@ mod tests {
         let narrow = build_spec("", "pods", None, None, false);
         assert_eq!(
             narrow.headers(),
-            vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
+            vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE", "CPU", "MEM"]
         );
         let wide = build_spec("", "pods", None, None, true);
         assert_eq!(
             wide.headers(),
-            vec!["NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE"]
+            vec![
+                "NAME", "READY", "STATUS", "RESTARTS", "IP", "NODE", "AGE", "CPU", "MEM"
+            ]
         );
     }
 
@@ -3144,7 +3252,7 @@ mod tests {
         let spec = build_spec("", "pods", None, Some(&crd), false);
         assert_eq!(
             spec.headers(),
-            vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE"]
+            vec!["NAME", "READY", "STATUS", "RESTARTS", "AGE", "CPU", "MEM"]
         );
         // Explicit user view outranks printer columns.
         let user = view(

--- a/src/columns_metrics.rs
+++ b/src/columns_metrics.rs
@@ -1,0 +1,209 @@
+use kube::core::DynamicObject;
+use serde_json::Value;
+
+use crate::columns::{
+    fmt_cpu_sample, fmt_mem_sample, fmt_pct, parse_cpu_milli, parse_mem_bytes, usage_pct,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricColumn {
+    Cpu,
+    Memory,
+    CpuRequest,
+    CpuLimit,
+    MemoryRequest,
+    MemoryLimit,
+    CpuRequestUtilization,
+    CpuLimitUtilization,
+    MemoryRequestUtilization,
+    MemoryLimitUtilization,
+    NodePods,
+    NodeCpuUtilization,
+    NodeMemoryUtilization,
+}
+
+impl MetricColumn {
+    pub fn parse(name: &str) -> Option<Self> {
+        Some(match name {
+            "cpu" => Self::Cpu,
+            "memory" => Self::Memory,
+            "cpu-request" => Self::CpuRequest,
+            "cpu-limit" => Self::CpuLimit,
+            "memory-request" => Self::MemoryRequest,
+            "memory-limit" => Self::MemoryLimit,
+            "cpu-request-utilization" => Self::CpuRequestUtilization,
+            "cpu-limit-utilization" => Self::CpuLimitUtilization,
+            "memory-request-utilization" => Self::MemoryRequestUtilization,
+            "memory-limit-utilization" => Self::MemoryLimitUtilization,
+            "node-pods" => Self::NodePods,
+            "node-cpu-utilization" => Self::NodeCpuUtilization,
+            "node-memory-utilization" => Self::NodeMemoryUtilization,
+            _ => return None,
+        })
+    }
+
+    pub fn supported(self, group: &str, plural: &str) -> bool {
+        group.is_empty()
+            && match self {
+                Self::Cpu | Self::Memory => matches!(plural, "pods" | "nodes"),
+                Self::NodePods | Self::NodeCpuUtilization | Self::NodeMemoryUtilization => {
+                    plural == "nodes"
+                }
+                _ => plural == "pods",
+            }
+    }
+
+    pub fn percentage(self) -> bool {
+        matches!(
+            self,
+            Self::CpuRequestUtilization
+                | Self::CpuLimitUtilization
+                | Self::MemoryRequestUtilization
+                | Self::MemoryLimitUtilization
+                | Self::NodeCpuUtilization
+                | Self::NodeMemoryUtilization
+        )
+    }
+
+    pub fn cpu(self) -> bool {
+        matches!(
+            self,
+            Self::Cpu
+                | Self::CpuRequest
+                | Self::CpuLimit
+                | Self::CpuRequestUtilization
+                | Self::CpuLimitUtilization
+                | Self::NodeCpuUtilization
+        )
+    }
+
+    pub fn format(self, value: Option<i64>) -> String {
+        if self.percentage() {
+            fmt_pct(value)
+        } else if self == Self::NodePods {
+            value.map_or_else(|| "-".into(), |v| v.to_string())
+        } else if self.cpu() {
+            fmt_cpu_sample(value)
+        } else {
+            fmt_mem_sample(value)
+        }
+    }
+
+    pub fn value(
+        self,
+        obj: &DynamicObject,
+        usage: Option<(i64, i64)>,
+        pods: Option<usize>,
+    ) -> Option<i64> {
+        match self {
+            Self::Cpu => usage.map(|v| v.0),
+            Self::Memory => usage.map(|v| v.1),
+            Self::NodePods => pods.map(|v| v as i64),
+            Self::NodeCpuUtilization => {
+                usage_pct(usage?.0, crate::columns::node_allocatable(obj).0)
+            }
+            Self::NodeMemoryUtilization => {
+                usage_pct(usage?.1, crate::columns::node_allocatable(obj).1)
+            }
+            _ => {
+                let limit = matches!(
+                    self,
+                    Self::CpuLimit
+                        | Self::MemoryLimit
+                        | Self::CpuLimitUtilization
+                        | Self::MemoryLimitUtilization
+                );
+                let base = pod_resource(obj, self.cpu(), limit);
+                if self.percentage() {
+                    let usage = usage?;
+                    usage_pct(if self.cpu() { usage.0 } else { usage.1 }, base)
+                } else {
+                    base
+                }
+            }
+        }
+    }
+}
+
+// These totals describe application containers and native sidecars after startup.
+// Pod-level declarations take precedence. Init peaks and overhead are excluded.
+fn pod_resource(obj: &DynamicObject, cpu: bool, limit: bool) -> Option<i64> {
+    let resource = if cpu { "cpu" } else { "memory" };
+    let section = if limit { "limits" } else { "requests" };
+    let parse = if cpu {
+        parse_cpu_milli
+    } else {
+        parse_mem_bytes
+    };
+    let read = |resources: &Value| resources.get(section)?.get(resource)?.as_str().map(parse);
+    if let Some(value) = obj.data.pointer("/spec/resources").and_then(read) {
+        return Some(value);
+    }
+    let containers = obj.data.pointer("/spec/containers")?.as_array()?;
+    let sidecars = obj
+        .data
+        .pointer("/spec/initContainers")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|c| c.get("restartPolicy").and_then(Value::as_str) == Some("Always"));
+    let mut total = 0i64;
+    let mut any = false;
+    for container in containers.iter().chain(sidecars) {
+        match container.get("resources").and_then(read) {
+            Some(value) => {
+                total = total.checked_add(value)?;
+                any = true;
+            }
+            None if limit => return None,
+            None => {}
+        }
+    }
+    any.then_some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn resource_totals_preserve_missing_zero_and_pod_declarations() {
+        let pod = |spec| {
+            serde_json::from_value::<DynamicObject>(json!({
+                "apiVersion": "v1", "kind": "Pod", "metadata": {"name": "test"}, "spec": spec
+            }))
+            .unwrap()
+        };
+        let missing = pod(json!({"containers": [{"name": "app"}]}));
+        assert_eq!(MetricColumn::CpuRequest.value(&missing, None, None), None);
+        let zero = pod(json!({"containers": [{"resources": {"requests": {"cpu": "0"}}}]}));
+        assert_eq!(MetricColumn::CpuRequest.value(&zero, None, None), Some(0));
+        assert_eq!(
+            MetricColumn::CpuRequestUtilization.value(&zero, Some((0, 0)), None),
+            None
+        );
+        let declared = pod(json!({
+            "resources": {"requests": {"cpu": "2"}, "limits": {"memory": "1Gi"}},
+            "overhead": {"cpu": "100m"},
+            "containers": [{"resources": {"requests": {"cpu": "500m", "memory": "128Mi"}}}, {}]
+        }));
+        assert_eq!(
+            MetricColumn::CpuRequest.value(&declared, None, None),
+            Some(2000)
+        );
+        assert_eq!(
+            MetricColumn::MemoryRequest.value(&declared, None, None),
+            Some(128 * 1024 * 1024)
+        );
+        assert_eq!(
+            MetricColumn::MemoryLimit.value(&declared, None, None),
+            Some(1024 * 1024 * 1024)
+        );
+        assert_eq!(
+            MetricColumn::MemoryLimitUtilization.value(&declared, Some((0, 0)), None),
+            Some(0)
+        );
+        assert_eq!(MetricColumn::CpuLimit.value(&declared, None, None), None);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -767,6 +767,10 @@ pub struct DrillConfig {
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct ViewColumnConfig {
+    /// Built-in metric source. Use exactly one of path, metric, or builtin.
+    pub metric: Option<String>,
+    /// Existing built-in column, such as READY or AGE.
+    pub builtin: Option<String>,
     /// Column header (displayed uppercased).
     pub name: String,
     /// JSON Pointer to the cell value, e.g. `/status/phase`.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -67,14 +67,15 @@ pub enum Term {
 }
 
 impl Term {
-    pub fn metrics_sensitive(&self) -> bool {
+    pub fn metrics_sensitive(&self, is_metric: &impl Fn(&str) -> bool) -> bool {
         match self {
             Self::Cmp(Cmp {
                 value: CmpValue::Cpu(_) | CmpValue::Mem(_),
                 ..
             }) => true,
+            Self::Cmp(cmp) => is_metric(&cmp.key),
             Self::All(terms) | Self::Any(terms) | Self::Not(terms) => {
-                terms.iter().any(Self::metrics_sensitive)
+                terms.iter().any(|t| t.metrics_sensitive(is_metric))
             }
             _ => false,
         }
@@ -245,6 +246,8 @@ impl Op {
 pub enum CmpValue {
     /// Plain number (`restarts>=5`).
     Num(f64),
+    /// A quantity for metric columns, with text retained for other columns.
+    Quantity { value: f64, text: String },
     /// CPU quantity in millicores (`cpu>500m`).
     Cpu(i64),
     /// Memory quantity in bytes (`memory>1Gi`).
@@ -258,8 +261,8 @@ pub enum CmpValue {
 }
 
 impl ParsedFilter {
-    pub fn uses_metrics(&self) -> bool {
-        matches!(self, Self::Structured(s) if s.terms.iter().any(Term::metrics_sensitive))
+    pub fn uses_metrics(&self, is_metric: &impl Fn(&str) -> bool) -> bool {
+        matches!(self, Self::Structured(s) if s.terms.iter().any(|t| t.metrics_sensitive(is_metric)))
     }
 
     pub fn labels(&self) -> Option<&str> {
@@ -685,12 +688,12 @@ fn split_cmp(tok: &str) -> Option<(&str, Op, &str)> {
     if !tok
         .chars()
         .next()
-        .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
+        .is_some_and(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '%'))
     {
         return None;
     }
-    let key_end =
-        tok.find(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.')))?;
+    let key_end = tok
+        .find(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '%' | '/')))?;
     let (key, rest) = tok.split_at(key_end);
     let (op, value) = if let Some(v) = rest.strip_prefix("!=") {
         (Op::Ne, v)
@@ -757,7 +760,12 @@ fn typed_value(key: &str, raw: &str) -> Result<CmpValue, String> {
             Err(_) if key.eq_ignore_ascii_case("restarts") => {
                 Err(format!("bad restart count '{raw}'"))
             }
-            Err(_) => Ok(CmpValue::Str(fold_lower(raw))),
+            Err(_) => Ok(crate::views::parse_quantity(raw)
+                .map(|value| CmpValue::Quantity {
+                    value,
+                    text: fold_lower(raw),
+                })
+                .unwrap_or_else(|| CmpValue::Str(fold_lower(raw)))),
         },
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -559,14 +559,18 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
 
 fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     let show_ns = app.show_namespace_column();
-    let metrics_cols = app.metrics_columns();
     let headers = app.display_headers();
     let sort_col = app.sort_column;
     let sort_arrow = if app.sort_desc { " ↓" } else { " ↑" };
-    // Offset from a displayed column index back to the view spec's (the spec
-    // doesn't know about the prepended NAMESPACE or appended CPU/MEM).
+    // The namespace column is added before the view columns.
     let ns_off = usize::from(show_ns);
-    let name_col = usize::from(show_ns);
+    let name_col = (0..headers.len())
+        .find(|i| {
+            i.checked_sub(ns_off)
+                .and_then(|si| app.view_spec().canonical_header(si))
+                == Some("NAME")
+        })
+        .unwrap_or(ns_off);
     // Per-column custom alignment, precomputed so cells don't re-borrow app.
     let aligns: Vec<Option<Alignment>> = (0..headers.len())
         .map(|i| {
@@ -609,13 +613,27 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     // Column indices (fixed for the whole table) for the columns that get
     // their own visibility treatment below, computed once rather than
     // string-compared per cell.
-    let age_idx = headers.iter().position(|h| h == "AGE");
-    let ready_idx = headers.iter().position(|h| h == "READY");
-    let restarts_idx = headers.iter().position(|h| h == "RESTARTS");
-    let cpu_idx = headers.iter().position(|h| h == "CPU");
-    let mem_idx = headers.iter().position(|h| h == "MEM");
-    let pct_cpu_idx = headers.iter().position(|h| h == "%CPU");
-    let pct_mem_idx = headers.iter().position(|h| h == "%MEM");
+    let age_idx = (0..headers.len()).find(|i| {
+        i.checked_sub(ns_off)
+            .and_then(|si| app.view_spec().canonical_header(si))
+            == Some("AGE")
+    });
+    let ready_idx = (0..headers.len()).find(|i| {
+        i.checked_sub(ns_off)
+            .and_then(|si| app.view_spec().canonical_header(si))
+            == Some("READY")
+    });
+    let restarts_idx = (0..headers.len()).find(|i| {
+        i.checked_sub(ns_off)
+            .and_then(|si| app.view_spec().canonical_header(si))
+            == Some("RESTARTS")
+    });
+    let metric_columns: Vec<_> = (0..headers.len())
+        .map(|i| {
+            i.checked_sub(ns_off)
+                .and_then(|si| app.view_spec().metric_at(si))
+        })
+        .collect();
 
     let count = app.row_count();
     let visible_rows = area.height.saturating_sub(3).max(1) as usize;
@@ -663,6 +681,14 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 .and_then(|si| app.view_spec().width_at(si))
             {
                 ColWidth::Exact(w)
+            } else if let Some(metric) = metric_columns[i] {
+                ColWidth::Exact(match metric {
+                    columns::MetricColumn::NodePods
+                    | columns::MetricColumn::NodeCpuUtilization
+                    | columns::MetricColumn::NodeMemoryUtilization => 5,
+                    _ if metric.percentage() => 7,
+                    _ => 8,
+                })
             } else {
                 match h.as_str() {
                     // NAME is the column you actually read — its weight takes
@@ -755,33 +781,13 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 style_idx = status_idx.map(|i| i + 1);
             }
             for (i, cell) in base_cells.iter().enumerate() {
-                if let Some(value) =
-                    spec.volatile_cached(obj, &app.kind_plural, i, now, helm_updated)
+                if let Some(value) = app
+                    .live_cell(obj, i)
+                    .or_else(|| spec.volatile_cached(obj, &app.kind_plural, i, now, helm_updated))
                 {
                     cells.push(TableCellText::Owned(value));
                 } else {
                     cells.push(TableCellText::Borrowed(cell.as_str()));
-                }
-            }
-            if app.node_capacity_columns() {
-                cells.push(TableCellText::Owned(app.node_pods_cell(obj)));
-            }
-            let mut metrics_raw = None;
-            let mut node_pcts: (Option<i64>, Option<i64>) = (None, None);
-            if metrics_cols {
-                metrics_raw = app.metrics_for(obj);
-                let cpu = metrics_raw.map(|(cpu, _)| cpu);
-                let mem = metrics_raw.map(|(_, mem)| mem);
-                cells.push(TableCellText::Owned(columns::fmt_cpu_sample(cpu)));
-                cells.push(TableCellText::Owned(columns::fmt_mem_sample(mem)));
-                if app.node_capacity_columns() {
-                    let (alloc_cpu, alloc_mem) = columns::node_allocatable(obj);
-                    node_pcts = (
-                        cpu.and_then(|cpu| columns::usage_pct(cpu, alloc_cpu)),
-                        mem.and_then(|mem| columns::usage_pct(mem, alloc_mem)),
-                    );
-                    cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.0)));
-                    cells.push(TableCellText::Owned(columns::fmt_pct(node_pcts.1)));
                 }
             }
             // Combined colorer: the whole row takes a k9s-style status tint
@@ -843,23 +849,23 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                             .map(theme::severity_fg)
                             .unwrap_or(row_color);
                         c.into_cell_aligned(align).style(Style::default().fg(color))
-                    } else if Some(i) == cpu_idx {
-                        let color = metrics_raw
-                            .and_then(|(cpu, _)| thresholds.cpu.severity(cpu))
-                            .map(theme::severity_fg)
-                            .unwrap_or(row_color);
-                        c.into_cell_aligned(align).style(Style::default().fg(color))
-                    } else if Some(i) == mem_idx {
-                        let color = metrics_raw
-                            .and_then(|(_, mem)| thresholds.memory.severity(mem))
-                            .map(theme::severity_fg)
-                            .unwrap_or(row_color);
-                        c.into_cell_aligned(align).style(Style::default().fg(color))
-                    } else if Some(i) == pct_cpu_idx {
-                        let color = util_color(node_pcts.0, thresholds.utilization);
-                        c.into_cell_aligned(align).style(Style::default().fg(color))
-                    } else if Some(i) == pct_mem_idx {
-                        let color = util_color(node_pcts.1, thresholds.utilization);
+                    } else if let Some(metric) = metric_columns[i] {
+                        let value = app.metric_value(obj, metric);
+                        let color = if metric.percentage() {
+                            util_color(value, thresholds.utilization)
+                        } else if metric == columns::MetricColumn::NodePods {
+                            row_color
+                        } else {
+                            let band = if metric.cpu() {
+                                thresholds.cpu
+                            } else {
+                                thresholds.memory
+                            };
+                            value
+                                .and_then(|v| band.severity(v))
+                                .map(theme::severity_fg)
+                                .unwrap_or(row_color)
+                        };
                         c.into_cell_aligned(align).style(Style::default().fg(color))
                     } else {
                         c.into_cell_aligned(align)

--- a/src/views.rs
+++ b/src/views.rs
@@ -20,6 +20,8 @@ use serde_json::Value;
 /// How a custom column's value is rendered and sorted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ColumnKind {
+    Metric(crate::columns::MetricColumn),
+    Builtin,
     #[default]
     Text,
     /// Text that also drives the row's status coloring.
@@ -261,7 +263,7 @@ pub fn compile(
                 warnings.push(format!("views.\"{key}\": column with empty name skipped"));
                 continue;
             }
-            let kind = match c.kind.as_deref() {
+            let mut kind = match c.kind.as_deref() {
                 None | Some("text") => ColumnKind::Text,
                 Some("status") => ColumnKind::Status,
                 Some("number") => ColumnKind::Number,
@@ -276,6 +278,41 @@ pub fn compile(
                     ColumnKind::Text
                 }
             };
+            let sources = usize::from(!c.path.is_empty())
+                + usize::from(c.metric.is_some())
+                + usize::from(c.builtin.is_some());
+            if sources != 1 {
+                warnings.push(format!("views.\"{key}\": column {header}: set exactly one of path, metric, or builtin; column skipped"));
+                continue;
+            }
+            if columns
+                .iter()
+                .any(|column: &UserColumn| column.header == header)
+            {
+                warnings.push(format!(
+                    "views.\"{key}\": duplicate column {header}; column skipped"
+                ));
+                continue;
+            }
+            if c.kind.is_some() && (c.metric.is_some() || c.builtin.is_some()) {
+                warnings.push(format!("views.\"{key}\": column {header}: type applies only to path columns; column skipped"));
+                continue;
+            }
+            let mut pointer = c.path.trim().to_string();
+            if let Some(metric) = &c.metric {
+                let Some(metric) = crate::columns::MetricColumn::parse(metric) else {
+                    warnings.push(format!("views.\"{key}\": column {header}: unknown metric '{metric}'; column skipped"));
+                    continue;
+                };
+                kind = ColumnKind::Metric(metric);
+            } else if let Some(builtin) = &c.builtin {
+                pointer = builtin.trim().to_uppercase();
+                if pointer.is_empty() {
+                    warnings.push(format!("views.\"{key}\": column {header}: builtin must name a column; column skipped"));
+                    continue;
+                }
+                kind = ColumnKind::Builtin;
+            }
             // A condition column's path is the condition *type* name, not a
             // pointer — conditions are found by name because their array
             // order isn't guaranteed by anything.
@@ -287,7 +324,9 @@ pub fn compile(
                     ));
                     continue;
                 }
-            } else if !c.path.starts_with('/') {
+            } else if !matches!(kind, ColumnKind::Metric(_) | ColumnKind::Builtin)
+                && !c.path.starts_with('/')
+            {
                 warnings.push(format!(
                     "views.\"{key}\": column {header}: path '{}' is not a JSON Pointer \
                      (must start with '/', e.g. /status/phase); column skipped",
@@ -310,7 +349,7 @@ pub fn compile(
             };
             columns.push(UserColumn {
                 header,
-                pointer: c.path.trim().to_string(),
+                pointer,
                 kind,
                 wide: c.wide,
                 width: c.width,
@@ -616,6 +655,9 @@ fn extract_string_map<'a>(
 
 /// Render one custom column's cell. Missing values read as `<none>`.
 pub fn render_cell(obj: &DynamicObject, col: &UserColumn, now: i64) -> String {
+    if matches!(col.kind, ColumnKind::Metric(_)) {
+        return "-".into();
+    }
     if col.kind == ColumnKind::Condition {
         return condition_status(obj, &col.pointer).unwrap_or_else(|| "<none>".into());
     }
@@ -716,7 +758,11 @@ pub fn sort_value(obj: &DynamicObject, col: &UserColumn, now: i64) -> SortValue 
         ),
         // Condition is handled above (its "pointer" is a condition name, not
         // something `extract` understands).
-        ColumnKind::Text | ColumnKind::Status | ColumnKind::Condition => SortValue::Text(
+        ColumnKind::Text
+        | ColumnKind::Status
+        | ColumnKind::Condition
+        | ColumnKind::Metric(_)
+        | ColumnKind::Builtin => SortValue::Text(
             v.as_ref()
                 .map(Extracted::render)
                 .unwrap_or_default()
@@ -927,6 +973,28 @@ mod tests {
 
     fn obj(v: serde_json::Value) -> DynamicObject {
         serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn column_sources_validate_without_discarding_other_columns() {
+        let cfg: crate::config::Config = toml::from_str(
+            r#"
+            [views."v1/pods"]
+            columns = [
+                { name = "NAME", builtin = "NAME" },
+                { name = "CPU", metric = "cpu" },
+                { name = "CPU", metric = "memory" },
+                { name = "BOTH", path = "/spec/cpu", metric = "cpu" },
+                { name = "UNKNOWN", metric = "cpus" },
+                { name = "BAD", builtin = "" },
+                { name = "TYPED", metric = "memory", type = "text" },
+            ]
+        "#,
+        )
+        .unwrap();
+        let (views, warnings) = compile(&cfg.views);
+        assert_eq!(views["v1/pods"].columns.len(), 2);
+        assert_eq!(warnings.len(), 5);
     }
 
     fn col(pointer: &str, kind: ColumnKind) -> UserColumn {


### PR DESCRIPTION
CPU and MEM were appended outside the view definition. This prevented column ordering and caused duplicate headers. Pod request and limit percentages were available only in the container picker.

Add `metric` and `builtin` column sources. A replacement view can now retain computed columns such as READY and place usage, resource totals, and utilization percentages in declaration order. Metric columns share numeric sorting, structured filters, threshold colors, snapshots, and copied values. Filters and sorts update when new samples arrive. Existing default layouts and missing-value sort order are preserved.

Pod totals include application containers and native sidecars. Pod-level resource declarations take priority. Regular init containers and pod overhead are excluded. A missing container limit makes the total limit unknown unless a pod-level limit is set. These rules and a complete configuration example are documented.

Validation: `just check` passes. Tests cover keyboard-driven column selection, wide mode, percentage and quantity filters, sample updates, colors, snapshots, copied values, source validation, and renamed built-in columns. The full test suite runs without a cluster.

Closes #345
