### PR TITLE
chore: add coverage reports to pull request CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,36 @@ jobs:
 
       - name: Test
         run: cargo test --locked
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache coverage build
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          key: coverage
+          workspaces: . -> target/llvm-cov-target
+
+      - name: Install coverage tool
+        run: cargo install cargo-llvm-cov --version 0.9.1 --locked
+
+      - name: Generate coverage report
+        run: cargo llvm-cov --locked --html
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-html
+          path: target/llvm-cov/html
+          if-no-files-found: error
+          retention-days: 14

--- a/.just/rust.just
+++ b/.just/rust.just
@@ -23,6 +23,10 @@ clippy:
 test:
     cd "{{ root }}" && cargo test --locked
 
+# Generate an HTML coverage report.
+coverage:
+    cd "{{ root }}" && cargo llvm-cov --locked --html
+
 # Build the debug binary.
 build:
     cd "{{ root }}" && cargo build

--- a/Justfile
+++ b/Justfile
@@ -24,6 +24,9 @@ clippy: rust::clippy
 # Run the unit test suite.
 test: rust::test
 
+# Generate an HTML coverage report.
+coverage: rust::coverage
+
 # Fast local confidence check.
 check: fmt-check clippy test
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,6 +72,24 @@ cargo test                   # unit tests (no cluster required)
 cargo clippy --all-targets   # lints (clean)
 ```
 
+### Test coverage
+
+Install the coverage tools once:
+
+```sh
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov --version 0.9.1 --locked
+```
+
+Run `just coverage` to test the code with coverage enabled and generate
+`target/llvm-cov/html/index.html`. Open this file in a browser to inspect which
+lines the tests execute. The report uses the default Cargo features.
+
+Pull requests run a separate coverage job. Download the `coverage-html` artifact
+from the CI run, extract it, and open `index.html`. Reports are kept for 14 days.
+There is no minimum coverage percentage. Use the report to find missing tests;
+coverage alone does not show whether a test checks the correct behavior.
+
 ## Release
 
 After merging the release-ready changes to `main`, run one of:


### PR DESCRIPTION
The test suite did not report which code it executes. Add a separate pull request job that runs `cargo-llvm-cov` with default features and uploads an HTML report as `coverage-html`, kept for 14 days. The existing Rust checks remain in place, with no minimum coverage percentage.

Add `just coverage` and document local setup and how to open CI reports. Pin the coverage tool to version 0.9.1 and reuse the existing pinned actions.

Validation:
- `just check` passed (format check, Clippy, and tests).
- `just coverage` passed: 1,099 tests passed and one was ignored; the HTML report was generated.
- Workflow security checks (`zizmor`) and formatter hooks passed.

Closes #251
