### PR TITLE
feat: add a compact mode startup preference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ default_resource  = "deployments"
 readonly          = false  # true disables every mutating action (delete, edit,
                            # scale, shell, plugins, …); --readonly/--write win
 hide_header = false # true hides the header and logo
+compact_mode = false # true starts with a one-line header and no footer
 mouse             = true   # false keeps the terminal's native mouse behavior
                            # (text selection) instead of scroll/click/sort
 terminal_title = true # false disables terminal title changes
@@ -41,6 +42,13 @@ Set `hide_header = true` to remove the header and logo and give more space to
 the active view. The default is `false`. This option supports cluster and
 context overrides and `:reload`. It also hides the one-line header in compact
 mode (`Ctrl-E`). The footer and command input keep their existing behavior.
+
+Set `compact_mode = true` to start with a one-line header containing resource,
+namespace, context, and live status, with the footer hidden. The default is
+`false`. `Ctrl-E` toggles compact mode during the session. Cluster and context
+overrides are resolved at startup; `:reload` and subsequent context switches do
+not reset the current compact mode. With `hide_header = true`, the compact
+header is hidden too. Command and filter input still appears when needed.
 
 `remember_sort` is enabled by default. Set it to `false` to stop saving and
 restoring sort choices from `S`, `I`, and column header clicks. Existing saved

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   The namespace is `all` when all namespaces are selected. Set
   `terminal_title = false` to disable title changes. Sofka clears the title on exit.
 
+- **Compact startup** - set `compact_mode = true` to start with a one-line
+  header and no footer. `Ctrl-E` toggles the layout for the session; reloads and
+  context switches preserve it.
+
 - **Optional header** - set `hide_header = true` in the configuration to hide
   the header and logo, including the one-line header in compact mode.
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20601,6 +20601,60 @@ async fn hide_header_reloads_and_keeps_command_input_in_compact_mode() {
 }
 
 #[tokio::test]
+async fn compact_startup_preference_preserves_session_toggles() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    let dir = std::env::temp_dir().join(format!("sofka-compact-startup-{}", std::process::id()));
+    write_config(&dir, "compact_mode = false\n");
+    write_config(
+        &dir.join("clusters/test-cluster/dev"),
+        "compact_mode = true\n",
+    );
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    assert!(
+        !app.config
+            .resolve("prod", "test-cluster")
+            .config
+            .compact_mode
+    );
+    let cfg = app.config.resolve("dev", "test-cluster").config;
+    app.compact = cfg.compact_mode;
+    assert!(app.compact);
+    palette(&mut app, "pods");
+    let mut terminal = Terminal::new(TestBackend::new(180, 24)).unwrap();
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let compact = app.table_hit.borrow().clone().unwrap();
+
+    app.handle_key(ctrl(KeyCode::Char('e'))).unwrap();
+    assert!(!app.compact);
+    terminal
+        .draw(|frame| crate::ui::draw(frame, &mut app))
+        .unwrap();
+    let full = app.table_hit.borrow().clone().unwrap();
+    assert_eq!(full.header_y, compact.header_y + 6);
+    assert_eq!(compact.rows_h, full.rows_h + 8);
+
+    land_context(&mut app, "dev");
+    palette(&mut app, "reload");
+    assert!(
+        !app.compact,
+        "true preference must not override session toggle"
+    );
+    app.handle_key(ctrl(KeyCode::Char('e'))).unwrap();
+    assert!(app.compact);
+    land_context(&mut app, "prod");
+    palette(&mut app, "reload");
+    assert!(
+        app.compact,
+        "false preference must not override session toggle"
+    );
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
 async fn hide_header_follows_context_overrides() {
     let dir =
         std::env::temp_dir().join(format!("sofka-hide-header-context-{}", std::process::id()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,8 @@ pub struct Config {
     pub readonly: bool,
     /// Hide the header, including the logo. Defaults to false.
     pub hide_header: bool,
+    /// Start in compact mode; runtime toggles survive reloads and context switches.
+    pub compact_mode: bool,
     /// Custom alias -> canonical resource (plural/kind) mappings.
     pub aliases: HashMap<String, String>,
     /// Namespaces pinned to the top of the switcher (a curated team list, in
@@ -1523,6 +1525,20 @@ fn config_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compact_mode_defaults_false_and_accepts_booleans() {
+        assert!(!Config::default().compact_mode);
+        for (text, expected) in [
+            ("", false),
+            ("compact_mode = false", false),
+            ("compact_mode = true", true),
+        ] {
+            let cfg: Config = toml::from_str(text).unwrap();
+            assert_eq!(cfg.compact_mode, expected);
+        }
+        assert!(toml::from_str::<Config>("compact_mode = 'true'").is_err());
+    }
 
     #[test]
     fn palette_keys_default_when_unset() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,7 @@ async fn run_main(args: Args) -> Result<()> {
     app.sort_memory_path = Some(sort_memory_path);
     app.remember_sort = cfg.remember_sort.unwrap_or(true);
     app.hide_header = cfg.hide_header;
+    app.compact = cfg.compact_mode;
     app.terminal_title = cfg.terminal_title.unwrap_or(true);
     // The last namespace picked per context persists too, so a relaunch (or
     // a `:ctx` switch back) lands where you left off.


### PR DESCRIPTION
## Summary

Add `compact_mode = true` as a startup preference for the existing compact layout. It defaults to false and respects the initial cluster/context configuration overrides.

`Ctrl-E` remains the session toggle. Reloads and context switches preserve the current layout, and `hide_header` retains its independent behavior. Includes configuration documentation and regression coverage for parsing, layout, toggles, reloads, and context changes.

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/387
Closes #388

## Verification

- `just check` passed (format check, Clippy with warnings denied, and tests).
- LSP and session diagnostics reported no errors.
- `git diff --check` passed.
