### PR TITLE
fix: preserve workspace resource errors

### DIFF
--- a/src/app/bookmarks.rs
+++ b/src/app/bookmarks.rs
@@ -47,19 +47,19 @@ impl App {
     }
 
     /// Apply a bookmark against the current cluster: namespace, resource,
-    /// filter, sort, then an optional view.
-    pub(super) fn apply_bookmark_local(&mut self, bm: crate::config::Bookmark) {
+    /// filter, sort, then an optional view. Return false if validation fails.
+    pub(super) fn apply_bookmark_local(&mut self, bm: crate::config::Bookmark) -> bool {
         if bm.resource.trim().is_empty() {
             self.flash_warn("bookmark has no resource");
-            return;
+            return false;
         }
         if self.cluster.resolve(bm.resource.trim()).is_none() {
             self.flash_warn(&format!("No resource matches '{}'", bm.resource));
-            return;
+            return false;
         }
         if let Some(error) = crate::filter::parse(bm.filter.as_deref().unwrap_or("")).error() {
             self.flash_warn(&format!("filter: {error}"));
-            return;
+            return false;
         }
         self.apply_resource_query(crate::filter::ResourceQuery {
             resource: bm.resource.clone(),
@@ -77,6 +77,7 @@ impl App {
         }
         self.flash = format!("bookmark: {}", bm.name);
         self.flash_err = false;
+        true
     }
 
     /// Apply a stashed bookmark once its context switch has connected.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10391,6 +10391,73 @@ async fn workspace_opens_first_view_and_tab_cycles() {
     assert_eq!(app.namespace, "checkout");
 }
 
+#[tokio::test]
+async fn workspace_rejected_view_keeps_error_and_previous_view() {
+    for cycle in [false, true] {
+        for (resource, filter, error) in [
+            (
+                "nonexistentcrd",
+                "replacement",
+                "No resource matches 'nonexistentcrd'",
+            ),
+            ("", "replacement", "bookmark has no resource"),
+            ("pods", "(", "filter:"),
+        ] {
+            let (mut app, _rx) = test_app();
+            let initial = crate::config::WorkspaceView {
+                name: "current pods".into(),
+                resource: "pods".into(),
+                namespace: Some("checkout".into()),
+                filter: Some("api".into()),
+                sort: Some("NAME:asc".into()),
+                ..Default::default()
+            };
+            let mut bookmark = initial.as_bookmark();
+            bookmark.key = Some("z".into());
+            app.bookmarks = vec![bookmark];
+            app.handle_key(press(KeyCode::Char('z'))).unwrap();
+            assert!(!app.flash_err, "{}", app.flash);
+            let previous_sort = app.sort_column;
+            assert!(previous_sort.is_some());
+
+            let invalid = crate::config::WorkspaceView {
+                name: "invalid".into(),
+                resource: resource.into(),
+                namespace: Some("other".into()),
+                filter: Some(filter.into()),
+                sort: Some("NAME:desc".into()),
+                view: Some("pulse".into()),
+            };
+            app.workspaces = vec![crate::config::Workspace {
+                key: Some("ctrl-w".into()),
+                name: "ops".into(),
+                context: None,
+                views: if cycle {
+                    vec![initial, invalid]
+                } else {
+                    vec![invalid]
+                },
+            }];
+            app.handle_key(ctrl(KeyCode::Char('w'))).unwrap();
+            if cycle {
+                assert_eq!(app.flash, "workspace ops [1/2]: current pods");
+                assert!(!app.flash_err);
+                app.handle_key(press(KeyCode::Tab)).unwrap();
+            }
+
+            assert!(app.flash_err, "{}", app.flash);
+            assert!(app.flash.starts_with(error), "{}", app.flash);
+            assert_eq!(app.kind.as_ref().unwrap().ar.plural, "pods");
+            assert_eq!(app.kind_plural, "pods");
+            assert_eq!(app.namespace, "checkout");
+            assert_eq!(app.filter, "api");
+            assert_eq!(app.sort_column, previous_sort);
+            assert!(!app.sort_desc);
+            assert!(matches!(app.mode, Mode::Table));
+        }
+    }
+}
+
 fn resource_cycle_app() -> (App, Receiver<Msg>) {
     let (mut app, rx) = test_app();
     for (group, kind, plural) in [

--- a/src/app/workspaces.rs
+++ b/src/app/workspaces.rs
@@ -137,8 +137,7 @@ impl App {
         let bookmark = view.as_bookmark();
         // Reuse the bookmark application path (resource/ns/filter/sort/view),
         // then relabel the status line for the workspace.
-        self.apply_bookmark_local(bookmark);
-        if self.kind.is_some() {
+        if self.apply_bookmark_local(bookmark) {
             self.flash = format!("workspace {name} [{i}/{n}]: {vname}");
             self.flash_err = false;
         }


### PR DESCRIPTION
An invalid workspace view leaves the previous resource kind set. The workspace then replaces the validation error with a success message. For example, opening a workspace that refers to an unknown resource from a pods view reports success while the pods view stays open.

Return an explicit validation result from local bookmark application. Set the workspace success message only when validation succeeds. This keeps the error visible and preserves the previous view when validation fails. The earlier fix in 48dcadf already prevents invalid bookmarks from changing the previous filter, sort, or view.

Tests use `handle_key` to check unknown resources, empty resources, and invalid filters when opening a workspace and cycling with Tab. They also check successful navigation to the same resource.

Validation: `just check` (format check, clippy with warnings denied, and the full test suite).

Closes #321
