### PR TITLE
feat: add global default sort and optional sort memory

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,8 @@ readonly          = false  # true disables every mutating action (delete, edit,
                            # scale, shell, plugins, …); --readonly/--write win
 mouse             = true   # false keeps the terminal's native mouse behavior
                            # (text selection) instead of scroll/click/sort
+remember_sort     = true   # save and restore sort choices per resource kind
+                           # false makes sort changes temporary
 
 # Namespaces pinned to the top of the `n` switcher (★); session recents (·)
 # follow them.
@@ -24,6 +26,24 @@ favorite_namespaces = ["kube-system", "monitoring"]
 [aliases]
 dep = "deployments"
 ```
+
+`remember_sort` is enabled by default. Set it to `false` to stop saving and
+restoring sort choices from `S`, `I`, and column header clicks. Existing saved
+choices stay on disk and become available again when you enable the option.
+The option supports cluster and context overrides and `:reload`. A reload
+keeps the active sort; the option controls later sort changes and view starts.
+
+To use an initial sort for all resource tables, set a global default:
+
+```toml
+remember_sort = false
+
+[views."*"]
+sort = "AGE:desc"
+```
+
+A resource-specific sort has priority over this default. Tables without the
+specified column ignore the global sort. See [Views](views.md) for details.
 
 CRD short names are discovered automatically. To override a short name, add it
 under `[aliases]`. Use a group-qualified target when resource names overlap:

--- a/docs/features.md
+++ b/docs/features.md
@@ -120,6 +120,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   session recents (·) above the rest, plus a context switcher (`:ctx`). The
   last namespace picked in each context is remembered across restarts
   (`<state-dir>/namespaces.toml`); `-n`/`-A` override it for a session.
+- **Default sort** - `[views."*"].sort` sets a global initial sort, with
+  resource-specific overrides. Sort choices are saved per kind by default.
+  Set `remember_sort = false` to make user sort changes temporary.
 - **Mouse support** - the wheel scrolls every view (one notch is three steps of
   that view's own up/down), clicking a row selects it, clicking a column header
   sorts by it (click again to flip). Document views (YAML/describe, diff,

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -24,7 +24,7 @@ for the grammar and selector persistence rules.
 | `esc`                                         | go back / pop the view stack / clear filter / clear marks                                                                                                     |
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                                                      |
 | `ctrl-f` / `ctrl-b`, `PgDn` / `PgUp`          | page forward / back - one screenful at a time                                                                                                                 |
-| `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction — remembered per kind across views and restarts                            |
+| `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction; saved per kind by default (`remember_sort = false` disables this)         |
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                                                      |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                                              |
 | `/`                                           | filter: fuzzy text · `"exact"` · `/regex/` · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                             |

--- a/docs/views.md
+++ b/docs/views.md
@@ -164,8 +164,9 @@ another resource key. If it has no `sort`, `[views."*"].sort` supplies the
 global default. The `"*"` key supports only the default sort; it does not
 supply columns or navigation settings. A table without the specified column
 ignores the global sort until that column is available. The default sort is
-checked again when CRD printer columns arrive or wide mode changes. An active
-sort keeps its priority. Columns still overlay the built-in layout unless
+checked again when CRD printer columns arrive or wide mode changes. A saved
+sort can replace a configured default when its column becomes available.
+An active user or bookmark sort keeps its priority. Columns still overlay the built-in layout unless
 `replace = true`. In this example, the `matlab` view adds TENANT and MODEL,
 but does not add OWNERKIND. Wide mode works as usual. An active sort stays
 on its column if that column is still present. A saved user sort has priority

--- a/docs/views.md
+++ b/docs/views.md
@@ -163,7 +163,9 @@ The selected layout does not inherit columns, `replace`, or `sort` from
 another resource key. If it has no `sort`, `[views."*"].sort` supplies the
 global default. The `"*"` key supports only the default sort; it does not
 supply columns or navigation settings. A table without the specified column
-ignores the global sort. Columns still overlay the built-in layout unless
+ignores the global sort until that column is available. The default sort is
+checked again when CRD printer columns arrive or wide mode changes. An active
+sort keeps its priority. Columns still overlay the built-in layout unless
 `replace = true`. In this example, the `matlab` view adds TENANT and MODEL,
 but does not add OWNERKIND. Wide mode works as usual. An active sort stays
 on its column if that column is still present. A saved user sort has priority

--- a/docs/views.md
+++ b/docs/views.md
@@ -11,7 +11,8 @@ lowercase kind. The most specific key wins.
 [views."cert-manager.io/v1/certificates"]
 sort = "EXPIRES:desc"     # initial sort column, ":asc" (default) or ":desc";
                           # a sort you pick in the TUI (S/I/header click) is
-                          # remembered per kind and wins over this
+                          # saved per kind by default and has priority
+                          # set remember_sort = false at the top level to disable
 # replace = true          # replace the curated columns instead of overlaying
 
 [[views."cert-manager.io/v1/certificates".columns]]
@@ -159,11 +160,18 @@ All-namespaces mode and cluster-scoped resources use only unqualified keys.
 A row filter does not change the namespace used for this lookup.
 
 The selected layout does not inherit columns, `replace`, or `sort` from
-another view key. Columns still overlay the built-in layout unless
+another resource key. If it has no `sort`, `[views."*"].sort` supplies the
+global default. The `"*"` key supports only the default sort; it does not
+supply columns or navigation settings. A table without the specified column
+ignores the global sort. Columns still overlay the built-in layout unless
 `replace = true`. In this example, the `matlab` view adds TENANT and MODEL,
 but does not add OWNERKIND. Wide mode works as usual. An active sort stays
 on its column if that column is still present. A saved user sort has priority
-over the configured initial sort.
+over the configured initial sort when `remember_sort` is enabled (the default).
+Set `remember_sort = false` at the top level of the config to stop saving
+and restoring user sort choices. Sort changes still work in the active view.
+On a new view start, the configured sort applies again. Existing saved
+choices stay on disk while the option is disabled.
 
 The `node` and `drill` settings use the same key order, but each setting
 falls back separately. A view that sets only columns does not hide a

--- a/docs/views.md
+++ b/docs/views.md
@@ -180,6 +180,11 @@ The sort picker's no-sort entry clears sorting in the active view. Column
 updates, wide mode, config reload, and watch refresh keep that choice.
 Opening a resource view again applies its saved or configured sort as usual.
 
+A user or bookmark sort waits while its column is hidden or unavailable.
+The table uses its natural order during that time. When the column returns,
+the selected sort and direction return, even with `remember_sort = false`.
+Clearing the sort or selecting another column cancels the waiting choice.
+
 The `node` and `drill` settings use the same key order, but each setting
 falls back separately. A view that sets only columns does not hide a
 `node` or `drill` setting on a less specific key. Built-in navigation rules

--- a/docs/views.md
+++ b/docs/views.md
@@ -176,6 +176,10 @@ and restoring user sort choices. Sort changes still work in the active view.
 On a new view start, the configured sort applies again. Existing saved
 choices stay on disk while the option is disabled.
 
+The sort picker's no-sort entry clears sorting in the active view. Column
+updates, wide mode, config reload, and watch refresh keep that choice.
+Opening a resource view again applies its saved or configured sort as usual.
+
 The `node` and `drill` settings use the same key order, but each setting
 falls back separately. A view that sets only columns does not hide a
 `node` or `drill` setting on a less specific key. Built-in navigation rules

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1450,6 +1450,7 @@ impl App {
         let mut warnings = resolved.warnings;
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
+        self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/bookmarks.rs
+++ b/src/app/bookmarks.rs
@@ -98,6 +98,7 @@ impl App {
             Some(i) => {
                 self.sort_column = Some(i);
                 self.sort_desc = desc;
+                self.sort_from_config = false;
                 self.invalidate_rows();
             }
             None => self.flash_warn(&format!("bookmark sort column '{header}' not found")),

--- a/src/app/bookmarks.rs
+++ b/src/app/bookmarks.rs
@@ -98,7 +98,7 @@ impl App {
             Some(i) => {
                 self.sort_column = Some(i);
                 self.sort_desc = desc;
-                self.sort_from_config = false;
+                self.sort_origin = SortOrigin::Selected;
                 self.invalidate_rows();
             }
             None => self.flash_warn(&format!("bookmark sort column '{header}' not found")),

--- a/src/app/bookmarks.rs
+++ b/src/app/bookmarks.rs
@@ -94,14 +94,12 @@ impl App {
             _ => (spec.trim(), false),
         };
         let header = name.to_uppercase();
-        match self.display_headers().iter().position(|h| *h == header) {
-            Some(i) => {
-                self.sort_column = Some(i);
-                self.sort_desc = desc;
-                self.sort_origin = SortOrigin::Selected;
-                self.invalidate_rows();
-            }
-            None => self.flash_warn(&format!("bookmark sort column '{header}' not found")),
+        self.sort_column = self.display_headers().iter().position(|h| *h == header);
+        self.sort_desc = self.sort_column.is_some() && desc;
+        if self.sort_column.is_none() {
+            self.flash_warn(&format!("bookmark sort column '{header}' not found"));
         }
+        self.sort_origin = SortOrigin::Selected { header, desc };
+        self.invalidate_rows();
     }
 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1044,6 +1044,7 @@ impl App {
                     // A remembered sort on a printer column only becomes
                     // resolvable now that the CRD's columns are known.
                     self.apply_remembered_sort();
+                    self.apply_view_sort();
                 }
             }
             Msg::FindResults {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1623,6 +1623,7 @@ pub struct App {
     /// Column index (into the displayed headers) to sort the table by, or
     /// `None` for the natural namespace/name order.
     pub sort_column: Option<usize>,
+    pub sort_from_config: bool,
     pub sort_desc: bool,
     /// Horizontal offset in terminal cells after NAMESPACE/NAME.
     /// The renderer clamps this when the viewport or columns change.
@@ -2029,6 +2030,7 @@ impl App {
             table_page_rows: 10,
             marked: HashSet::new(),
             sort_column: None,
+            sort_from_config: false,
             sort_desc: false,
             col_offset: 0,
             col_scroll_max: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1573,6 +1573,14 @@ struct Frame {
     selected: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SortOrigin {
+    Unset,
+    Configured,
+    Selected,
+    Cleared,
+}
+
 pub struct App {
     pub cluster: Cluster,
     pub store: Store,
@@ -1623,7 +1631,7 @@ pub struct App {
     /// Column index (into the displayed headers) to sort the table by, or
     /// `None` for the natural namespace/name order.
     pub sort_column: Option<usize>,
-    pub sort_from_config: bool,
+    sort_origin: SortOrigin,
     pub sort_desc: bool,
     /// Horizontal offset in terminal cells after NAMESPACE/NAME.
     /// The renderer clamps this when the viewport or columns change.
@@ -2030,7 +2038,7 @@ impl App {
             table_page_rows: 10,
             marked: HashSet::new(),
             sort_column: None,
-            sort_from_config: false,
+            sort_origin: SortOrigin::Unset,
             sort_desc: false,
             col_offset: 0,
             col_scroll_max: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1573,11 +1573,11 @@ struct Frame {
     selected: Option<usize>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum SortOrigin {
     Unset,
     Configured,
-    Selected,
+    Selected { header: String, desc: bool },
     Cleared,
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1770,6 +1770,7 @@ pub struct App {
     /// Remembered sort per kind (`S`/`I`/header click), restored on every
     /// view start. Persisted to `sort_memory_path` on every change.
     pub sort_memory: crate::sortmem::SortMemory,
+    pub remember_sort: bool,
     /// Where remembered sorts persist (`<state-dir>/sort.toml`, set at
     /// startup); `None` (tests) keeps them in memory only.
     pub sort_memory_path: Option<std::path::PathBuf>,
@@ -2102,6 +2103,7 @@ impl App {
             fleet_marks: crate::fleet::FleetMarks::default(),
             fleet_marks_path: None,
             sort_memory: crate::sortmem::SortMemory::default(),
+            remember_sort: true,
             sort_memory_path: None,
             namespace_memory: crate::nsmem::NamespaceMemory::default(),
             namespace_memory_path: None,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -828,6 +828,7 @@ impl App {
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
+        self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -890,6 +890,7 @@ impl App {
             Some(i) => {
                 self.sort_column = Some(i);
                 self.sort_desc = desc;
+                self.sort_from_config = true;
                 self.invalidate_rows();
             }
             None if is_specific => {
@@ -1050,6 +1051,7 @@ impl App {
     pub(super) fn reset_sort(&mut self) {
         self.sort_column = None;
         self.sort_desc = false;
+        self.sort_from_config = false;
     }
 
     /// Record the active sort for the current kind (and persist it), so the
@@ -1058,6 +1060,7 @@ impl App {
     /// kind's entry is forgotten instead. View switches call `reset_sort`
     /// directly and must NOT land here — a switch isn't a sort choice.
     pub(super) fn remember_sort(&mut self) {
+        self.sort_from_config = false;
         if !self.remember_sort || self.kind_plural.is_empty() {
             return;
         }
@@ -1081,14 +1084,14 @@ impl App {
         }
     }
 
-    /// Restore the remembered sort for the current kind, unless a sort is
-    /// already active (a bookmark's sort spec, or a header repinned across a
-    /// spec refresh, must win). A remembered header missing from the current
+    /// Restore the remembered sort for the current kind. It can replace a
+    /// configured default, but an active user or bookmark sort has priority.
+    /// A remembered header missing from the current
     /// layout is left in memory untouched: CRD printer columns arrive after
     /// the watch starts (see `Msg::PrinterColumns`, which retries this), and
     /// a wide-only column simply stays dormant until `w`.
     pub(super) fn apply_remembered_sort(&mut self) {
-        if !self.remember_sort || self.sort_column.is_some() {
+        if !self.remember_sort || (self.sort_column.is_some() && !self.sort_from_config) {
             return;
         }
         let Some((header, desc)) = self.sort_memory.get(&self.kind_plural) else {
@@ -1097,6 +1100,7 @@ impl App {
         if let Some(i) = self.display_headers().iter().position(|h| *h == header) {
             self.sort_column = Some(i);
             self.sort_desc = desc;
+            self.sort_from_config = false;
             self.invalidate_rows();
         }
     }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -906,6 +906,7 @@ impl App {
         // A remembered sort on a wide-only column comes back the moment its
         // column does.
         self.apply_remembered_sort();
+        self.apply_view_sort();
         self.flash = format!("wide columns: {}", if self.wide { "on" } else { "off" });
         self.flash_err = false;
     }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -879,7 +879,11 @@ impl App {
         if self.sort_column.is_some() {
             return;
         }
-        let Some((header, desc)) = self.active_user_view().and_then(|v| v.sort.clone()) else {
+        let specific_sort = self.active_user_view().and_then(|v| v.sort.clone());
+        let is_specific = specific_sort.is_some();
+        let Some((header, desc)) =
+            specific_sort.or_else(|| self.user_views.get("*").and_then(|v| v.sort.clone()))
+        else {
             return;
         };
         match self.display_headers().iter().position(|h| *h == header) {
@@ -888,7 +892,10 @@ impl App {
                 self.sort_desc = desc;
                 self.invalidate_rows();
             }
-            None => self.flash_warn(&format!("view sort column '{header}' not found")),
+            None if is_specific => {
+                self.flash_warn(&format!("view sort column '{header}' not found"));
+            }
+            None => {}
         }
     }
 
@@ -1050,7 +1057,7 @@ impl App {
     /// kind's entry is forgotten instead. View switches call `reset_sort`
     /// directly and must NOT land here — a switch isn't a sort choice.
     pub(super) fn remember_sort(&mut self) {
-        if self.kind_plural.is_empty() {
+        if !self.remember_sort || self.kind_plural.is_empty() {
             return;
         }
         let kind = self.kind_plural.clone();
@@ -1080,7 +1087,7 @@ impl App {
     /// the watch starts (see `Msg::PrinterColumns`, which retries this), and
     /// a wide-only column simply stays dormant until `w`.
     pub(super) fn apply_remembered_sort(&mut self) {
-        if self.sort_column.is_some() {
+        if !self.remember_sort || self.sort_column.is_some() {
             return;
         }
         let Some((header, desc)) = self.sort_memory.get(&self.kind_plural) else {

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -816,13 +816,19 @@ impl App {
 
     /// Rebuild the active column layout from the current kind, user views,
     /// printer-column fallback, and wide mode. An active sort stays pinned to
-    /// its column *header* — indices shift when columns appear/disappear (wide
-    /// toggle, printer columns arriving) — and resets if the column is gone.
+    /// its column header as indices change. A selected sort waits while its
+    /// column is hidden and returns when that column is available again.
     /// Cached cells are laid out for the old spec, so they're always dropped.
     pub(super) fn refresh_view_spec(&mut self) {
-        let sort_header = self
-            .sort_column
-            .and_then(|i| self.display_headers().get(i).cloned());
+        let sort = match &self.sort_origin {
+            SortOrigin::Selected { header, desc } => Some((header.clone(), *desc)),
+            _ => self.sort_column.and_then(|i| {
+                self.display_headers()
+                    .get(i)
+                    .cloned()
+                    .map(|h| (h, self.sort_desc))
+            }),
+        };
         let resource = self.kind.as_ref().map(Kind::resource_key);
         let warnings = crate::columns::view_warnings(
             self.kind.as_ref().map_or("", |kind| kind.ar.group.as_str()),
@@ -846,11 +852,9 @@ impl App {
         );
         self.spec = spec;
         self.spec_rev = self.spec_rev.wrapping_add(1);
-        if let Some(h) = sort_header {
+        if let Some((h, desc)) = sort {
             self.sort_column = self.display_headers().iter().position(|x| *x == h);
-            if self.sort_column.is_none() {
-                self.sort_desc = false;
-            }
+            self.sort_desc = self.sort_column.is_some() && desc;
         }
         self.clear_rows_cache();
         self.col_offset = 0;
@@ -876,7 +880,12 @@ impl App {
     /// Apply a view's configured initial sort, unless a sort is already
     /// active (a refresh must not clobber the user's choice).
     pub(super) fn apply_view_sort(&mut self) {
-        if self.sort_column.is_some() || self.sort_origin == SortOrigin::Cleared {
+        if self.sort_column.is_some()
+            || matches!(
+                self.sort_origin,
+                SortOrigin::Selected { .. } | SortOrigin::Cleared
+            )
+        {
             return;
         }
         let specific_sort = self.active_user_view().and_then(|v| v.sort.clone());
@@ -1060,19 +1069,21 @@ impl App {
     /// kind's entry is forgotten instead. View switches call `reset_sort`
     /// directly and must NOT land here — a switch isn't a sort choice.
     pub(super) fn remember_sort(&mut self) {
-        self.sort_origin = if self.sort_column.is_some() {
-            SortOrigin::Selected
-        } else {
-            SortOrigin::Cleared
+        let header = self
+            .sort_column
+            .and_then(|i| self.display_headers().get(i).cloned());
+        self.sort_origin = match &header {
+            Some(header) => SortOrigin::Selected {
+                header: header.clone(),
+                desc: self.sort_desc,
+            },
+            None => SortOrigin::Cleared,
         };
         if !self.remember_sort || self.kind_plural.is_empty() {
             return;
         }
         let kind = self.kind_plural.clone();
-        match self
-            .sort_column
-            .and_then(|i| self.display_headers().get(i).cloned())
-        {
+        match header {
             Some(h) => self.sort_memory.set(&kind, &h, self.sort_desc),
             None if self.sort_memory.clear(&kind) => {}
             None => return, // nothing was remembered; skip the disk write
@@ -1096,7 +1107,10 @@ impl App {
     /// a wide-only column simply stays dormant until `w`.
     pub(super) fn apply_remembered_sort(&mut self) {
         if !self.remember_sort
-            || self.sort_origin == SortOrigin::Cleared
+            || matches!(
+                self.sort_origin,
+                SortOrigin::Selected { .. } | SortOrigin::Cleared
+            )
             || (self.sort_column.is_some() && self.sort_origin != SortOrigin::Configured)
         {
             return;
@@ -1107,7 +1121,7 @@ impl App {
         if let Some(i) = self.display_headers().iter().position(|h| *h == header) {
             self.sort_column = Some(i);
             self.sort_desc = desc;
-            self.sort_origin = SortOrigin::Selected;
+            self.sort_origin = SortOrigin::Selected { header, desc };
             self.invalidate_rows();
         }
     }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -876,7 +876,7 @@ impl App {
     /// Apply a view's configured initial sort, unless a sort is already
     /// active (a refresh must not clobber the user's choice).
     pub(super) fn apply_view_sort(&mut self) {
-        if self.sort_column.is_some() {
+        if self.sort_column.is_some() || self.sort_origin == SortOrigin::Cleared {
             return;
         }
         let specific_sort = self.active_user_view().and_then(|v| v.sort.clone());
@@ -890,7 +890,7 @@ impl App {
             Some(i) => {
                 self.sort_column = Some(i);
                 self.sort_desc = desc;
-                self.sort_from_config = true;
+                self.sort_origin = SortOrigin::Configured;
                 self.invalidate_rows();
             }
             None if is_specific => {
@@ -1051,7 +1051,7 @@ impl App {
     pub(super) fn reset_sort(&mut self) {
         self.sort_column = None;
         self.sort_desc = false;
-        self.sort_from_config = false;
+        self.sort_origin = SortOrigin::Unset;
     }
 
     /// Record the active sort for the current kind (and persist it), so the
@@ -1060,7 +1060,11 @@ impl App {
     /// kind's entry is forgotten instead. View switches call `reset_sort`
     /// directly and must NOT land here — a switch isn't a sort choice.
     pub(super) fn remember_sort(&mut self) {
-        self.sort_from_config = false;
+        self.sort_origin = if self.sort_column.is_some() {
+            SortOrigin::Selected
+        } else {
+            SortOrigin::Cleared
+        };
         if !self.remember_sort || self.kind_plural.is_empty() {
             return;
         }
@@ -1091,7 +1095,10 @@ impl App {
     /// the watch starts (see `Msg::PrinterColumns`, which retries this), and
     /// a wide-only column simply stays dormant until `w`.
     pub(super) fn apply_remembered_sort(&mut self) {
-        if !self.remember_sort || (self.sort_column.is_some() && !self.sort_from_config) {
+        if !self.remember_sort
+            || self.sort_origin == SortOrigin::Cleared
+            || (self.sort_column.is_some() && self.sort_origin != SortOrigin::Configured)
+        {
             return;
         }
         let Some((header, desc)) = self.sort_memory.get(&self.kind_plural) else {
@@ -1100,7 +1107,7 @@ impl App {
         if let Some(i) = self.display_headers().iter().position(|h| *h == header) {
             self.sort_column = Some(i);
             self.sort_desc = desc;
-            self.sort_from_config = false;
+            self.sort_origin = SortOrigin::Selected;
             self.invalidate_rows();
         }
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6434,6 +6434,58 @@ async fn wildcard_sort_applies_when_printer_columns_arrive_without_replacing_use
 }
 
 #[tokio::test]
+async fn saved_printer_sort_replaces_config_default_but_not_a_new_user_choice() {
+    for (remember, invert) in [(true, false), (true, true), (false, false), (false, true)] {
+        let (mut app, _rx) = test_app();
+        app.remember_sort = remember;
+        app.sort_memory.set("certificates", "READY", false);
+        install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+        palette(&mut app, "certificates");
+        assert_eq!(app.sort_column, Some(1));
+        assert!(app.sort_from_config);
+        if invert {
+            app.handle_key(press(KeyCode::Char('I'))).unwrap();
+            assert!(!app.sort_from_config);
+        }
+        let crd = json!({"spec": {"versions": [{
+            "name": "v1", "served": true, "storage": true,
+            "additionalPrinterColumns": [
+                {"name": "Ready", "type": "string", "jsonPath": ".status.ready"}
+            ]
+        }]}});
+        app.handle_msg(Msg::PrinterColumns {
+            generation: app.generation,
+            resource: app.cluster.resolve("certificates").unwrap().resource_key(),
+            view: Box::new(crate::views::printer_columns_view(&crd, "v1")),
+        });
+        let header = if remember && !invert { "READY" } else { "AGE" };
+        assert_eq!(
+            app.sort_column,
+            app.display_headers().iter().position(|h| h == header)
+        );
+        assert_eq!(app.sort_desc, !remember && !invert);
+    }
+}
+
+#[tokio::test]
+async fn saved_wide_sort_replaces_config_default_when_its_column_appears() {
+    let (mut app, _rx) = test_app();
+    app.sort_memory.set("pods", "IP", false);
+    install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+    palette(&mut app, "pods");
+    assert!(app.sort_from_config);
+    assert!(app.sort_desc);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "IP")
+    );
+    assert!(app.sort_column.is_some());
+    assert!(!app.sort_from_config);
+    assert!(!app.sort_desc);
+}
+
+#[tokio::test]
 async fn disabled_sort_memory_keeps_changes_local_and_preserves_saved_state() {
     let dir = std::env::temp_dir().join(format!("sofka-sort-option-{}", std::process::id()));
     write_config(&dir, "remember_sort = false\n");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6393,8 +6393,156 @@ async fn wildcard_sort_applies_when_wide_columns_appear() {
         app.handle_key(press(KeyCode::Char('w'))).unwrap();
         assert_eq!(app.sort_column, None);
         app.handle_key(press(KeyCode::Char('w'))).unwrap();
-        assert_eq!(app.sort_desc, !remember);
+        assert!(!app.sort_desc);
     }
+}
+
+#[tokio::test]
+async fn temporary_wide_sort_keeps_its_column_and_direction_until_cleared_or_navigation() {
+    for remember in [true, false] {
+        for desc in [true, false] {
+            let (mut app, _rx) = test_app();
+            app.remember_sort = remember;
+            app.sort_memory.set("pods", "NAME", false);
+            install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+            palette(&mut app, "pods");
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            select_sort_with_keys(&mut app, "IP");
+            if desc {
+                app.handle_key(press(KeyCode::Char('I'))).unwrap();
+            }
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            assert_eq!(app.sort_column, None);
+            assert!(!app.sort_desc);
+            assert_eq!(
+                app.sort_origin,
+                SortOrigin::Selected {
+                    header: "IP".into(),
+                    desc
+                }
+            );
+            app.handle_key(ctrl(KeyCode::Char('r'))).unwrap();
+            assert_eq!(app.sort_column, None);
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            assert_eq!(
+                app.sort_column,
+                app.display_headers().iter().position(|h| h == "IP")
+            );
+            assert_eq!(app.sort_desc, desc);
+            assert_eq!(
+                app.sort_memory.get("pods"),
+                Some(if remember {
+                    ("IP".into(), desc)
+                } else {
+                    ("NAME".into(), false)
+                })
+            );
+
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            clear_sort_with_keys(&mut app);
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            assert_eq!(app.sort_column, None);
+            assert_eq!(app.sort_origin, SortOrigin::Cleared);
+            palette(&mut app, "services");
+            palette(&mut app, "pods");
+            assert_eq!(
+                app.sort_column,
+                app.display_headers().iter().position(|h| h == "AGE")
+            );
+            assert!(app.sort_desc);
+        }
+    }
+}
+
+fn select_sort_with_keys(app: &mut App, header: &str) {
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    for c in header.chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == header)
+    );
+    assert!(app.sort_column.is_some());
+}
+
+#[tokio::test]
+async fn new_sort_selection_replaces_a_hidden_temporary_sort() {
+    let (mut app, _rx) = test_app();
+    app.remember_sort = false;
+    install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+    palette(&mut app, "pods");
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    select_sort_with_keys(&mut app, "IP");
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.sort_column, None);
+    select_sort_with_keys(&mut app, "NAME");
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.sort_column, Some(0));
+    assert!(!app.sort_desc);
+    assert_eq!(app.sort_memory.get("pods"), None);
+}
+
+#[tokio::test]
+async fn bookmark_sort_waits_for_a_hidden_column_without_using_sort_memory() {
+    for remember in [true, false] {
+        let (mut app, _rx) = test_app();
+        app.remember_sort = remember;
+        app.sort_memory.set("pods", "NAME", false);
+        install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+        app.bookmarks = vec![crate::config::Bookmark {
+            key: Some("ctrl-y".into()),
+            name: "pods by IP".into(),
+            resource: "pods".into(),
+            sort: Some("IP:desc".into()),
+            ..Default::default()
+        }];
+        app.handle_key(ctrl(KeyCode::Char('y'))).unwrap();
+        assert_eq!(app.sort_column, None);
+        app.handle_key(ctrl(KeyCode::Char('r'))).unwrap();
+        assert_eq!(app.sort_column, None);
+        for _ in 0..2 {
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            assert_eq!(
+                app.sort_column,
+                app.display_headers().iter().position(|h| h == "IP")
+            );
+            assert!(app.sort_column.is_some());
+            assert!(app.sort_desc);
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            assert_eq!(app.sort_column, None);
+        }
+        assert_eq!(app.sort_memory.get("pods"), Some(("NAME".into(), false)));
+    }
+}
+
+#[tokio::test]
+async fn temporary_printer_sort_waits_when_its_column_is_removed_then_restored() {
+    let (mut app, _rx) = test_app();
+    app.remember_sort = false;
+    app.sort_memory.set("certificates", "NAME", false);
+    install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+    palette(&mut app, "certificates");
+    deliver_ready_printer_column(&mut app);
+    select_sort_with_keys(&mut app, "READY");
+    app.handle_key(press(KeyCode::Char('I'))).unwrap();
+    app.handle_msg(Msg::PrinterColumns {
+        generation: app.generation,
+        resource: app.cluster.resolve("certificates").unwrap().resource_key(),
+        view: Box::new(None),
+    });
+    assert_eq!(app.sort_column, None);
+    deliver_ready_printer_column(&mut app);
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "READY")
+    );
+    assert!(app.sort_desc);
+    assert_eq!(
+        app.sort_memory.get("certificates"),
+        Some(("NAME".into(), false))
+    );
 }
 
 #[tokio::test]
@@ -6445,7 +6593,7 @@ async fn saved_printer_sort_replaces_config_default_but_not_a_new_user_choice() 
         assert_eq!(app.sort_origin, SortOrigin::Configured);
         if invert {
             app.handle_key(press(KeyCode::Char('I'))).unwrap();
-            assert_eq!(app.sort_origin, SortOrigin::Selected);
+            assert!(matches!(app.sort_origin, SortOrigin::Selected { .. }));
         }
         let crd = json!({"spec": {"versions": [{
             "name": "v1", "served": true, "storage": true,
@@ -6481,7 +6629,7 @@ async fn saved_wide_sort_replaces_config_default_when_its_column_appears() {
         app.display_headers().iter().position(|h| h == "IP")
     );
     assert!(app.sort_column.is_some());
-    assert_eq!(app.sort_origin, SortOrigin::Selected);
+    assert!(matches!(app.sort_origin, SortOrigin::Selected { .. }));
     assert!(!app.sort_desc);
 }
 
@@ -6602,7 +6750,7 @@ async fn bookmark_sort_keeps_priority_over_delayed_saved_and_configured_sorts() 
         app.handle_key(press(KeyCode::Char('w'))).unwrap();
         assert_eq!(app.sort_column, Some(0));
         assert!(app.sort_desc);
-        assert_eq!(app.sort_origin, SortOrigin::Selected);
+        assert!(matches!(app.sort_origin, SortOrigin::Selected { .. }));
         assert_eq!(
             app.sort_memory.get("certificates"),
             Some(("READY".into(), false))
@@ -6646,7 +6794,7 @@ async fn sort_can_be_selected_again_after_clearing_with_memory_disabled() {
         deliver_ready_printer_column(&mut app);
         assert_eq!(app.sort_column, Some(0));
         assert!(app.sort_desc);
-        assert_eq!(app.sort_origin, SortOrigin::Selected);
+        assert!(matches!(app.sort_origin, SortOrigin::Selected { .. }));
         assert_eq!(
             app.sort_memory.get("certificates"),
             Some(("READY".into(), false))

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6374,6 +6374,66 @@ async fn wildcard_sort_skips_missing_columns() {
 }
 
 #[tokio::test]
+async fn wildcard_sort_applies_when_wide_columns_appear() {
+    for remember in [true, false] {
+        let (mut app, _rx) = test_app();
+        app.remember_sort = remember;
+        install_views(&mut app, "[views.\"*\"]\nsort = \"IP:desc\"\n");
+        palette(&mut app, "pods");
+        assert_eq!(app.sort_column, None);
+        app.handle_key(press(KeyCode::Char('w'))).unwrap();
+        assert_eq!(
+            app.sort_column,
+            app.display_headers().iter().position(|h| h == "IP")
+        );
+        assert!(app.sort_column.is_some());
+        assert!(app.sort_desc);
+
+        app.handle_key(press(KeyCode::Char('I'))).unwrap();
+        app.handle_key(press(KeyCode::Char('w'))).unwrap();
+        assert_eq!(app.sort_column, None);
+        app.handle_key(press(KeyCode::Char('w'))).unwrap();
+        assert_eq!(app.sort_desc, !remember);
+    }
+}
+
+#[tokio::test]
+async fn wildcard_sort_applies_when_printer_columns_arrive_without_replacing_user_sort() {
+    for choose_name in [false, true] {
+        let (mut app, _rx) = test_app();
+        app.remember_sort = false;
+        install_views(&mut app, "[views.\"*\"]\nsort = \"READY:desc\"\n");
+        palette(&mut app, "certificates");
+        assert_eq!(app.sort_column, None);
+        if choose_name {
+            app.handle_key(press(KeyCode::Char('S'))).unwrap();
+            for c in "name".chars() {
+                app.handle_key(press(KeyCode::Char(c))).unwrap();
+            }
+            app.handle_key(press(KeyCode::Enter)).unwrap();
+        }
+        let crd = json!({"spec": {"versions": [{
+            "name": "v1", "served": true, "storage": true,
+            "additionalPrinterColumns": [
+                {"name": "Ready", "type": "string", "jsonPath": ".status.ready"}
+            ]
+        }]}});
+        app.handle_msg(Msg::PrinterColumns {
+            generation: app.generation,
+            resource: app.cluster.resolve("certificates").unwrap().resource_key(),
+            view: Box::new(crate::views::printer_columns_view(&crd, "v1")),
+        });
+        let header = if choose_name { "NAME" } else { "READY" };
+        assert_eq!(
+            app.sort_column,
+            app.display_headers().iter().position(|h| h == header)
+        );
+        assert!(app.sort_column.is_some());
+        assert_eq!(app.sort_desc, !choose_name);
+    }
+}
+
+#[tokio::test]
 async fn disabled_sort_memory_keeps_changes_local_and_preserves_saved_state() {
     let dir = std::env::temp_dir().join(format!("sofka-sort-option-{}", std::process::id()));
     write_config(&dir, "remember_sort = false\n");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6442,10 +6442,10 @@ async fn saved_printer_sort_replaces_config_default_but_not_a_new_user_choice() 
         install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
         palette(&mut app, "certificates");
         assert_eq!(app.sort_column, Some(1));
-        assert!(app.sort_from_config);
+        assert_eq!(app.sort_origin, SortOrigin::Configured);
         if invert {
             app.handle_key(press(KeyCode::Char('I'))).unwrap();
-            assert!(!app.sort_from_config);
+            assert_eq!(app.sort_origin, SortOrigin::Selected);
         }
         let crd = json!({"spec": {"versions": [{
             "name": "v1", "served": true, "storage": true,
@@ -6473,7 +6473,7 @@ async fn saved_wide_sort_replaces_config_default_when_its_column_appears() {
     app.sort_memory.set("pods", "IP", false);
     install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
     palette(&mut app, "pods");
-    assert!(app.sort_from_config);
+    assert_eq!(app.sort_origin, SortOrigin::Configured);
     assert!(app.sort_desc);
     app.handle_key(press(KeyCode::Char('w'))).unwrap();
     assert_eq!(
@@ -6481,8 +6481,177 @@ async fn saved_wide_sort_replaces_config_default_when_its_column_appears() {
         app.display_headers().iter().position(|h| h == "IP")
     );
     assert!(app.sort_column.is_some());
-    assert!(!app.sort_from_config);
+    assert_eq!(app.sort_origin, SortOrigin::Selected);
     assert!(!app.sort_desc);
+}
+
+#[tokio::test]
+async fn cleared_sort_survives_column_changes_and_watch_refresh_until_navigation() {
+    for remember in [true, false] {
+        for view_key in ["*", "certificates"] {
+            for header in ["AGE", "READY"] {
+                let (mut app, _rx) = test_app();
+                app.remember_sort = remember;
+                app.sort_memory.set("certificates", "READY", false);
+                install_views(
+                    &mut app,
+                    &format!("[views.\"{view_key}\"]\nsort = \"{header}:desc\"\n"),
+                );
+                palette(&mut app, "certificates");
+                clear_sort_with_keys(&mut app);
+                deliver_ready_printer_column(&mut app);
+                assert_eq!(app.sort_column, None);
+                assert!(!app.sort_desc);
+                for key in [
+                    press(KeyCode::Char('w')),
+                    press(KeyCode::Char('w')),
+                    ctrl(KeyCode::Char('r')),
+                ] {
+                    app.handle_key(key).unwrap();
+                    assert_eq!(app.sort_column, None);
+                    assert_eq!(app.sort_origin, SortOrigin::Cleared);
+                }
+                assert_eq!(
+                    app.sort_memory.get("certificates"),
+                    (!remember).then(|| ("READY".into(), false))
+                );
+
+                palette(&mut app, "services");
+                palette(&mut app, "certificates");
+                assert_eq!(
+                    app.sort_column,
+                    app.display_headers().iter().position(|h| h == header)
+                );
+                assert!(app.sort_column.is_some());
+                assert!(app.sort_desc);
+            }
+        }
+    }
+}
+
+fn clear_sort_with_keys(app: &mut App) {
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    while app.sort_picker_state.selected().unwrap() > 0 {
+        app.handle_key(press(KeyCode::Up)).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.sort_column, None);
+}
+
+fn deliver_ready_printer_column(app: &mut App) {
+    let crd = json!({"spec": {"versions": [{
+        "name": "v1", "served": true, "storage": true,
+        "additionalPrinterColumns": [
+            {"name": "Ready", "type": "string", "jsonPath": ".status.ready"}
+        ]
+    }]}});
+    app.handle_msg(Msg::PrinterColumns {
+        generation: app.generation,
+        resource: app.cluster.resolve("certificates").unwrap().resource_key(),
+        view: Box::new(crate::views::printer_columns_view(&crd, "v1")),
+    });
+}
+
+#[tokio::test]
+async fn enabling_sort_memory_does_not_replace_a_cleared_sort_in_the_active_view() {
+    let dir = std::env::temp_dir().join(format!("sofka-sort-clear-reload-{}", std::process::id()));
+    write_config(&dir, "remember_sort = false\n");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+    app.sort_memory.set("certificates", "READY", false);
+    palette(&mut app, "reload");
+    palette(&mut app, "certificates");
+    clear_sort_with_keys(&mut app);
+    write_config(&dir, "remember_sort = true\n");
+    palette(&mut app, "reload");
+    assert!(app.remember_sort);
+    deliver_ready_printer_column(&mut app);
+    assert_eq!(app.sort_column, None);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(app.sort_column, None);
+    palette(&mut app, "services");
+    palette(&mut app, "certificates");
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "READY")
+    );
+    assert!(!app.sort_desc);
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn bookmark_sort_keeps_priority_over_delayed_saved_and_configured_sorts() {
+    for remember in [true, false] {
+        let (mut app, _rx) = test_app();
+        app.remember_sort = remember;
+        install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+        app.sort_memory.set("certificates", "READY", false);
+        palette(&mut app, "certificates");
+        clear_sort_with_keys(&mut app);
+        app.sort_memory.set("certificates", "READY", false);
+        app.bookmarks = vec![crate::config::Bookmark {
+            key: Some("ctrl-y".into()),
+            name: "sorted certificates".into(),
+            resource: "certificates".into(),
+            sort: Some("NAME:desc".into()),
+            ..Default::default()
+        }];
+        app.handle_key(ctrl(KeyCode::Char('y'))).unwrap();
+        deliver_ready_printer_column(&mut app);
+        app.handle_key(press(KeyCode::Char('w'))).unwrap();
+        assert_eq!(app.sort_column, Some(0));
+        assert!(app.sort_desc);
+        assert_eq!(app.sort_origin, SortOrigin::Selected);
+        assert_eq!(
+            app.sort_memory.get("certificates"),
+            Some(("READY".into(), false))
+        );
+    }
+}
+
+#[tokio::test]
+async fn sort_can_be_selected_again_after_clearing_with_memory_disabled() {
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    for mouse in [true, false] {
+        let (mut app, _rx) = test_app();
+        app.remember_sort = false;
+        install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+        app.sort_memory.set("certificates", "READY", false);
+        palette(&mut app, "certificates");
+        clear_sort_with_keys(&mut app);
+        if mouse {
+            let mut term = Terminal::new(TestBackend::new(120, 32)).unwrap();
+            term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+            let hit = app.table_hit.borrow().clone().unwrap();
+            let (column, _, _) = hit.cols.iter().find(|(_, _, idx)| *idx == 0).unwrap();
+            app.handle_mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: *column,
+                row: hit.header_y,
+                modifiers: KeyModifiers::NONE,
+            })
+            .unwrap();
+        } else {
+            app.handle_key(press(KeyCode::Char('S'))).unwrap();
+            for c in "name".chars() {
+                app.handle_key(press(KeyCode::Char(c))).unwrap();
+            }
+            app.handle_key(press(KeyCode::Enter)).unwrap();
+        }
+        app.handle_key(press(KeyCode::Char('I'))).unwrap();
+        deliver_ready_printer_column(&mut app);
+        assert_eq!(app.sort_column, Some(0));
+        assert!(app.sort_desc);
+        assert_eq!(app.sort_origin, SortOrigin::Selected);
+        assert_eq!(
+            app.sort_memory.get("certificates"),
+            Some(("READY".into(), false))
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6323,6 +6323,111 @@ async fn sort_choice_is_remembered_per_kind_across_view_switches() {
 }
 
 #[tokio::test]
+async fn wildcard_sort_is_the_fallback_for_resource_views() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."*"]
+        sort = "AGE:desc"
+        [views.pods]
+        [views.services]
+        sort = "NAME:asc"
+        "#,
+    );
+    for (resource, header, desc) in [
+        ("pods", "AGE", true),
+        ("deployments", "AGE", true),
+        ("services", "NAME", false),
+    ] {
+        palette(&mut app, resource);
+        assert_eq!(app.kind_plural, resource);
+        assert_eq!(
+            app.sort_column,
+            app.display_headers().iter().position(|h| h == header)
+        );
+        assert!(app.sort_column.is_some());
+        assert_eq!(app.sort_desc, desc);
+    }
+
+    palette(&mut app, "pods");
+    app.handle_key(press(KeyCode::Char('I'))).unwrap();
+    palette(&mut app, "services");
+    palette(&mut app, "pods");
+    assert!(!app.sort_desc, "saved choice has priority over the default");
+}
+
+#[tokio::test]
+async fn wildcard_sort_skips_missing_columns() {
+    let (mut app, _rx) = test_app();
+    install_views(&mut app, "[views.\"*\"]\nsort = \"RESTARTS:desc\"\n");
+    palette(&mut app, "services");
+    assert_eq!(app.sort_column, None);
+    assert!(!app.flash_err);
+    palette(&mut app, "pods");
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "RESTARTS")
+    );
+    assert!(app.sort_column.is_some());
+    assert!(app.sort_desc);
+}
+
+#[tokio::test]
+async fn disabled_sort_memory_keeps_changes_local_and_preserves_saved_state() {
+    let dir = std::env::temp_dir().join(format!("sofka-sort-option-{}", std::process::id()));
+    write_config(&dir, "remember_sort = false\n");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    install_views(&mut app, "[views.\"*\"]\nsort = \"AGE:desc\"\n");
+    let path = dir.join("sort.toml");
+    app.sort_memory.set("pods", "NAME", false);
+    app.sort_memory.save(&path).unwrap();
+    app.sort_memory_path = Some(path.clone());
+    let saved = std::fs::read(&path).unwrap();
+
+    palette(&mut app, "reload");
+    assert!(!app.remember_sort);
+    palette(&mut app, "pods");
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "AGE")
+    );
+    assert!(app.sort_desc);
+    app.handle_key(press(KeyCode::Char('I'))).unwrap();
+    assert!(!app.sort_desc);
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    for c in "rst".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "RESTARTS")
+    );
+    palette(&mut app, "services");
+    palette(&mut app, "pods");
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "AGE")
+    );
+    assert!(app.sort_desc);
+    assert_eq!(app.sort_memory.get("pods"), Some(("NAME".into(), false)));
+    assert_eq!(std::fs::read(&path).unwrap(), saved);
+
+    write_config(&dir, "");
+    palette(&mut app, "reload");
+    assert!(app.remember_sort, "sort memory is enabled by default");
+    palette(&mut app, "services");
+    palette(&mut app, "pods");
+    assert_eq!(
+        app.sort_column,
+        app.display_headers().iter().position(|h| h == "NAME")
+    );
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
 async fn sort_picker_esc_clears_filter_then_closes() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,6 +98,8 @@ pub struct Config {
     /// behavior (text selection) everywhere. Document views release capture
     /// on their own regardless — see [`crate::app::App::wants_mouse_capture`].
     pub mouse: Option<bool>,
+    /// Save and restore sort choices per kind. Defaults to true.
+    pub remember_sort: Option<bool>,
     /// How `:notify` events are delivered — see [`NotifyConfig`].
     pub notify: NotifyConfig,
     /// Command-palette completion key rebinds — see [`KeysConfig`]. Compiled

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,7 @@ async fn run_main(args: Args) -> Result<()> {
     let sort_memory_path = sortmem::SortMemory::default_path();
     app.sort_memory = sortmem::SortMemory::load(&sort_memory_path);
     app.sort_memory_path = Some(sort_memory_path);
+    app.remember_sort = cfg.remember_sort.unwrap_or(true);
     // The last namespace picked per context persists too, so a relaunch (or
     // a `:ctx` switch back) lands where you left off.
     let namespace_memory_path = nsmem::NamespaceMemory::default_path();


### PR DESCRIPTION
The `[views."*"].sort` setting had no effect, and sort choices were always saved. This change adds a global initial sort and an option to keep user sort changes temporary.

```toml
remember_sort = false

[views."*"]
sort = "AGE:desc"
```

Sort memory stays enabled by default. When disabled, `S`, `I`, and header clicks still change the active sort, but do not save or restore per-kind choices. Existing saved choices stay on disk. The option supports config reload and cluster/context overrides.

A resource-specific sort has priority over the global default. The wildcard key supplies only a sort default. Tables without the specified column wait until it is available. When CRD printer columns arrive or wide mode changes, a saved sort can replace a configured default. Active user and bookmark sorts keep their column and direction while a column is hidden, even with sort memory disabled. They return when the column becomes available. Clearing or replacing the choice cancels it.

An explicit no-sort choice is kept through column updates, wide mode, watch refresh, and config reload. Navigation resets that choice, and new sort selections still work.

Validation: `just check` and all pre-commit checks passed. 1,000 tests passed; 1 ignored. Tests use `handle_key` and mouse input to cover sort precedence, missing and delayed columns, reload, temporary choices with unchanged saved state, explicit no-sort choices, navigation resets, later keyboard, mouse, and bookmark choices, and hidden sorts that must return with their selected direction.

Closes #316
