### PR TITLE
feat: discover direct CR children in the adjacent view

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -211,6 +211,24 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   describe. Relations are data: a built-in table for core kinds, extended per
   CRD with `[[views."…".refs]]` and `children`. Reverse lookups stay in the
   row's namespace unless the rule says `cluster`.
+  Press `c` in this view to discover direct children of a namespaced custom
+  resource with a UID, including resources with no configured child kinds.
+  Wait for the initial adjacent lookup to finish first. The search uses API
+  discovery from the current cluster connection. It selects namespaced resources
+  that support listing, excludes subresources, and selects one API version per
+  resource. It searches only the source namespace and matches owner UIDs, not
+  names or labels. Results are added to the view as pages arrive. `⏎` opens a
+  result. The initial lookup and Enter action on the resource table stay the same.
+  Each search permits four concurrent requests, 200 objects per page, at most
+  200 list requests and 20,000 objects checked, five seconds per request, and
+  30 seconds in total. Objects with other owners count towards the object limit.
+  Access denial, request errors, timeouts, skipped API discovery, and search
+  limits mark the search as incomplete. Results already found remain available.
+  The search status stays above the results. Leaving the view, opening an
+  overlay, refreshing, or changing the source or context cancels the search.
+  Late replies are ignored. `c` starts another search; `r` repeats the initial
+  adjacent lookup. This action does not search across namespaces, follow
+  descendants recursively, or start background watches.
 - **Watch notifications** (`:notify`) - toggle a notification on the selected
   object and Sophie watches it for you. See [Notifications](debugging.md#notifications).
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -37,6 +37,7 @@ for the grammar and selector persistence rules.
 | `x`                                           | secrets: show `data` base64-decoded (as `stringData`) · PVCs: browse the volume                                                                                     |
 | `X` / `T`                                     | explain why the selection is unhealthy / session-local state-change timeline                                                                                        |
 | `u` / `:adjacent`                             | adjacent view: owners, children, and the objects the selection names or is named by (`⏎` opens one)                                                                 |
+| `c` (adjacent view)                           | Discover direct children of a namespaced custom resource. Search starts on request. Results can be incomplete; see the limits in [Features](features.md).           |
 | `:gitops` / `:flux`                           | Flux owner, source, revisions & reconciliation chain for the selection (`⏎` to jump)                                                                                |
 | `:can-i` / `:can-i <verb> <resource> [ns]`    | what you can do here / check a single action (`SelfSubjectAccessReview`)                                                                                            |
 | `:journal` / `:audit`                         | session-local log of the mutating actions you've taken                                                                                                              |

--- a/src/app/adjacent.rs
+++ b/src/app/adjacent.rs
@@ -7,6 +7,8 @@ use crate::store::AdjacentItem;
 use kube::core::GroupVersionResource;
 use std::collections::hash_map::Entry;
 
+mod children;
+
 type ListCache = HashMap<(GroupVersionResource, String), Vec<DynamicObject>>;
 
 /// The cluster's registry, answering the plan's kind lookups.
@@ -56,6 +58,9 @@ impl App {
             self.flash_warn("no selection");
             return;
         };
+        self.cancel_adjacent_request();
+        self.child_status.clear();
+        self.adjacent_warning = None;
         self.set_return_mode();
         self.adjacent_return = self.return_mode;
         let name = obj.metadata.name.clone().unwrap_or_default();
@@ -70,6 +75,9 @@ impl App {
     /// `r` in the adjacent view — gather again for the same object.
     pub(super) fn refresh_adjacent(&mut self) {
         if self.adjacent_source.is_some() {
+            self.cancel_children();
+            self.child_status.clear();
+            self.adjacent_warning = None;
             self.spawn_adjacent();
         }
     }
@@ -201,6 +209,7 @@ impl App {
     }
 
     pub(super) fn cancel_adjacent_request(&mut self) {
+        self.cancel_children();
         self.adjacent_request = self.adjacent_request.wrapping_add(1);
         if let Some(claim) = self.adjacent_claim.take() {
             self.clear_claimed_status(claim);
@@ -231,6 +240,7 @@ impl App {
                 }
             }
             KeyCode::Char('r') => self.refresh_adjacent(),
+            KeyCode::Char('c') => self.discover_children(),
             KeyCode::Enter => self.adjacent_goto(),
             KeyCode::Char('y') => self.adjacent_yaml(),
             KeyCode::Char('d') => self.adjacent_describe(),

--- a/src/app/adjacent/children.rs
+++ b/src/app/adjacent/children.rs
@@ -1,0 +1,403 @@
+use super::*;
+use futures_util::{StreamExt, stream::FuturesUnordered};
+use kube::api::ListParams;
+use std::collections::VecDeque;
+use tokio::time::{Duration, Instant, timeout, timeout_at};
+
+#[derive(Clone, Copy)]
+struct Limits {
+    concurrency: usize,
+    page_size: u32,
+    requests: usize,
+    objects: usize,
+    request_time: Duration,
+    total_time: Duration,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            concurrency: 4,
+            page_size: 200,
+            requests: 200,
+            objects: 20_000,
+            request_time: Duration::from_secs(5),
+            total_time: Duration::from_secs(30),
+        }
+    }
+}
+
+impl App {
+    pub fn can_discover_children(&self) -> bool {
+        self.kind
+            .as_ref()
+            .is_some_and(|k| k.namespaced && k.is_custom())
+            && self.adjacent_source.as_ref().is_some_and(|o| {
+                o.metadata
+                    .namespace
+                    .as_ref()
+                    .is_some_and(|ns| !ns.is_empty())
+                    && o.metadata.uid.as_ref().is_some_and(|uid| !uid.is_empty())
+            })
+    }
+
+    pub(in crate::app) fn discover_children(&mut self) {
+        if !self.can_discover_children() {
+            self.flash_warn("child discovery requires a namespaced custom resource with a UID");
+            return;
+        }
+        if self.adjacent_pending() {
+            self.flash_warn("wait for the initial adjacent lookup to finish");
+            return;
+        }
+        self.cancel_children();
+        let source = self.adjacent_source.as_ref().unwrap();
+        let search = Search {
+            client: self.cluster.client.clone(),
+            kinds: self.cluster.child_kinds.clone(),
+            namespace: source.metadata.namespace.clone().unwrap(),
+            uid: source.metadata.uid.clone().unwrap(),
+            discovery_warnings: self.cluster.discovery_warnings.clone(),
+            limits: Limits::default(),
+        };
+        self.child_status = "children: searching".into();
+        self.child_task = Some(tokio::spawn(search.run(
+            self.tx.clone(),
+            self.generation,
+            self.child_request,
+        )));
+    }
+
+    pub(in crate::app) fn cancel_children(&mut self) {
+        self.child_request = self.child_request.wrapping_add(1);
+        if let Some(task) = self.child_task.take() {
+            task.abort();
+            self.child_status = "children: incomplete (search cancelled)".into();
+        }
+    }
+}
+
+struct Search {
+    client: Client,
+    kinds: Vec<crate::k8s::Kind>,
+    namespace: String,
+    uid: String,
+    discovery_warnings: Vec<String>,
+    limits: Limits,
+}
+
+impl Search {
+    async fn run(self, tx: tokio::sync::mpsc::Sender<Msg>, generation: u64, request: u64) {
+        let deadline = Instant::now() + self.limits.total_time;
+        let mut queue: VecDeque<_> = self
+            .kinds
+            .into_iter()
+            .map(|k| (k, None::<String>))
+            .collect();
+        let total = queue.len();
+        let mut pending = FuturesUnordered::new();
+        let mut requests = 0;
+        let mut objects = 0;
+        let mut searched = 0;
+        let mut failures = self.discovery_warnings.len();
+        let mut reason = self.discovery_warnings.first().cloned();
+        let mut limited = false;
+        loop {
+            if Instant::now() >= deadline {
+                limited = true;
+                reason = Some("time limit reached".into());
+                break;
+            }
+            while pending.len() < self.limits.concurrency && requests < self.limits.requests {
+                let Some((kind, token)) = queue.pop_front() else {
+                    break;
+                };
+                requests += 1;
+                let client = self.client.clone();
+                let ns = self.namespace.clone();
+                let limits = self.limits;
+                pending.push(async move {
+                    let api: Api<DynamicObject> = Api::namespaced_with(client, &ns, &kind.ar);
+                    let mut params = ListParams::default().limit(limits.page_size);
+                    if let Some(token) = token {
+                        params = params.continue_token(&token);
+                    }
+                    let result = match timeout(limits.request_time, api.list(&params)).await {
+                        Ok(result) => result.map_err(|e| e.to_string()),
+                        Err(_) => Err("request timed out".into()),
+                    };
+                    (kind, result)
+                });
+            }
+            if pending.is_empty() {
+                if !queue.is_empty() {
+                    limited = true;
+                    reason = Some("request limit reached".into());
+                }
+                break;
+            }
+            let (kind, result) = match timeout_at(deadline, pending.next()).await {
+                Ok(Some(result)) => result,
+                Ok(None) => break,
+                Err(_) => {
+                    limited = true;
+                    reason = Some("time limit reached".into());
+                    break;
+                }
+            };
+            let mut items = Vec::new();
+            match result {
+                Ok(page) => {
+                    let available = self.limits.objects.saturating_sub(objects);
+                    let overflow = page.items.len() > available;
+                    let r = kind_ref(kind.clone());
+                    for object in page.items.into_iter().take(available) {
+                        objects += 1;
+                        if object.metadata.namespace.as_deref() == Some(self.namespace.as_str())
+                            && owned_by(&object, Some(&self.uid))
+                        {
+                            items.push(item(Direction::Child, "owns", &r, object));
+                        }
+                    }
+                    if let Some(token) = page.metadata.continue_.filter(|t| !t.is_empty()) {
+                        queue.push_back((kind, Some(token)));
+                    } else if !overflow {
+                        searched += 1;
+                    }
+                    if overflow
+                        || (objects >= self.limits.objects
+                            && (!queue.is_empty() || !pending.is_empty()))
+                    {
+                        limited = true;
+                        reason = Some("object limit reached".into());
+                    }
+                }
+                Err(error) => {
+                    failures += 1;
+                    reason.get_or_insert_with(|| format!("{}: {error}", kind.title()));
+                }
+            }
+            if tx
+                .send(Msg::AdjacentChildren {
+                    generation,
+                    request,
+                    items,
+                    status: format!(
+                        "children: searching ({searched}/{total} kinds, {objects} objects checked)"
+                    ),
+                    done: false,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if limited {
+                break;
+            }
+        }
+        // Dropping page futures cancels all outstanding HTTP requests.
+        drop(pending);
+        let status = if failures > 0 || limited {
+            format!(
+                "children: incomplete ({searched}/{total} kinds; {failures} errors; {})",
+                reason.unwrap_or_else(|| "search limit reached".into())
+            )
+        } else {
+            format!("children: complete ({searched}/{total} kinds, {objects} objects checked)")
+        };
+        let _ = tx
+            .send(Msg::AdjacentChildren {
+                generation,
+                request,
+                items: Vec::new(),
+                status,
+                done: true,
+            })
+            .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    fn fixture(delay: Duration, repeat: bool, denied: bool) -> (Search, Arc<AtomicUsize>) {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let seen = requests.clone();
+        let client = Client::new(
+            tower::service_fn(move |req: http::Request<kube::client::Body>| {
+                seen.fetch_add(1, Ordering::SeqCst);
+                assert!(req.uri().path().contains("/namespaces/prod/"));
+                assert!(req.uri().query().unwrap().contains("limit=200"));
+                let second = req.uri().query().unwrap().contains("continue=");
+                async move {
+                    tokio::time::sleep(delay).await;
+                    let (code, body) = if denied && second {
+                        (
+                            403,
+                            json!({"kind":"Status", "apiVersion":"v1", "status":"Failure", "reason":"Forbidden", "message":"access denied", "code":403}),
+                        )
+                    } else {
+                        (
+                            200,
+                            json!({"apiVersion":"v1", "kind":"PodList",
+                            "metadata":{"continue": if repeat || !second {"next"} else {""}},
+                            "items":[
+                                {"apiVersion":"v1", "kind":"Pod", "metadata":{"name":if second {"second"} else {"first"}, "namespace":"prod", "ownerReferences":[{"apiVersion":"example.io/v1", "kind":"Widget", "name":"parent", "uid":"parent-uid"}]}},
+                                {"apiVersion":"v1", "kind":"Pod", "metadata":{"name":"old-owner", "namespace":"prod", "ownerReferences":[{"apiVersion":"example.io/v1", "kind":"Widget", "name":"parent", "uid":"old-uid"}]}}
+                            ]}),
+                        )
+                    };
+                    Ok::<_, std::convert::Infallible>(
+                        http::Response::builder()
+                            .status(code)
+                            .body(http_body_util::Full::new(hyper::body::Bytes::from(
+                                body.to_string(),
+                            )))
+                            .unwrap(),
+                    )
+                }
+            }),
+            "default",
+        );
+        let search = Search {
+            client,
+            kinds: vec![crate::k8s::Cluster::fake().resolve("pods").unwrap()],
+            namespace: "prod".into(),
+            uid: "parent-uid".into(),
+            discovery_warnings: Vec::new(),
+            limits: Limits::default(),
+        };
+        (search, requests)
+    }
+
+    async fn results(search: Search) -> (Vec<AdjacentItem>, String) {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(256);
+        search.run(tx, 1, 2).await;
+        let mut found = Vec::new();
+        let mut status = String::new();
+        while let Some(Msg::AdjacentChildren {
+            items,
+            status: update,
+            ..
+        }) = rx.recv().await
+        {
+            found.extend(items);
+            status = update;
+        }
+        (found, status)
+    }
+
+    #[tokio::test]
+    async fn pagination_matches_only_the_current_owner_uid() {
+        let (search, calls) = fixture(Duration::ZERO, false, false);
+        let (items, status) = results(search).await;
+        assert_eq!(
+            items.iter().map(|i| i.name.as_str()).collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(status.contains("complete (1/1"), "{status}");
+    }
+
+    #[tokio::test]
+    async fn forbidden_page_keeps_previous_results() {
+        let (search, _) = fixture(Duration::ZERO, false, true);
+        let (items, status) = results(search).await;
+        assert_eq!(items.len(), 1);
+        assert!(status.contains("incomplete"), "{status}");
+        assert!(status.contains("access denied"), "{status}");
+    }
+
+    #[tokio::test]
+    async fn request_limit_stops_repeated_continuation_tokens() {
+        let (mut search, calls) = fixture(Duration::ZERO, true, false);
+        search.limits.requests = 3;
+        let (items, status) = results(search).await;
+        assert_eq!(items.len(), 3);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert!(
+            status.contains("incomplete") && status.contains("request limit"),
+            "{status}"
+        );
+    }
+
+    #[tokio::test]
+    async fn object_limit_counts_objects_with_other_owners() {
+        let (mut search, calls) = fixture(Duration::ZERO, true, false);
+        search.limits.objects = 2;
+        let (items, status) = results(search).await;
+        assert_eq!(items.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(
+            status.contains("incomplete") && status.contains("object limit"),
+            "{status}"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_page_is_incomplete() {
+        let (mut search, _) = fixture(Duration::ZERO, false, false);
+        search.limits.objects = 1;
+        let (items, status) = results(search).await;
+        assert_eq!(items.len(), 1);
+        assert!(status.contains("object limit"), "{status}");
+    }
+
+    #[tokio::test]
+    async fn request_timeout_and_total_timeout_are_incomplete() {
+        for total in [false, true] {
+            let (mut search, _) = fixture(Duration::from_secs(1), false, false);
+            if total {
+                search.limits.total_time = Duration::from_millis(10);
+            } else {
+                search.limits.request_time = Duration::from_millis(10);
+            }
+            let (items, status) = results(search).await;
+            assert!(items.is_empty());
+            assert!(status.contains("incomplete"), "{status}");
+            assert!(
+                status.contains(if total { "time limit" } else { "timed out" }),
+                "{status}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn discovery_failure_cannot_produce_a_complete_empty_result() {
+        let (mut search, _) = fixture(Duration::ZERO, false, false);
+        search.kinds.clear();
+        search
+            .discovery_warnings
+            .push("API discovery access denied".into());
+        let (items, status) = results(search).await;
+        assert!(items.is_empty());
+        assert!(status.contains("incomplete") && status.contains("API discovery access denied"));
+    }
+
+    #[tokio::test]
+    async fn concurrency_is_bounded_and_aborting_stops_new_requests() {
+        let (mut search, calls) = fixture(Duration::from_secs(60), false, false);
+        search.kinds = vec![search.kinds[0].clone(); 10];
+        let (tx, _rx) = tokio::sync::mpsc::channel(256);
+        let task = tokio::spawn(search.run(tx, 1, 2));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while calls.load(Ordering::SeqCst) < 4 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+    }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -17,6 +17,9 @@ impl App {
         let run = self.plugin_run;
         let result = self.handle_key_inner(key);
         self.check_describe_refresh();
+        if self.should_quit || self.mode != Mode::Adjacent {
+            self.cancel_children();
+        }
         let overlay = matches!(
             self.mode,
             Mode::Command

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -323,6 +323,7 @@ impl App {
         self.applied_filter_fields = filter_fields;
         self.clear_progress_flash();
         self.stop_plugins();
+        self.cancel_adjacent_request();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -843,6 +844,7 @@ impl App {
         self.stop_event_stream();
         self.clear_progress_flash();
         self.stop_plugins();
+        self.cancel_adjacent_request();
         self.generation += 1;
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
@@ -858,6 +860,9 @@ impl App {
     pub fn handle_msg(&mut self, msg: Msg) {
         self.handle_msg_inner(msg);
         self.check_describe_refresh();
+        if self.mode != Mode::Adjacent {
+            self.cancel_children();
+        }
         let overlay = matches!(
             self.mode,
             Mode::PvcExplore
@@ -1154,6 +1159,7 @@ impl App {
                 warn,
             } if generation == self.generation && request == self.adjacent_request => {
                 self.adjacent_claim = None;
+                self.adjacent_warning = warn.clone();
                 let count = items.len();
                 self.adjacent_items = items;
                 self.adjacent_title = title;
@@ -1165,6 +1171,23 @@ impl App {
                         true,
                     ),
                     None => self.clear_claimed_status(claim),
+                }
+            }
+            Msg::AdjacentChildren {
+                generation,
+                request,
+                items,
+                status,
+                done,
+            } if generation == self.generation && request == self.child_request => {
+                self.adjacent_items.extend(items);
+                crate::adjacent::dedup(&mut self.adjacent_items);
+                if self.adjacent_state.selected().is_none() && !self.adjacent_items.is_empty() {
+                    self.adjacent_state.select(Some(0));
+                }
+                self.child_status = status;
+                if done {
+                    self.child_task = None;
                 }
             }
             Msg::Gitops {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1953,6 +1953,10 @@ pub struct App {
     pub adjacent_title: String,
     pub adjacent_source: Option<DynamicObject>,
     adjacent_request: u64,
+    child_request: u64,
+    child_task: Option<JoinHandle<()>>,
+    pub child_status: String,
+    pub adjacent_warning: Option<String>,
     adjacent_claim: Option<StatusClaim>,
     /// Parent of the adjacent view, kept separately because a YAML/describe
     /// opened from it uses `return_mode` to come back to the list.
@@ -2223,6 +2227,10 @@ impl App {
             adjacent_title: String::new(),
             adjacent_source: None,
             adjacent_request: 0,
+            child_request: 0,
+            child_task: None,
+            child_status: String::new(),
+            adjacent_warning: None,
             adjacent_claim: None,
             adjacent_return: Mode::Table,
             gitops_items: Vec::new(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20593,3 +20593,309 @@ async fn hide_header_follows_context_overrides() {
     assert!(app.hide_header);
     std::fs::remove_dir_all(&dir).unwrap();
 }
+
+fn child_discovery_app(denied: bool) -> (App, Receiver<Msg>, Arc<std::sync::Mutex<Vec<String>>>) {
+    let (mut app, rx) = test_app();
+    app.cluster
+        .register_kind("example.io", "Widget", "widgets", true);
+    app.switch_kind("widgets.example.io");
+    let root = json!({"apiVersion":"example.io/v1", "kind":"Widget", "metadata":{
+        "name":"parent", "namespace":"prod", "uid":"current-uid"
+    }});
+    apply(&mut app, root.clone());
+    app.table_state.select(Some(0));
+    app.cluster.child_kinds = vec![
+        app.cluster.resolve("pods").unwrap(),
+        app.cluster.resolve("secrets").unwrap(),
+    ];
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = requests.clone();
+    app.cluster.client = Client::new(
+        tower::service_fn(move |req: http::Request<kube::client::Body>| {
+            let uri = req.uri().to_string();
+            seen.lock().unwrap().push(uri.clone());
+            let (code, body) = if req.uri().path().ends_with("/widgets/parent") {
+                (200, root.clone())
+            } else if denied && req.uri().path().ends_with("/secrets") {
+                (
+                    403,
+                    json!({"apiVersion":"v1", "kind":"Status", "status":"Failure", "reason":"Forbidden", "code":403, "message":"secrets access denied"}),
+                )
+            } else {
+                assert!(uri.starts_with("/api/v1/namespaces/prod/"), "{uri}");
+                assert!(uri.contains("limit=200"), "{uri}");
+                let secret = req.uri().path().ends_with("/secrets");
+                let second = uri.contains("continue=");
+                let kind = if secret { "Secret" } else { "Pod" };
+                let name = if secret {
+                    "settings"
+                } else if second {
+                    "pod-2"
+                } else {
+                    "pod-1"
+                };
+                (
+                    200,
+                    json!({"apiVersion":"v1", "kind":format!("{kind}List"), "metadata":{
+                        "continue":if !secret && !second {"next-page"} else {""}
+                    }, "items":[
+                        {"apiVersion":"v1", "kind":kind, "metadata":{"name":name, "namespace":"prod", "ownerReferences":[{"apiVersion":"example.io/v1", "kind":"Widget", "name":"parent", "uid":"current-uid"}]}},
+                        {"apiVersion":"v1", "kind":kind, "metadata":{"name":"old-child", "namespace":"prod", "ownerReferences":[{"apiVersion":"example.io/v1", "kind":"Widget", "name":"parent", "uid":"old-uid"}]}}
+                    ]}),
+                )
+            };
+            async move {
+                Ok::<_, std::convert::Infallible>(
+                    http::Response::builder()
+                        .status(code)
+                        .body(http_body_util::Full::new(hyper::body::Bytes::from(
+                            body.to_string(),
+                        )))
+                        .unwrap(),
+                )
+            }
+        }),
+        "default",
+    );
+    (app, rx, requests)
+}
+
+async fn receive_children(app: &mut App, rx: &mut Receiver<Msg>) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(message) = rx.recv().await {
+            if matches!(message, Msg::AdjacentChildren { .. }) {
+                let done = matches!(message, Msg::AdjacentChildren { done: true, .. });
+                app.handle_msg(message);
+                if done {
+                    return;
+                }
+            }
+        }
+        panic!("child search channel closed");
+    })
+    .await
+    .expect("child search did not finish");
+}
+
+#[tokio::test]
+async fn adjacent_c_discovers_multiple_kinds_and_pages_only_on_request() {
+    let (mut app, mut rx, requests) = child_discovery_app(false);
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    assert!(app.adjacent_items.is_empty());
+    assert!(app.child_task.is_none());
+    assert_eq!(requests.lock().unwrap().len(), 1);
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.child_status.contains("searching"));
+    receive_children(&mut app, &mut rx).await;
+    assert!(
+        app.child_status.contains("complete (2/2"),
+        "{}",
+        app.child_status
+    );
+    assert_eq!(app.adjacent_items.len(), 3);
+    assert!(app.adjacent_items.iter().all(|i| i.name != "old-child"));
+    assert!(
+        requests
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|uri| uri.contains("continue=next-page"))
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    receive_children(&mut app, &mut rx).await;
+    assert_eq!(
+        app.adjacent_items.len(),
+        3,
+        "repeated discovery removes duplicates"
+    );
+    let row = app
+        .adjacent_items
+        .iter()
+        .position(|i| i.name == "settings")
+        .unwrap();
+    for _ in 0..row {
+        app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.kind_plural, "secrets");
+    assert_eq!(app.namespace, "prod");
+    assert_eq!(app.fields.as_deref(), Some("metadata.name=settings"));
+}
+
+#[tokio::test]
+async fn adjacent_c_keeps_usable_results_when_another_kind_is_denied() {
+    let (mut app, mut rx, _) = child_discovery_app(true);
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    receive_children(&mut app, &mut rx).await;
+    assert_eq!(app.adjacent_items.len(), 2);
+    assert!(app.child_status.contains("incomplete"));
+    assert!(app.child_status.contains("secrets access denied"));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.kind_plural, "pods");
+}
+
+#[tokio::test]
+async fn adjacent_c_cancels_on_exit_refresh_and_overlay_and_drops_late_results() {
+    for key in [
+        KeyCode::Esc,
+        KeyCode::Char('r'),
+        KeyCode::Char('?'),
+        KeyCode::Char(':'),
+    ] {
+        let (mut app, mut rx, _) = child_discovery_app(false);
+        app.handle_key(press(KeyCode::Char('u'))).unwrap();
+        receive_adjacent(&mut app, &mut rx).await;
+        app.handle_key(press(KeyCode::Char('c'))).unwrap();
+        let request = app.child_request;
+        let task = app.child_task.as_ref().unwrap().abort_handle();
+        app.handle_key(press(key)).unwrap();
+        assert!(app.child_task.is_none());
+        assert_ne!(app.child_request, request);
+        tokio::task::yield_now().await;
+        assert!(task.is_finished());
+        app.handle_msg(Msg::AdjacentChildren {
+            generation: app.generation,
+            request,
+            items: pod_neighbours(),
+            status: "children: complete".into(),
+            done: true,
+        });
+        assert!(app.adjacent_items.is_empty());
+        assert_ne!(app.child_status, "children: complete");
+    }
+}
+
+#[tokio::test]
+async fn adjacent_c_rejects_missing_uid_namespace_and_builtin_parents() {
+    for invalid in ["uid", "namespace", "builtin", "cluster"] {
+        let (mut app, mut rx, _) = child_discovery_app(false);
+        app.handle_key(press(KeyCode::Char('u'))).unwrap();
+        receive_adjacent(&mut app, &mut rx).await;
+        match invalid {
+            "uid" => app.adjacent_source.as_mut().unwrap().metadata.uid = None,
+            "namespace" => app.adjacent_source.as_mut().unwrap().metadata.namespace = None,
+            "builtin" => app.kind = app.cluster.resolve("pods"),
+            "cluster" => app.kind.as_mut().unwrap().namespaced = false,
+            _ => unreachable!(),
+        }
+        app.handle_key(press(KeyCode::Char('c'))).unwrap();
+        assert!(app.child_task.is_none());
+        assert!(app.flash.contains("namespaced custom resource with a UID"));
+    }
+}
+
+#[tokio::test]
+async fn adjacent_c_waits_for_the_source_lookup_and_context_change_cancels_it() {
+    let (mut app, mut rx, _) = child_discovery_app(false);
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert!(app.child_task.is_none());
+    assert!(app.flash.contains("initial adjacent lookup"));
+    receive_adjacent(&mut app, &mut rx).await;
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let generation = app.generation;
+    let request = app.child_request;
+    let task = app.child_task.as_ref().unwrap().abort_handle();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "ctx".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.child_task.is_none());
+    tokio::task::yield_now().await;
+    assert!(task.is_finished());
+    app.handle_msg(Msg::AdjacentChildren {
+        generation,
+        request,
+        items: pod_neighbours(),
+        status: "late".into(),
+        done: true,
+    });
+    assert!(app.adjacent_items.is_empty());
+}
+
+#[tokio::test]
+async fn adjacent_c_cancels_when_a_background_reply_opens_a_document() {
+    let (mut app, mut rx, _) = child_discovery_app(false);
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let task = app.child_task.as_ref().unwrap().abort_handle();
+    let claim = app.claim_status("reading document");
+    app.handle_msg(Msg::Detail {
+        generation: app.generation,
+        claim,
+        title: "document".into(),
+        lines: vec!["document".into()],
+        warn: None,
+    });
+    assert_eq!(app.mode, Mode::Detail);
+    assert!(app.child_task.is_none());
+    tokio::task::yield_now().await;
+    assert!(task.is_finished());
+}
+
+#[tokio::test]
+async fn adjacent_c_retains_existing_rows_and_rejects_replaced_search_results() {
+    let (mut app, mut rx, _) = child_discovery_app(false);
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    app.adjacent_claim = Some(app.claim_status("gathering connections"));
+    deliver_adjacent(&mut app, pod_neighbours(), None);
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let request = app.child_request;
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    assert_eq!(app.adjacent_state.selected(), Some(1));
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    app.handle_msg(Msg::AdjacentChildren {
+        generation: app.generation,
+        request,
+        items: Vec::new(),
+        status: "obsolete search".into(),
+        done: true,
+    });
+    assert!(app.child_task.is_some());
+    assert!(app.child_status.contains("searching"));
+    receive_children(&mut app, &mut rx).await;
+    assert_eq!(app.adjacent_items.len(), 6);
+    assert_eq!(app.adjacent_state.selected(), Some(1));
+}
+
+#[tokio::test]
+async fn adjacent_c_incomplete_empty_results_remain_visible_without_a_flash() {
+    let (mut app, mut rx, _) = child_discovery_app(false);
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    app.cluster.child_kinds.clear();
+    app.cluster
+        .discovery_warnings
+        .push("API discovery access denied".into());
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    receive_children(&mut app, &mut rx).await;
+    app.flash.clear();
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let screen: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+    assert!(screen.contains("children: incomplete"), "{screen}");
+    assert!(
+        screen.contains("no results found; lookup is incomplete"),
+        "{screen}"
+    );
+    assert!(
+        !screen.contains("nothing connected to this object was found"),
+        "{screen}"
+    );
+}

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -252,6 +252,7 @@ pub struct Cluster {
     /// unknown, supported, or unsupported. Shared by all view watches so one
     /// negotiation failure avoids retrying the extension on every switch.
     streaming_lists: Arc<AtomicU8>,
+    pub child_kinds: Vec<Kind>,
     pub discovery_warnings: Vec<String>,
     pub discovery_fallback: Option<String>,
 }
@@ -330,6 +331,7 @@ impl Cluster {
             connected: true,
             allow_v1_client_cert,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
+            child_kinds: Vec::new(),
             discovery_warnings: Vec::new(),
             discovery_fallback: None,
         };
@@ -414,6 +416,7 @@ impl Cluster {
             connected: false,
             allow_v1_client_cert: false,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
+            child_kinds: Vec::new(),
             discovery_warnings: Vec::new(),
             discovery_fallback: None,
         }
@@ -450,6 +453,7 @@ impl Cluster {
         // Aggregated discovery needs two requests and tolerates stale APIService
         // entries. Legacy discovery is used when negotiation fails.
         let discovered = discovery::discover(&self.client).await?;
+        self.child_kinds = discovered.child_kinds;
         self.discovery_warnings = discovered.skipped;
         self.discovery_fallback = discovered.fallback;
         self.register_resources(discovered.resources);
@@ -965,6 +969,7 @@ impl Cluster {
             registry: HashMap::new(),
             catalog: Vec::new(),
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
+            child_kinds: Vec::new(),
             discovery_warnings: Vec::new(),
             discovery_fallback: None,
         };
@@ -1056,6 +1061,9 @@ impl Cluster {
             },
             namespaced,
         };
+        if namespaced {
+            self.child_kinds.push(k.clone());
+        }
         self.registry.insert(kind.to_lowercase(), k.clone());
         self.registry.insert(plural.clone(), k.clone());
         self.catalog.push(plural.clone());

--- a/src/k8s/discovery.rs
+++ b/src/k8s/discovery.rs
@@ -11,10 +11,12 @@ use super::{ApiResource, Kind};
 pub(super) struct Resource {
     pub kind: Kind,
     pub short_names: Vec<String>,
+    pub listable: bool,
 }
 
 pub(super) struct Discovered {
     pub resources: Vec<Resource>,
+    pub child_kinds: Vec<Kind>,
     pub skipped: Vec<String>,
     pub fallback: Option<String>,
 }
@@ -42,10 +44,12 @@ pub(super) async fn discover(client: &Client) -> Result<Discovered> {
             Reverse(Version::parse(&r.kind.ar.version).priority()),
         )
     });
+    let child_kinds = child_candidates(&resources);
     resources
         .dedup_by(|a, b| a.kind.ar.group == b.kind.ar.group && a.kind.ar.kind == b.kind.ar.kind);
     Ok(Discovered {
         resources,
+        child_kinds,
         skipped,
         fallback,
     })
@@ -89,6 +93,7 @@ fn append_aggregated(out: &mut Vec<Resource>, list: APIGroupDiscoveryList) -> Re
                         },
                         namespaced: resource.scope.as_deref() == Some("Namespaced"),
                     },
+                    listable: resource.verbs.iter().any(|v| v == "list"),
                     short_names: resource.short_names,
                 });
             }
@@ -156,6 +161,7 @@ fn append_legacy(out: &mut Vec<Resource>, list: APIResourceList) -> Result<()> {
                 },
                 namespaced: resource.namespaced,
             },
+            listable: resource.verbs.iter().any(|v| v == "list"),
             short_names: resource.short_names.unwrap_or_default(),
         });
     }
@@ -167,5 +173,65 @@ fn api_version(group: &str, version: &str) -> String {
         version.to_string()
     } else {
         format!("{group}/{version}")
+    }
+}
+
+fn child_candidates(resources: &[Resource]) -> Vec<Kind> {
+    let mut kinds: Vec<_> = resources
+        .iter()
+        .filter(|r| r.listable && r.kind.namespaced && !r.kind.ar.plural.contains('/'))
+        .map(|r| r.kind.clone())
+        .collect();
+    kinds.sort_by_cached_key(|k| {
+        (
+            k.ar.group.clone(),
+            k.ar.plural.clone(),
+            Reverse(Version::parse(&k.ar.version).priority()),
+        )
+    });
+    kinds.dedup_by(|a, b| a.ar.group == b.ar.group && a.ar.plural == b.ar.plural);
+    kinds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn children_use_listable_namespaced_resources_and_one_version() {
+        let mut resources = Vec::new();
+        for version in ["v1beta1", "v1"] {
+            append_legacy(&mut resources, serde_json::from_value(json!({
+                "groupVersion": format!("example.io/{version}"),
+                "resources": [
+                    {"name":"widgets", "kind":"Widget", "namespaced":true, "verbs":["list"]},
+                    {"name":"widgets/status", "kind":"Widget", "namespaced":true, "verbs":["list"]},
+                    {"name":"global", "kind":"Global", "namespaced":false, "verbs":["list"]},
+                    {"name":"writeonly", "kind":"WriteOnly", "namespaced":true, "verbs":["create"]}
+                ]
+            })).unwrap()).unwrap();
+        }
+        let kinds = child_candidates(&resources);
+        assert_eq!(kinds.len(), 1);
+        assert_eq!(kinds[0].ar.plural, "widgets");
+        assert_eq!(kinds[0].ar.version, "v1");
+    }
+
+    #[test]
+    fn aggregated_children_require_the_list_verb() {
+        let mut resources = Vec::new();
+        append_aggregated(&mut resources, serde_json::from_value(json!({
+            "items": [{"metadata":{"name":"example.io"}, "versions":[{
+                "version":"v1", "resources":[
+                    {"resource":"widgets", "responseKind":{"kind":"Widget"}, "scope":"Namespaced", "verbs":["get","list"]},
+                    {"resource":"writeonly", "responseKind":{"kind":"WriteOnly"}, "scope":"Namespaced", "verbs":["create"]},
+                    {"resource":"globals", "responseKind":{"kind":"Global"}, "scope":"Cluster", "verbs":["list"]}
+                ]
+            }]}]
+        })).unwrap()).unwrap();
+        let kinds = child_candidates(&resources);
+        assert_eq!(kinds.len(), 1);
+        assert_eq!(kinds[0].ar.plural, "widgets");
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -103,6 +103,13 @@ pub enum Msg {
         /// A read that failed — the list may be incomplete.
         warn: Option<String>,
     },
+    AdjacentChildren {
+        generation: u64,
+        request: u64,
+        items: Vec<AdjacentItem>,
+        status: String,
+        done: bool,
+    },
     /// Reconciliation-chain findings for the GitOps view, gathered off-thread.
     Gitops {
         generation: u64,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2284,7 +2284,7 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         ),
         bind(
             "u · :adjacent",
-            "adjacent view: owners, children, and the objects the selection names or is named by (⏎ opens one)",
+            "adjacent view: owners, children, and references (⏎ opens one; c discovers direct children of a namespaced custom resource)",
         ),
         bind(
             ":rightsize",
@@ -2846,9 +2846,46 @@ fn draw_find(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_adjacent(frame: &mut Frame, app: &mut App, area: Rect) {
+    let status = [
+        app.child_status.clone(),
+        app.adjacent_warning
+            .as_ref()
+            .map(|w| format!("adjacent: incomplete ({w})"))
+            .unwrap_or_default(),
+    ]
+    .into_iter()
+    .filter(|s| !s.is_empty())
+    .collect::<Vec<_>>()
+    .join("\n");
+    let area = if status.is_empty() {
+        area
+    } else {
+        let height = status
+            .lines()
+            .map(|line| line.width().div_ceil(usize::from(area.width.max(1))))
+            .sum::<usize>();
+        let chunks = Layout::vertical([
+            Constraint::Length(
+                height
+                    .min(4)
+                    .min(usize::from(area.height.saturating_sub(3))) as u16,
+            ),
+            Constraint::Min(0),
+        ])
+        .split(area);
+        frame.render_widget(
+            Paragraph::new(status).wrap(ratatui::widgets::Wrap { trim: true }),
+            chunks[0],
+        );
+        chunks[1]
+    };
     let items: Vec<ListItem> = if app.adjacent_items.is_empty() {
         let msg = if app.adjacent_pending() {
             "gathering…"
+        } else if app.adjacent_warning.is_some() || app.child_status.contains("incomplete") {
+            "no results found; lookup is incomplete"
+        } else if app.child_status.contains("searching") {
+            "searching for children..."
         } else {
             "nothing connected to this object was found"
         };
@@ -2889,9 +2926,14 @@ fn draw_adjacent(frame: &mut Frame, app: &mut App, area: Rect) {
             .collect()
     };
     let title = format!(
-        " {} [{}]  (⏎ open · y yaml · d describe · r refresh · esc back) ",
+        " {} [{}] {} ",
         app.adjacent_title,
-        app.adjacent_items.len()
+        app.adjacent_items.len(),
+        if app.can_discover_children() {
+            "(c discover children)"
+        } else {
+            ""
+        },
     );
     render_framed_list(
         frame,
@@ -3979,7 +4021,7 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             theme::dim(),
         )),
         Mode::Adjacent => Line::from(Span::styled(
-            "  j/k: move   ⏎: open the object   y: yaml   d: describe   r: refresh   esc: back",
+            "  j/k: move   ⏎: open the object   y: yaml   d: describe   c: discover children   r: refresh   esc: back",
             theme::dim(),
         )),
         Mode::FluxMenu => Line::from(Span::styled(


### PR DESCRIPTION
The adjacent view could find children only for built-in or configured child kinds. Press `c` in this view to discover direct children of a namespaced custom resource with a UID. Results from multiple kinds are added as pages arrive and can be opened with Enter.

The search uses API discovery from the current connection, selects one listable API version per namespaced resource, and matches owner UIDs within the source namespace. Each search permits four concurrent requests, 200 objects per page, 200 requests, 20,000 objects checked, five seconds per request, and 30 seconds in total. Partial results remain available with a persistent incomplete status. Navigation, refresh, source changes, and context changes cancel the search and invalidate late replies.

The initial adjacent lookup and Enter action on the resource table stay the same. The key reference, help text, and feature documentation describe the action and its limits.

Validation: `just check` passed, including formatting, Clippy with warnings denied, 1,123 library tests, and one binary test. Tests cover discovery filtering, pagination, UID matching, access denial, timeouts, search limits, cancellation, late replies, result navigation, and the incomplete result display. Application tests use `handle_key` and require no cluster.

Scope follows #367 and the [maintainer scope note in #242](https://github.com/nklmilojevic/sofka/issues/242#issuecomment-5582992449).

Closes #367
