### PR TITLE
feat: add image-tag formatting for custom path columns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,10 @@ Every semantic color - row status, severity badges, headers, borders - is derive
 from the active palette, so one skin change lands everywhere at once. `:skin`
 switches live, `:skin gruvbox-dark` applies directly.
 
+Custom text path columns accept `format = "image-tag"` to show only the image
+tag. See the [image tag example](views.md#image-tags) for configuration and
+validation rules.
+
 ## Other sections
 
 Each of these is documented where the feature itself is:

--- a/docs/features.md
+++ b/docs/features.md
@@ -71,7 +71,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Custom views** - define columns for any resource in the config file.
   Select and order built-in columns, live CPU/MEM usage, pod request and limit
   totals, and utilization percentages. Metric columns support numeric sorting,
-  structured filters, and threshold colors. An
+  structured filters, and threshold colors. Custom text path columns support
+  `format = "image-tag"` to show image tags, with registry ports and digests
+  handled separately. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
   automatically. `w` toggles wide-only columns (kubectl `-o wide`), including
   node labels. Add `@<namespace>` to a view key to select columns for one

--- a/docs/views.md
+++ b/docs/views.md
@@ -48,6 +48,34 @@ the layout. By default columns overlay the curated ones: a matching header
 replaces it in place, new columns go before AGE. Invalid entries are skipped with
 a warning in the app - they never take down the TUI.
 
+### Image tags
+
+Use `format = "image-tag"` on a text path column to show the image tag:
+
+```toml
+[[views."v1/pods".columns]]
+name = "TAG"
+path = "/spec/containers/0/image"
+format = "image-tag"
+```
+
+The path selects one image field with JSON Pointer. This example selects the
+first container. The formatter separates registry ports, tags, and digests:
+
+- `registry:5000/app:1.2.3` shows `1.2.3`.
+- `app` or `registry:5000/app` shows `latest`.
+- `app@sha256:…` shows `-` because the reference has no tag.
+- `app:1.2.3@sha256:…` shows `1.2.3`.
+
+The digest examples are abbreviated. Missing or null fields still show `<none>`.
+Empty strings and values that are not strings keep their usual display.
+Sorting and text filters use the displayed tag. If `format` is omitted, the
+column keeps its usual behavior. The default Pod columns do not change.
+
+The formatter accepts an omitted `type` or `type = "text"`. Other types,
+`metric` sources, and `builtin` sources are incompatible with `format`.
+Unsupported formats and incompatible columns are skipped with a config warning.
+
 ### Built-in and metric columns
 
 Set exactly one source for each column: `path`, `builtin`, or `metric`.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -21147,3 +21147,57 @@ async fn terminal_title_removes_control_characters() {
     palette(&mut app, "pods kube-system");
     assert_eq!(app.terminal_title(), Some("sofka: dev/kube-system".into()));
 }
+
+#[tokio::test]
+async fn image_tag_columns_render_selected_paths_and_filter_by_tag() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/pods"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "IMAGE", path = "/spec/containers/0/image" },
+            { name = "TAG", path = "/spec/containers/0/image", format = "image-tag" },
+            { name = "SECOND", path = "/spec/containers/1/image", format = "image-tag", wide = true },
+        ]
+        "#,
+    );
+    palette(&mut app, "pods");
+    let digest = format!("sha256:{}", "a".repeat(64));
+    let cases = [
+        (Some("registry:5000/app:1.2.3".to_string()), "1.2.3"),
+        (Some("app".to_string()), "latest"),
+        (Some(format!("app@{digest}")), "-"),
+        (Some(format!("app:1.2.3@{digest}")), "1.2.3"),
+        (None, "<none>"),
+    ];
+    for (i, (image, _)) in cases.iter().enumerate() {
+        let mut first = json!({"name": "app"});
+        if let Some(image) = image {
+            first["image"] = json!(image);
+        }
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": format!("pod-{i}"), "namespace": "default"},
+                "spec": {"containers": [first, {"name": "sidecar", "image": "sidecar:2"}]}
+            }),
+        );
+    }
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    let (headers, rows) = app.snapshot_table();
+    assert_eq!(headers, ["NAME", "IMAGE", "TAG", "SECOND"]);
+    for (row, (image, tag)) in rows.iter().zip(&cases) {
+        assert_eq!(row[1], image.as_deref().unwrap_or("<none>"));
+        assert_eq!(row[2], *tag);
+        assert_eq!(row[3], "2");
+    }
+    assert_eq!(rows.len(), cases.len());
+    type_filter(&mut app, "tag=1.2.3");
+    let (_, rows) = app.snapshot_table();
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|row| row[2] == "1.2.3"));
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -884,6 +884,8 @@ pub struct ViewColumnConfig {
     /// Value type: `text` (default), `status`, `number`, `quantity`, `time`.
     #[serde(rename = "type")]
     pub kind: Option<String>,
+    /// Optional text path formatter: `image-tag`.
+    pub format: Option<String>,
     /// Only shown in wide mode.
     pub wide: bool,
     /// Fixed display width in columns (defaults to a flexible share).

--- a/src/views.rs
+++ b/src/views.rs
@@ -24,6 +24,8 @@ pub enum ColumnKind {
     Builtin,
     #[default]
     Text,
+    /// Container image tag, sorted as text.
+    ImageTag,
     /// Text that also drives the row's status coloring.
     Status,
     /// Sorted numerically.
@@ -310,6 +312,17 @@ pub fn compile(
             if c.kind.is_some() && (c.metric.is_some() || c.builtin.is_some()) {
                 warnings.push(format!("views.\"{key}\": column {header}: type applies only to path columns; column skipped"));
                 continue;
+            }
+            if let Some(format) = &c.format {
+                if format != "image-tag" {
+                    warnings.push(format!("views.\"{key}\": column {header}: unknown format '{format}' (expected image-tag); column skipped"));
+                    continue;
+                }
+                if c.path.is_empty() || c.kind.as_deref().is_some_and(|kind| kind != "text") {
+                    warnings.push(format!("views.\"{key}\": column {header}: format applies only to text path columns; column skipped"));
+                    continue;
+                }
+                kind = ColumnKind::ImageTag;
             }
             let mut pointer = c.path.trim().to_string();
             if let Some(metric) = &c.metric {
@@ -739,7 +752,25 @@ pub fn render_cell(obj: &DynamicObject, col: &UserColumn, now: i64) -> String {
     };
     match col.kind {
         ColumnKind::Time => render_time(&v, now),
+        ColumnKind::ImageTag => render_image_tag(&v),
         _ => v.render(),
+    }
+}
+
+fn render_image_tag(v: &Extracted<'_>) -> String {
+    let Some(image) = v.as_str().filter(|image| !image.is_empty()) else {
+        return v.render();
+    };
+    let (name, digest) = image
+        .split_once('@')
+        .map_or((image, None), |(name, digest)| (name, Some(digest)));
+    let last_component = name.rsplit('/').next().unwrap_or(name);
+    if let Some((_, tag)) = last_component.rsplit_once(':') {
+        tag.into()
+    } else if digest.is_some() {
+        "-".into()
+    } else {
+        "latest".into()
     }
 }
 
@@ -814,6 +845,12 @@ pub fn sort_value(obj: &DynamicObject, col: &UserColumn, now: i64) -> SortValue 
     }
     let v = cell_value(obj, col);
     match col.kind {
+        ColumnKind::ImageTag => SortValue::Text(
+            v.as_ref()
+                .map(render_image_tag)
+                .unwrap_or_default()
+                .to_lowercase(),
+        ),
         ColumnKind::Number => {
             SortValue::Num(v.as_ref().and_then(Extracted::number).unwrap_or(f64::MAX))
         }
@@ -1070,6 +1107,67 @@ mod tests {
         let (views, warnings) = compile(&cfg.views);
         assert_eq!(views["v1/pods"].columns.len(), 2);
         assert_eq!(warnings.len(), 5);
+    }
+
+    #[test]
+    fn image_tag_formats_validate_without_discarding_valid_columns() {
+        let (views, warnings) = compile_toml(
+            r#"
+            [views.pods]
+            columns = [
+                { name = "TAG", path = "/spec/image", format = "image-tag" },
+                { name = "TEXT", path = "/spec/image", type = "text", format = "image-tag" },
+                { name = "RAW", path = "/spec/image" },
+                { name = "UNKNOWN", path = "/spec/image", format = "split" },
+                { name = "CPU", metric = "cpu", format = "image-tag" },
+                { name = "NAME", builtin = "NAME", format = "image-tag" },
+                { name = "NUMBER", path = "/spec/image", type = "number", format = "image-tag" },
+                { name = "QUANTITY", path = "/spec/image", type = "quantity", format = "image-tag" },
+                { name = "TIME", path = "/spec/image", type = "time", format = "image-tag" },
+                { name = "STATUS", path = "/spec/image", type = "status", format = "image-tag" },
+                { name = "CONDITION", path = "Ready", type = "condition", format = "image-tag" },
+                { name = "BADPATH", path = "image", format = "image-tag" },
+            ]
+            "#,
+        );
+        let columns = &views["pods"].columns;
+        assert_eq!(columns.len(), 3);
+        assert_eq!(columns[0].kind, ColumnKind::ImageTag);
+        assert_eq!(columns[1].kind, ColumnKind::ImageTag);
+        assert_eq!(columns[2].kind, ColumnKind::Text);
+        assert_eq!(warnings.len(), 9, "{warnings:?}");
+        assert!(warnings[0].contains("unknown format 'split'"));
+        assert!(
+            warnings[1..8]
+                .iter()
+                .all(|w| w.contains("format applies only to text path columns"))
+        );
+        assert!(warnings[8].contains("JSON Pointer"));
+    }
+
+    #[test]
+    fn image_tag_rendering_and_sorting_use_the_tag() {
+        let digest = format!("sha256:{}", "a".repeat(64));
+        for (image, expected) in [
+            (json!("registry:5000/app:1.2.3"), "1.2.3"),
+            (json!("registry:5000/team/app"), "latest"),
+            (json!("app"), "latest"),
+            (json!(format!("app@{digest}")), "-"),
+            (json!(format!("registry:5000/app@{digest}")), "-"),
+            (json!(format!("app:1.2.3@{digest}")), "1.2.3"),
+            (json!(format!("registry:5000/app:RC1@{digest}")), "RC1"),
+            (json!("[::1]:5000/app:2"), "2"),
+            (json!(""), ""),
+            (Value::Null, "<none>"),
+            (json!(42), "42"),
+        ] {
+            let o = obj(json!({"apiVersion": "v1", "kind": "Pod", "spec": {"image": image}}));
+            let column = col("/spec/image", ColumnKind::ImageTag);
+            assert_eq!(render_cell(&o, &column, 0), expected);
+            assert!(
+                matches!(sort_value(&o, &column, 0), SortValue::Text(value) if value == expected.to_lowercase())
+            );
+        }
     }
 
     fn col(pointer: &str, kind: ColumnKind) -> UserColumn {


### PR DESCRIPTION
Custom path columns can now show an image tag with `format = "image-tag"`. For example, `registry:5000/app:1.2.3` shows `1.2.3`. References without a tag show `latest`, or `-` when a digest is present. Missing fields keep their usual display.

The change adds config warnings for unsupported formats and incompatible column settings, tests for rendering and keyboard input, and documentation. JSON Pointer selection and columns without a format keep their current behavior.

Validation: `just check` passed (formatting, Clippy, and 1,138 tests; two tests ignored). The pre-commit hooks also passed.

Agreed scope: https://github.com/nklmilojevic/sofka/discussions/370#discussioncomment-18350808

Closes #393
