### PR TITLE
fix: support minus key chords with modifiers

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -20,6 +20,9 @@ character (`"g"`), a modifier combination (`"ctrl-g"`, `"alt-x"`, `"shift-b"`), 
 a function or named key (`"f5"`, `"ctrl-f2"`). A built-in key wins over a plugin
 on the same chord.
 
+For the minus key, use `"-"` alone or `"ctrl--"`, `"alt--"`, or `"ctrl-alt--"`
+with modifiers. The final two hyphens are the separator and the minus key.
+
 ```toml
 [[plugins]]
 key = "shift-y"

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,6 +22,9 @@ on the same chord.
 
 For the minus key, use `"-"` alone or `"ctrl--"`, `"alt--"`, or `"ctrl-alt--"`
 with modifiers. The final two hyphens are the separator and the minus key.
+`"shift--"` is not supported. Bind the character that your keyboard produces
+instead. For example, use `"_"` if Shift+minus produces an underscore, or
+`"ctrl-_"` to add Ctrl.
 
 ```toml
 [[plugins]]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5550,6 +5550,36 @@ async fn palette_completion_accepts_minus_chords() {
 }
 
 #[tokio::test]
+async fn palette_shifted_minus_uses_the_resulting_character() {
+    for modifiers in [KeyModifiers::NONE, KeyModifiers::SHIFT] {
+        let (mut app, _rx) = test_app();
+        let config: crate::config::Config = toml::from_str(
+            r#"
+            [keys]
+            palette_next = ["shift--", "_"]
+            "#,
+        )
+        .unwrap();
+        let (palette_keys, warnings) = crate::config::compile_palette_keys(&config.keys);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("bind the resulting character"));
+        app.palette_keys = palette_keys;
+
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        app.handle_key(press(KeyCode::Char('-'))).unwrap();
+        assert_eq!(app.command, "-");
+        app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+        assert!(app.command.is_empty());
+        assert!(app.cmd_suggestions.len() > 1);
+        assert_eq!(app.cmd_sel, 0);
+        app.handle_key(KeyEvent::new(KeyCode::Char('_'), modifiers))
+            .unwrap();
+        assert_eq!(app.cmd_sel, 1);
+        assert!(app.command.is_empty());
+    }
+}
+
+#[tokio::test]
 async fn palette_completion_keys_are_rebindable() {
     let (mut app, _rx) = test_app();
     let keys_cfg: crate::config::Config = toml::from_str(

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5523,6 +5523,33 @@ async fn crd_plural_outranks_builtin_command() {
 }
 
 #[tokio::test]
+async fn palette_completion_accepts_minus_chords() {
+    let (mut app, _rx) = test_app();
+    let config: crate::config::Config = toml::from_str(
+        r#"
+        [keys]
+        palette_next = "ctrl--"
+        palette_prev = "alt--"
+        "#,
+    )
+    .unwrap();
+    let (palette_keys, warnings) = crate::config::compile_palette_keys(&config.keys);
+    assert!(warnings.is_empty(), "{warnings:?}");
+    app.palette_keys = palette_keys;
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert_eq!(app.mode, Mode::Command);
+    assert!(app.cmd_suggestions.len() > 1);
+    assert_eq!(app.cmd_sel, 0);
+    app.handle_key(ctrl(KeyCode::Char('-'))).unwrap();
+    assert_eq!(app.cmd_sel, 1);
+    app.handle_key(KeyEvent::new(KeyCode::Char('-'), KeyModifiers::ALT))
+        .unwrap();
+    assert_eq!(app.cmd_sel, 0);
+    assert!(app.command.is_empty());
+}
+
+#[tokio::test]
 async fn palette_completion_keys_are_rebindable() {
     let (mut app, _rx) = test_app();
     let keys_cfg: crate::config::Config = toml::from_str(

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -66,6 +66,11 @@ impl KeyChord {
         }
 
         let mut code = parse_key(key).ok_or_else(|| format!("{s:?}: unknown key {key:?}"))?;
+        if shift && code == KeyCode::Char('-') {
+            return Err(format!(
+                "{s:?}: Shift with minus is not supported; bind the resulting character instead (for example, \"_\")"
+            ));
+        }
 
         // Fold shift into a letter's case so matching stays case-based (like the
         // built-in bindings); keep it as a flag for function/named keys.
@@ -232,7 +237,6 @@ mod tests {
             ("-", KeyModifiers::NONE),
             ("ctrl--", KeyModifiers::CONTROL),
             ("alt--", KeyModifiers::ALT),
-            ("shift--", KeyModifiers::SHIFT),
             ("ctrl-alt--", KeyModifiers::CONTROL | KeyModifiers::ALT),
         ] {
             let chord = KeyChord::parse(input).unwrap();
@@ -250,6 +254,28 @@ mod tests {
         );
         for input in ["--", "---", "ctrl-", "ctrl---", "ctrl--g", "-alt--"] {
             assert!(KeyChord::parse(input).is_err(), "{input}");
+        }
+    }
+
+    #[test]
+    fn shifted_minus_requires_the_resulting_character() {
+        for input in ["shift--", "s--", "SHIFT--", "ctrl-shift--", "shift-alt--"] {
+            let error = KeyChord::parse(input).unwrap_err();
+            assert!(error.contains("bind the resulting character"), "{error}");
+        }
+        for input in ["_", "ctrl-_", "alt-_"] {
+            let chord = KeyChord::parse(input).unwrap();
+            let modifiers = if chord.ctrl {
+                KeyModifiers::CONTROL
+            } else if chord.alt {
+                KeyModifiers::ALT
+            } else {
+                KeyModifiers::NONE
+            };
+            for shift in [KeyModifiers::NONE, KeyModifiers::SHIFT] {
+                assert!(chord.matches(&ev(KeyCode::Char('_'), modifiers | shift)));
+                assert!(!chord.matches(&ev(KeyCode::Char('-'), modifiers | shift)));
+            }
         }
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -46,12 +46,16 @@ impl KeyChord {
             });
         }
 
-        let parts: Vec<&str> = trimmed.split('-').collect();
-        let (mods, key) = parts.split_at(parts.len() - 1);
-        let key = key[0];
+        let (mods, key) = if let Some(mods) = trimmed.strip_suffix("--") {
+            (Some(mods), "-")
+        } else if let Some((mods, key)) = trimmed.rsplit_once('-') {
+            (Some(mods), key)
+        } else {
+            (None, trimmed)
+        };
 
         let (mut ctrl, mut alt, mut shift) = (false, false, false);
-        for m in mods {
+        for m in mods.into_iter().flat_map(|mods| mods.split('-')) {
             match m.to_ascii_lowercase().as_str() {
                 "ctrl" | "control" | "c" => ctrl = true,
                 "alt" | "option" | "opt" | "meta" | "a" | "m" => alt = true,
@@ -220,6 +224,33 @@ mod tests {
             KeyChord::parse("option-x").unwrap(),
             KeyChord::parse("alt-x").unwrap()
         );
+    }
+
+    #[test]
+    fn parses_minus_chords() {
+        for (input, modifiers) in [
+            ("-", KeyModifiers::NONE),
+            ("ctrl--", KeyModifiers::CONTROL),
+            ("alt--", KeyModifiers::ALT),
+            ("shift--", KeyModifiers::SHIFT),
+            ("ctrl-alt--", KeyModifiers::CONTROL | KeyModifiers::ALT),
+        ] {
+            let chord = KeyChord::parse(input).unwrap();
+            assert_eq!(chord.code, KeyCode::Char('-'));
+            assert_eq!(chord.ctrl, modifiers.contains(KeyModifiers::CONTROL));
+            assert_eq!(chord.alt, modifiers.contains(KeyModifiers::ALT));
+            assert_eq!(chord.shift, modifiers.contains(KeyModifiers::SHIFT));
+            assert!(chord.matches(&ev(KeyCode::Char('-'), modifiers)));
+            assert_eq!(chord.label(), input);
+            assert_eq!(KeyChord::parse(&chord.label()).unwrap(), chord);
+        }
+        assert_eq!(
+            KeyChord::parse(" CONTROL-option-- ").unwrap(),
+            KeyChord::parse("ctrl-alt--").unwrap()
+        );
+        for input in ["--", "---", "ctrl-", "ctrl---", "ctrl--g", "-alt--"] {
+            assert!(KeyChord::parse(input).is_err(), "{input}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Minus key bindings such as `ctrl--` and `alt--` failed because the parser treated the minus key as an empty modifier. The parser now treats a final `--` as the separator and minus key. Invalid separators still produce errors.

Shift with minus is rejected with an error that tells users to bind the resulting character, such as `_` or `ctrl-_`. This prevents a Shift-minus binding from running on plain minus and avoids an assumption about the keyboard layout.

Added parser tests for modifiers, labels, invalid input, and shifted characters, plus palette binding tests through `handle_key`. Documented the supported syntax.

Validation: `just check` and all pre-commit checks passed. 985 tests passed; 1 ignored.

Closes #331
