### PR TITLE
fix: map fuzzy highlights to character positions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "toml",
  "tower",
  "tower-http 0.7.1",
+ "unicode-segmentation",
  "unicode-width",
  "x509-parser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 toml = "1.1.2"
 tower = { version = "0.5.3", features = ["util"] }
 tower-http = { version = "0.7.0", features = ["decompression-gzip", "trace", "util", "map-response-body"] }
+unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
 x509-parser = { version = "0.18", default-features = false }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1226,6 +1226,32 @@ async fn filter_match_indices_highlight_matched_chars() {
 }
 
 #[tokio::test]
+async fn fuzzy_filter_highlights_complete_graphemes_at_char_positions() {
+    let (mut app, _rx) = test_app();
+    let cases = [
+        ("test-e\u{0301}lastic-role", "lastic", "lastic"),
+        ("test-e\u{0301}lastic-role", "elastic", "e\u{0301}lastic"),
+        ("a\u{0301}b\u{0308}c-role", "ac", "a\u{0301}c"),
+        ("test-👩‍💻-role", "role", "role"),
+        ("test-👩‍💻-role", "👩", "👩‍💻"),
+        ("test-élastic-role", "lastic", "lastic"),
+        ("test-elastic-role", "lastic", "lastic"),
+    ];
+    for (name, filter, expected) in cases {
+        retype_filter(&mut app, filter);
+        let indices = app.filter_match_indices(name).unwrap();
+        let highlighted: String = name
+            .chars()
+            .enumerate()
+            .filter(|(i, _)| indices.contains(i))
+            .map(|(_, ch)| ch)
+            .collect();
+        assert_eq!(highlighted, expected, "name={name:?}, filter={filter:?}");
+        assert!(indices.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+}
+
+#[tokio::test]
 async fn table_cell_cache_invalidates_on_apply() {
     let (mut app, _rx) = test_app();
     app.kind_plural = "pods".into();

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -9,6 +9,7 @@ use std::cell::RefCell;
 
 use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Normalization};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
+use unicode_segmentation::UnicodeSegmentation;
 
 /// A shared fuzzy matcher.
 ///
@@ -107,8 +108,8 @@ impl Fuzzy {
         atom.score(utf32(haystack, buf), matcher).map(i64::from)
     }
 
-    /// The char positions in `haystack` that `needle` matched, ascending, or
-    /// `None` when it does not match.
+    /// The char positions of all matched graphemes in `haystack`, ascending,
+    /// or `None` when `needle` does not match.
     pub fn indices(&self, haystack: &str, needle: &str) -> Option<Vec<usize>> {
         let mut inner = self.inner.borrow_mut();
         inner.sync(needle);
@@ -125,7 +126,27 @@ impl Fuzzy {
         // repeat a position; callers highlight by walking them in order.
         indices.sort_unstable();
         indices.dedup();
-        Some(indices.iter().map(|&i| i as usize).collect())
+        if haystack.is_ascii() {
+            return Some(indices.iter().map(|&i| i as usize).collect());
+        }
+
+        // The matcher counts graphemes; the renderer counts chars. Include
+        // every char in each matched grapheme so its style stays consistent.
+        let mut matched = indices.iter().peekable();
+        let mut positions = Vec::with_capacity(indices.len());
+        let mut char_offset = 0;
+        for (i, grapheme) in haystack.graphemes(true).enumerate() {
+            if matched.peek().is_none() {
+                break;
+            }
+            let end = char_offset + grapheme.chars().count();
+            if matched.peek().is_some_and(|&&pos| pos as usize == i) {
+                positions.extend(char_offset..end);
+                matched.next();
+            }
+            char_offset = end;
+        }
+        Some(positions)
     }
 }
 


### PR DESCRIPTION
Fuzzy filter highlights shift after a combining character because the matcher returns grapheme indices and the renderer uses character indices. Convert matched graphemes to character positions and include every character in each matched grapheme. For example, filtering `test-e\u{0301}lastic-role` with `lastic` now highlights all of `lastic`.

Add a regression test that enters filters through `handle_key`. It covers combining accents, multiple combined graphemes, joined emoji, precomposed Unicode, and ASCII. Use the existing locked version of `unicode-segmentation` as a direct dependency.

Validation: the new test failed before the fix. `just check` passes after the fix, including formatting, Clippy with warnings denied, and the full test suite.

Closes #335
