### PR TITLE
fix: skip unreadable API groups during discovery and report them

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -175,6 +175,12 @@ counts, and the state/snapshot/bundle directories. `sofka --info` prints the
 static subset without connecting to a cluster. Identifiers and counts only,
 never credentials, tokens, or Secret values.
 
+When a kind you expect is missing, check the discovery line first. An API group
+whose discovery document could not be read is skipped with a warning at
+startup (`warning: API discovery skipped <group>/<version>: <reason>`), and
+`:info` lists the same warnings under the cluster's discovery status.
+`sofka --check` prints them too and reports how many groups were skipped.
+
 ## X.509 v1 client certificates
 
 Some MicroK8s kubeconfigs contain an X.509 v1 client certificate. The standard

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -175,11 +175,14 @@ counts, and the state/snapshot/bundle directories. `sofka --info` prints the
 static subset without connecting to a cluster. Identifiers and counts only,
 never credentials, tokens, or Secret values.
 
-When a kind you expect is missing, check the discovery line first. An API group
-whose discovery document could not be read is skipped with a warning at
-startup (`warning: API discovery skipped <group>/<version>: <reason>`), and
-`:info` lists the same warnings under the cluster's discovery status.
-`sofka --check` prints them too and reports how many groups were skipped.
+If a kind is missing, check the discovery line first. When sofka cannot read an
+API group, it shows a warning at startup:
+`warning: API discovery could not read <group>/<version>: <reason>`. `:info`
+shows the same warnings under the cluster discovery status. `sofka --check`
+also prints the warnings and the number of API groups that sofka did not read.
+Sofka cannot skip the core API group. If it cannot read `v1`, the connection
+fails with the reason. If aggregated discovery fails, sofka shows the reason
+and reads each API group separately.
 
 ## X.509 v1 client certificates
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,10 +19,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   Resource names and built-in aliases take priority over discovered short names.
   Shared short names use group priority, then alphabetical group and resource
   order. User aliases override discovered aliases.
-  An API group whose discovery document cannot be read (an extension API
-  server that is down, or one that answers with a non-`v1` `apiVersion`) is
-  skipped instead of blocking the connection. Startup warns about it, the
-  first screen flashes it, and `:info` names the group and the reason.
+  Sofka can connect when it cannot read one API group. Examples: the
+  extension API server is down, or it sends an `apiVersion` that is not `v1`.
+  Sofka does not load that group. It shows a warning at startup and a flash
+  on the first screen. `:info` shows the group and the reason.
 - **Live watch** of any kind through `kube::runtime::watcher`, streamed into an
   in-memory store. Watch requests use uncompressed responses to avoid gzip
   stream errors. List requests retain gzip compression.
