### PR TITLE
fix: scope notifications to cluster context

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -47,7 +47,9 @@ conditions) flashes in the status line, rings the terminal bell, and fires a
 
 Each notify is its own bounded single-object watch, so it keeps firing while you
 browse other views - "tell me when this rollout finishes" and keep working.
-`:notify` on the same row turns it off. Everything is session-local.
+`:notify` on the same row turns it off. Switching contexts stops all active
+notifications so events from the previous cluster cannot cross contexts.
+Everything is session-local.
 
 ```toml
 [notify]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -968,7 +968,7 @@ impl App {
                 self.last_error = Some(error.clone());
                 self.borrow_status(format!("internal error: {error}"), true);
             }
-            Msg::Notify(text) => {
+            Msg::Notify { epoch, text } if epoch == self.notify_epoch => {
                 self.borrow_status(format!("🔔 {text}"), false);
                 // Delivery happens once per frame in the run loop (see
                 // `take_notification`), so a batch of these coalesces.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1956,8 +1956,11 @@ pub struct App {
     /// Active `:notify` watches, keyed by `plural/ns/name`. Each is its own
     /// single-object background watcher, deliberately NOT in [`Self::tasks`]:
     /// a notify must survive `bump_generation` (view switches) and fire from
-    /// anywhere until toggled off.
+    /// anywhere until toggled off or the context changes.
     pub(super) notify_tasks: HashMap<String, tokio::task::JoinHandle<()>>,
+    /// Lifecycle shared by notification watchers and their messages. Unlike
+    /// the view generation, this advances only when the cluster context changes.
+    pub(super) notify_epoch: u64,
     /// Notifications waiting for the main loop to deliver (bell, desktop
     /// escape sequence, notifier subprocess). Drained once per frame and
     /// joined, so a burst arriving in one batch is one delivery — sinks
@@ -2204,6 +2207,7 @@ impl App {
             timeline: crate::timeline::Timeline::default(),
             table_hit: RefCell::new(None),
             notify_tasks: HashMap::new(),
+            notify_epoch: 0,
             pending_notify: Vec::new(),
             prev_revisions: PrevRevisions::default(),
             timeline_target: None,

--- a/src/app/notify.rs
+++ b/src/app/notify.rs
@@ -7,7 +7,8 @@ impl App {
     /// waiting reasons, conditions) flashes, rings the terminal bell, and
     /// emits a desktop notification (`[notify]`). Each notify is its own bounded
     /// single-object watch, so it keeps firing no matter which view is open,
-    /// until toggled off or the session ends. Nothing touches disk.
+    /// until toggled off, the context changes, or the session ends. Nothing
+    /// touches disk.
     pub(super) fn toggle_notify(&mut self) {
         if matches!(self.kind_plural.as_str(), "helm" | "helmhistory") {
             self.flash_warn("notify is not available for Helm views");
@@ -47,6 +48,7 @@ impl App {
         let ar = kind.ar.clone();
         let namespaced = kind.namespaced;
         let tx = self.tx.clone();
+        let epoch = self.notify_epoch;
 
         let handle = tokio::spawn(async move {
             let api: Api<DynamicObject> = if namespaced && !ns.is_empty() {
@@ -81,7 +83,7 @@ impl App {
                         };
                         if !items.is_empty() {
                             let text = format!("{label}: {}", items.join(" · "));
-                            if tx.send(Msg::Notify(text)).await.is_err() {
+                            if tx.send(Msg::Notify { epoch, text }).await.is_err() {
                                 return;
                             }
                         }
@@ -90,7 +92,10 @@ impl App {
                     Ok(watcher::Event::Delete(_)) => {
                         prev = None;
                         if tx
-                            .send(Msg::Notify(format!("{label}: deleted")))
+                            .send(Msg::Notify {
+                                epoch,
+                                text: format!("{label}: deleted"),
+                            })
                             .await
                             .is_err()
                         {
@@ -111,6 +116,16 @@ impl App {
             self.notify_tasks.len()
         );
         self.flash_err = false;
+    }
+
+    /// Stop watches tied to the old cluster and invalidate anything they
+    /// already queued before their cancellation completed.
+    pub(super) fn stop_notifications(&mut self) {
+        self.notify_epoch += 1;
+        for (_, task) in self.notify_tasks.drain() {
+            task.abort();
+        }
+        self.pending_notify.clear();
     }
 
     /// The message the main loop should deliver (bell, escape sequence,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -825,6 +825,7 @@ impl App {
     /// re-resolved so per-cluster/per-context overrides (aliases, plugins,
     /// skin, defaults) follow the new context.
     pub(super) fn apply_context_switch(&mut self, name: String, mut cluster: Box<Cluster>) {
+        self.stop_notifications();
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2906,18 +2906,86 @@ async fn notify_survives_view_switches() {
     app.table_state.select(Some(0));
     assert!(app.run_palette_command("notify"));
     assert_eq!(app.notify_tasks.len(), 1);
+    let epoch = app.notify_epoch;
 
     // bump_generation (any view switch) aborts self.tasks — the notify watch
     // must not be among them.
     app.switch_kind("services");
     assert_eq!(app.notify_tasks.len(), 1);
     assert!(!app.notify_tasks["pods/default/web"].is_finished());
+    assert_eq!(app.notify_epoch, epoch);
+    app.handle_msg(Msg::Notify {
+        epoch,
+        text: "pod/web: Ready True → False".into(),
+    });
+    assert_eq!(
+        app.take_notification().as_deref(),
+        Some("pod/web: Ready True → False")
+    );
+}
+
+#[tokio::test]
+async fn context_switch_stops_notifications_and_drops_stale_messages() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "web", "namespace": "default"}}),
+    );
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    for ch in ":notify".chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.notify_tasks.len(), 1);
+    let old_epoch = app.notify_epoch;
+    let old_task = app.notify_tasks["pods/default/web"].abort_handle();
+
+    app.handle_msg(Msg::Notify {
+        epoch: old_epoch,
+        text: "pod/web: old cluster".into(),
+    });
+    assert_eq!(app.pending_notify.len(), 1);
+
+    pick_context(&mut app, "west");
+    assert_eq!(app.notify_tasks.len(), 1);
+    assert_eq!(app.notify_epoch, old_epoch);
+    land_context(&mut app, "west");
+    tokio::task::yield_now().await;
+    assert!(app.notify_tasks.is_empty());
+    assert!(old_task.is_finished());
+    assert_eq!(app.notify_epoch, old_epoch + 1);
+    assert_eq!(app.take_notification(), None);
+
+    let flash = app.flash.clone();
+    app.handle_msg(Msg::Notify {
+        epoch: old_epoch,
+        text: "pod/web: late old cluster".into(),
+    });
+    assert_eq!(app.flash, flash);
+    assert_eq!(app.take_notification(), None);
+
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "web", "namespace": "default"}}),
+    );
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    for ch in ":notify".chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.notify_tasks.contains_key("pods/default/web"));
 }
 
 #[tokio::test]
 async fn notify_msg_flashes_and_queues_bell() {
     let (mut app, _rx) = test_app();
-    app.handle_msg(Msg::Notify("pod/web: Ready True → False".into()));
+    app.handle_msg(Msg::Notify {
+        epoch: app.notify_epoch,
+        text: "pod/web: Ready True → False".into(),
+    });
     assert!(!app.flash_err);
     assert!(app.flash.contains("pod/web"), "{}", app.flash);
     assert_eq!(
@@ -2933,8 +3001,15 @@ async fn notification_bursts_coalesce_into_one_delivery() {
     // the first of a burst) — everything pending in one frame batch must
     // leave as a single bounded delivery.
     let (mut app, _rx) = test_app();
-    app.handle_msg(Msg::Notify("pod/a: Ready True → False".into()));
-    app.handle_msg(Msg::Notify("pod/a: deleted".into()));
+    let epoch = app.notify_epoch;
+    app.handle_msg(Msg::Notify {
+        epoch,
+        text: "pod/a: Ready True → False".into(),
+    });
+    app.handle_msg(Msg::Notify {
+        epoch,
+        text: "pod/a: deleted".into(),
+    });
     assert_eq!(
         app.take_notification().as_deref(),
         Some("pod/a: Ready True → False · pod/a: deleted")
@@ -2942,7 +3017,10 @@ async fn notification_bursts_coalesce_into_one_delivery() {
     assert_eq!(app.take_notification(), None);
 
     for i in 0..100 {
-        app.handle_msg(Msg::Notify(format!("pod/pod-{i}: restarts 0 → 1")));
+        app.handle_msg(Msg::Notify {
+            epoch,
+            text: format!("pod/pod-{i}: restarts 0 → 1"),
+        });
     }
     let text = app.take_notification().unwrap();
     assert!(text.chars().count() <= 300, "bounded: {}", text.len());
@@ -4780,7 +4858,10 @@ async fn background_status_borrows_the_bar_without_orphaning_an_action() {
     assert_eq!(app.flash, "scaled web → 3");
 
     let claim = app.claim_status("draining node-1…");
-    app.handle_msg(Msg::Notify("pod/web: Ready True → False".into()));
+    app.handle_msg(Msg::Notify {
+        epoch: app.notify_epoch,
+        text: "pod/web: Ready True → False".into(),
+    });
     assert!(app.flash.starts_with('🔔'), "{}", app.flash);
 
     // A transient notification may expire before the action. The pending

--- a/src/store.rs
+++ b/src/store.rs
@@ -300,9 +300,12 @@ pub enum Msg {
     /// Deliberately generation-free: it must surface no matter which view is
     /// current.
     Panic(String),
-    /// A state change on a `:notify`-watched object. Generation-free like
-    /// [`Msg::Panic`]: the whole point is firing from any view.
-    Notify(String),
+    /// A state change on a `:notify`-watched object. The notification epoch
+    /// survives view changes but invalidates messages from a previous context.
+    Notify {
+        epoch: u64,
+        text: String,
+    },
 }
 
 /// One hit from the global fuzzy find (`:find <text>`).


### PR DESCRIPTION
Stop active notification watches after context switches and discard late events from the previous cluster. Closes #326.