### PR TITLE
feat: navigate resources across contexts with completion

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -97,6 +97,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `events`, `pf`, `notify`, `find`, `vlogs`, `rightsize`, `fleet`, `skin`,
   `reload`, `config`, `info`). `:` and `?` open the palette and help from every
   navigation screen, then close back to the screen where they were opened.
+- **Cross-context resource navigation** - `:pods @production-cluster default`
+  switches context, resource, and namespace together without changing kubeconfig's
+  `current-context`. Context names after `@` fuzzy-complete: Tab/Shift-Tab select
+  a suggestion and Enter opens it. Omit the namespace to use the target context's
+  remembered or default namespace. Namespace completion after `@context` is not
+  provided.
 - **Help scrolling** (`?`) - browse all bindings, including plugins, bookmarks,
   and workspaces. `j` / `k` and `↑` / `↓` scroll one line. `ctrl-f`, `PgDn`,
   and `space` move forward one page; `ctrl-b` and `PgUp` move back one page.

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -8,6 +8,10 @@ pickers keep both characters available as input.
 ## Table views
 
 Use `:resource -n namespace --context context /filter` to apply a complete query.
+Use `:resource @context [namespace]` for cross-context navigation. Context names
+fuzzy-complete after `@`; Tab/Shift-Tab select a suggestion and Enter opens it.
+Without a namespace, a context switch uses its remembered or default namespace.
+This does not change kubeconfig's `current-context`.
 Scope options precede the slash. Structured filter terms combine with spaces or
 `&&`, with `||` for OR and `!(...)` for group negation. `/` edits the active filter
 and Esc clears it. See [filtering](filtering.md)
@@ -16,6 +20,7 @@ for the grammar and selector persistence rules.
 | Key                                           | Action                                                                                                                                                              |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `:resource -n ns --context ctx /filter`       | query resource, namespace, context, and filter together                                                                                                             |