@@ -411,8 +411,8 @@ pod is rejected; browse through a pod that already mounts the claim instead.
   [Snapshots](debugging.md#snapshots).
 - **Runtime diagnostics** (`:info`, or `sofka --info`) - version and build,
   config sources, live context/cluster/API server and Kubernetes revision,
-  discovery status (including any API group skipped as unreadable) and Metrics
-  API status, watch error counts, and the state/snapshot/bundle directories.
+  discovery status with the API groups that sofka could not read, Metrics API
+  status, watch error counts, and the state/snapshot/bundle directories.
   The connected Kubernetes revision also
   stays visible in the main header.
   Identifiers and counts only, never credentials, tokens, or Secret values.

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,6 +19,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   Resource names and built-in aliases take priority over discovered short names.
   Shared short names use group priority, then alphabetical group and resource
   order. User aliases override discovered aliases.
+  An API group whose discovery document cannot be read (an extension API
+  server that is down, or one that answers with a non-`v1` `apiVersion`) is
+  skipped instead of blocking the connection. Startup warns about it, the
+  first screen flashes it, and `:info` names the group and the reason.
 - **Live watch** of any kind through `kube::runtime::watcher`, streamed into an
   in-memory store. Watch requests use uncompressed responses to avoid gzip
   stream errors. List requests retain gzip compression.
@@ -407,8 +411,9 @@ pod is rejected; browse through a pod that already mounts the claim instead.
   [Snapshots](debugging.md#snapshots).
 - **Runtime diagnostics** (`:info`, or `sofka --info`) - version and build,
   config sources, live context/cluster/API server and Kubernetes revision,
-  discovery and Metrics API status, watch error counts, and the
-  state/snapshot/bundle directories. The connected Kubernetes revision also
+  discovery status (including any API group skipped as unreadable) and Metrics
+  API status, watch error counts, and the state/snapshot/bundle directories.
+  The connected Kubernetes revision also
   stays visible in the main header.
   Identifiers and counts only, never credentials, tokens, or Secret values.
 

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -43,6 +43,9 @@ impl App {
             "  discovery:   {} resource kinds",
             self.cluster.catalog.len()
         ));
+        for w in &self.cluster.discovery_warnings {
+            lines.push(format!("    • {w}"));
+        }
         lines.push(format!(
             "  metrics API: {}",
             if self.metrics_seen {
@@ -142,6 +145,17 @@ impl App {
             ..Default::default()
         };
         self.mode = Mode::Detail;
+    }
+
+    pub fn flash_discovery_warnings(&mut self) {
+        let n = self.cluster.discovery_warnings.len();
+        if n == 0 {
+            return;
+        }
+        let noun = if n == 1 { "group" } else { "groups" };
+        self.flash_warn(&format!(
+            "API discovery could not read {n} API {noun}. Refer to :info for details."
+        ));
     }
 }
 

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -43,6 +43,9 @@ impl App {
             "  discovery:   {} resource kinds",
             self.cluster.catalog.len()
         ));
+        if let Some(note) = &self.cluster.discovery_fallback {
+            lines.push(format!("    • {note}"));
+        }
         for w in &self.cluster.discovery_warnings {
             lines.push(format!("    • {w}"));
         }
@@ -149,7 +152,7 @@ impl App {
 
     pub fn flash_discovery_warnings(&mut self) {
         let n = self.cluster.discovery_warnings.len();
-        if n == 0 {
+        if n == 0 || self.flash_err {
             return;
         }
         let noun = if n == 1 { "group" } else { "groups" };

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -898,16 +898,14 @@ impl App {
         self.apply_context_skin(resolved.skin_override);
         self.flash = format!("context: {name}");
         self.flash_err = false;
-        if let Some(w) = resolved
+        let first_warning = resolved
             .warnings
             .first()
             .or(view_warnings.first())
             .or(plugin_warnings.first())
             .or(threshold_warnings.first())
             .or(provider_warnings.first())
-        {
-            self.flash_warn(w);
-        }
+            .cloned();
         // Keep `:config` in sync with the layers just resolved for this context.
         self.config_warnings = resolved.warnings;
         self.config_warnings.extend(plugin_warnings);
@@ -927,6 +925,9 @@ impl App {
                 .default_resource
                 .unwrap_or_else(|| "pods".into());
             self.switch_kind(&kind);
+        }
+        if let Some(w) = &first_warning {
+            self.flash_warn(w);
         }
         self.flash_discovery_warnings();
         // Saved forwards for the new context. Running ones from the previous

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -928,6 +928,7 @@ impl App {
                 .unwrap_or_else(|| "pods".into());
             self.switch_kind(&kind);
         }
+        self.flash_discovery_warnings();
         // Saved forwards for the new context. Running ones from the previous
         // context are deliberately left alone (kubectl pinned their context
         // at spawn); autostart only adds what's missing here.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11352,6 +11352,53 @@ fn land_context(app: &mut App, name: &str) {
     });
 }
 
+#[tokio::test]
+async fn landing_a_context_flashes_skipped_discovery_groups() {
+    let (mut app, _rx) = test_app();
+    let mut cluster = Cluster::fake();
+    cluster.context = "dev".into();
+    cluster.discovery_warnings =
+        vec!["API discovery could not read odd.example.com/v1alpha3: expected v1".into()];
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: "dev".into(),
+        result: Ok(Box::new(cluster)),
+    });
+    assert_eq!(
+        app.flash,
+        "API discovery could not read 1 API group. Refer to :info for details."
+    );
+    assert!(app.flash_err);
+
+    land_context(&mut app, "prod");
+    assert_eq!(app.flash, "Viewing pods");
+    assert!(!app.flash_err);
+}
+
+#[tokio::test]
+async fn info_lists_skipped_discovery_groups() {
+    let (mut app, _rx) = test_app();
+    app.cluster.discovery_warnings = vec![
+        "API discovery could not read odd.example.com/v1alpha3: expected v1".into(),
+        "API discovery could not read broken.example.com/v1beta1: 503".into(),
+    ];
+    palette(&mut app, "info");
+    let lines: Vec<String> = app.detail.lines.iter().map(|l| l.to_string()).collect();
+    let discovery = lines
+        .iter()
+        .position(|l| l.starts_with("  discovery:"))
+        .expect("discovery line");
+    assert_eq!(
+        lines[discovery + 1],
+        "    • API discovery could not read odd.example.com/v1alpha3: expected v1"
+    );
+    assert_eq!(
+        lines[discovery + 2],
+        "    • API discovery could not read broken.example.com/v1beta1: 503"
+    );
+    assert!(app.config_warnings.is_empty());
+}
+
 /// Choose `name` in the context switcher, through the switcher's own keys.
 fn pick_context(app: &mut App, name: &str) {
     let mut list = vec![app.cluster.context.clone(), name.to_string()];

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11376,8 +11376,41 @@ async fn landing_a_context_flashes_skipped_discovery_groups() {
 }
 
 #[tokio::test]
+async fn discovery_flash_yields_to_a_config_warning_on_context_switch() {
+    let dir = std::env::temp_dir().join(format!(
+        "sofka-discovery-flash-yields-{}",
+        std::process::id()
+    ));
+    let cluster_dir = dir.join("clusters").join("test-cluster");
+    std::fs::create_dir_all(&cluster_dir).unwrap();
+    std::fs::write(cluster_dir.join("config.toml"), "readonly = \n").unwrap();
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+
+    let mut cluster = Cluster::fake();
+    cluster.context = "dev".into();
+    cluster.discovery_warnings =
+        vec!["API discovery could not read odd.example.com/v1alpha3: expected v1".into()];
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: "dev".into(),
+        result: Ok(Box::new(cluster)),
+    });
+    assert!(app.flash_err);
+    assert!(
+        app.flash.starts_with("ignoring invalid "),
+        "config warning must stay visible, got: {}",
+        app.flash
+    );
+    assert_eq!(app.config_warnings.len(), 1);
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
 async fn info_lists_skipped_discovery_groups() {
     let (mut app, _rx) = test_app();
+    app.cluster.discovery_fallback =
+        Some("Aggregated API discovery failed: boom. Sofka read each API group separately.".into());
     app.cluster.discovery_warnings = vec![
         "API discovery could not read odd.example.com/v1alpha3: expected v1".into(),
         "API discovery could not read broken.example.com/v1beta1: 503".into(),
@@ -11390,10 +11423,14 @@ async fn info_lists_skipped_discovery_groups() {
         .expect("discovery line");
     assert_eq!(
         lines[discovery + 1],
-        "    • API discovery could not read odd.example.com/v1alpha3: expected v1"
+        "    • Aggregated API discovery failed: boom. Sofka read each API group separately."
     );
     assert_eq!(
         lines[discovery + 2],
+        "    • API discovery could not read odd.example.com/v1alpha3: expected v1"
+    );
+    assert_eq!(
+        lines[discovery + 3],
         "    • API discovery could not read broken.example.com/v1beta1: 503"
     );
     assert!(app.config_warnings.is_empty());

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -108,6 +108,7 @@ pub struct Cluster {
     /// negotiation failure avoids retrying the extension on every switch.
     streaming_lists: Arc<AtomicU8>,
     pub discovery_warnings: Vec<String>,
+    pub discovery_fallback: Option<String>,
 }
 
 const STREAMING_UNKNOWN: u8 = 0;
@@ -185,6 +186,7 @@ impl Cluster {
             allow_v1_client_cert,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
             discovery_warnings: Vec::new(),
+            discovery_fallback: None,
         };
         // Version is useful metadata, not a connectivity prerequisite. Fetch
         // it alongside discovery so it adds no serial startup latency, and
@@ -253,6 +255,7 @@ impl Cluster {
             allow_v1_client_cert: false,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
             discovery_warnings: Vec::new(),
+            discovery_fallback: None,
         }
     }
 
@@ -287,7 +290,8 @@ impl Cluster {
         // Aggregated discovery needs two requests and tolerates stale APIService
         // entries. Legacy discovery is used when negotiation fails.
         let discovered = discovery::discover(&self.client).await?;
-        self.discovery_warnings = discovered.warnings;
+        self.discovery_warnings = discovered.skipped;
+        self.discovery_fallback = discovered.fallback;
         self.register_resources(discovered.resources);
         Ok(())
     }
@@ -626,6 +630,7 @@ impl Cluster {
             catalog: Vec::new(),
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
             discovery_warnings: Vec::new(),
+            discovery_fallback: None,
         };
         cluster.register_kind("", "Pod", "pods", true);
         cluster.register_kind("apps", "Deployment", "deployments", true);
@@ -946,16 +951,37 @@ pub(crate) mod tests {
         include_broken: bool,
         serve_version: bool,
     ) -> String {
-        mock_apiserver_with_requests(supports_aggregated, include_broken, serve_version)
-            .await
-            .0
+        mock_apiserver_with_requests(MockOptions {
+            supports_aggregated,
+            include_broken,
+            serve_version,
+            ..MockOptions::default()
+        })
+        .await
+        .0
+    }
+
+    #[derive(Clone, Copy, Default)]
+    pub(crate) struct MockOptions {
+        pub supports_aggregated: bool,
+        pub include_broken: bool,
+        pub serve_version: bool,
+        pub core_unreadable: bool,
+        pub aggregated_unreadable: bool,
+    }
+
+    pub(crate) async fn mock_apiserver_opts(opts: MockOptions) -> String {
+        mock_apiserver_with_requests(opts).await.0
     }
 
     async fn mock_apiserver_with_requests(
-        supports_aggregated: bool,
-        include_broken: bool,
-        serve_version: bool,
+        opts: MockOptions,
     ) -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+        let MockOptions {
+            supports_aggregated,
+            serve_version,
+            ..
+        } = opts;
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
         let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -965,7 +991,8 @@ pub(crate) mod tests {
             .expect("bind mock apiserver");
         let addr = listener.local_addr().expect("local addr");
 
-        fn route(path: &str, aggregated: bool, include_broken: bool) -> (&'static str, String) {
+        fn route(path: &str, aggregated: bool, opts: MockOptions) -> (&'static str, String) {
+            let include_broken = opts.include_broken;
             let broken_legacy = r#",{"name":"broken.example.com","versions":[{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}},{"name":"odd.example.com","versions":[{"groupVersion":"odd.example.com/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"odd.example.com/v1alpha3","version":"v1alpha3"}}"#;
             let broken_v2 = r#",{"metadata":{"name":"broken.example.com"},"versions":[{"version":"v1beta1","resources":[],"freshness":"Stale"}]}"#;
             // A mixed-version group modeled on the netbird.io operator: the
@@ -977,6 +1004,14 @@ pub(crate) mod tests {
             let capi_legacy = r#",{"name":"cluster.x-k8s.io","versions":[{"groupVersion":"cluster.x-k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"cluster.x-k8s.io/v1beta1","version":"v1beta1"}}"#;
             let capi_v2 = r#",{"metadata":{"name":"cluster.x-k8s.io"},"versions":[{"version":"v1beta1","freshness":"Current","resources":[{"resource":"machinedeployments","responseKind":{"kind":"MachineDeployment"},"scope":"Namespaced","shortNames":["md","cross"],"verbs":["get","list","watch"]},{"resource":"machinedrainrules","responseKind":{"kind":"MachineDrainRule"},"scope":"Namespaced","verbs":["get","list","watch"]}]}]}"#;
             match (path, aggregated) {
+                ("/apis", true) if opts.aggregated_unreadable => (
+                    "200 OK",
+                    r#"{"kind":"APIGroupDiscoveryList","apiVersion":"apidiscovery.k8s.io/v2","metadata":{},"items":[{"metadata":{"name":"apps"},"versions":"not-a-list"}]}"#.into(),
+                ),
+                ("/api/v1", _) if opts.core_unreadable => (
+                    "200 OK",
+                    r#"{"kind":"APIResourceList","apiVersion":"v1alpha3","groupVersion":"v1","resources":[]}"#.into(),
+                ),
                 ("/version", _) => (
                     "200 OK",
                     r#"{"major":"1","minor":"36","gitVersion":"v1.36.2-eks-bca9cf6","gitCommit":"abc123","gitTreeState":"clean","buildDate":"2026-08-20T00:00:00Z","goVersion":"go1.25.0","compiler":"gc","platform":"linux/amd64"}"#.into(),
@@ -1078,11 +1113,8 @@ pub(crate) mod tests {
                         if path == "/version" && !serve_version {
                             continue;
                         }
-                        let (status, body) = route(
-                            &path,
-                            wants_aggregated && supports_aggregated,
-                            include_broken,
-                        );
+                        let (status, body) =
+                            route(&path, wants_aggregated && supports_aggregated, opts);
                         let response = format!(
                             "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
                             body.len()
@@ -1109,7 +1141,12 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn short_names_do_not_need_extra_discovery_requests() {
         for aggregated in [true, false] {
-            let (url, requests) = mock_apiserver_with_requests(aggregated, false, true).await;
+            let (url, requests) = mock_apiserver_with_requests(MockOptions {
+                supports_aggregated: aggregated,
+                serve_version: true,
+                ..MockOptions::default()
+            })
+            .await;
             let cluster = connect_mock(url).await.unwrap();
             assert_eq!(cluster.resolve("md").unwrap().ar.kind, "MachineDeployment");
             let mut requests = requests.lock().unwrap().clone();
@@ -1143,6 +1180,7 @@ pub(crate) mod tests {
         assert!(cluster.resolve("deployments").is_some());
         assert!(cluster.resolve("pods").is_some());
         assert!(cluster.discovery_warnings.is_empty());
+        assert!(cluster.discovery_fallback.is_none());
     }
 
     #[test]
@@ -1189,6 +1227,7 @@ pub(crate) mod tests {
         assert!(cluster.resolve("deployments").is_some());
         assert!(cluster.resolve("pods").is_some());
         assert!(cluster.discovery_warnings.is_empty());
+        assert!(cluster.discovery_fallback.is_none());
     }
 
     /// Asserts every kind of the mixed-version group resolved: `widgets` at
@@ -1249,5 +1288,51 @@ pub(crate) mod tests {
             .expect("v1alpha3 group is named");
         assert!(odd.contains("expected v1"), "{odd}");
         assert_eq!(odd.matches("expected v1").count(), 1, "{odd}");
+        assert!(cluster.discovery_fallback.is_none());
+    }
+
+    #[tokio::test]
+    async fn legacy_walk_fails_when_the_core_group_is_unreadable() {
+        let url = mock_apiserver_opts(MockOptions {
+            supports_aggregated: false,
+            serve_version: true,
+            core_unreadable: true,
+            ..MockOptions::default()
+        })
+        .await;
+        let err = connect_mock(url)
+            .await
+            .err()
+            .expect("a cluster without a readable core group is unusable");
+        let text = format!("{err:#}");
+        assert!(text.contains("reading core API group v1"), "{text}");
+        assert!(text.contains("expected v1"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn failed_aggregated_discovery_is_reported_but_not_counted_as_skipped() {
+        let url = mock_apiserver_opts(MockOptions {
+            supports_aggregated: true,
+            serve_version: true,
+            aggregated_unreadable: true,
+            ..MockOptions::default()
+        })
+        .await;
+        let cluster = connect_mock(url).await.expect("legacy walk still connects");
+        assert!(cluster.resolve("deployments").is_some());
+        assert!(cluster.resolve("pods").is_some());
+        assert!(cluster.discovery_warnings.is_empty());
+        let note = cluster
+            .discovery_fallback
+            .as_deref()
+            .expect("the fallback reason is kept");
+        assert!(
+            note.starts_with("Aggregated API discovery failed: "),
+            "{note}"
+        );
+        assert!(
+            note.ends_with("Sofka read each API group separately."),
+            "{note}"
+        );
     }
 }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -107,6 +107,7 @@ pub struct Cluster {
     /// unknown, supported, or unsupported. Shared by all view watches so one
     /// negotiation failure avoids retrying the extension on every switch.
     streaming_lists: Arc<AtomicU8>,
+    pub discovery_warnings: Vec<String>,
 }
 
 const STREAMING_UNKNOWN: u8 = 0;
@@ -183,6 +184,7 @@ impl Cluster {
             connected: true,
             allow_v1_client_cert,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
+            discovery_warnings: Vec::new(),
         };
         // Version is useful metadata, not a connectivity prerequisite. Fetch
         // it alongside discovery so it adds no serial startup latency, and
@@ -250,6 +252,7 @@ impl Cluster {
             connected: false,
             allow_v1_client_cert: false,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
+            discovery_warnings: Vec::new(),
         }
     }
 
@@ -283,8 +286,9 @@ impl Cluster {
     async fn discover(&mut self) -> Result<()> {
         // Aggregated discovery needs two requests and tolerates stale APIService
         // entries. Legacy discovery is used when negotiation fails.
-        let resources = discovery::discover(&self.client).await?;
-        self.register_resources(resources);
+        let discovered = discovery::discover(&self.client).await?;
+        self.discovery_warnings = discovered.warnings;
+        self.register_resources(discovered.resources);
         Ok(())
     }
 
@@ -621,6 +625,7 @@ impl Cluster {
             registry: HashMap::new(),
             catalog: Vec::new(),
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
+            discovery_warnings: Vec::new(),
         };
         cluster.register_kind("", "Pod", "pods", true);
         cluster.register_kind("apps", "Deployment", "deployments", true);
@@ -961,7 +966,7 @@ pub(crate) mod tests {
         let addr = listener.local_addr().expect("local addr");
 
         fn route(path: &str, aggregated: bool, include_broken: bool) -> (&'static str, String) {
-            let broken_legacy = r#",{"name":"broken.example.com","versions":[{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}}"#;
+            let broken_legacy = r#",{"name":"broken.example.com","versions":[{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"broken.example.com/v1beta1","version":"v1beta1"}},{"name":"odd.example.com","versions":[{"groupVersion":"odd.example.com/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"odd.example.com/v1alpha3","version":"v1alpha3"}}"#;
             let broken_v2 = r#",{"metadata":{"name":"broken.example.com"},"versions":[{"version":"v1beta1","resources":[],"freshness":"Stale"}]}"#;
             // A mixed-version group modeled on the netbird.io operator: the
             // preferred version (v1) serves `widgets`, while `gadgets` is
@@ -1017,6 +1022,10 @@ pub(crate) mod tests {
                 ("/apis/mixed.example.com/v1alpha1", _) => (
                     "200 OK",
                     r#"{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"mixed.example.com/v1alpha1","resources":[{"name":"gadgets","singularName":"gadget","shortNames":["gd","shared"],"namespaced":true,"kind":"Gadget","verbs":["get","list","watch"]}]}"#.into(),
+                ),
+                ("/apis/odd.example.com/v1alpha3", _) => (
+                    "200 OK",
+                    r#"{"kind":"APIResourceList","apiVersion":"v1alpha3","groupVersion":"odd.example.com/v1alpha3","resources":[{"name":"oddities","singularName":"oddity","namespaced":true,"kind":"Oddity","verbs":["get","list","watch"]}]}"#.into(),
                 ),
                 ("/apis/broken.example.com/v1beta1", _) => (
                     "503 Service Unavailable",
@@ -1133,6 +1142,7 @@ pub(crate) mod tests {
             .expect("connect with broken APIService");
         assert!(cluster.resolve("deployments").is_some());
         assert!(cluster.resolve("pods").is_some());
+        assert!(cluster.discovery_warnings.is_empty());
     }
 
     #[test]
@@ -1178,6 +1188,7 @@ pub(crate) mod tests {
             .expect("connect via legacy discovery walk");
         assert!(cluster.resolve("deployments").is_some());
         assert!(cluster.resolve("pods").is_some());
+        assert!(cluster.discovery_warnings.is_empty());
     }
 
     /// Asserts every kind of the mixed-version group resolved: `widgets` at
@@ -1216,13 +1227,27 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_walk_still_fails_on_broken_apiservice() {
-        // Documents the failure mode the aggregated path exists to avoid:
-        // the per-group walk hits the broken group's 503 and discovery fails
-        // (after ~4 minutes of client-side 503 retries with the default
-        // config). If kube-rs ever makes run() tolerant, this starts failing
-        // and the aggregated workaround can be simplified.
+    async fn legacy_walk_skips_unreadable_groups_with_warnings() {
         let url = mock_apiserver(false, true, true).await;
-        assert!(connect_mock(url).await.is_err());
+        let cluster = connect_mock(url)
+            .await
+            .expect("connect despite unreadable groups");
+        assert!(cluster.resolve("deployments").is_some());
+        assert!(cluster.resolve("pods").is_some());
+        assert!(cluster.resolve("oddities").is_none());
+        let warnings = &cluster.discovery_warnings;
+        assert_eq!(warnings.len(), 2, "{warnings:?}");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.starts_with("API discovery could not read broken.example.com/v1beta1: ")),
+            "{warnings:?}"
+        );
+        let odd = warnings
+            .iter()
+            .find(|w| w.starts_with("API discovery could not read odd.example.com/v1alpha3: "))
+            .expect("v1alpha3 group is named");
+        assert!(odd.contains("expected v1"), "{odd}");
+        assert_eq!(odd.matches("expected v1").count(), 1, "{odd}");
     }
 }

--- a/src/k8s/discovery.rs
+++ b/src/k8s/discovery.rs
@@ -15,20 +15,22 @@ pub(super) struct Resource {
 
 pub(super) struct Discovered {
     pub resources: Vec<Resource>,
-    pub warnings: Vec<String>,
+    pub skipped: Vec<String>,
+    pub fallback: Option<String>,
 }
 
 // Keep short names from the wire documents. kube's Discovery conversion drops them.
 pub(super) async fn discover(client: &Client) -> Result<Discovered> {
-    let mut warnings = Vec::new();
+    let mut skipped = Vec::new();
+    let mut fallback = None;
     let mut resources = match aggregated(client).await {
         Ok(Some(resources)) => resources,
-        Ok(None) => legacy(client, &mut warnings).await?,
+        Ok(None) => legacy(client, &mut skipped).await?,
         Err(e) => {
-            warnings.push(format!(
+            fallback = Some(format!(
                 "Aggregated API discovery failed: {e}. Sofka read each API group separately."
             ));
-            legacy(client, &mut warnings).await?
+            legacy(client, &mut skipped).await?
         }
     };
     // Select the most stable served version of each kind, including kinds absent
@@ -44,7 +46,8 @@ pub(super) async fn discover(client: &Client) -> Result<Discovered> {
         .dedup_by(|a, b| a.kind.ar.group == b.kind.ar.group && a.kind.ar.kind == b.kind.ar.kind);
     Ok(Discovered {
         resources,
-        warnings,
+        skipped,
+        fallback,
     })
 }
 
@@ -94,7 +97,7 @@ fn append_aggregated(out: &mut Vec<Resource>, list: APIGroupDiscoveryList) -> Re
     Ok(())
 }
 
-async fn legacy(client: &Client, warnings: &mut Vec<String>) -> Result<Vec<Resource>> {
+async fn legacy(client: &Client, skipped: &mut Vec<String>) -> Result<Vec<Resource>> {
     let mut resources = Vec::new();
     for group in client
         .list_api_groups()
@@ -103,7 +106,7 @@ async fn legacy(client: &Client, warnings: &mut Vec<String>) -> Result<Vec<Resou
         .groups
     {
         if group.versions.is_empty() {
-            warnings.push(format!(
+            skipped.push(format!(
                 "API discovery could not read {}: the group has no versions",
                 group.name
             ));
@@ -116,7 +119,7 @@ async fn legacy(client: &Client, warnings: &mut Vec<String>) -> Result<Vec<Resou
                 Err(e) => Err(e.into()),
             };
             if let Err(e) = result {
-                warnings.push(format!("API discovery could not read {gv}: {e}"));
+                skipped.push(format!("API discovery could not read {gv}: {e}"));
             }
         }
     }
@@ -126,18 +129,13 @@ async fn legacy(client: &Client, warnings: &mut Vec<String>) -> Result<Vec<Resou
         .context("running API discovery")?;
     ensure!(!core.versions.is_empty(), "empty core API group");
     for version in core.versions {
-        let result = match client.list_core_api_resources(&version).await {
-            Ok(list) => append_legacy(&mut resources, list),
-            Err(e) => Err(e.into()),
-        };
-        if let Err(e) = result {
-            warnings.push(format!("API discovery could not read {version}: {e}"));
-        }
+        let list = client
+            .list_core_api_resources(&version)
+            .await
+            .with_context(|| format!("running API discovery: reading core API group {version}"))?;
+        append_legacy(&mut resources, list)
+            .with_context(|| format!("running API discovery: reading core API group {version}"))?;
     }
-    ensure!(
-        !resources.is_empty(),
-        "running API discovery: sofka could not read any API group"
-    );
     Ok(resources)
 }
 

--- a/src/k8s/discovery.rs
+++ b/src/k8s/discovery.rs
@@ -13,11 +13,23 @@ pub(super) struct Resource {
     pub short_names: Vec<String>,
 }
 
+pub(super) struct Discovered {
+    pub resources: Vec<Resource>,
+    pub warnings: Vec<String>,
+}
+
 // Keep short names from the wire documents. kube's Discovery conversion drops them.
-pub(super) async fn discover(client: &Client) -> Result<Vec<Resource>> {
+pub(super) async fn discover(client: &Client) -> Result<Discovered> {
+    let mut warnings = Vec::new();
     let mut resources = match aggregated(client).await {
-        Ok(resources) => resources,
-        Err(_) => legacy(client).await.context("running API discovery")?,
+        Ok(Some(resources)) => resources,
+        Ok(None) => legacy(client, &mut warnings).await?,
+        Err(e) => {
+            warnings.push(format!(
+                "Aggregated API discovery failed: {e}. Sofka read each API group separately."
+            ));
+            legacy(client, &mut warnings).await?
+        }
     };
     // Select the most stable served version of each kind, including kinds absent
     // from the group's preferred version.
@@ -30,21 +42,23 @@ pub(super) async fn discover(client: &Client) -> Result<Vec<Resource>> {
     });
     resources
         .dedup_by(|a, b| a.kind.ar.group == b.kind.ar.group && a.kind.ar.kind == b.kind.ar.kind);
-    Ok(resources)
+    Ok(Discovered {
+        resources,
+        warnings,
+    })
 }
 
-async fn aggregated(client: &Client) -> Result<Vec<Resource>> {
+async fn aggregated(client: &Client) -> Result<Option<Vec<Resource>>> {
     let groups = client.list_api_groups_aggregated().await?;
     let core = client.list_core_api_versions_aggregated().await?;
     // Legacy responses deserialize as empty lists when negotiation is unsupported.
-    ensure!(
-        !groups.items.is_empty() || !core.items.is_empty(),
-        "aggregated discovery is unavailable"
-    );
+    if groups.items.is_empty() && core.items.is_empty() {
+        return Ok(None);
+    }
     let mut resources = Vec::new();
     append_aggregated(&mut resources, groups)?;
     append_aggregated(&mut resources, core)?;
-    Ok(resources)
+    Ok(Some(resources))
 }
 
 fn append_aggregated(out: &mut Vec<Resource>, list: APIGroupDiscoveryList) -> Result<()> {
@@ -80,29 +94,50 @@ fn append_aggregated(out: &mut Vec<Resource>, list: APIGroupDiscoveryList) -> Re
     Ok(())
 }
 
-async fn legacy(client: &Client) -> Result<Vec<Resource>> {
+async fn legacy(client: &Client, warnings: &mut Vec<String>) -> Result<Vec<Resource>> {
     let mut resources = Vec::new();
-    for group in client.list_api_groups().await?.groups {
-        ensure!(
-            !group.versions.is_empty(),
-            "empty API group: {}",
-            group.name
-        );
+    for group in client
+        .list_api_groups()
+        .await
+        .context("running API discovery")?
+        .groups
+    {
+        if group.versions.is_empty() {
+            warnings.push(format!(
+                "API discovery could not read {}: the group has no versions",
+                group.name
+            ));
+            continue;
+        }
         for version in group.versions {
-            let list = client
-                .list_api_group_resources(&version.group_version)
-                .await?;
-            append_legacy(&mut resources, list)?;
+            let gv = version.group_version;
+            let result = match client.list_api_group_resources(&gv).await {
+                Ok(list) => append_legacy(&mut resources, list),
+                Err(e) => Err(e.into()),
+            };
+            if let Err(e) = result {
+                warnings.push(format!("API discovery could not read {gv}: {e}"));
+            }
         }
     }
-    let core = client.list_core_api_versions().await?;
+    let core = client
+        .list_core_api_versions()
+        .await
+        .context("running API discovery")?;
     ensure!(!core.versions.is_empty(), "empty core API group");
     for version in core.versions {
-        append_legacy(
-            &mut resources,
-            client.list_core_api_resources(&version).await?,
-        )?;
+        let result = match client.list_core_api_resources(&version).await {
+            Ok(list) => append_legacy(&mut resources, list),
+            Err(e) => Err(e.into()),
+        };
+        if let Err(e) = result {
+            warnings.push(format!("API discovery could not read {version}: {e}"));
+        }
     }
+    ensure!(
+        !resources.is_empty(),
+        "running API discovery: sofka could not read any API group"
+    );
     Ok(resources)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,11 @@ async fn run_main(args: Args) -> Result<()> {
         }
     };
     cluster.allow_v1_client_cert = args.allow_v1_client_cert;
-    for w in &cluster.discovery_warnings {
+    for w in cluster
+        .discovery_fallback
+        .iter()
+        .chain(&cluster.discovery_warnings)
+    {
         eprintln!("\x1b[33mwarning:\x1b[0m {w}");
     }
     // Per-cluster/per-context override files merge over the base config.
@@ -208,11 +212,10 @@ async fn run_main(args: Args) -> Result<()> {
             "  kinds:      {} resource types discovered",
             cluster.catalog.len()
         );
-        if !cluster.discovery_warnings.is_empty() {
-            println!(
-                "  not read:   {} API groups. Refer to the warnings above.",
-                cluster.discovery_warnings.len()
-            );
+        let not_read = cluster.discovery_warnings.len();
+        if not_read > 0 {
+            let noun = if not_read == 1 { "group" } else { "groups" };
+            println!("  not read:   {not_read} API {noun}. Refer to the warnings above.");
         }
         for alias in ["pods", "po", "dp", "svc", "no", "ns", "cm"] {
             match cluster.resolve(alias) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,9 @@ async fn run_main(args: Args) -> Result<()> {
         }
     };
     cluster.allow_v1_client_cert = args.allow_v1_client_cert;
+    for w in &cluster.discovery_warnings {
+        eprintln!("\x1b[33mwarning:\x1b[0m {w}");
+    }
     // Per-cluster/per-context override files merge over the base config.
     let resolved = loader.resolve(&cluster.context, &cluster.cluster_name);
     for w in &resolved.warnings {
@@ -205,6 +208,12 @@ async fn run_main(args: Args) -> Result<()> {
             "  kinds:      {} resource types discovered",
             cluster.catalog.len()
         );
+        if !cluster.discovery_warnings.is_empty() {
+            println!(
+                "  not read:   {} API groups. Refer to the warnings above.",
+                cluster.discovery_warnings.len()
+            );
+        }
         for alias in ["pods", "po", "dp", "svc", "no", "ns", "cm"] {
             match cluster.resolve(alias) {
                 Some(k) => println!(
@@ -377,6 +386,7 @@ async fn run_main(args: Args) -> Result<()> {
         app.flash = w.clone();
         app.flash_err = true;
     }
+    app.flash_discovery_warnings();
 
     if args.snapshot {
         return snapshot(&mut app, &mut rx).await;


### PR DESCRIPTION
## Summary
- Discovery no longer fails on the first API group it cannot read. It skips that group version, keeps the rest, and records a warning that names the group and the reason. This matches what client-go does with `ErrGroupDiscoveryFailed`, which is why k9s and kubectl work on the same cluster.
- Root cause of #357: an extension API server answers its resource list with `apiVersion: v1alpha3`. k8s-openapi only accepts `v1` there.
- The core `v1` group stays fatal. A cluster without a readable core group is not usable, and the error names the group and the reason.
- A failed aggregated discovery is recorded as its own note, printed at startup and listed in `:info`, but never counted as a skipped group.
- The warnings are visible at startup on stderr, counted by `sofka --check`, flashed on the first screen and after a context switch, and listed in `:info`. The discovery flash yields to an existing warning flash, so a config warning is not hidden. The context-switch handler now flashes its config warning after the landing view instead of before it, where the view's own flash used to replace it.
- Docs updated in `docs/features.md` and `docs/debugging.md`.

Closes #357

## Test plan
- [x] Mock apiserver gained `odd.example.com/v1alpha3` with the exact response shape from the issue. The legacy walk connects, resolves `deployments` and `pods`, and names both unreadable groups once each.
- [x] An unreadable core `v1` resource list fails the connection with the group and reason in the error.
- [x] A malformed aggregated discovery document falls back to the legacy walk, keeps the reason, and counts zero skipped groups.
- [x] Context switch onto a cluster with discovery warnings flashes the summary. A clean landing does not. A config warning on the same switch wins the flash.
- [x] `:info` through the palette lists the fallback note and each warning under the discovery line and leaves `config_warnings` empty.
- [x] `just check` passes: fmt, clippy `-D warnings`, 1004 tests.
- [ ] Reporter confirms `sofka --check` connects against their cluster and shows which group was skipped.

## Known limitation
On the legacy path, the kube client's default retry policy still applies per group. A group whose backend answers 503 is retried with backoff before it is skipped, so startup can be slow on such a cluster. Aggregated discovery avoids this, and the deserialization case from #357 is not retried.