### PR TITLE
fix: correct rightsize pod queries and patch previews

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,6 +12,20 @@ CPU and memory over the window, a suggested request (P95 plus headroom), OOM and
 throttle evidence, and a **strategic-merge patch preview** (`c` copies it). It
 **never mutates** - apply the patch with `kubectl patch` yourself if you agree.
 
+Pod queries match the exact name. Workload queries match the standard pod-name
+format for the selected controller: a template hash and random suffix for
+Deployments, an ordinal for StatefulSets, and a random suffix for ReplicaSets
+and DaemonSets. This excludes pods from workloads with longer name prefixes,
+such as `api-worker` when `api` is selected, while retaining past rollout data.
+Names are matched literally, including dots. Matching uses names, not verified
+owner references; adopted pods with other names are not included, and a name
+that follows the same format can still match. The backend must contain data
+for the selected cluster and namespace.
+
+The patch uses `spec.containers` for a Pod and `spec.template.spec.containers`
+for a workload. Kubernetes can still reject a resource change that the cluster
+does not support.
+
 With no `[providers.metrics]` section, sofka finds a Prometheus or
 VictoriaMetrics query `Service` in the cluster by well-known labels and reaches
 it through the API-server proxy.

--- a/src/app/rightsize.rs
+++ b/src/app/rightsize.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::columns::{fmt_cpu, fmt_mem, parse_cpu_milli, parse_mem_bytes};
-use crate::rightsize::{ContainerRec, Quantiles, patch_preview, suggest};
+use crate::rightsize::{ContainerRec, PatchTarget, Quantiles, patch_preview, suggest};
 
 /// One container's spec pulled off the selected object before the gather.
 struct ContainerSpec {
@@ -21,20 +21,20 @@ impl App {
         };
         let name = obj.metadata.name.clone().unwrap_or_default();
         let ns = obj.metadata.namespace.clone().unwrap_or_default();
-        // Container list + a PromQL `pod` matcher: a bare pod matches exactly;
-        // a workload matches its replica pods by name prefix.
-        let (path, pod_matcher) = match self.kind_plural.as_str() {
-            "pods" => ("/spec/containers", format!("^{}$", regex_escape(&name))),
-            "deployments" | "statefulsets" | "daemonsets" | "replicasets" => (
-                "/spec/template/spec/containers",
-                format!("^{}-.*", regex_escape(&name)),
-            ),
+        // Match the controller's generated suffix, including past rollouts.
+        // A prefix alone also includes workloads such as api-worker under api.
+        let (target, suffix) = match self.kind_plural.as_str() {
+            "pods" => (PatchTarget::Pod, ""),
+            "deployments" => (PatchTarget::Workload, "-[a-z0-9]{1,10}-[a-z0-9]{5}"),
+            "statefulsets" => (PatchTarget::Workload, "-[0-9]+"),
+            "daemonsets" | "replicasets" => (PatchTarget::Workload, "-[a-z0-9]{5}"),
             _ => {
                 self.flash_warn("right-size applies to workloads (deploy/sts/ds/rs) and pods");
                 return;
             }
         };
-        let containers = container_specs(obj, path);
+        let pod_matcher = format!("^{}{suffix}$", regex::escape(&name));
+        let containers = container_specs(obj, target.containers_path());
         if containers.is_empty() {
             self.flash_warn("no containers found to right-size");
             return;
@@ -92,7 +92,14 @@ impl App {
                 errors.extend(errs);
             }
 
-            let lines = render_report(&provider.location(), &window, headroom, &recs, &errors);
+            let lines = render_report(
+                &provider.location(),
+                &window,
+                headroom,
+                &recs,
+                &errors,
+                target,
+            );
             let warn =
                 (!errors.is_empty()).then(|| format!("{} metrics queries failed", errors.len()));
             let _ = tx
@@ -121,8 +128,10 @@ async fn gather_container(
     headroom: u32,
 ) -> (ContainerRec, Vec<String>) {
     let sel = format!(
-        "namespace=\"{ns}\",pod=~\"{pod_matcher}\",container=\"{}\"",
-        spec.name
+        "namespace={},pod=~{},container={}",
+        json!(ns),
+        json!(pod_matcher),
+        json!(spec.name),
     );
     let cpu_q = |q: &str| {
         format!(
@@ -193,6 +202,7 @@ fn render_report(
     headroom: u32,
     recs: &[ContainerRec],
     errors: &[String],
+    target: PatchTarget,
 ) -> Vec<String> {
     let opt_cpu = |v: Option<f64>| v.map(|n| fmt_cpu(n as i64)).unwrap_or_else(|| "—".into());
     let opt_mem = |v: Option<f64>| v.map(|n| fmt_mem(n as i64)).unwrap_or_else(|| "—".into());
@@ -241,10 +251,10 @@ fn render_report(
         lines.push(String::new());
     }
 
-    match patch_preview(recs) {
+    match patch_preview(recs, target) {
         Some(patch) => {
             lines.push(
-                "suggested patch (preview only — copy with c, apply with kubectl patch):".into(),
+                "suggested patch (preview only; copy with c, apply with kubectl patch):".into(),
             );
             lines.push(String::new());
             lines.extend(patch.lines().map(String::from));
@@ -284,10 +294,4 @@ fn container_specs(obj: &DynamicObject, path: &str) -> Vec<ContainerSpec> {
                 .collect()
         })
         .unwrap_or_default()
-}
-
-/// Escape the regex metacharacters that can appear in a Kubernetes object name
-/// (really just `.`), so the PromQL `pod=~` matcher is anchored to the literal.
-fn regex_escape(name: &str) -> String {
-    name.replace('.', "\\.")
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11481,7 +11481,7 @@ async fn rightsize_rejects_non_workload_kinds() {
                "metadata": {"name": "cm", "namespace": "default"}}),
     );
     app.table_state.select(Some(0));
-    app.open_rightsize();
+    plugin_command(&mut app, "rightsize");
     assert_ne!(app.mode, Mode::Detail);
     assert!(app.flash.contains("right-size applies"), "{}", app.flash);
 }
@@ -11511,9 +11511,247 @@ async fn rightsize_report_renders_verdicts_and_patch() {
     }];
     assert_eq!(recs[0].cpu_verdict(), crate::rightsize::Verdict::Over);
     assert_eq!(recs[0].mem_verdict(), crate::rightsize::Verdict::Under);
-    let patch = crate::rightsize::patch_preview(&recs).unwrap();
+    let patch =
+        crate::rightsize::patch_preview(&recs, crate::rightsize::PatchTarget::Workload).unwrap();
     assert!(patch.contains("\"name\": \"app\""));
     assert!(patch.contains("cpu") && patch.contains("memory"));
+}
+
+async fn rightsize_command_report(plural: &str, name: &str) -> (App, Vec<String>) {
+    use http_body_util::BodyExt;
+
+    let (mut app, mut rx) = test_app();
+    for (kind, plural) in [
+        ("StatefulSet", "statefulsets"),
+        ("DaemonSet", "daemonsets"),
+        ("ReplicaSet", "replicasets"),
+    ] {
+        app.cluster.register_kind("apps", kind, plural, true);
+    }
+    app.switch_kind(plural);
+    let containers = json!([{
+        "name": "app",
+        "resources": {"requests": {"cpu": "500m", "memory": "64Mi"}}
+    }]);
+    let spec = if plural == "pods" {
+        json!({"containers": containers})
+    } else {
+        json!({"template": {"spec": {"containers": containers}}})
+    };
+    let resource = json!({
+        "apiVersion": if plural == "pods" { "v1" } else { "apps/v1" },
+        "kind": app.kind.as_ref().unwrap().ar.kind,
+        "metadata": {"name": name, "namespace": "default"},
+        "spec": spec,
+    });
+    apply(&mut app, resource);
+    app.table_state.select(Some(0));
+    let queries = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = queries.clone();
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            let seen = seen.clone();
+            async move {
+                let response = match request.uri().path() {
+                    "/api/v1/namespaces" => {
+                        assert_eq!(request.method(), http::Method::GET);
+                        json!({"apiVersion":"v1", "kind":"NamespaceList", "items":[]})
+                    }
+                    "/api/v1/services" => {
+                        assert_eq!(request.method(), http::Method::GET);
+                        json!({"apiVersion":"v1", "kind":"ServiceList", "items":[{
+                            "metadata":{"name":"prometheus", "namespace":"monitoring"},
+                            "spec":{"ports":[{"name":"http", "port":9090}]}
+                        }]})
+                    }
+                    "/api/v1/namespaces/monitoring/services/prometheus:9090/proxy/api/v1/query" => {
+                        assert_eq!(request.method(), http::Method::POST);
+                        let body = request.into_body().collect().await.unwrap().to_bytes();
+                        let query = form_urlencoded::parse(&body)
+                            .find(|(key, _)| key == "query")
+                            .unwrap()
+                            .1
+                            .into_owned();
+                        let value = if query.contains("container_cpu_usage_seconds_total") {
+                            "100"
+                        } else if query.contains("container_memory_working_set_bytes") {
+                            "134217728"
+                        } else {
+                            "0"
+                        };
+                        seen.lock().unwrap().push(query);
+                        json!({"status":"success", "data":{"resultType":"vector",
+                            "result":[{"metric":{}, "value":[1, value]}]}})
+                    }
+                    path => panic!("unexpected rightsize request: {path}"),
+                };
+                Ok::<_, std::convert::Infallible>(http::Response::new(http_body_util::Full::new(
+                    hyper::body::Bytes::from(response.to_string()),
+                )))
+            }
+        }),
+        "default",
+    );
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "rightsize".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(message) = rx.recv().await {
+            if matches!(message, Msg::Detail { .. }) {
+                app.handle_msg(message);
+                return;
+            }
+        }
+        panic!("rightsize report channel closed");
+    })
+    .await
+    .expect("rightsize report did not finish");
+    assert_eq!(app.mode, Mode::Detail, "{plural}: {}", app.flash);
+    let queries = queries.lock().unwrap().clone();
+    (app, queries)
+}
+
+#[tokio::test]
+async fn rightsize_command_excludes_other_workload_prefixes_in_every_query() {
+    for (plural, name, included, excluded) in [
+        (
+            "deployments",
+            "api",
+            vec!["api-75675f5897-bcdf2", "api-5b6ff54-ghjk4"],
+            vec![
+                "api-worker-75675f5897-bcdf2",
+                "api-gateway-5b6ff54-ghjk4",
+                "api-0",
+                "api-bcdf2",
+                "other-api-75675f5897-bcdf2",
+            ],
+        ),
+        (
+            "statefulsets",
+            "api",
+            vec!["api-0", "api-12"],
+            vec!["api-worker-0", "api-gateway-12", "api-bcdf2", "api-0-extra"],
+        ),
+        (
+            "daemonsets",
+            "api",
+            vec!["api-bcdf2", "api-ghjk4"],
+            vec![
+                "api-worker-bcdf2",
+                "api-gateway-ghjk4",
+                "api-0",
+                "api-bcdf2-extra",
+            ],
+        ),
+        (
+            "replicasets",
+            "api-75675f5897",
+            vec!["api-75675f5897-bcdf2", "api-75675f5897-ghjk4"],
+            vec![
+                "api-75675f5897-worker-bcdf2",
+                "api-5b6ff54-bcdf2",
+                "api-75675f5897-0",
+            ],
+        ),
+        (
+            "pods",
+            "api.v2",
+            vec!["api.v2"],
+            vec!["apiXv2", "api.v2-worker", "other-api.v2"],
+        ),
+        (
+            "deployments",
+            "api.v2",
+            vec!["api.v2-75675f5897-bcdf2"],
+            vec!["apiXv2-75675f5897-bcdf2", "api.v2-worker-75675f5897-bcdf2"],
+        ),
+    ] {
+        let (_, queries) = rightsize_command_report(plural, name).await;
+        assert_eq!(queries.len(), 8, "{plural}: all usage and evidence queries");
+        for query in queries {
+            assert!(query.contains("namespace=\"default\""), "{query}");
+            assert!(query.contains("container=\"app\""), "{query}");
+            let literal = query
+                .split_once("pod=~")
+                .unwrap()
+                .1
+                .split_once(",container=")
+                .unwrap()
+                .0;
+            let pattern: String = serde_json::from_str(literal).unwrap();
+            let matcher = regex::Regex::new(&pattern).unwrap();
+            for pod in &included {
+                assert!(matcher.is_match(pod), "{plural}: {pod} omitted by {query}");
+            }
+            for pod in &excluded {
+                assert!(
+                    !matcher.is_match(pod),
+                    "{plural}: {pod} included by {query}"
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn rightsize_command_renders_patch_for_selected_resource_kind() {
+    for plural in [
+        "pods",
+        "deployments",
+        "statefulsets",
+        "daemonsets",
+        "replicasets",
+    ] {
+        let (app, _) = rightsize_command_report(plural, "api").await;
+        let patch_start = app
+            .detail
+            .lines
+            .iter()
+            .position(|line| line == "{")
+            .unwrap();
+        let patch_text = app
+            .detail
+            .lines
+            .iter()
+            .skip(patch_start)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let patch: Value = serde_json::from_str(&patch_text).unwrap();
+        let expected = json!([{
+            "name":"app",
+            "resources":{"requests":{"cpu":"115m", "memory":"148Mi"}}
+        }]);
+        if plural == "pods" {
+            assert_eq!(patch, json!({"spec":{"containers":expected}}));
+        } else {
+            assert_eq!(
+                patch,
+                json!({"spec":{"template":{"spec":{"containers":expected}}}}),
+                "{plural}"
+            );
+        }
+        assert!(
+            app.detail
+                .lines
+                .iter()
+                .any(|line| line.contains("over-provisioned"))
+        );
+        assert!(
+            app.detail
+                .lines
+                .iter()
+                .any(|line| line.contains("under-provisioned"))
+        );
+        assert!(
+            app.detail
+                .lines
+                .iter()
+                .any(|line| line.contains("preview only"))
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/rightsize.rs
+++ b/src/rightsize.rs
@@ -125,11 +125,24 @@ pub fn mem_quantity(bytes: f64) -> String {
     format!("{mi}Mi")
 }
 
-/// Build the strategic-merge patch that would apply the suggested requests to a
-/// workload's pod template, as pretty JSON. `path_root` is the pointer prefix
-/// to the container list — `spec.template.spec` for Deployments/StatefulSets/
-/// DaemonSets. Returns `None` when no container has a suggestion.
-pub fn patch_preview(recs: &[ContainerRec]) -> Option<String> {
+#[derive(Clone, Copy)]
+pub enum PatchTarget {
+    Pod,
+    Workload,
+}
+
+impl PatchTarget {
+    pub fn containers_path(self) -> &'static str {
+        match self {
+            Self::Pod => "/spec/containers",
+            Self::Workload => "/spec/template/spec/containers",
+        }
+    }
+}
+
+/// Build a strategic-merge patch for the selected resource type.
+/// Return `None` when no container has a recommendation.
+pub fn patch_preview(recs: &[ContainerRec], target: PatchTarget) -> Option<String> {
     let containers: Vec<Value> = recs
         .iter()
         .filter(|r| r.suggested_cpu.is_some() || r.suggested_mem.is_some())
@@ -147,9 +160,12 @@ pub fn patch_preview(recs: &[ContainerRec]) -> Option<String> {
     if containers.is_empty() {
         return None;
     }
-    let patch = json!({
-        "spec": { "template": { "spec": { "containers": containers } } }
-    });
+    let patch = match target {
+        PatchTarget::Pod => json!({"spec": {"containers": containers}}),
+        PatchTarget::Workload => json!({
+            "spec": { "template": { "spec": { "containers": containers } } }
+        }),
+    };
     serde_json::to_string_pretty(&patch).ok()
 }
 
@@ -244,12 +260,13 @@ mod tests {
                 suggested_mem: None,
             },
         ];
-        let patch = patch_preview(&recs).unwrap();
+        let patch = patch_preview(&recs, PatchTarget::Workload).unwrap();
         assert!(patch.contains("\"name\": \"app\""));
         assert!(patch.contains("\"cpu\": \"120m\""));
         assert!(patch.contains("\"memory\": \"128Mi\""));
         assert!(!patch.contains("sidecar"), "no-data container omitted");
         // Empty input → no patch at all.
-        assert!(patch_preview(&[]).is_none());
+        assert!(patch_preview(&[], PatchTarget::Workload).is_none());
+        assert!(patch_preview(&[], PatchTarget::Pod).is_none());
     }
 }


### PR DESCRIPTION
`:rightsize` could include usage from `api-worker` when sizing `api`, because every workload query used an unrestricted name prefix. Queries now match each controller's standard pod-name format and escape names correctly in PromQL. This retains past rollout data.

Pod patch previews now use `spec.containers`; workload previews retain `spec.template.spec.containers`. The command still only previews recommendations and patches.

Regression tests run through `handle_key` and a mock metrics provider. They check all eight queries, longer workload prefixes, dotted names, past rollout hashes, and patch output for all five supported resource types.

Validation: `just check` passed, including formatting, Clippy, and the full test suite after updating the branch onto current `main`. Markdown formatting also passed. No live cluster was used.

Matching remains name-based. The provider documentation explains the limits for adopted pods and overlapping name formats.

Closes #330
Closes #329
