### PR TITLE
feat: add configuration option to hide the header

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ default_namespace = "kube-system"  # fallback only: the last namespace picked in
 default_resource  = "deployments"
 readonly          = false  # true disables every mutating action (delete, edit,
                            # scale, shell, plugins, …); --readonly/--write win
+hide_header = false # true hides the header and logo
 mouse             = true   # false keeps the terminal's native mouse behavior
                            # (text selection) instead of scroll/click/sort
 remember_sort     = true   # save and restore sort choices per resource kind
@@ -26,6 +27,11 @@ favorite_namespaces = ["kube-system", "monitoring"]
 [aliases]
 dep = "deployments"
 ```
+
+Set `hide_header = true` to remove the header and logo and give more space to
+the active view. The default is `false`. This option supports cluster and
+context overrides and `:reload`. It also hides the one-line header in compact
+mode (`Ctrl-E`). The footer and command input keep their existing behavior.
 
 `remember_sort` is enabled by default. Set it to `false` to stop saving and
 restoring sort choices from `S`, `I`, and column header clicks. Existing saved

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Optional header** - set `hide_header = true` in the configuration to hide
+  the header and logo, including the one-line header in compact mode.
+
 - **Connect** to the current kubeconfig context, including exec credential
   plugins (GKE, EKS, and friends).
 - **Optional v1 client certificates** through `--allow-v1-client-cert`, disabled

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1451,6 +1451,7 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
+        self.hide_header = resolved.config.hide_header;
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2034,6 +2034,8 @@ pub struct App {
     /// Compact mode (`ctrl-e`): collapse the header to one line and hide the
     /// footer, so a tiled/multiplexed pane shows mostly table.
     pub compact: bool,
+    /// Hide the header in normal and compact modes.
+    pub hide_header: bool,
     /// Active column layout for the current view; rebuilt by
     /// [`App::refresh_view_spec`] whenever kind/views/wide change.
     spec: crate::columns::ViewSpec,
@@ -2266,6 +2268,7 @@ impl App {
             crd_views: HashMap::new(),
             wide: false,
             compact: false,
+            hide_header: false,
             spec: crate::columns::build_spec("", "", None, None, false),
         }
     }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -829,6 +829,7 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
+        self.hide_header = resolved.config.hide_header;
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20147,3 +20147,102 @@ async fn edit_and_describe_use_selected_api_resource() {
         }
     }
 }
+
+#[tokio::test]
+async fn hide_header_reloads_and_keeps_command_input_in_compact_mode() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let dir = std::env::temp_dir().join(format!("sofka-hide-header-{}", std::process::id()));
+    write_config(&dir, "");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "pods");
+    let mut terminal = Terminal::new(TestBackend::new(180, 24)).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let normal = app.table_hit.borrow().clone().unwrap();
+    assert!(!app.hide_header);
+
+    write_config(&dir, "hide_header = true\n");
+    palette(&mut app, "reload");
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let hidden = app.table_hit.borrow().clone().unwrap();
+    assert!(app.hide_header);
+    assert_eq!(hidden.header_y + 7, normal.header_y);
+    assert_eq!(hidden.rows_h, normal.rows_h + 7);
+    let screen: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+    assert!(screen.contains("y:yaml"), "{screen}");
+
+    app.handle_key(ctrl(KeyCode::Char('e'))).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    assert_eq!(
+        app.table_hit.borrow().as_ref().unwrap().header_y,
+        hidden.header_y
+    );
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "reload".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let screen: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+    assert!(screen.contains(":reload"), "{screen}");
+
+    write_config(&dir, "");
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    assert!(!app.hide_header);
+    assert_eq!(
+        app.table_hit.borrow().as_ref().unwrap().header_y,
+        hidden.header_y + 1
+    );
+    app.handle_key(ctrl(KeyCode::Char('e'))).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    assert_eq!(
+        app.table_hit.borrow().as_ref().unwrap().header_y,
+        normal.header_y
+    );
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn hide_header_follows_context_overrides() {
+    let dir =
+        std::env::temp_dir().join(format!("sofka-hide-header-context-{}", std::process::id()));
+    write_config(&dir, "hide_header = true\n");
+    write_config(
+        &dir.join("clusters/test-cluster/dev"),
+        "hide_header = false\n",
+    );
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "reload");
+    assert!(app.hide_header);
+    land_context(&mut app, "dev");
+    assert!(!app.hide_header);
+    land_context(&mut app, "prod");
+    assert!(app.hide_header);
+    std::fs::remove_dir_all(&dir).unwrap();
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,8 @@ pub struct Config {
     /// and plugins. Overridden by the `--readonly`/`--write` CLI flags. Set
     /// it in a per-cluster/per-context override file to lock down just prod.
     pub readonly: bool,
+    /// Hide the header, including the logo. Defaults to false.
+    pub hide_header: bool,
     /// Custom alias -> canonical resource (plural/kind) mappings.
     pub aliases: HashMap<String, String>,
     /// Namespaces pinned to the top of the switcher (a curated team list, in

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,6 +303,7 @@ async fn run_main(args: Args) -> Result<()> {
     app.sort_memory = sortmem::SortMemory::load(&sort_memory_path);
     app.sort_memory_path = Some(sort_memory_path);
     app.remember_sort = cfg.remember_sort.unwrap_or(true);
+    app.hide_header = cfg.hide_header;
     // The last namespace picked per context persists too, so a relaunch (or
     // a `:ctx` switch back) lands where you left off.
     let namespace_memory_path = nsmem::NamespaceMemory::default_path();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -111,8 +111,14 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         return;
     }
     let mut constraints = vec![
-        Constraint::Length(if compact { 1 } else { 7 }), // header
-        Constraint::Min(3),                              // body
+        Constraint::Length(if app.hide_header {
+            0
+        } else if compact {
+            1
+        } else {
+            7
+        }), // header
+        Constraint::Min(3), // body
     ];
     let prompt_idx = if !compact || needs_prompt {
         constraints.push(Constraint::Length(1));
@@ -131,10 +137,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         .constraints(constraints)
         .split(frame.area());
 
-    if compact {
-        draw_compact_header(frame, app, chunks[0]);
-    } else {
-        draw_header(frame, app, chunks[0]);
+    if !app.hide_header {
+        if compact {
+            draw_compact_header(frame, app, chunks[0]);
+        } else {
+            draw_header(frame, app, chunks[0]);
+        }
     }
 
     match app.mode {
@@ -4012,7 +4020,7 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 "Tab/⇧Tab: resources  "
             };
-            let hint = if header_hints_fit(frame.area().width) {
+            let hint = if !app.hide_header && header_hints_fit(frame.area().width) {
                 format!(
                     "  {cycle}:resource  /filter  S:sort I:invert  w:wide  space:mark  [ ]:history  0:all-ns  ?:help"
                 )


### PR DESCRIPTION
The header uses seven terminal rows even when a user does not need the cluster details or logo. Add `hide_header = true` to give those rows to the active view. The header stays visible by default.

The option applies at startup, on context changes, and through `:reload`. It also hides the compact header. Resource action hints remain in the footer when the header is hidden. The configuration and feature documentation describe the option.

Validation: `just check` (format check, Clippy with warnings denied, and all tests). New tests use keyboard input to check reload, layout, compact mode, command input, and context overrides.

The maintainer approved implementation directly in the work session.

Closes #315
