### PR TITLE
feat: show context and namespace in the terminal title

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ readonly          = false  # true disables every mutating action (delete, edit,
 hide_header = false # true hides the header and logo
 mouse             = true   # false keeps the terminal's native mouse behavior
                            # (text selection) instead of scroll/click/sort
+terminal_title = true # false disables terminal title changes
 remember_sort     = true   # save and restore sort choices per resource kind
                            # false makes sort changes temporary
 
@@ -27,6 +28,14 @@ favorite_namespaces = ["kube-system", "monitoring"]
 [aliases]
 dep = "deployments"
 ```
+
+`terminal_title` is enabled by default. The title is `sofka: <context>/<namespace>`;
+`all` means all namespaces. It follows context and namespace changes, context
+overrides, and `:reload`. Sofka sets the title again after an external command
+returns. It clears the title when the setting is disabled, on normal exit, and
+on a fatal main-thread panic. It does not restore the title from before startup.
+Set `terminal_title = false` to keep your shell or terminal in control of the
+title. Headless modes do not change the title.
 
 Set `hide_header = true` to remove the header and logo and give more space to
 the active view. The default is `false`. This option supports cluster and

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Terminal title** shows `sofka: <context>/<namespace>` and follows navigation.
+  The namespace is `all` when all namespaces are selected. Set
+  `terminal_title = false` to disable title changes. Sofka clears the title on exit.
+
 - **Optional header** - set `hide_header = true` in the configuration to hide
   the header and logo, including the one-line header in compact mode.
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1452,6 +1452,7 @@ impl App {
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
         self.hide_header = resolved.config.hide_header;
+        self.terminal_title = resolved.config.terminal_title.unwrap_or(true);
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35,6 +35,20 @@ pub(crate) use guardrails::ConfirmLevel;
 pub use pvcexplore::{Pane, PvcExplore, PvcIntent};
 
 impl App {
+    pub fn terminal_title(&self) -> Option<String> {
+        self.terminal_title.then(|| {
+            let namespace = if self.namespace.is_empty() {
+                "all"
+            } else {
+                &self.namespace
+            };
+            format!("sofka: {}/{namespace}", self.cluster.context)
+                .chars()
+                .filter(|c| !c.is_control())
+                .collect()
+        })
+    }
+
     /// Mark the row ordering stale without touching the store — the shape of a
     /// filter keystroke or a sort toggle. `invalidate_rows` is `pub(super)`;
     /// this exposes it to `benchsupport` under the bench feature only, rather
@@ -2043,6 +2057,7 @@ pub struct App {
     pub compact: bool,
     /// Hide the header in normal and compact modes.
     pub hide_header: bool,
+    pub terminal_title: bool,
     /// Active column layout for the current view; rebuilt by
     /// [`App::refresh_view_spec`] whenever kind/views/wide change.
     spec: crate::columns::ViewSpec,
@@ -2281,6 +2296,7 @@ impl App {
             wide: false,
             compact: false,
             hide_header: false,
+            terminal_title: true,
             spec: crate::columns::build_spec("", "", None, None, false),
         }
     }

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -831,6 +831,7 @@ impl App {
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
         self.hide_header = resolved.config.hide_header;
+        self.terminal_title = resolved.config.terminal_title.unwrap_or(true);
         self.plugins = resolved.config.plugins;
         self.bookmarks = resolved.config.bookmarks;
         self.workspaces = resolved.config.workspaces;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20968,3 +20968,58 @@ async fn timeline_key_keeps_recently_changed_history_at_capacity() {
         3
     );
 }
+
+#[tokio::test]
+async fn terminal_title_tracks_namespace_and_context() {
+    let (mut app, _rx) = test_app();
+    assert_eq!(app.terminal_title(), Some("sofka: test/default".into()));
+    palette(&mut app, "pods kube-system");
+    assert_eq!(app.terminal_title(), Some("sofka: test/kube-system".into()));
+    palette(&mut app, "pods all");
+    assert_eq!(app.terminal_title(), Some("sofka: test/all".into()));
+    palette(&mut app, "ctx prod");
+    land_context(&mut app, "prod");
+    assert_eq!(
+        app.terminal_title(),
+        Some(format!(
+            "sofka: prod/{}",
+            if app.namespace.is_empty() {
+                "all"
+            } else {
+                &app.namespace
+            }
+        ))
+    );
+}
+
+#[tokio::test]
+async fn terminal_title_setting_reloads_and_follows_context_overrides() {
+    let dir = std::env::temp_dir().join(format!("sofka-terminal-title-{}", std::process::id()));
+    write_config(&dir, "terminal_title = false\n");
+    write_config(
+        &dir.join("clusters/test-cluster/dev"),
+        "terminal_title = true\n",
+    );
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "reload");
+    assert_eq!(app.terminal_title(), None);
+    palette(&mut app, "ctx dev");
+    land_context(&mut app, "dev");
+    assert!(app.terminal_title().unwrap().starts_with("sofka: dev/"));
+    palette(&mut app, "ctx prod");
+    land_context(&mut app, "prod");
+    assert_eq!(app.terminal_title(), None);
+    write_config(&dir, "");
+    palette(&mut app, "reload");
+    assert!(app.terminal_title().unwrap().starts_with("sofka: prod/"));
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn terminal_title_removes_control_characters() {
+    let (mut app, _rx) = test_app();
+    app.cluster.context = "dev\x1b\x07\n\u{009c}".into();
+    palette(&mut app, "pods kube-system");
+    assert_eq!(app.terminal_title(), Some("sofka: dev/kube-system".into()));
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,8 @@ pub struct Config {
     /// behavior (text selection) everywhere. Document views release capture
     /// on their own regardless — see [`crate::app::App::wants_mouse_capture`].
     pub mouse: Option<bool>,
+    /// Set the terminal title to the context and namespace. Defaults to true.
+    pub terminal_title: Option<bool>,
     /// Save and restore sort choices per kind. Defaults to true.
     pub remember_sort: Option<bool>,
     /// How `:notify` events are delivered — see [`NotifyConfig`].

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ use sofka::{
     theme, thresholds, ui, views,
 };
 
+mod terminal_title;
+
 const EVENT_CHANNEL_CAP: usize = 4096;
 
 /// sofka: navigate, observe, and inspect your Kubernetes clusters.
@@ -304,6 +306,7 @@ async fn run_main(args: Args) -> Result<()> {
     app.sort_memory_path = Some(sort_memory_path);
     app.remember_sort = cfg.remember_sort.unwrap_or(true);
     app.hide_header = cfg.hide_header;
+    app.terminal_title = cfg.terminal_title.unwrap_or(true);
     // The last namespace picked per context persists too, so a relaunch (or
     // a `:ctx` switch back) lands where you left off.
     let namespace_memory_path = nsmem::NamespaceMemory::default_path();
@@ -440,6 +443,7 @@ async fn run_main(args: Args) -> Result<()> {
     // Disable before leaving the alternate screen so the shell never sees
     // mouse-report sequences (harmless if capture was never enabled).
     let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
+    terminal_title::clear();
     ratatui::restore();
     // `restore()` leaves the alternate screen but never re-shows the cursor
     // that `draw` hid, so without this the user's shell prompt has no cursor.
@@ -466,6 +470,7 @@ fn install_panic_hook(tx: mpsc::Sender<store::Msg>) {
             // alternate screen, and stray mouse reports would land in the
             // shell after a crash.
             let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
+            terminal_title::clear();
             prev(info);
             let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
         } else {
@@ -942,6 +947,7 @@ fn take_suspend(terminal: &mut ratatui::DefaultTerminal, app: &mut App, captured
         app.flash = format!("ran: {}", argv.join(" "));
         app.flash_err = false;
         app.after_suspend();
+        terminal_title::set(app.terminal_title().as_deref());
     }
 }
 
@@ -968,11 +974,14 @@ async fn run(
     // while capture is released, which is the only time they can arrive.
     let mut repair = altscroll::Repair::default();
 
+    let mut title = terminal_title::Title::default();
     terminal.draw(|f| ui::draw(f, app))?;
     loop {
         if app.should_quit {
             return Ok(());
         }
+
+        title.update(app.terminal_title());
 
         if mouse && app.wants_mouse_capture() != captured {
             captured = !captured;

--- a/src/terminal_title.rs
+++ b/src/terminal_title.rs
@@ -1,0 +1,67 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Default)]
+pub(crate) struct Title {
+    current: Option<String>,
+}
+
+impl Title {
+    pub(crate) fn update(&mut self, next: Option<String>) {
+        self.update_with(next, set);
+    }
+
+    fn update_with(&mut self, next: Option<String>, write: impl FnOnce(Option<&str>)) {
+        if self.current != next {
+            write(next.as_deref());
+            self.current = next;
+        }
+    }
+}
+
+pub(crate) fn set(title: Option<&str>) {
+    if let Some(title) = title {
+        ACTIVE.store(true, Ordering::Relaxed);
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::terminal::SetTitle(title));
+    } else {
+        clear();
+    }
+}
+
+pub(crate) fn clear() {
+    if ACTIVE.swap(false, Ordering::Relaxed) {
+        let _ = crossterm::execute!(std::io::stdout(), crossterm::terminal::SetTitle(""));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_only_changes_and_clears_on_disable() {
+        let mut title = Title::default();
+        let mut writes = Vec::new();
+        for next in [
+            None,
+            Some("sofka: dev/all"),
+            Some("sofka: dev/all"),
+            Some("sofka: prod/default"),
+            None,
+            None,
+        ] {
+            title.update_with(next.map(str::to_owned), |value| {
+                writes.push(value.map(str::to_owned))
+            });
+        }
+        assert_eq!(
+            writes,
+            [
+                Some("sofka: dev/all".into()),
+                Some("sofka: prod/default".into()),
+                None
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Terminal tabs now show `sofka: <context>/<namespace>` so users can identify the active connection. The title uses `all` for all namespaces and follows namespace and context changes.

The `terminal_title` setting is enabled by default and supports context overrides and `:reload`. Sofka sets the title again after an external command returns. It clears the title when disabled, on exit, and on a fatal main-thread panic. It does not restore the title from before startup. Pod titles during `exec` remain outside this change.

Validation: `just check` and all pre-commit hooks passed. Tests cover navigation through `handle_key`, configuration reloads and overrides, control character removal, and duplicate title updates.

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/384

Closes #385
