### PR TITLE
fix: retain recently changed timeline history

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20492,3 +20492,46 @@ async fn hide_header_follows_context_overrides() {
     assert!(app.hide_header);
     std::fs::remove_dir_all(&dir).unwrap();
 }
+
+#[tokio::test]
+async fn timeline_key_keeps_recently_changed_history_at_capacity() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let pod = |name: &str, generation: i64| {
+        json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": name, "namespace": "default",
+                "generation": generation, "resourceVersion": generation.to_string(),
+                "creationTimestamp": "2999-01-01T00:00:00Z"}})
+    };
+    apply(&mut app, pod("a-active", 1));
+    for i in 0..1999 {
+        apply(&mut app, pod(&format!("idle-{i:04}"), 1));
+    }
+    for generation in 2..=3 {
+        apply(&mut app, pod("a-active", generation));
+    }
+    apply(&mut app, pod("z-new", 1));
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Char('T'))).unwrap();
+    assert_eq!(app.mode, Mode::Timeline);
+    let (plural, key) = app.timeline_target.as_ref().unwrap();
+    assert_eq!(key, "default/a-active");
+    let entries = app.timeline.entries(plural, key).unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].text, "Pod created");
+    assert_eq!(entries[2].text, "spec changed: generation 2 → 3");
+    assert!(app.timeline.entries("pods", "default/idle-0000").is_none());
+    assert!(app.timeline.entries("pods", "default/idle-0001").is_some());
+    assert!(app.timeline.entries("pods", "default/z-new").is_some());
+
+    apply(&mut app, pod("idle-0000", 2));
+    assert!(app.timeline.entries("pods", "default/idle-0000").is_some());
+    assert!(app.timeline.entries("pods", "default/idle-0001").is_none());
+    assert_eq!(
+        app.timeline
+            .entries("pods", "default/a-active")
+            .unwrap()
+            .len(),
+        3
+    );
+}

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -132,7 +132,13 @@ impl Timeline {
     fn push(&mut self, key: &str, at: i64, level: Level, text: String) {
         let entry = Entry { at, level, text };
         let dq = match self.history.get_mut(key) {
-            Some(dq) => dq,
+            Some(dq) => {
+                if self.order.back().is_none_or(|last| last != key) {
+                    self.order.retain(|existing| existing != key);
+                    self.order.push_back(key.to_string());
+                }
+                dq
+            }
             None => {
                 if self.order.len() >= MAX_OBJECTS
                     && let Some(evict) = self.order.pop_front()


### PR DESCRIPTION
When the timeline already holds history for 2,000 objects, adding history for another object can remove an active object's recent history. Existing entries did not update the eviction queue, so the queue used insertion order.

Move an existing object to the back of the queue when a timeline entry is recorded. Repeated entries for the most recently changed object need no queue update. This makes eviction follow the documented least-recently-touched policy. Queue updates scan at most 2,000 keys and require no new dependency.

The regression test feeds watch messages through the app and opens the timeline with `T`. It checks recent history retention, idle history eviction, and new history for an object whose history was removed. The test failed before the fix.

Validation: `just check` (format check, clippy with warnings denied, and all tests).

Closes #336