+| `:resource @context [namespace]`              | switch context and resource; context names fuzzy-complete                                                                                                           |
 | `:<resource>`                                 | command palette - fuzzy over kinds and built-in commands                                                                                                            |
 | `:<resource> <ns>`                            | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                                                       |
 | `[` / `]`                                     | view history - back / forward through visited kind+namespace views                                                                                                  |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -419,7 +419,7 @@ impl App {
 
     /// Run the highlighted palette suggestion (or the raw typed text).
     fn palette_accept(&mut self) {
-        let typed = self.command.trim().to_string();
+        let mut typed = self.command.trim().to_string();
         let picked = self.cmd_suggestions.get(self.cmd_sel).cloned();
         self.mode = Mode::Table;
         self.command.clear();
@@ -453,8 +453,14 @@ impl App {
             && (typed.contains(" /")
                 || typed
                     .split_whitespace()
-                    .any(|s| matches!(s, "-n" | "--namespace" | "--context")))
+                    .any(|s| s.starts_with('@') || matches!(s, "-n" | "--namespace" | "--context")))
         {
+            if let Some(s) = picked.as_ref().filter(|s| s.kind == SuggestKind::Context)
+                && let Some((head, rest)) = typed.split_once(char::is_whitespace)
+                && rest.trim_start().starts_with('@')
+            {
+                typed = format!("{head} @{}", s.label);
+            }
             match crate::filter::ResourceQuery::parse(&typed) {
                 Ok(query) => self.apply_resource_query(query),
                 Err(error) => self.flash_warn(&format!("query: {error}")),
@@ -702,6 +708,26 @@ impl App {
         }) {
             if is_ctx_command(&head) {
                 self.suggest_contexts(&arg);
+                return;
+            }
+            if let Some(context) = arg.strip_prefix('@')
+                && (self.cluster.resolve(&head).is_some()
+                    || (!PALETTE_COMMANDS
+                        .iter()
+                        .any(|c| c.names.contains(&head.as_str()))
+                        && !self
+                            .plugins
+                            .iter()
+                            .any(|p| p.palette.as_deref() == Some(&head))))
+            {
+                if self.command.split_whitespace().count() == 2
+                    && !self.command.ends_with(char::is_whitespace)
+                {
+                    self.suggest_contexts(context);
+                } else {
+                    self.cmd_suggestions.clear();
+                    self.cmd_sel = 0;
+                }
                 return;
             }
             if self.cluster.resolve(&head).is_some() {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -13113,6 +13113,76 @@ async fn a_deferred_navigation_disarms_the_one_it_replaces() {
 }
 
 #[tokio::test]
+async fn resource_context_shortcut_preserves_explicit_namespace() {
+    let (mut app, _rx) = test_app();
+    app.all_contexts = vec!["west".into()];
+    type_resource_query(&mut app, "services @west prod");
+    assert_eq!(
+        app.pending_resource_query
+            .as_ref()
+            .unwrap()
+            .namespace
+            .as_deref(),
+        Some("prod")
+    );
+    land_context(&mut app, "west");
+    assert_eq!(app.cluster.context, "west");
+    assert_eq!(app.kind_plural, "services");
+    assert_eq!(app.namespace, "prod");
+}
+
+#[tokio::test]
+async fn resource_context_shortcut_completes_long_names_and_uses_target_default() {
+    let (mut app, _rx) = test_app();
+    let context = "gke_project_europe-west1_production-cluster";
+    app.all_contexts = vec![context.into()];
+    app.namespace = "old-namespace".into();
+    type_resource_query(&mut app, "services @gke");
+    assert_eq!(
+        app.pending_resource_query
+            .as_ref()
+            .unwrap()
+            .context
+            .as_deref(),
+        Some(context)
+    );
+    let mut cluster = Cluster::fake();
+    cluster.context = context.into();
+    cluster.default_namespace = "target-default".into();
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: context.into(),
+        result: Ok(Box::new(cluster)),
+    });
+    assert_eq!(app.kind_plural, "services");
+    assert_eq!(app.namespace, "target-default");
+}
+
+#[tokio::test]
+async fn resource_context_shortcut_rejects_malformed_and_handles_failed_switch() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    let generation = app.generation;
+    for query in ["pods @", "pods @west @east", "pods @west prod extra"] {
+        type_resource_query(&mut app, query);
+        assert!(app.flash_err, "{query}");
+        assert_eq!(app.generation, generation);
+    }
+    let context = app.cluster.context.clone();
+    type_resource_query(&mut app, "pods @missing");
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: "missing".into(),
+        result: Err("unknown context: missing".into()),
+    });
+    assert_eq!(app.cluster.context, context);
+    assert_eq!(app.kind_plural, "deployments");
+    assert!(app.flash_err);
+    assert!(app.flash.contains("missing"));
+    assert!(app.pending_resource_query.is_none());
+}
+
+#[tokio::test]
 async fn palette_query_waits_for_context_and_rejects_invalid_input() {
     let (mut app, _rx) = test_app();
     app.switch_kind("deployments");

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -589,6 +589,17 @@ impl ResourceQuery {
             let slot = match word {
                 "-n" | "--namespace" => &mut query.namespace,
                 "--context" => &mut query.context,
+                _ if word.starts_with('@') => {
+                    let context = &word[1..];
+                    if context.is_empty() {
+                        return Err("expected context after @".into());
+                    }
+                    if query.context.is_some() {
+                        return Err("duplicate context".into());
+                    }
+                    query.context = Some(context.into());
+                    continue;
+                }
                 _ if !word.starts_with('-') && query.namespace.is_none() => {
                     query.namespace = Some(word.into());
                     continue;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2246,6 +2246,10 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
             "query resource, namespace, context and filter together",
         ),
         bind(
+            ":resource @context [namespace]",
+            "switch context and resource (context fuzzy-completes; kubeconfig unchanged)",
+        ),
+        bind(
             "ctrl-u · ctrl-w",
             "text inputs: clear line (cmd-⌫) · delete word (opt-⌫)",
         ),


### PR DESCRIPTION
## Summary

Support `:resource @context [namespace]`, for example `:pods @production-cluster default`, with fuzzy context-name completion from kubeconfig. Tab/Shift-Tab select a context suggestion; Enter opens it.

Reuse the existing deferred context-switch path and remembered/default namespace behaviour without changing kubeconfig's `current-context`. Explicit namespaces are preserved, and malformed queries and connection failures use the existing error handling. Namespace autocomplete after `@context` is deferred.

Includes key-driven regression tests and updated key documentation, features, and help.

Closes #391

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/390

## Validation

- `just check`: formatting, locked clippy (`-D warnings`), and tests passed (1,135 tests passed).
- `oxfmt` on changed Markdown.
- No live-cluster validation; context-switch results are simulated in tests.
