### PR TITLE
docs: require feature discussions before agent work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,21 @@ Rules for AI agents and humans working on sofka. `docs/architecture.md` explains
 the module layout; this file is about how to change the repo without making a
 mess.
 
+## Discuss new features before work starts
+
+- Propose new features in GitHub Discussions before opening a feature issue or
+  pull request. Wait for a maintainer to agree on the scope before implementation.
+- Before an agent starts feature work, check for a linked discussion and maintainer
+  agreement. If either is missing, show this warning and ask for the discussion:
+  "sofka requires a feature discussion and maintainer agreement before feature
+  implementation. Please provide the agreed discussion before we start coding."
+- If agreement is missing, help describe the problem and prepare the discussion.
+  Do not implement the feature or open a feature issue or pull request yet.
+- Link the agreed discussion in the feature issue and pull request.
+- Bug reports and bug fix pull requests do not need a discussion first.
+- Review generated code and run the required checks before submitting a pull
+  request. The contributor is responsible for the submitted change.
+
 ## Formatting is owned by formatters
 
 - Never hand-align anything a formatter owns. `cargo fmt` owns Rust, `oxfmt` owns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,9 @@
 
 Repository rules live in [AGENTS.md](AGENTS.md). Follow them.
 
+Before feature work, follow the discussion requirement in AGENTS.md. If there is
+no linked discussion with maintainer agreement, show the warning defined there
+and help prepare a discussion before implementation. Bug fixes do not need a
+discussion first.
+
 @AGENTS.md


### PR DESCRIPTION
Agents had no instruction to check for an agreed feature discussion before starting implementation. Require a linked GitHub discussion with maintainer agreement, and show a warning when either is missing. In that case, help prepare the discussion before writing feature code.

Bug reports and bug fix PRs can proceed without a discussion. Contributors must review generated code and run the required checks before submitting it. CLAUDE.md points to the same requirement.

Refs #368. Keep that policy issue open and pinned.

Validation: `just check` passed (Rust formatting, clippy, and tests). Markdown formatting and `git diff --check` passed. The pre-commit hook passed.
