### PR TITLE
fix: exclude terminating pods from health

### DIFF
--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -242,8 +242,12 @@ async fn gather_context(ctx: &str, readonly: bool, allow_v1_client_cert: bool) -
     row
 }
 
-/// A pod counts as healthy when it's Running-and-ready or Succeeded.
+/// A pod counts as healthy when it isn't terminating and is Running-and-ready
+/// or Succeeded.
 fn pod_healthy(o: &DynamicObject) -> bool {
+    if o.metadata.deletion_timestamp.is_some() {
+        return false;
+    }
     match phase(o).as_str() {
         "Succeeded" => true,
         "Running" => o
@@ -277,4 +281,34 @@ fn ready_is_false(o: &DynamicObject) -> bool {
 /// First line of a connection error, trimmed for the one-line status cell.
 fn short_error(e: &str) -> String {
     crate::text::ellipsize(e.lines().next().unwrap_or(e).trim(), 60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn pod(phase: &str, deleting: bool) -> DynamicObject {
+        serde_json::from_value(json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "web",
+                "deletionTimestamp": deleting.then_some("2026-09-07T10:00:00Z"),
+            },
+            "status": {
+                "phase": phase,
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn terminating_pods_are_unhealthy() {
+        for phase in ["Running", "Succeeded"] {
+            assert!(pod_healthy(&pod(phase, false)), "{phase}");
+            assert!(!pod_healthy(&pod(phase, true)), "{phase}");
+        }
+    }
 }

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -220,8 +220,7 @@ async fn gather_context(ctx: &str, readonly: bool, allow_v1_client_cert: bool) -
 
     if let Some(k) = cluster.resolve("pods") {
         let pods = list_or_warn(&client, &k.ar, k.namespaced, "", &mut warn).await;
-        row.pods_total = pods.len();
-        row.pods_unhealthy = pods.iter().filter(|o| !pod_healthy(o)).count();
+        update_pod_counts(&mut row, &pods);
     }
 
     // Flux failures: only report a count when the toolkit CRDs exist.
@@ -240,6 +239,11 @@ async fn gather_context(ctx: &str, readonly: bool, allow_v1_client_cert: bool) -
         None => FleetStatus::Ok,
     };
     row
+}
+
+pub(super) fn update_pod_counts(row: &mut FleetRow, pods: &[DynamicObject]) {
+    row.pods_total = pods.len();
+    row.pods_unhealthy = pods.iter().filter(|o| !pod_healthy(o)).count();
 }
 
 /// A pod counts as healthy when it isn't terminating and is Running-and-ready

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15524,6 +15524,22 @@ fn explain_selected_with_pure_evidence(app: &mut App) {
 }
 
 #[tokio::test]
+async fn explain_key_reports_terminating_ready_pods_as_unhealthy() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let mut pod = health_test_pod("web");
+    pod["metadata"]["deletionTimestamp"] = json!("2026-09-07T10:00:00Z");
+    apply(&mut app, pod);
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    explain_selected_with_pure_evidence(&mut app);
+    assert_eq!(app.explain_items[0].level, crate::explain::Level::Warn);
+    assert_eq!(
+        app.explain_items[0].text,
+        "Pod/web is Terminating (1/1 ready)"
+    );
+}
+
+#[tokio::test]
 async fn explain_key_reports_node_pressure_without_warning_on_healthy_conditions() {
     for state in ["False", "True", "Unknown"] {
         let (mut app, _rx) = test_app();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10245,6 +10245,73 @@ async fn fleet_seeds_connecting_rows_and_applies_summaries() {
 }
 
 #[tokio::test]
+async fn fleet_command_counts_terminating_pods_as_unhealthy() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let (mut app, _rx) = test_app();
+    app.fleet_cfg.contexts = vec!["staging".into()];
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for ch in "fleet".chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Fleet);
+
+    for deleting in [false, true] {
+        if deleting {
+            app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        }
+        assert_eq!(
+            app.fleet_rows[0].status,
+            crate::fleet::FleetStatus::Connecting
+        );
+        let pods = [
+            ("running", "Running", false),
+            ("completed", "Succeeded", false),
+            ("deleting-running", "Running", deleting),
+            ("deleting-completed", "Succeeded", deleting),
+        ]
+        .map(|(name, phase, terminating)| {
+            obj(json!({
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": name,
+                    "deletionTimestamp": terminating.then_some("2026-09-07T10:00:00Z"),
+                },
+                "status": {
+                    "phase": phase,
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                },
+            }))
+        });
+        let mut row = crate::fleet::FleetRow::connecting("staging".into(), false);
+        super::fleet::update_pod_counts(&mut row, &pods);
+        row.status = crate::fleet::FleetStatus::Ok;
+        app.handle_msg(Msg::FleetRow {
+            generation: app.generation,
+            row: Box::new(row),
+        });
+
+        let expected_unhealthy = if deleting { 2 } else { 0 };
+        assert_eq!(app.fleet_rows[0].pods_total, 4);
+        assert_eq!(app.fleet_rows[0].pods_unhealthy, expected_unhealthy);
+        assert_eq!(app.fleet_rows[0].is_healthy(), !deleting);
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 24)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let screen: String = (0..buffer.area.height)
+            .flat_map(|y| (0..buffer.area.width).map(move |x| buffer[(x, y)].symbol()))
+            .collect();
+        assert!(
+            screen.contains(&format!("pods {expected_unhealthy}✗/4")),
+            "{screen}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn ctrl_e_toggles_compact_mode_from_any_mode() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -392,6 +392,9 @@ fn pod_ready_counts(pod: &DynamicObject) -> (usize, usize) {
 }
 
 fn pod_is_ready(pod: &DynamicObject) -> bool {
+    if pod.metadata.deletion_timestamp.is_some() {
+        return false;
+    }
     // A pod is healthy when its Ready condition is True, or (Succeeded) it
     // completed. Fall back to container readiness when conditions are absent.
     if let Some(c) = condition(pod, "Ready")


### PR DESCRIPTION
Treat terminating pods as unhealthy in explain reports and fleet totals, even while Kubernetes retains their ready state. Closes #334.