### PR TITLE
feat: make built-in key bindings configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "toml",
+ "toml_edit",
  "tower",
  "tower-http 0.7.1",
  "unicode-segmentation",
@@ -3440,6 +3441,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3967,6 +3981,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ similar = "3.1.1"
 terminal-colorsaurus = "1.0.3"
 tokio = { version = "1.52.3", features = ["full"] }
 toml = "1.1.2"
+toml_edit = "0.25.13"
 tower = { version = "0.5.3", features = ["util"] }
 tower-http = { version = "0.7.0", features = ["decompression-gzip", "trace", "util", "map-response-body"] }
 unicode-segmentation = "1.13.3"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,11 @@ sofka reads `$XDG_CONFIG_HOME/sofka/config.toml` (or
 `~/.config/sofka/config.toml`). `:reload` re-reads it live, `:config` shows the
 sources and any warnings.
 
+Legacy palette keys are automatically moved to `[keys.command]`, with the
+original file saved as `config.toml.bak`. If the file is read-only or managed
+through a symlink, sofka warns and uses the converted settings in memory.
+See [palette migration](keybindings.md#legacy-palette-migration).
+
 Everything below is optional. An empty config behaves exactly like no config.
 
 ## Base options

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ Each of these is documented where the feature itself is:
 | `[[guardrails]]`      | enforced rules on destructive actions       | [Safety](safety.md#guardrails)                             |
 | `[logs]`              | log tail, follow buffer, `since` lookback   | [Log controls](debugging.md#log-controls)                  |
 | `[notify]`            | bell and desktop notification delivery      | [Notifications](debugging.md#notifications)                |
-| `[keys]`              | palette completion key rebinds              | [Key reference](keys.md#palette-completion-keys)           |
+| `[keys]`              | built-in keyboard bindings                  | [Key bindings](keybindings.md)                             |
 | `[debug]`             | ephemeral and node debug images             | [Debug containers](debugging.md#debug-containers-and-pods) |
 | `[bundle]`            | redaction and size caps for `:bundle`       | [Diagnostic bundles](debugging.md#diagnostic-bundles)      |
 | `[logging]`           | sofka's own structured log file             | [Runtime diagnostics](debugging.md#runtime-diagnostics)    |

--- a/docs/features.md
+++ b/docs/features.md
@@ -153,6 +153,11 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Default sort** - `[views."*"].sort` sets a global initial sort, with
   resource-specific overrides. Sort choices are saved per kind by default.
   Set `remember_sort = false` to make user sort changes temporary.
+- **Configurable key bindings** - change or disable built-in keyboard actions
+  under `[keys]`. Shared navigation settings and mode overrides keep text input
+  separate from navigation. Help and key hints show the effective bindings.
+  Changes support `:reload` and cluster/context overrides. Invalid bindings keep
+  the previous keymap. See [Configure key bindings](keybindings.md).
 - **Mouse support** - the wheel scrolls every view (one notch is three steps of
   that view's own up/down), clicking a row selects it, clicking a column header
   sorts by it (click again to flip). Document views (YAML/describe, diff,

--- a/docs/features.md
+++ b/docs/features.md
@@ -157,7 +157,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   under `[keys]`. Shared navigation settings and mode overrides keep text input
   separate from navigation. Help and key hints show the effective bindings.
   Changes support `:reload` and cluster/context overrides. Invalid bindings keep
-  the previous keymap. See [Configure key bindings](keybindings.md).
+  the previous keymap. Legacy palette settings are migrated with a config
+  backup; managed files produce a warning and use the converted keys in memory.
+  See [Configure key bindings](keybindings.md).
 - **Mouse support** - the wheel scrolls every view (one notch is three steps of
   that view's own up/down), clicking a row selects it, clicking a column header
   sorts by it (click again to flip). Document views (YAML/describe, diff,

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -27,9 +27,8 @@ the line.
 - A string sets one key combination. An array sets multiple combinations.
 - A configured value replaces the inherited bindings for that action. Include
   the default keys in the array if you want to keep them.
-- An omitted action keeps its inherited bindings. In scoped settings, an empty
-  array (`[]`) disables all keyboard bindings for that action. Legacy palette
-  fields retain their previous fallback behavior, described below.
+- An omitted action keeps its inherited bindings. An empty array (`[]`)
+  disables all keyboard bindings for that action.
 - `[keys.global]` sets `quit` and `compact` in every mode.
 - `[keys.navigation]` sets shared navigation actions in modes that support them.
   It does not affect text input modes. The shared actions are `up`, `down`,
@@ -41,12 +40,9 @@ the line.
   `accept` in text input modes that support them.
 - A mode table, such as `[keys.logs]` or `[keys.table]`, replaces the shared
   setting for that mode. File order does not affect this precedence.
-- The existing `palette_next`, `palette_prev`, and `palette_accept` fields under
-  `[keys]` configure the same actions as `down`, `up`, and `accept` under
-  `[keys.command]`. Do not set the same action through both forms. Explicit
-  completion keys take priority over text editing and cancellation in both
-  forms. For example, either form can use `ctrl-w` for the next suggestion or
-  `esc` to accept it.
+- Explicit completion keys under `[keys.command]` take priority over text
+  editing and cancellation. For example, use `down = "ctrl-w"` for the next
+  suggestion or `accept = "esc"` to accept it.
 
 Text input modes are `command`, `filter`, `log_filter`, `doc_filter`, `prompt`,
 `sort_picker`, `copy_picker`, `namespaces`, and `context_filter`.
@@ -92,15 +88,6 @@ views apply at startup or on a context switch. Key value
 errors do not reject the rest of the config file. Invalid TOML syntax can still
 prevent a file from loading. `:config` shows the source paths and key errors.
 
-Legacy `palette_*` fields keep warning-and-fallback behavior: invalid or
-reserved entries are ignored, valid entries remain active, and an empty or
-unusable list restores that action's defaults. These warnings do not reject
-valid scoped bindings. Legacy completion conflicts retain the previous priority:
-next, then previous, then accept. Warnings identify entries hidden by that
-priority. Use scoped settings for strict validation or to disable an action.
-The legacy fields continue to reserve `ctrl-c` and `ctrl-e`; use scoped settings
-to assign those keys after moving the global actions.
-
 Built-in bindings keep their current priority over bookmarks, workspaces, and
 plugins. A released key becomes available to them. `:config` reports keys hidden
 by a built-in action when that action is available. The existing exception stays:
@@ -117,6 +104,37 @@ Disabling or changing the accept binding never changes required confirmation tex
 Quit and compact mode have no reserved keys. If you disable all ways to open
 help, open the command palette, or quit, edit the config outside sofka and
 restart it to restore access.
+
+## Legacy palette migration
+
+When sofka loads a config with legacy palette fields, it moves the values to
+`[keys.command]`:
+
+| Old field under `[keys]` | New field under `[keys.command]` |
+| ------------------------ | -------------------------------- |
+| `palette_next`           | `down`                           |
+| `palette_prev`           | `up`                             |
+| `palette_accept`         | `accept`                         |
+
+Migration preserves comments and unrelated settings. Before replacing a file,
+sofka saves the original as `config.toml.bak` in the same directory. An existing
+backup is never overwritten. Each base, cluster, or context file is converted
+before the settings are merged, so override order stays the same.
+
+If a file cannot be updated, sofka shows a warning and uses the converted keys
+in memory. Symlinks and read-only files are left intact. For a Nix-managed
+config, update the Nix source to use `[keys.command]`. The warning includes the
+field mapping. After a manual change, use `:reload`.
+
+If both formats define the same action in one file, or a legacy value is
+invalid, sofka leaves that file unchanged and reports the problem. It does not
+save migration results when the effective keymap has conflicts or errors.
+Correct these settings and reload, or move them to the new format manually.
+
+The old per-key fallback is removed. Values move without substitution, and an
+empty list disables the action. Migrated keys use the same validation rules as
+other scoped settings. To assign `ctrl-c` or `ctrl-e`, first move or disable
+`quit` or `compact` under `[keys.global]`.
 
 ## Key syntax
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,0 +1,606 @@
+# Configure key bindings
+
+All built-in keyboard actions can be changed in `config.toml`. With no `[keys]`
+settings, the default bindings remain active. `?` shows the effective bindings
+for each mode. The header and footer show the first binding for each action.
+An action with no binding is shown as `unbound`.
+
+## Example: Ctrl+U and Ctrl+D for paging
+
+```toml
+[keys.navigation]
+page_up = ["pageup", "ctrl-b", "ctrl-u"]
+page_down = ["pagedown", "ctrl-f", "ctrl-d"]
+
+[keys.table]
+delete = "alt-d"
+```
+
+The example retains the listed paging keys and adds `ctrl-u` and `ctrl-d`.
+The page size stays the same as before in each view. `ctrl-d` normally starts
+deletion in tables, so the example moves deletion to `alt-d`. Deletion still
+uses confirmation and read-only checks. In text inputs, `ctrl-u` still clears
+the line.
+
+## Values and scopes
+
+- A string sets one key combination. An array sets multiple combinations.
+- A configured value replaces the inherited bindings for that action. Include
+  the default keys in the array if you want to keep them.
+- An omitted action keeps its inherited bindings. An empty array (`[]`) disables
+  all keyboard bindings for that action.
+- `[keys.global]` sets `quit` and `compact` in every mode.
+- `[keys.navigation]` sets shared navigation actions in modes that support them.
+  It does not affect text input modes. The shared actions are `up`, `down`,
+  `first`, `last`, `page_up`, `page_down`, `left`, `right`, `back`, `close`,
+  `command`, and `help`.
+- `[keys.input]` sets `clear_line`, `delete_word`, `backspace`, `back`, and
+  `accept` in text input modes that support them.
+- A mode table, such as `[keys.logs]` or `[keys.table]`, replaces the shared
+  setting for that mode. File order does not affect this precedence.
+- The existing `palette_next`, `palette_prev`, and `palette_accept` fields under
+  `[keys]` remain aliases for `down`, `up`, and `accept` under `[keys.command]`.
+  Do not set the same action through both forms. For compatibility, legacy
+  palette fields take priority over shared line editing bindings in the palette.
+
+Text input modes are `command`, `filter`, `log_filter`, `doc_filter`, `prompt`,
+`sort_picker`, `copy_picker`, `namespaces`, and `context_filter`.
+`contexts` is the context browser; `context_filter` is its text entry state.
+Ordinary text and required confirmation text remain input. External editors
+and shells use their own key bindings. Mouse wheel events still move rows,
+even if the keyboard bindings for row movement change or are disabled.
+
+For example, use a shared paging key, disable it in logs, and set two different
+keys for the table:
+
+```toml
+[keys.navigation]
+page_down = "alt-d"
+
+[keys.logs]
+page_down = []
+
+[keys.table]
+page_down = ["f8", "f9"]
+```
+
+Changes apply at startup, on `:reload`, and when a context switch resolves the
+configuration. Cluster and context files use the normal configuration merge
+rules: tables merge by key; strings and arrays replace earlier values.
+
+## Conflicts and errors
+
+Two built-in actions cannot share a key when both are active in the same mode.
+The same key can be used in separate modes. Mode settings first replace shared
+settings, then validation checks the resulting bindings.
+
+Changing `page_down` to `ctrl-d` without moving or disabling `table.delete`
+reports a conflict. There is no silent reassignment. Unknown scopes, unknown
+actions, and invalid key combinations report errors. Equivalent spellings,
+such as `shift-tab` and `backtab`, count as the same binding.
+
+At startup, invalid bindings leave the default keymap active. On reload or a
+context switch, they leave the previous keymap active. Other valid configuration
+settings can still apply. `:config` shows the source paths and key errors.
+
+Built-in bindings keep their current priority over bookmarks, workspaces, and
+plugins. A released key becomes available to them. `:config` reports keys hidden
+by a built-in action when that action is available. The existing exception stays:
+bookmarks, workspaces, and matching plugins take priority over the table's
+`faults` action.
+
+The default confirmation dialog cancels on any unhandled key. Configuring
+`[keys.confirm].back`, or the shared navigation `back`, replaces this fallback
+with the explicit bindings. Set `back = []` to disable keyboard cancellation.
+Disabling or changing the accept binding never changes required confirmation text.
+
+Quit and compact mode have no reserved keys. If you disable all ways to open
+help, open the command palette, or quit, edit the config outside sofka and
+restart it to restore access.
+
+## Key syntax
+
+Use the same syntax as [plugin bindings](plugins.md):
+
+- Characters: `j`, `G`, `?`, `/`, `-`.
+- Modifiers: `ctrl-u`, `alt-d`, `ctrl-alt-delete`, `shift-f5`.
+- Named keys: `enter`, `tab`, `backtab`, `esc`, `space`, `backspace`, `delete`,
+  `insert`, `home`, `end`, `pageup`, `pagedown`, `up`, `down`, `left`, `right`.
+- Function keys: `f1` through `f24`.
+
+Letters without Ctrl are case-sensitive. `shift-g` and `G` are equivalent.
+Ctrl-letter matching ignores letter case because terminals commonly send a
+lowercase letter. `shift-tab` and `backtab` are equivalent. For shifted
+punctuation, bind the resulting character, such as `_`, rather than `shift--`.
+
+Some terminals send the same event for different physical key combinations.
+For example, Ctrl+I may arrive as Tab and Ctrl+M as Enter. Bind the event that
+the terminal sends. A terminal can also intercept a key before sofka receives
+it. The keymap does not add a new terminal input protocol.
+
+Key sequences such as `gg`, macros, and new movement actions are not supported.
+
+## Action reference
+
+The tables below list local defaults. Every mode also has `quit = "ctrl-c"` and
+`compact = "ctrl-e"`. Each text input mode also has `clear_line = "ctrl-u"` and
+`delete_word = ["ctrl-w", "alt-backspace", "ctrl-backspace"]`.
+
+Navigation screens also have `command = ":"` and `help = "?"`. These are the
+table, documents, logs, help, containers, confirm, dashboards, explain, timeline,
+gitops, adjacent, action menus, port-forwards, skins, snapshots, fleet, find, and
+PVC browser. In help, `?` closes the view instead.
+
+`back` clears a search or returns to the previous view, depending on the mode.
+`close` leaves the view directly. `accept` uses the selected item or input.
+Table actions such as `shell_or_scale`, `restart_or_refresh`, and `action_menu`
+keep their current resource-specific behavior. See the [default key reference](keys.md)
+for those operations.
+
+### `[keys.adjacent]`
+
+| Action              | Default bindings |
+| ------------------- | ---------------- |
+| `accept`            | `enter`          |
+| `back`              | `esc`            |
+| `close`             | `q`              |
+| `describe`          | `d`              |
+| `discover_children` | `c`              |
+| `down`              | `j`, `down`      |
+| `first`             | `g`, `home`      |
+| `last`              | `G`, `end`       |
+| `refresh`           | `r`              |
+| `up`                | `k`, `up`        |
+| `yaml`              | `y`              |
+
+### `[keys.command]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+| `down`      | `tab`, `down`    |
+| `up`        | `backtab`, `up`  |
+
+### `[keys.confirm]`
+
+| Action    | Default bindings     |
+| --------- | -------------------- |
+| `accept`  | `y`, `Y`, `enter`    |
+| `back`    | `esc`, `n`, `N`, `q` |
+| `cascade` | `c`, `C`             |
+| `force`   | `f`, `F`             |
+
+### `[keys.containers]`
+
+| Action          | Default bindings |
+| --------------- | ---------------- |
+| `back`          | `esc`            |
+| `close`         | `q`              |
+| `debug`         | `d`              |
+| `down`          | `j`, `down`      |
+| `logs`          | `enter`, `l`     |
+| `previous_logs` | `p`              |
+| `provider_logs` | `L`              |
+| `shell`         | `s`              |
+| `transfer`      | `t`              |
+| `up`            | `k`, `up`        |
+
+### `[keys.context_filter]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+| `down`      | `down`           |
+| `up`        | `up`             |
+
+### `[keys.contexts]`
+
+| Action       | Default bindings |
+| ------------ | ---------------- |
+| `accept`     | `enter`          |
+| `back`       | `esc`            |
+| `down`       | `down`, `j`      |
+| `filter`     | `/`              |
+| `fleet_mark` | `space`          |
+| `rename`     | `r`, `R`         |
+| `up`         | `up`, `k`        |
+
+### `[keys.copy_picker]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+| `down`      | `down`, `ctrl-n` |
+| `up`        | `up`, `ctrl-p`   |
+
+### `[keys.detail]`
+
+| Action           | Default bindings              |
+| ---------------- | ----------------------------- |
+| `auto_refresh`   | `r`                           |
+| `back`           | `esc`                         |
+| `close`          | `q`                           |
+| `copy`           | `c`                           |
+| `decode_secret`  | `x`                           |
+| `down`           | `j`, `down`                   |
+| `filter`         | `/`                           |
+| `first`          | `g`, `home`                   |
+| `last`           | `G`, `end`                    |
+| `left`           | `h`, `left`                   |
+| `next_match`     | `n`                           |
+| `page_down`      | `pagedown`, `space`, `ctrl-f` |
+| `page_up`        | `pageup`, `ctrl-b`            |
+| `previous_match` | `N`                           |
+| `right`          | `l`, `right`                  |
+| `up`             | `k`, `up`                     |
+| `wrap`           | `w`                           |
+
+### `[keys.diff]`
+
+| Action           | Default bindings              |
+| ---------------- | ----------------------------- |
+| `back`           | `esc`                         |
+| `close`          | `q`                           |
+| `copy`           | `c`                           |
+| `down`           | `j`, `down`                   |
+| `filter`         | `/`                           |
+| `first`          | `g`, `home`                   |
+| `last`           | `G`, `end`                    |
+| `left`           | `h`, `left`                   |
+| `next_match`     | `n`                           |
+| `page_down`      | `pagedown`, `space`, `ctrl-f` |
+| `page_up`        | `pageup`, `ctrl-b`            |
+| `previous_match` | `N`                           |
+| `right`          | `l`, `right`                  |
+| `up`             | `k`, `up`                     |
+| `wrap`           | `w`                           |
+
+### `[keys.doc_filter]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+
+### `[keys.events]`
+
+| Action           | Default bindings              |
+| ---------------- | ----------------------------- |
+| `back`           | `esc`                         |
+| `close`          | `q`                           |
+| `copy`           | `c`                           |
+| `down`           | `j`, `down`                   |
+| `filter`         | `/`                           |
+| `first`          | `g`, `home`                   |
+| `last`           | `G`, `end`                    |
+| `left`           | `h`, `left`                   |
+| `next_match`     | `n`                           |
+| `page_down`      | `pagedown`, `space`, `ctrl-f` |
+| `page_up`        | `pageup`, `ctrl-b`            |
+| `previous_match` | `N`                           |
+| `right`          | `l`, `right`                  |
+| `up`             | `k`, `up`                     |
+| `wrap`           | `w`                           |
+
+### `[keys.explain]`
+
+| Action    | Default bindings |
+| --------- | ---------------- |
+| `accept`  | `enter`          |
+| `back`    | `esc`            |
+| `close`   | `q`              |
+| `down`    | `j`, `down`      |
+| `events`  | `E`              |
+| `first`   | `g`, `home`      |
+| `last`    | `G`, `end`       |
+| `logs`    | `l`              |
+| `refresh` | `r`              |
+| `up`      | `k`, `up`        |
+
+### `[keys.filter]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+
+### `[keys.find]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `accept` | `enter`          |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `down`   | `j`, `down`      |
+| `first`  | `g`, `home`      |
+| `last`   | `G`, `end`       |
+| `up`     | `k`, `up`        |
+
+### `[keys.fleet]`
+
+| Action    | Default bindings |
+| --------- | ---------------- |
+| `accept`  | `enter`          |
+| `back`    | `esc`            |
+| `close`   | `q`              |
+| `down`    | `j`, `down`      |
+| `refresh` | `r`              |
+| `up`      | `k`, `up`        |
+
+### `[keys.flux_menu]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `accept` | `enter`          |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `down`   | `j`, `down`      |
+| `up`     | `k`, `up`        |
+
+### `[keys.gitops]`
+
+| Action    | Default bindings |
+| --------- | ---------------- |
+| `accept`  | `enter`          |
+| `back`    | `esc`            |
+| `close`   | `q`              |
+| `down`    | `j`, `down`      |
+| `first`   | `g`, `home`      |
+| `last`    | `G`, `end`       |
+| `refresh` | `r`              |
+| `up`      | `k`, `up`        |
+
+### `[keys.help]`
+
+| Action      | Default bindings              |
+| ----------- | ----------------------------- |
+| `back`      | `esc`                         |
+| `close`     | `q`, `?`                      |
+| `down`      | `j`, `down`                   |
+| `filter`    | `/`                           |
+| `first`     | `g`, `home`                   |
+| `last`      | `G`, `end`                    |
+| `page_down` | `pagedown`, `space`, `ctrl-f` |
+| `page_up`   | `pageup`, `ctrl-b`            |
+| `up`        | `k`, `up`                     |
+
+### `[keys.log_filter]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+
+### `[keys.logs]`
+
+| Action       | Default bindings    |
+| ------------ | ------------------- |
+| `anchor_0`   | `0`                 |
+| `anchor_1`   | `1`                 |
+| `anchor_2`   | `2`                 |
+| `anchor_3`   | `3`                 |
+| `anchor_4`   | `4`                 |
+| `anchor_5`   | `5`                 |
+| `back`       | `esc`               |
+| `clear`      | `z`                 |
+| `close`      | `q`                 |
+| `copy`       | `c`                 |
+| `down`       | `j`, `down`         |
+| `filter`     | `/`                 |
+| `first`      | `g`, `home`         |
+| `follow`     | `s`, `f`            |
+| `fullscreen` | `F`                 |
+| `last`       | `G`, `end`          |
+| `lookback`   | `T`                 |
+| `page_down`  | `pagedown`, `space` |
+| `page_up`    | `pageup`            |
+| `save`       | `ctrl-s`            |
+| `stream`     | `x`                 |
+| `timestamps` | `t`                 |
+| `up`         | `k`, `up`           |
+| `wrap`       | `w`                 |
+
+### `[keys.namespaces]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+| `down`      | `down`           |
+| `up`        | `up`             |
+
+### `[keys.port_forward_picker]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `accept` | `enter`          |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `down`   | `j`, `down`      |
+| `up`     | `k`, `up`        |
+
+### `[keys.port_forwards]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `down`   | `j`, `down`      |
+| `start`  | `enter`          |
+| `toggle` | `x`, `s`         |
+| `up`     | `k`, `up`        |
+
+### `[keys.prompt]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+
+### `[keys.pulse]`
+
+| Action    | Default bindings |
+| --------- | ---------------- |
+| `back`    | `esc`            |
+| `close`   | `q`              |
+| `refresh` | `r`              |
+
+### `[keys.pvc_explore]`
+
+| Action        | Default bindings |
+| ------------- | ---------------- |
+| `accept`      | `enter`          |
+| `back`        | `esc`            |
+| `close`       | `q`              |
+| `copy`        | `c`              |
+| `down`        | `j`, `down`      |
+| `first`       | `g`, `home`      |
+| `last`        | `G`, `end`       |
+| `left`        | `left`           |
+| `parent`      | `backspace`, `-` |
+| `refresh`     | `r`              |
+| `right`       | `right`          |
+| `shell`       | `s`              |
+| `switch_pane` | `tab`, `backtab` |
+| `up`          | `k`, `up`        |
+
+### `[keys.set_image]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `accept` | `enter`          |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `down`   | `j`, `down`      |
+| `up`     | `k`, `up`        |
+
+### `[keys.skins]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `accept` | `enter`          |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `down`   | `j`, `down`      |
+| `up`     | `k`, `up`        |
+
+### `[keys.snapshots]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `accept` | `enter`          |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `delete` | `d`              |
+| `down`   | `j`, `down`      |
+| `up`     | `k`, `up`        |
+
+### `[keys.sort_picker]`
+
+| Action      | Default bindings |
+| ----------- | ---------------- |
+| `accept`    | `enter`          |
+| `back`      | `esc`            |
+| `backspace` | `backspace`      |
+| `down`      | `down`, `ctrl-n` |
+| `up`        | `up`, `ctrl-p`   |
+
+### `[keys.table]`
+
+| Action               | Default bindings     |
+| -------------------- | -------------------- |
+| `action_menu`        | `t`                  |
+| `adjacent`           | `u`                  |
+| `all_namespaces`     | `0`                  |
+| `attach`             | `a`                  |
+| `back`               | `esc`                |
+| `copy_cell`          | `Y`                  |
+| `copy_name`          | `c`                  |
+| `cordon`             | `C`                  |
+| `delete`             | `ctrl-d`             |
+| `describe`           | `d`                  |
+| `down`               | `j`, `down`          |
+| `drain`              | `D`                  |
+| `edit`               | `e`                  |
+| `events`             | `E`                  |
+| `exit`               | `q`                  |
+| `explain`            | `X`                  |
+| `faults`             | `ctrl-z`             |
+| `filter`             | `/`                  |
+| `first`              | `g`, `home`          |
+| `force_delete`       | `ctrl-k`             |
+| `history_back`       | `[`                  |
+| `history_forward`    | `]`                  |
+| `inspect`            | `x`                  |
+| `invert_sort`        | `I`                  |
+| `last`               | `G`, `end`           |
+| `left`               | `left`               |
+| `logs`               | `l`                  |
+| `mark`               | `space`              |
+| `namespaces`         | `n`                  |
+| `next_view`          | `tab`                |
+| `node`               | `o`                  |
+| `open`               | `enter`              |
+| `owner`              | `J`                  |
+| `page_down`          | `pagedown`, `ctrl-f` |
+| `page_up`            | `pageup`, `ctrl-b`   |
+| `port_forward`       | `f`, `F`             |
+| `previous_logs`      | `p`                  |
+| `previous_view`      | `backtab`            |
+| `provider_logs`      | `L`                  |
+| `refresh`            | `ctrl-r`             |
+| `restart_or_refresh` | `r`                  |
+| `right`              | `right`              |
+| `set_image`          | `i`                  |
+| `shell_or_scale`     | `s`                  |
+| `sort`               | `S`                  |
+| `timeline`           | `T`                  |
+| `uncordon`           | `U`                  |
+| `up`                 | `k`, `up`            |
+| `wide`               | `w`                  |
+| `yaml`               | `y`                  |
+
+### `[keys.timeline]`
+
+| Action  | Default bindings |
+| ------- | ---------------- |
+| `back`  | `esc`            |
+| `close` | `q`              |
+| `down`  | `j`, `down`      |
+| `first` | `g`, `home`      |
+| `last`  | `G`, `end`       |
+| `up`    | `k`, `up`        |
+
+### `[keys.transfer_menu]`
+
+| Action   | Default bindings |
+| -------- | ---------------- |
+| `accept` | `enter`          |
+| `back`   | `esc`            |
+| `close`  | `q`              |
+| `down`   | `j`, `down`      |
+| `up`     | `k`, `up`        |
+
+### `[keys.xray]`
+
+| Action    | Default bindings |
+| --------- | ---------------- |
+| `back`    | `esc`            |
+| `close`   | `q`              |
+| `down`    | `j`, `down`      |
+| `first`   | `g`, `home`      |
+| `last`    | `G`, `end`       |
+| `logs`    | `enter`, `l`     |
+| `refresh` | `r`              |
+| `up`      | `k`, `up`        |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -27,21 +27,26 @@ the line.
 - A string sets one key combination. An array sets multiple combinations.
 - A configured value replaces the inherited bindings for that action. Include
   the default keys in the array if you want to keep them.
-- An omitted action keeps its inherited bindings. An empty array (`[]`) disables
-  all keyboard bindings for that action.
+- An omitted action keeps its inherited bindings. In scoped settings, an empty
+  array (`[]`) disables all keyboard bindings for that action. Legacy palette
+  fields retain their previous fallback behavior, described below.
 - `[keys.global]` sets `quit` and `compact` in every mode.
 - `[keys.navigation]` sets shared navigation actions in modes that support them.
   It does not affect text input modes. The shared actions are `up`, `down`,
   `first`, `last`, `page_up`, `page_down`, `left`, `right`, `back`, `close`,
-  `command`, and `help`.
+  `command`, and `help`. Shared `back` settings do not change confirmation
+  dialogs. Shared `close` settings do not change the table's `exit` action or
+  the global `quit` action; configure those separately.
 - `[keys.input]` sets `clear_line`, `delete_word`, `backspace`, `back`, and
   `accept` in text input modes that support them.
 - A mode table, such as `[keys.logs]` or `[keys.table]`, replaces the shared
   setting for that mode. File order does not affect this precedence.
 - The existing `palette_next`, `palette_prev`, and `palette_accept` fields under
-  `[keys]` remain aliases for `down`, `up`, and `accept` under `[keys.command]`.
-  Do not set the same action through both forms. For compatibility, legacy
-  palette fields take priority over shared line editing bindings in the palette.
+  `[keys]` configure the same actions as `down`, `up`, and `accept` under
+  `[keys.command]`. Do not set the same action through both forms. Explicit
+  completion keys take priority over text editing and cancellation in both
+  forms. For example, either form can use `ctrl-w` for the next suggestion or
+  `esc` to accept it.
 
 Text input modes are `command`, `filter`, `log_filter`, `doc_filter`, `prompt`,
 `sort_picker`, `copy_picker`, `namespaces`, and `context_filter`.
@@ -70,18 +75,31 @@ rules: tables merge by key; strings and arrays replace earlier values.
 
 ## Conflicts and errors
 
-Two built-in actions cannot share a key when both are active in the same mode.
-The same key can be used in separate modes. Mode settings first replace shared
-settings, then validation checks the resulting bindings.
+Scoped settings reject conflicting actions in the same mode, except for the
+palette completion priority described above. The same key can be used in
+separate modes. Mode settings first replace shared settings, then validation
+checks the resulting bindings.
 
 Changing `page_down` to `ctrl-d` without moving or disabling `table.delete`
-reports a conflict. There is no silent reassignment. Unknown scopes, unknown
-actions, and invalid key combinations report errors. Equivalent spellings,
+reports a conflict. Unknown scopes, unknown actions, invalid key combinations,
+and incorrect value types report errors. Equivalent spellings,
 such as `shift-tab` and `backtab`, count as the same binding.
 
 At startup, invalid bindings leave the default keymap active. On reload or a
 context switch, they leave the previous keymap active. Other valid configuration
-settings can still apply. `:config` shows the source paths and key errors.
+settings still apply, including plugins, bookmarks, skins, and views. Custom
+views apply at startup or on a context switch. Key value
+errors do not reject the rest of the config file. Invalid TOML syntax can still
+prevent a file from loading. `:config` shows the source paths and key errors.
+
+Legacy `palette_*` fields keep warning-and-fallback behavior: invalid or
+reserved entries are ignored, valid entries remain active, and an empty or
+unusable list restores that action's defaults. These warnings do not reject
+valid scoped bindings. Legacy completion conflicts retain the previous priority:
+next, then previous, then accept. Warnings identify entries hidden by that
+priority. Use scoped settings for strict validation or to disable an action.
+The legacy fields continue to reserve `ctrl-c` and `ctrl-e`; use scoped settings
+to assign those keys after moving the global actions.
 
 Built-in bindings keep their current priority over bookmarks, workspaces, and
 plugins. A released key becomes available to them. `:config` reports keys hidden
@@ -90,8 +108,10 @@ bookmarks, workspaces, and matching plugins take priority over the table's
 `faults` action.
 
 The default confirmation dialog cancels on any unhandled key. Configuring
-`[keys.confirm].back`, or the shared navigation `back`, replaces this fallback
-with the explicit bindings. Set `back = []` to disable keyboard cancellation.
+`[keys.confirm].back` replaces this fallback with the explicit bindings.
+Shared navigation `back` settings leave the dialog's `n`, `q`, and other
+cancellation keys unchanged. The mouse wheel also cancels a default dialog.
+Set `[keys.confirm] back = []` to disable keyboard and wheel cancellation.
 Disabling or changing the accept binding never changes required confirmation text.
 
 Quit and compact mode have no reserved keys. If you disable all ways to open
@@ -118,11 +138,17 @@ For example, Ctrl+I may arrive as Tab and Ctrl+M as Enter. Bind the event that
 the terminal sends. A terminal can also intercept a key before sofka receives
 it. The keymap does not add a new terminal input protocol.
 
+Default list navigation bindings also accept Shift+arrow, Shift+PageUp/Down,
+and Shift+Home/End. These are explicit default aliases, shown in help. The
+command palette retains its previous exact completion matching. User settings
+replace the aliases, so use `["down", "shift-down"]` to accept both, or assign
+the two combinations to separate actions.
+
 Key sequences such as `gg`, macros, and new movement actions are not supported.
 
 ## Action reference
 
-The tables below list local defaults. Every mode also has `quit = "ctrl-c"` and
+The tables below list local defaults without the shifted navigation aliases. Every mode also has `quit = "ctrl-c"` and
 `compact = "ctrl-e"`. Each text input mode also has `clear_line = "ctrl-u"` and
 `delete_word = ["ctrl-w", "alt-backspace", "ctrl-backspace"]`.
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -167,12 +167,16 @@ palette_accept = ["ctrl-y", "enter"]
 Each value is one [key combination](plugins.md) or a list of combinations.
 It replaces the default set for that action: `["tab", "down"]`,
 `["backtab", "up"]`, or `["enter"]`. Include a default in the list to keep it.
-An empty list disables the bindings.
+Invalid or reserved entries produce warnings and are ignored. An empty or
+unusable list restores the action's default bindings.
 
-These fields remain aliases for `[keys.command]` actions `down`, `up`, and
-`accept`. Do not set an action through both forms. To assign `ctrl-c` or
-`ctrl-e` to another action, first change or disable `quit` or `compact` under
-`[keys.global]`. See [conflicts](keybindings.md#conflicts-and-errors).
+The scoped settings `[keys.command]` actions `down`, `up`, and `accept`
+configure the same actions, with strict validation and `[]` to disable them.
+Both forms give explicit completion bindings priority over text editing and
+cancellation. Do not set an action through both forms.
+To assign `ctrl-c` or `ctrl-e`, use scoped settings after moving or disabling
+`quit` or `compact` under `[keys.global]`. The legacy fields still reserve those
+keys. See [conflicts and recovery](keybindings.md#conflicts-and-errors).
 
 ## What suspends the TUI
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,6 +1,8 @@
 # Key reference
 
-The full keymap. `?` inside sofka shows the same thing, including your own
+The default keymap. All built-in keyboard actions are configurable.
+See [Configure key bindings](keybindings.md) for scopes and action names.
+`?` inside sofka shows the effective bindings, including your own
 plugin, bookmark, and workspace chords. `:` and `?` work from every navigation
 screen; closing either returns to the screen where it was opened. Text-entry
 pickers keep both characters available as input.
@@ -162,10 +164,15 @@ palette_prev   = "ctrl-p"
 palette_accept = ["ctrl-y", "enter"]
 ```
 
-Each value is one [key chord](plugins.md) or a list of chords, and replaces
-the default set for that action (`["tab", "down"]`, `["backtab", "up"]`,
-`["enter"]`) — include a default in the list to keep it too. `ctrl-c` (quit)
-and `ctrl-e` (compact mode) are reserved by built-ins and can't be bound.
+Each value is one [key combination](plugins.md) or a list of combinations.
+It replaces the default set for that action: `["tab", "down"]`,
+`["backtab", "up"]`, or `["enter"]`. Include a default in the list to keep it.
+An empty list disables the bindings.
+
+These fields remain aliases for `[keys.command]` actions `down`, `up`, and
+`accept`. Do not set an action through both forms. To assign `ctrl-c` or
+`ctrl-e` to another action, first change or disable `quit` or `compact` under
+`[keys.global]`. See [conflicts](keybindings.md#conflicts-and-errors).
 
 ## What suspends the TUI
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -154,29 +154,29 @@ See [Views](views.md#navigating-between-kinds) for adding CRD relations.
 ## Palette completion keys
 
 In the `:` palette, `tab`/`↓` and `shift-tab`/`↑` move through the suggestion
-list and `⏎` runs the highlighted one. Rebind them under `[keys]` in
-`config.toml` — emacs/cmp style, for example:
+list and `⏎` runs the highlighted one. Rebind them under `[keys.command]` in
+`config.toml`, for example:
 
 ```toml
-[keys]
-palette_next   = "ctrl-n"
-palette_prev   = "ctrl-p"
-palette_accept = ["ctrl-y", "enter"]
+[keys.command]
+down = "ctrl-n"
+up = "ctrl-p"
+accept = ["ctrl-y", "enter"]
 ```
 
 Each value is one [key combination](plugins.md) or a list of combinations.
 It replaces the default set for that action: `["tab", "down"]`,
 `["backtab", "up"]`, or `["enter"]`. Include a default in the list to keep it.
-Invalid or reserved entries produce warnings and are ignored. An empty or
-unusable list restores the action's default bindings.
+An empty list disables the action. Invalid values report errors. Explicit
+completion bindings take priority over text editing and cancellation.
+To assign `ctrl-c` or `ctrl-e`, first move or disable `quit` or `compact` under
+`[keys.global]`.
 
-The scoped settings `[keys.command]` actions `down`, `up`, and `accept`
-configure the same actions, with strict validation and `[]` to disable them.
-Both forms give explicit completion bindings priority over text editing and
-cancellation. Do not set an action through both forms.
-To assign `ctrl-c` or `ctrl-e`, use scoped settings after moving or disabling
-`quit` or `compact` under `[keys.global]`. The legacy fields still reserve those
-keys. See [conflicts and recovery](keybindings.md#conflicts-and-errors).
+Legacy `palette_next`, `palette_prev`, and `palette_accept` settings are
+automatically migrated to this format, with a `config.toml.bak` backup.
+If the file cannot be updated, sofka warns and uses the converted settings in
+memory. See [migration](keybindings.md#legacy-palette-migration) for managed
+configs, conflicts, and invalid values.
 
 ## What suspends the TUI
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -18,7 +18,8 @@ See [Language choice](plugin-authoring.md#language-choice).
 `[[plugins]]` assigns an external command to a key or palette command. `key` is a **chord**: a single
 character (`"g"`), a modifier combination (`"ctrl-g"`, `"alt-x"`, `"shift-b"`), or
 a function or named key (`"f5"`, `"ctrl-f2"`). A built-in key wins over a plugin
-on the same chord.
+on the same chord. You can [change or disable that built-in binding](keybindings.md)
+to release the key. `:config` reports bindings hidden by built-in actions.
 
 For the minus key, use `"-"` alone or `"ctrl--"`, `"alt--"`, or `"ctrl-alt--"`
 with modifiers. The final two hyphens are the separator and the minus key.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -778,13 +778,13 @@ impl App {
         self.mode = Mode::SetImage;
     }
 
-    pub(super) fn key_set_image(&mut self, key: KeyEvent) {
+    pub(super) fn key_set_image(&mut self, key: KeyInput) {
         let len = self.container_list.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.container_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.container_state, len, false),
-            KeyCode::Enter => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.container_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.container_state, len, false),
+            (Some(Action::Accept), _) => {
                 if let Some(i) = self.container_state.selected()
                     && let Some(container) = self.container_list.get(i).cloned()
                     && let Some((ns, name, plural)) = self.image_target.clone()
@@ -1335,21 +1335,21 @@ impl App {
     /// The `:pf` list is the running forwards followed by the saved-but-
     /// stopped `[[forwards]]` entries; `x`/`s` stops a running one, `⏎`/`s`
     /// starts a stopped one.
-    pub(super) fn key_port_forwards(&mut self, key: KeyEvent) {
+    pub(super) fn key_port_forwards(&mut self, key: KeyInput) {
         let running = self.port_forwards.len();
         let len = running + self.stopped_configured_forwards().len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.pf_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.pf_state, len, false),
-            KeyCode::Char('x') | KeyCode::Char('s') | KeyCode::Enter => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.pf_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.pf_state, len, false),
+            (Some(Action::Toggle), _) | (Some(Action::Start), _) => {
                 let Some(i) = self.pf_state.selected() else {
                     return;
                 };
                 if i < running {
                     // Enter on a running forward is a no-op, not a stop — a
                     // reflexive ⏎ shouldn't kill a tunnel.
-                    if key.code != KeyCode::Enter {
+                    if key.action == Some(Action::Toggle) {
                         self.stop_selected_port_forward();
                     }
                 } else if let Some(&(idx, _)) = self.stopped_configured_forwards().get(i - running)
@@ -1370,13 +1370,13 @@ impl App {
         self.mode = Mode::Skins;
     }
 
-    pub(super) fn key_skins(&mut self, key: KeyEvent) {
+    pub(super) fn key_skins(&mut self, key: KeyInput) {
         let len = self.skin_list.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.skin_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.skin_state, len, false),
-            KeyCode::Enter => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.skin_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.skin_state, len, false),
+            (Some(Action::Accept), _) => {
                 if let Some(name) = self
                     .skin_state
                     .selected()
@@ -1472,10 +1472,7 @@ impl App {
         warnings.extend(crate::config::forward_warnings(&self.forwards_cfg));
         warnings.extend(crate::config::notify_warnings(&self.notify_cfg));
         warnings.extend(crate::config::pvc_explore_warnings(&self.pvc_cfg));
-        let (palette_keys, key_warnings) =
-            crate::config::compile_palette_keys(&resolved.config.keys);
-        self.palette_keys = palette_keys;
-        warnings.extend(key_warnings);
+        warnings.extend(self.configure_keys(&resolved.config.keys));
         // Thresholds only change cell coloring (never the column layout), so —
         // unlike custom views — they're safe to re-apply live without yanking
         // the current view.
@@ -1655,20 +1652,16 @@ impl App {
         self.mode = Mode::TransferMenu;
     }
 
-    pub(super) fn key_transfer_menu(&mut self, key: KeyEvent) {
+    pub(super) fn key_transfer_menu(&mut self, key: KeyInput) {
         let len = TRANSFER_MENU_ITEMS.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 self.transfer_target = None;
                 self.mode = Mode::Table;
             }
-            KeyCode::Char('j') | KeyCode::Down => {
-                list_step(&mut self.transfer_menu_state, len, true)
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                list_step(&mut self.transfer_menu_state, len, false)
-            }
-            KeyCode::Enter => {
+            (Some(Action::Down), _) => list_step(&mut self.transfer_menu_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.transfer_menu_state, len, false),
+            (Some(Action::Accept), _) => {
                 let choice = self
                     .transfer_menu_state
                     .selected()
@@ -1872,14 +1865,14 @@ impl App {
         self.mode = Mode::FluxMenu;
     }
 
-    pub(super) fn key_flux_menu(&mut self, key: KeyEvent) {
+    pub(super) fn key_flux_menu(&mut self, key: KeyInput) {
         let items = self.action_menu_items();
         let len = items.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.flux_menu_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.flux_menu_state, len, false),
-            KeyCode::Enter => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.flux_menu_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.flux_menu_state, len, false),
+            (Some(Action::Accept), _) => {
                 let choice = self
                     .flux_menu_state
                     .selected()

--- a/src/app/adjacent.rs
+++ b/src/app/adjacent.rs
@@ -216,10 +216,10 @@ impl App {
         }
     }
 
-    pub(super) fn key_adjacent(&mut self, key: KeyEvent) {
+    pub(super) fn key_adjacent(&mut self, key: KeyInput) {
         let len = self.adjacent_items.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 let destination = self.adjacent_return;
                 self.mode = destination;
                 self.adjacent_return = Mode::Table;
@@ -227,23 +227,23 @@ impl App {
                     self.restore_selection();
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.adjacent_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.adjacent_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home => {
+            (Some(Action::Down), _) => list_step(&mut self.adjacent_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.adjacent_state, len, false),
+            (Some(Action::First), _) => {
                 if len > 0 {
                     self.adjacent_state.select(Some(0));
                 }
             }
-            KeyCode::Char('G') | KeyCode::End => {
+            (Some(Action::Last), _) => {
                 if len > 0 {
                     self.adjacent_state.select(Some(len - 1));
                 }
             }
-            KeyCode::Char('r') => self.refresh_adjacent(),
-            KeyCode::Char('c') => self.discover_children(),
-            KeyCode::Enter => self.adjacent_goto(),
-            KeyCode::Char('y') => self.adjacent_yaml(),
-            KeyCode::Char('d') => self.adjacent_describe(),
+            (Some(Action::Refresh), _) => self.refresh_adjacent(),
+            (Some(Action::DiscoverChildren), _) => self.discover_children(),
+            (Some(Action::Accept), _) => self.adjacent_goto(),
+            (Some(Action::Yaml), _) => self.adjacent_yaml(),
+            (Some(Action::Describe), _) => self.adjacent_describe(),
             _ => {}
         }
         if !matches!(self.mode, Mode::Adjacent | Mode::Detail) {

--- a/src/app/dashboards.rs
+++ b/src/app/dashboards.rs
@@ -109,13 +109,13 @@ impl App {
         self.tasks.push(handle);
     }
 
-    pub(super) fn key_pulse(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+    pub(super) fn key_pulse(&mut self, key: KeyInput) {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 self.mode = Mode::Table;
                 self.start_watch();
             }
-            KeyCode::Char('r') => {
+            (Some(Action::Refresh), _) => {
                 self.bump_generation();
                 self.spawn_pulse();
             }
@@ -208,27 +208,27 @@ impl App {
         self.tasks.push(handle);
     }
 
-    pub(super) fn key_xray(&mut self, key: KeyEvent) {
+    pub(super) fn key_xray(&mut self, key: KeyInput) {
         let len = self.xray_items.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 self.mode = Mode::Table;
                 self.start_watch();
             }
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.xray_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.xray_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home => {
+            (Some(Action::Down), _) => list_step(&mut self.xray_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.xray_state, len, false),
+            (Some(Action::First), _) => {
                 if len > 0 {
                     self.xray_state.select(Some(0));
                 }
             }
-            KeyCode::Char('G') | KeyCode::End => {
+            (Some(Action::Last), _) => {
                 if len > 0 {
                     self.xray_state.select(Some(len - 1));
                 }
             }
             // Enter on a pod/container streams logs.
-            KeyCode::Enter | KeyCode::Char('l') => {
+            (Some(Action::Logs), _) => {
                 if let Some(i) = self.xray_state.selected()
                     && let Some(item) = self.xray_items.get(i).cloned()
                 {
@@ -258,7 +258,7 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char('r') => {
+            (Some(Action::Refresh), _) => {
                 self.bump_generation();
                 self.spawn_xray();
             }

--- a/src/app/explain.rs
+++ b/src/app/explain.rs
@@ -129,10 +129,10 @@ impl App {
         }
     }
 
-    pub(super) fn key_explain(&mut self, key: KeyEvent) {
+    pub(super) fn key_explain(&mut self, key: KeyInput) {
         let len = self.explain_items.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 let destination = self.explain_return;
                 self.mode = destination;
                 self.explain_return = Mode::Table;
@@ -140,26 +140,26 @@ impl App {
                     self.restore_selection();
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.explain_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.explain_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home => {
+            (Some(Action::Down), _) => list_step(&mut self.explain_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.explain_state, len, false),
+            (Some(Action::First), _) => {
                 if len > 0 {
                     self.explain_state.select(Some(0));
                 }
             }
-            KeyCode::Char('G') | KeyCode::End => {
+            (Some(Action::Last), _) => {
                 if len > 0 {
                     self.explain_state.select(Some(len - 1));
                 }
             }
-            KeyCode::Char('r') => self.refresh_explain(),
+            (Some(Action::Refresh), _) => self.refresh_explain(),
             // Direct evidence navigation: jump to the resource behind the
             // selected finding (⏎), or open its events (E) / logs (l). With no
             // target on the current line, E/l fall back to the object being
             // explained — so the whole evidence trail is one keystroke away.
-            KeyCode::Enter => self.explain_goto(),
-            KeyCode::Char('E') => self.explain_events(),
-            KeyCode::Char('l') => self.explain_logs(),
+            (Some(Action::Accept), _) => self.explain_goto(),
+            (Some(Action::Events), _) => self.explain_events(),
+            (Some(Action::Logs), _) => self.explain_logs(),
             _ => {}
         }
         if !matches!(self.mode, Mode::Explain | Mode::Events | Mode::Logs) {

--- a/src/app/find.rs
+++ b/src/app/find.rs
@@ -117,23 +117,23 @@ impl App {
         });
     }
 
-    pub(super) fn key_find(&mut self, key: KeyEvent) {
+    pub(super) fn key_find(&mut self, key: KeyInput) {
         let len = self.find_items.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.find_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.find_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.find_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.find_state, len, false),
+            (Some(Action::First), _) => {
                 if len > 0 {
                     self.find_state.select(Some(0));
                 }
             }
-            KeyCode::Char('G') | KeyCode::End => {
+            (Some(Action::Last), _) => {
                 if len > 0 {
                     self.find_state.select(Some(len - 1));
                 }
             }
-            KeyCode::Enter => {
+            (Some(Action::Accept), _) => {
                 let Some(item) = self
                     .find_state
                     .selected()

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -158,13 +158,13 @@ impl App {
         }
     }
 
-    pub(super) fn key_fleet(&mut self, key: KeyEvent) {
+    pub(super) fn key_fleet(&mut self, key: KeyInput) {
         let len = self.fleet_rows.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.fleet_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.fleet_state, len, false),
-            KeyCode::Char('r') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.fleet_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.fleet_state, len, false),
+            (Some(Action::Refresh), _) => {
                 // Re-gather: reset rows to connecting, keeping resolved policy.
                 for r in &mut self.fleet_rows {
                     *r = FleetRow::connecting(r.context.clone(), r.readonly);
@@ -173,7 +173,7 @@ impl App {
             }
             // Enter switches to the highlighted context via the normal
             // context-switch path, landing on its default view.
-            KeyCode::Enter => {
+            (Some(Action::Accept), _) => {
                 if let Some(ctx) = self
                     .fleet_state
                     .selected()

--- a/src/app/gitops.rs
+++ b/src/app/gitops.rs
@@ -178,22 +178,22 @@ impl App {
         }
     }
 
-    pub(super) fn key_gitops(&mut self, key: KeyEvent) {
+    pub(super) fn key_gitops(&mut self, key: KeyInput) {
         let len = self.gitops_items.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
                     self.restore_selection();
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.gitops_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.gitops_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home if len > 0 => self.gitops_state.select(Some(0)),
-            KeyCode::Char('G') | KeyCode::End if len > 0 => self.gitops_state.select(Some(len - 1)),
-            KeyCode::Char('r') => self.refresh_gitops(),
+            (Some(Action::Down), _) => list_step(&mut self.gitops_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.gitops_state, len, false),
+            (Some(Action::First), _) if len > 0 => self.gitops_state.select(Some(0)),
+            (Some(Action::Last), _) if len > 0 => self.gitops_state.select(Some(len - 1)),
+            (Some(Action::Refresh), _) => self.refresh_gitops(),
             // Jump to the resource behind the selected chain node.
-            KeyCode::Enter => {
+            (Some(Action::Accept), _) => {
                 let target = self
                     .gitops_state
                     .selected()

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -199,19 +199,11 @@ pub(super) fn manual_job_name(cronjob: &str, suffix: &str) -> String {
     format!("{base}-manual-{suffix}")
 }
 
-/// Readline-style line edits shared by every text input (command palette,
-/// filters, prompts, pickers). These are what terminals send for the macOS
-/// editing chords: cmd+delete arrives as ctrl-u (kill line) and
-/// option+delete as alt-backspace or ctrl-w (kill word). Returns whether the
-/// key was handled, so callers run their post-edit refresh and skip the
-/// plain-key arms.
-pub(super) fn edit_chord(key: &KeyEvent, buf: &mut String) -> bool {
-    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    let alt = key.modifiers.contains(KeyModifiers::ALT);
-    match key.code {
-        KeyCode::Char('u') if ctrl => buf.clear(),
-        KeyCode::Char('w') if ctrl => pop_word(buf),
-        KeyCode::Backspace if alt || ctrl => pop_word(buf),
+/// Apply shared text editing actions.
+pub(super) fn edit_action(action: Option<Action>, buf: &mut String) -> bool {
+    match action {
+        Some(Action::ClearLine) => buf.clear(),
+        Some(Action::DeleteWord) => pop_word(buf),
         _ => return false,
     }
     true

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4,6 +4,11 @@ impl App {
     // ----- key handling --------------------------------------------------
 
     pub fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
+        let action = self.keymap.action(self.key_scope(), &key);
+        self.handle_input(KeyInput::new(action, key))
+    }
+
+    pub(super) fn handle_input(&mut self, key: KeyInput) -> Result<()> {
         let before = match self.mode {
             Mode::Command => self.palette_return,
             Mode::Help => self.help_return,
@@ -58,96 +63,26 @@ impl App {
         result
     }
 
-    fn handle_key_inner(&mut self, key: KeyEvent) -> Result<()> {
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
-                KeyCode::Char('c') => {
-                    self.stop_plugins();
-                    self.should_quit = true;
-                    return Ok(());
-                }
-                // Compact mode: collapse the header to one line and hide the
-                // footer (k9s ctrl-e/ctrl-g, folded into one toggle). Works in
-                // every mode, so it never reaches the plain-key bindings.
-                KeyCode::Char('e') => {
-                    self.compact = !self.compact;
-                    return Ok(());
-                }
-                KeyCode::Char('d') if self.mode == Mode::Table => {
-                    self.request_delete(false);
-                    return Ok(());
-                }
-                KeyCode::Char('k') if self.mode == Mode::Table => {
-                    self.request_delete(true); // kill = force delete
-                    return Ok(());
-                }
-                KeyCode::Char('r') if self.mode == Mode::Table => {
-                    self.start_watch();
-                    return Ok(());
-                }
-                KeyCode::Char('z')
-                    if self.mode == Mode::Table
-                        && self.kind_plural == "pods"
-                        && key.modifiers == KeyModifiers::CONTROL =>
-                {
-                    if self.try_bookmark_key(key)
-                        || self.try_workspace_key(key)
-                        || self.try_plugin_key(key)
-                    {
-                        return Ok(());
-                    }
-                    self.faults_only = !self.faults_only;
-                    self.invalidate_rows();
-                    self.table_state.select(Some(0));
-                    return Ok(());
-                }
-                KeyCode::Char('f')
-                    if self.mode == Mode::Table && key.modifiers == KeyModifiers::CONTROL =>
-                {
-                    self.move_page(1);
-                    return Ok(());
-                }
-                KeyCode::Char('b')
-                    if self.mode == Mode::Table && key.modifiers == KeyModifiers::CONTROL =>
-                {
-                    self.move_page(-1);
-                    return Ok(());
-                }
-                _ => {}
+    fn handle_key_inner(&mut self, key: KeyInput) -> Result<()> {
+        match key.action {
+            Some(Action::Quit) => {
+                self.stop_plugins();
+                self.should_quit = true;
+                return Ok(());
             }
-        }
-
-        // Ctrl/alt combos in the table are user plugin chords (the reserved
-        // built-in ctrl keys above already returned). Route them here so they
-        // never fall through to the plain-key table bindings — `ctrl-g` must
-        // not trigger `g`. Unmatched combos are swallowed rather than misfiring.
-        if self.mode == Mode::Table
-            && (key.modifiers.contains(KeyModifiers::CONTROL)
-                || key.modifiers.contains(KeyModifiers::ALT))
-        {
-            if !self.try_bookmark_key(key) && !self.try_workspace_key(key) {
-                self.try_plugin_key(key);
+            Some(Action::Compact) => {
+                self.compact = !self.compact;
+                return Ok(());
             }
-            return Ok(());
-        }
-
-        // Navigation screens share the command-palette and help bindings.
-        // Text-entry pickers deliberately stay out of this path so `:` and `?`
-        // remain ordinary input while filtering or filling a prompt.
-        let plain = !key.modifiers.contains(KeyModifiers::CONTROL)
-            && !key.modifiers.contains(KeyModifiers::ALT);
-        if plain && self.has_global_view_shortcuts() {
-            match key.code {
-                KeyCode::Char(':') => {
-                    self.open_palette();
-                    return Ok(());
-                }
-                KeyCode::Char('?') if self.mode != Mode::Help => {
-                    self.open_help();
-                    return Ok(());
-                }
-                _ => {}
+            Some(Action::Command) => {
+                self.open_palette();
+                return Ok(());
             }
+            Some(Action::Help) => {
+                self.open_help();
+                return Ok(());
+            }
+            _ => {}
         }
 
         match self.mode {
@@ -186,32 +121,113 @@ impl App {
         Ok(())
     }
 
-    fn has_global_view_shortcuts(&self) -> bool {
-        matches!(
-            self.mode,
-            Mode::Table
-                | Mode::Detail
-                | Mode::Logs
-                | Mode::Help
-                | Mode::Containers
-                | Mode::Confirm
-                | Mode::Pulse
-                | Mode::Xray
-                | Mode::Explain
-                | Mode::Timeline
-                | Mode::Gitops
-                | Mode::Adjacent
-                | Mode::Diff
-                | Mode::Events
-                | Mode::FluxMenu
-                | Mode::TransferMenu
-                | Mode::PortForwards
-                | Mode::Skins
-                | Mode::Snapshots
-                | Mode::Fleet
-                | Mode::Find
-                | Mode::PvcExplore
-        )
+    pub fn key_scope(&self) -> &'static str {
+        match self.mode {
+            Mode::Contexts if self.ctx_filtering => "context_filter",
+            Mode::Table => "table",
+            Mode::Command => "command",
+            Mode::Filter => "filter",
+            Mode::Detail => "detail",
+            Mode::Diff => "diff",
+            Mode::Events => "events",
+            Mode::Logs => "logs",
+            Mode::LogFilter => "log_filter",
+            Mode::DocFilter => "doc_filter",
+            Mode::Help => "help",
+            Mode::Namespaces => "namespaces",
+            Mode::Contexts => "contexts",
+            Mode::SortPicker => "sort_picker",
+            Mode::CopyPicker => "copy_picker",
+            Mode::Containers => "containers",
+            Mode::SetImage => "set_image",
+            Mode::Confirm => "confirm",
+            Mode::Prompt => "prompt",
+            Mode::Pulse => "pulse",
+            Mode::Xray => "xray",
+            Mode::Explain => "explain",
+            Mode::Timeline => "timeline",
+            Mode::Gitops => "gitops",
+            Mode::Adjacent => "adjacent",
+            Mode::FluxMenu => "flux_menu",
+            Mode::TransferMenu => "transfer_menu",
+            Mode::PortForwards => "port_forwards",
+            Mode::Skins => "skins",
+            Mode::Snapshots => "snapshots",
+            Mode::Fleet => "fleet",
+            Mode::Find => "find",
+            Mode::PvcExplore => "pvc_explore",
+            Mode::PortForwardPicker => "port_forward_picker",
+        }
+    }
+
+    pub fn configure_keys(&mut self, cfg: &crate::config::KeysConfig) -> Vec<String> {
+        let mut warnings = match Keymap::compile(cfg) {
+            Ok(map) => {
+                self.keymap = map;
+                Vec::new()
+            }
+            Err(errors) => {
+                let paths = self
+                    .config
+                    .base_path()
+                    .into_iter()
+                    .chain(
+                        self.config
+                            .override_paths(&self.cluster.context, &self.cluster.cluster_name),
+                    )
+                    .filter(|p| p.exists())
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                errors
+                    .into_iter()
+                    .map(|e| format!("{paths}: {e}; previous keymap kept"))
+                    .collect()
+            }
+        };
+        for (kind, name, binding, resources) in self
+            .plugins
+            .iter()
+            .map(|p| {
+                (
+                    "plugin",
+                    p.name.as_str(),
+                    Some(p.key.as_str()),
+                    p.scopes.as_slice(),
+                )
+            })
+            .chain(
+                self.bookmarks
+                    .iter()
+                    .map(|b| ("bookmark", b.name.as_str(), b.key.as_deref(), &[][..])),
+            )
+            .chain(
+                self.workspaces
+                    .iter()
+                    .map(|w| ("workspace", w.name.as_str(), w.key.as_deref(), &[][..])),
+            )
+        {
+            if let Some(binding) = binding
+                && let Ok(chord) = crate::keys::KeyChord::parse(binding)
+            {
+                for (scope, action, chords) in self.keymap.entries() {
+                    if scope == "table"
+                        && action != Action::Faults
+                        && (action != Action::Inspect
+                            || resources.is_empty()
+                            || resources.iter().any(|s| {
+                                matches!(s.as_str(), "secrets" | "persistentvolumeclaims")
+                            }))
+                        && chords
+                            .iter()
+                            .any(|other| crate::keymap::overlaps(&chord, other))
+                    {
+                        warnings.push(format!("{kind} {name:?}: {} is hidden by keys.table.{} when that action is available", chord.label(), action.name()));
+                    }
+                }
+            }
+        }
+        warnings
     }
 
     fn open_help(&mut self) {
@@ -221,11 +237,24 @@ impl App {
         self.mode = Mode::Help;
     }
 
-    pub(super) fn key_table(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Char('/') => self.mode = Mode::Filter,
-            KeyCode::Char('q') => self.should_quit = true,
-            KeyCode::Esc => {
+    pub(super) fn key_table(&mut self, key: KeyInput) {
+        match (key.action, key.code) {
+            (Some(Action::Delete), _) => self.request_delete(false),
+            (Some(Action::ForceDelete), _) => self.request_delete(true),
+            (Some(Action::Refresh), _) => self.start_watch(),
+            (Some(Action::Faults), _) if self.kind_plural == "pods" => {
+                if !self.try_bookmark_key(key.event())
+                    && !self.try_workspace_key(key.event())
+                    && !self.try_plugin_key(key.event())
+                {
+                    self.faults_only = !self.faults_only;
+                    self.invalidate_rows();
+                    self.table_state.select(Some(0));
+                }
+            }
+            (Some(Action::Filter), _) => self.mode = Mode::Filter,
+            (Some(Action::Exit), _) => self.should_quit = true,
+            (Some(Action::Back), _) => {
                 if !self.marked.is_empty() {
                     self.marked.clear();
                 } else if !self.filter.is_empty() {
@@ -239,44 +268,46 @@ impl App {
                     // at root, nothing to pop
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => self.move_selection(1),
-            KeyCode::Char('k') | KeyCode::Up => self.move_selection(-1),
-            KeyCode::Char('g') | KeyCode::Home => self.table_state.select(Some(0)),
-            KeyCode::Char('G') | KeyCode::End => {
+            (Some(Action::Down), _) => self.move_selection(1),
+            (Some(Action::Up), _) => self.move_selection(-1),
+            (Some(Action::First), _) => self.table_state.select(Some(0)),
+            (Some(Action::Last), _) => {
                 let len = self.row_count();
                 if len > 0 {
                     self.table_state.select(Some(len - 1));
                 }
             }
-            KeyCode::PageDown => self.move_page(1),
-            KeyCode::PageUp => self.move_page(-1),
+            (Some(Action::PageDown), _) => self.move_page(1),
+            (Some(Action::PageUp), _) => self.move_page(-1),
             // Move the viewport; keep NAMESPACE/NAME in place.
-            KeyCode::Right => self.scroll_columns(1),
-            KeyCode::Left => self.scroll_columns(-1),
+            (Some(Action::Right), _) => self.scroll_columns(1),
+            (Some(Action::Left), _) => self.scroll_columns(-1),
             // k9s: SPACE marks/unmarks the current row for bulk actions, then
             // advances so a range can be marked with repeated taps.
-            KeyCode::Char(' ') => {
+            (Some(Action::Mark), _) => {
                 self.toggle_mark();
                 self.move_selection(1);
             }
-            KeyCode::Enter => self.drill(),
-            KeyCode::Char('y') => self.open_detail(),
-            KeyCode::Char('d') => self.describe(),
+            (Some(Action::Open), _) => self.drill(),
+            (Some(Action::Yaml), _) => self.open_detail(),
+            (Some(Action::Describe), _) => self.describe(),
             // k9s: `x` shows a secret's data base64-decoded. Elsewhere `x`
             // stays free for user plugins (the fallthrough arm below).
-            KeyCode::Char('x') if self.kind_plural == "secrets" => self.open_decoded_secret(),
+            (Some(Action::Inspect), _) if self.kind_plural == "secrets" => {
+                self.open_decoded_secret()
+            }
             // `x` on a PVC opens the split-pane volume browser.
-            KeyCode::Char('x') if self.kind_plural == "persistentvolumeclaims" => {
+            (Some(Action::Inspect), _) if self.kind_plural == "persistentvolumeclaims" => {
                 self.open_pvc_explore()
             }
-            KeyCode::Char('E') => self.open_events(),
-            KeyCode::Char('l') => self.open_logs(),
+            (Some(Action::Events), _) => self.open_events(),
+            (Some(Action::Logs), _) => self.open_logs(),
             // Logs from the configured external provider ([providers.logs]).
-            KeyCode::Char('L') => self.open_provider_logs(),
-            KeyCode::Char('p') => self.open_previous_logs(),
-            KeyCode::Char('e') => self.request_edit(),
+            (Some(Action::ProviderLogs), _) => self.open_provider_logs(),
+            (Some(Action::PreviousLogs), _) => self.open_previous_logs(),
+            (Some(Action::Edit), _) => self.request_edit(),
             // k9s: `s` = shell on pods, scale on scalable workloads.
-            KeyCode::Char('s') => {
+            (Some(Action::ShellOrScale), _) => {
                 if self.kind_plural == "pods" {
                     self.request_exec();
                 } else if self.kind_plural == "persistentvolumeclaims" {
@@ -287,43 +318,43 @@ impl App {
                     self.request_scale();
                 }
             }
-            KeyCode::Char('a') => self.request_attach(),
-            KeyCode::Char('i') => self.request_set_image(),
-            KeyCode::Char('o') => self.show_node(),
-            KeyCode::Char('c') => self.copy_name(),
+            (Some(Action::Attach), _) => self.request_attach(),
+            (Some(Action::SetImage), _) => self.request_set_image(),
+            (Some(Action::Node), _) => self.show_node(),
+            (Some(Action::CopyName), _) => self.copy_name(),
             // Copy any displayed cell of the row via a field picker (`c`
             // above copies just the name).
-            KeyCode::Char('Y') => self.open_copy_picker(),
-            KeyCode::Char('J') => self.jump_owner(),
+            (Some(Action::CopyCell), _) => self.open_copy_picker(),
+            (Some(Action::Owner), _) => self.jump_owner(),
             // `X` — explain why the selection is unhealthy (evidence-backed).
-            KeyCode::Char('X') => self.open_explain(),
+            (Some(Action::Explain), _) => self.open_explain(),
             // `T` — session-local state-change timeline for the selection.
-            KeyCode::Char('T') => self.open_timeline(),
+            (Some(Action::Timeline), _) => self.open_timeline(),
             // `u` — the objects directly connected to the selection.
-            KeyCode::Char('u') => self.open_adjacent(),
-            KeyCode::Char('C') => self.request_cordon(true),
-            KeyCode::Char('U') => self.request_cordon(false),
-            KeyCode::Char('D') => self.request_drain(),
+            (Some(Action::Adjacent), _) => self.open_adjacent(),
+            (Some(Action::Cordon), _) => self.request_cordon(true),
+            (Some(Action::Uncordon), _) => self.request_cordon(false),
+            (Some(Action::Drain), _) => self.request_drain(),
             // Sorting: S opens the column picker, I inverts the direction.
-            KeyCode::Char('S') => self.open_sort_picker(),
-            KeyCode::Char('I') => self.toggle_sort_dir(),
+            (Some(Action::Sort), _) => self.open_sort_picker(),
+            (Some(Action::InvertSort), _) => self.toggle_sort_dir(),
             // Wide mode: show wide-only columns (kubectl `-o wide`).
-            KeyCode::Char('w') => self.toggle_wide(),
+            (Some(Action::Wide), _) => self.toggle_wide(),
             // `f`/Shift-F = port-forward.
-            KeyCode::Char('f') | KeyCode::Char('F') => self.request_port_forward(),
-            KeyCode::Char('n') => self.open_namespaces(),
+            (Some(Action::PortForward), _) => self.request_port_forward(),
+            (Some(Action::Namespaces), _) => self.open_namespaces(),
             // Browser-style view history: [ back, ] forward.
-            KeyCode::Char('[') => self.history_back(),
-            KeyCode::Char(']') => self.history_forward(),
+            (Some(Action::HistoryBack), _) => self.history_back(),
+            (Some(Action::HistoryForward), _) => self.history_forward(),
             // Cycle workspace views, or the default resources in this namespace.
-            KeyCode::Tab => {
+            (Some(Action::NextView), _) => {
                 self.cycle_views(true);
             }
-            KeyCode::BackTab => {
+            (Some(Action::PreviousView), _) => {
                 self.cycle_views(false);
             }
             // k9s: 0 = all namespaces.
-            KeyCode::Char('0') => {
+            (Some(Action::AllNamespaces), _) => {
                 self.save_history_filter();
                 self.namespace.clear();
                 self.drop_owner_scope();
@@ -337,7 +368,7 @@ impl App {
             // k9s: `r` = rollout restart on workloads, force-sync on external
             // secrets, rollback on a Helm release's revision history, else
             // refresh the watch.
-            KeyCode::Char('r') => {
+            (Some(Action::RestartOrRefresh), _) => {
                 if matches!(
                     self.kind_plural.as_str(),
                     "deployments" | "statefulsets" | "daemonsets"
@@ -355,7 +386,7 @@ impl App {
             // suspend/resume/reconcile, ArgoCD Application suspend/resume/sync,
             // ArgoCD ApplicationSet suspend/resume, CronJob trigger/suspend/resume.
             // On pods, `t` is the file-transfer menu (kubectl cp) instead.
-            KeyCode::Char('t') => {
+            (Some(Action::ActionMenu), _) => {
                 if self.kind_plural == "pods" {
                     self.request_transfer();
                 } else {
@@ -368,25 +399,21 @@ impl App {
             // are routed earlier, in `handle_key`, before the plain-key
             // bindings above can claim them.
             _ => {
-                if !self.try_bookmark_key(key) && !self.try_workspace_key(key) {
-                    self.try_plugin_key(key);
+                if !self.try_bookmark_key(key.event()) && !self.try_workspace_key(key.event()) {
+                    self.try_plugin_key(key.event());
                 }
             }
         }
     }
 
-    pub(super) fn key_command(&mut self, key: KeyEvent) {
-        // Configured completion chords win over everything else (including
-        // the shared line-editing chords), so a `[keys]` rebind like ctrl-w
-        // always does what the user asked. Defaults: tab/down, backtab/up,
-        // enter — see [`crate::config::PaletteKeys`].
-        if self.palette_keys.next.iter().any(|c| c.matches(&key)) {
+    pub(super) fn key_command(&mut self, key: KeyInput) {
+        if key.action == Some(Action::Down) {
             if !self.cmd_suggestions.is_empty() {
                 self.cmd_sel = (self.cmd_sel + 1) % self.cmd_suggestions.len();
             }
             return;
         }
-        if self.palette_keys.prev.iter().any(|c| c.matches(&key)) {
+        if key.action == Some(Action::Up) {
             if !self.cmd_suggestions.is_empty() {
                 self.cmd_sel = self
                     .cmd_sel
@@ -395,21 +422,21 @@ impl App {
             }
             return;
         }
-        if self.palette_keys.accept.iter().any(|c| c.matches(&key)) {
+        if key.action == Some(Action::Accept) {
             self.palette_accept();
             return;
         }
-        if edit_chord(&key, &mut self.command) {
+        if edit_action(key.action, &mut self.command) {
             self.update_suggestions();
             return;
         }
-        match key.code {
-            KeyCode::Esc => self.mode = self.palette_return,
-            KeyCode::Backspace => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => self.mode = self.palette_return,
+            (Some(Action::Backspace), _) => {
                 self.command.pop();
                 self.update_suggestions();
             }
-            KeyCode::Char(c) => {
+            (None, KeyCode::Char(c)) => {
                 self.command.push(c);
                 self.update_suggestions();
             }
@@ -946,20 +973,20 @@ impl App {
     /// Type the row filter. Local terms (fuzzy/inverse/column comparisons)
     /// apply live per keystroke; `-l`/`-f` selectors are sent to the API on
     /// ⏎, since that restarts the watch (see `sync_filter_selectors`).
-    pub(super) fn key_filter(&mut self, key: KeyEvent) {
-        if edit_chord(&key, &mut self.filter) {
+    pub(super) fn key_filter(&mut self, key: KeyInput) {
+        if edit_action(key.action, &mut self.filter) {
             self.invalidate_rows();
             self.table_state.select(Some(0));
             return;
         }
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 self.filter.clear();
                 self.mode = Mode::Table;
                 self.sync_filter_selectors();
                 self.save_history_filter();
             }
-            KeyCode::Enter => {
+            (Some(Action::Accept), _) => {
                 if let Some(err) = self.filter_error() {
                     self.flash_warn(&format!("filter: {err}"));
                 } else {
@@ -968,29 +995,29 @@ impl App {
                     self.save_history_filter();
                 }
             }
-            KeyCode::Backspace => {
+            (Some(Action::Backspace), _) => {
                 self.filter.pop();
             }
-            KeyCode::Char(c) => self.filter.push(c),
+            (None, KeyCode::Char(c)) => self.filter.push(c),
             _ => {}
         }
         self.invalidate_rows();
         self.table_state.select(Some(0));
     }
 
-    pub(super) fn key_scroll(&mut self, key: KeyEvent, detail: bool) {
+    pub(super) fn key_scroll(&mut self, key: KeyInput, detail: bool) {
         let target = if detail {
             &mut self.detail
         } else {
             &mut self.logs.view
         };
-        match key.code {
+        match (key.action, key.code) {
             // Esc backs out of an active search first (like the table view);
             // `q` always leaves.
-            KeyCode::Esc if detail && !target.filter.is_empty() => {
+            (Some(Action::Back), _) if detail && !target.filter.is_empty() => {
                 target.filter.clear();
             }
-            KeyCode::Esc | KeyCode::Char('q') => {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 // The underlying view (table/xray) watch kept running, so there
                 // is nothing to restart — just stop the log streams and return,
                 // landing back on the same row.
@@ -1009,41 +1036,43 @@ impl App {
             // Search within the document (k9s `/` in YAML/describe views):
             // matches are highlighted in place while the full document stays
             // rendered, vim-style, and `n`/`N` step between them.
-            KeyCode::Char('/') if detail => {
+            (Some(Action::Filter), _) if detail => {
                 self.doc_filter_return = self.mode;
                 self.mode = Mode::DocFilter;
             }
             // Jump to the next / previous search match (vim `n`/`N`). No-op
             // when no search is active.
-            KeyCode::Char('n') if detail => target.step_match(true),
-            KeyCode::Char('N') if detail => target.step_match(false),
-            KeyCode::Char('r') if self.mode == Mode::Detail => self.toggle_describe_refresh(),
+            (Some(Action::NextMatch), _) if detail => target.step_match(true),
+            (Some(Action::PreviousMatch), _) if detail => target.step_match(false),
+            (Some(Action::AutoRefresh), _) if self.mode == Mode::Detail => {
+                self.toggle_describe_refresh()
+            }
             // Copy the document to the clipboard (k9s `c`), same as the logs
             // view: an active search copies only the matching lines.
-            KeyCode::Char('c') if detail => {
+            (Some(Action::Copy), _) if detail => {
                 self.copy_doc();
             }
             // `x` decodes the secret's data from inside its describe/YAML
             // view too — no need to back out to the table first.
-            KeyCode::Char('x') if self.mode == Mode::Detail && self.kind_plural == "secrets" => {
+            (Some(Action::DecodeSecret), _)
+                if self.mode == Mode::Detail && self.kind_plural == "secrets" =>
+            {
                 self.show_decoded_secret();
             }
-            KeyCode::Char('j') | KeyCode::Down => target.scroll_by(1),
-            KeyCode::Char('k') | KeyCode::Up => target.scroll_by(-1),
-            KeyCode::Char('h') | KeyCode::Left => target.scroll_h(-5),
-            KeyCode::Char('l') | KeyCode::Right => target.scroll_h(5),
-            KeyCode::PageDown | KeyCode::Char(' ') => target.scroll_by(20),
-            KeyCode::PageUp => target.scroll_by(-20),
-            KeyCode::Char('f') if key.modifiers == KeyModifiers::CONTROL => target.scroll_by(20),
-            KeyCode::Char('b') if key.modifiers == KeyModifiers::CONTROL => target.scroll_by(-20),
-            KeyCode::Char('g') | KeyCode::Home => {
+            (Some(Action::Down), _) => target.scroll_by(1),
+            (Some(Action::Up), _) => target.scroll_by(-1),
+            (Some(Action::Left), _) => target.scroll_h(-5),
+            (Some(Action::Right), _) => target.scroll_h(5),
+            (Some(Action::PageDown), _) => target.scroll_by(20),
+            (Some(Action::PageUp), _) => target.scroll_by(-20),
+            (Some(Action::First), _) => {
                 target.scroll = 0;
                 target.hscroll = 0;
             }
-            KeyCode::Char('G') | KeyCode::End => target.scroll_to_bottom(),
+            (Some(Action::Last), _) => target.scroll_to_bottom(),
             // k9s: `w` toggles line wrap; folding long lines is the other way to
             // read content that runs past the right edge.
-            KeyCode::Char('w') => {
+            (Some(Action::Wrap), _) => {
                 let on = target.toggle_wrap();
                 self.flash = format!("wrap: {}", if on { "on" } else { "off" });
                 self.flash_err = false;
@@ -1052,15 +1081,15 @@ impl App {
         }
     }
 
-    pub(super) fn key_logs(&mut self, key: KeyEvent) {
+    pub(super) fn key_logs(&mut self, key: KeyInput) {
         // Ctrl-S saves the buffer to a file (k9s).
-        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+        if key.action == Some(Action::Save) {
             self.save_logs();
             return;
         }
-        match key.code {
+        match (key.action, key.code) {
             // k9s: `s` toggles autoscroll/follow (we also accept `f`).
-            KeyCode::Char('s') | KeyCode::Char('f') => {
+            (Some(Action::Follow), _) => {
                 self.logs.follow = !self.logs.follow;
                 if self.logs.follow {
                     // Resumed tailing — trim the backlog accumulated while paused.
@@ -1082,7 +1111,7 @@ impl App {
                 return;
             }
             // k9s: `w` toggles line wrap.
-            KeyCode::Char('w') => {
+            (Some(Action::Wrap), _) => {
                 self.logs.wrap = !self.logs.wrap;
                 self.flash = format!("wrap: {}", if self.logs.wrap { "on" } else { "off" });
                 self.flash_err = false;
@@ -1090,7 +1119,7 @@ impl App {
             }
             // Fullscreen: whole frame, no borders, so terminal text selection
             // copies clean lines (k9s binds `f`, taken here by follow).
-            KeyCode::Char('F') => {
+            (Some(Action::Fullscreen), _) => {
                 self.logs.fullscreen = !self.logs.fullscreen;
                 self.flash = format!(
                     "fullscreen: {}",
@@ -1100,12 +1129,33 @@ impl App {
                 return;
             }
             // k9s time anchors: `0` re-tails, `1`-`5` re-stream a window.
-            KeyCode::Char(c @ '0'..='5') => {
-                self.apply_log_anchor(c);
+            (Some(Action::Anchor0), _) => {
+                self.apply_log_anchor('0');
                 return;
             }
+            (Some(Action::Anchor1), _) => {
+                self.apply_log_anchor('1');
+                return;
+            }
+            (Some(Action::Anchor2), _) => {
+                self.apply_log_anchor('2');
+                return;
+            }
+            (Some(Action::Anchor3), _) => {
+                self.apply_log_anchor('3');
+                return;
+            }
+            (Some(Action::Anchor4), _) => {
+                self.apply_log_anchor('4');
+                return;
+            }
+            (Some(Action::Anchor5), _) => {
+                self.apply_log_anchor('5');
+                return;
+            }
+
             // Provider logs: `T` changes the lookback period (re-queries).
-            KeyCode::Char('T') => {
+            (Some(Action::Lookback), _) => {
                 if self.provider_logs_active() {
                     self.prompt_label = format!(
                         "lookback period — e.g. 30m, 4h, 2d (current: {})",
@@ -1120,7 +1170,7 @@ impl App {
                 return;
             }
             // k9s: `t` toggles timestamps (re-streams).
-            KeyCode::Char('t') => {
+            (Some(Action::Timestamps), _) => {
                 self.logs.timestamps = !self.logs.timestamps;
                 self.flash = format!(
                     "timestamps: {}",
@@ -1133,7 +1183,7 @@ impl App {
                 return;
             }
             // Stop / resume the live stream.
-            KeyCode::Char('x') => {
+            (Some(Action::Stream), _) => {
                 if self.logs.stopped {
                     self.logs.stopped = false;
                     self.flash = "log stream resumed".into();
@@ -1142,25 +1192,25 @@ impl App {
                 } else {
                     self.logs.stopped = true;
                     self.stop_log_stream(); // abort log tasks; view watch untouched
-                    self.flash = "log stream stopped (x to resume)".into();
+                    self.flash = "log stream stopped".into();
                     self.flash_err = false;
                 }
                 return;
             }
             // k9s: `c` copies the (filtered) buffer to the clipboard.
-            KeyCode::Char('c') => {
+            (Some(Action::Copy), _) => {
                 self.copy_logs();
                 return;
             }
             // Clear the on-screen buffer (the live stream keeps appending).
-            KeyCode::Char('z') => {
+            (Some(Action::Clear), _) => {
                 self.logs.view.clear_lines();
                 self.logs.view.scroll = 0;
                 self.flash = "log buffer cleared".into();
                 self.flash_err = false;
                 return;
             }
-            KeyCode::Char('/') => {
+            (Some(Action::Filter), _) => {
                 self.mode = Mode::LogFilter;
                 return;
             }
@@ -1174,35 +1224,35 @@ impl App {
         // Deepest useful offset: last full page pinned to the viewport bottom.
         let max = self.logs.viewport_rows.saturating_sub(self.logs.viewport_h);
         let cur = self.logs.view.scroll;
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 self.stop_log_stream();
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
                     self.restore_selection();
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => {
+            (Some(Action::Down), _) => {
                 self.logs.follow = false;
                 self.logs.view.scroll = cur.saturating_add(1).min(max);
             }
-            KeyCode::Char('k') | KeyCode::Up => {
+            (Some(Action::Up), _) => {
                 self.logs.follow = false;
                 self.logs.view.scroll = cur.saturating_sub(1);
             }
-            KeyCode::PageDown | KeyCode::Char(' ') => {
+            (Some(Action::PageDown), _) => {
                 self.logs.follow = false;
                 self.logs.view.scroll = cur.saturating_add(page).min(max);
             }
-            KeyCode::PageUp => {
+            (Some(Action::PageUp), _) => {
                 self.logs.follow = false;
                 self.logs.view.scroll = cur.saturating_sub(page);
             }
-            KeyCode::Char('g') | KeyCode::Home => {
+            (Some(Action::First), _) => {
                 self.logs.follow = false;
                 self.logs.view.scroll = 0;
             }
-            KeyCode::Char('G') | KeyCode::End => {
+            (Some(Action::Last), _) => {
                 // Resume autoscroll; the next draw anchors to the bottom.
                 self.logs.follow = true;
             }
@@ -1210,24 +1260,24 @@ impl App {
         }
     }
 
-    pub(super) fn key_log_filter(&mut self, key: KeyEvent) {
+    pub(super) fn key_log_filter(&mut self, key: KeyInput) {
         let mut edited = self.logs.filter.clone();
-        if edit_chord(&key, &mut edited) {
+        if edit_action(key.action, &mut edited) {
             self.logs.set_filter(edited);
             return;
         }
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 self.logs.set_filter(String::new());
                 self.mode = Mode::Logs;
             }
-            KeyCode::Enter => self.mode = Mode::Logs,
-            KeyCode::Backspace => {
+            (Some(Action::Accept), _) => self.mode = Mode::Logs,
+            (Some(Action::Backspace), _) => {
                 let mut f = self.logs.filter.clone();
                 f.pop();
                 self.logs.set_filter(f);
             }
-            KeyCode::Char(c) => {
+            (None, KeyCode::Char(c)) => {
                 let mut f = self.logs.filter.clone();
                 f.push(c);
                 self.logs.set_filter(f);
@@ -1236,47 +1286,38 @@ impl App {
         }
     }
 
-    pub(super) fn key_help(&mut self, key: KeyEvent) {
+    pub(super) fn key_help(&mut self, key: KeyInput) {
         let page = self.help_viewport_h.max(1);
-        match key.code {
+        match (key.action, key.code) {
             // Esc backs out of an active search first, then closes help.
-            KeyCode::Esc if !self.help_filter.is_empty() => {
+            (Some(Action::Back), _) if !self.help_filter.is_empty() => {
                 self.help_filter.clear();
                 self.help_scroll = 0;
             }
-            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 self.mode = self.help_return;
                 self.help_return = Mode::Table;
             }
-            KeyCode::Char('/') => {
+            (Some(Action::Filter), _) => {
                 self.help_scroll = 0;
                 self.doc_filter_return = self.mode;
                 self.mode = Mode::DocFilter;
             }
-            KeyCode::Char('j') | KeyCode::Down => {
+            (Some(Action::Down), _) => {
                 self.help_scroll = self.help_scroll.saturating_add(1).min(self.help_max_scroll);
             }
-            KeyCode::Char('k') | KeyCode::Up => {
+            (Some(Action::Up), _) => {
                 self.help_scroll = self.help_scroll.saturating_sub(1);
             }
-            KeyCode::PageDown | KeyCode::Char(' ') => {
+            (Some(Action::PageDown), _) => {
                 self.help_scroll = self
                     .help_scroll
                     .saturating_add(page)
                     .min(self.help_max_scroll);
             }
-            KeyCode::Char('f') if key.modifiers == KeyModifiers::CONTROL => {
-                self.help_scroll = self
-                    .help_scroll
-                    .saturating_add(page)
-                    .min(self.help_max_scroll);
-            }
-            KeyCode::PageUp => self.help_scroll = self.help_scroll.saturating_sub(page),
-            KeyCode::Char('b') if key.modifiers == KeyModifiers::CONTROL => {
-                self.help_scroll = self.help_scroll.saturating_sub(page);
-            }
-            KeyCode::Char('g') | KeyCode::Home => self.help_scroll = 0,
-            KeyCode::Char('G') | KeyCode::End => self.help_scroll = self.help_max_scroll,
+            (Some(Action::PageUp), _) => self.help_scroll = self.help_scroll.saturating_sub(page),
+            (Some(Action::First), _) => self.help_scroll = 0,
+            (Some(Action::Last), _) => self.help_scroll = self.help_max_scroll,
             _ => {}
         }
     }
@@ -1284,16 +1325,16 @@ impl App {
     /// Type the search query for a single-document view (YAML/describe, diff,
     /// events, help). Mirrors [`Self::key_log_filter`]: enter keeps the query,
     /// esc clears it; either returns to the view it was opened from.
-    pub(super) fn key_doc_filter(&mut self, key: KeyEvent) {
-        if edit_chord(&key, self.doc_filter_mut()) {
+    pub(super) fn key_doc_filter(&mut self, key: KeyInput) {
+        if edit_action(key.action, self.doc_filter_mut()) {
             return;
         }
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 self.doc_filter_mut().clear();
                 self.mode = self.doc_filter_return;
             }
-            KeyCode::Enter => {
+            (Some(Action::Accept), _) => {
                 // Finalize: on a document view, jump to the first match so the
                 // hit is on screen; help filters in place and needs no jump.
                 if self.doc_filter_return != Mode::Help {
@@ -1301,10 +1342,10 @@ impl App {
                 }
                 self.mode = self.doc_filter_return;
             }
-            KeyCode::Backspace => {
+            (Some(Action::Backspace), _) => {
                 self.doc_filter_mut().pop();
             }
-            KeyCode::Char(c) => {
+            (None, KeyCode::Char(c)) => {
                 self.doc_filter_mut().push(c);
             }
             _ => {}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -161,30 +161,43 @@ impl App {
     }
 
     pub fn configure_keys(&mut self, cfg: &crate::config::KeysConfig) -> Vec<String> {
-        let mut warnings = match Keymap::compile(cfg) {
+        let paths = self
+            .config
+            .base_path()
+            .into_iter()
+            .chain(
+                self.config
+                    .override_paths(&self.cluster.context, &self.cluster.cluster_name),
+            )
+            .filter(|p| p.exists())
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let warnings = match Keymap::compile(cfg) {
             Ok(map) => {
+                let warnings = map.warnings().to_vec();
                 self.keymap = map;
-                Vec::new()
+                warnings
             }
             Err(errors) => {
-                let paths = self
-                    .config
-                    .base_path()
-                    .into_iter()
-                    .chain(
-                        self.config
-                            .override_paths(&self.cluster.context, &self.cluster.cluster_name),
-                    )
-                    .filter(|p| p.exists())
-                    .map(|p| p.display().to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                errors
-                    .into_iter()
-                    .map(|e| format!("{paths}: {e}; previous keymap kept"))
-                    .collect()
+                let kept = if self.keymap.is_default() {
+                    "default keymap kept"
+                } else {
+                    "previous keymap kept"
+                };
+                errors.into_iter().map(|e| format!("{e}; {kept}")).collect()
             }
         };
+        let mut warnings: Vec<_> = warnings
+            .into_iter()
+            .map(|w| {
+                if paths.is_empty() {
+                    w
+                } else {
+                    format!("{paths}: {w}")
+                }
+            })
+            .collect();
         for (kind, name, binding, resources) in self
             .plugins
             .iter()

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1095,6 +1095,10 @@ impl App {
     }
 
     pub(super) fn key_logs(&mut self, key: KeyInput) {
+        if let Some(anchor) = key.action.and_then(Action::log_anchor) {
+            self.apply_log_anchor(anchor);
+            return;
+        }
         // Ctrl-S saves the buffer to a file (k9s).
         if key.action == Some(Action::Save) {
             self.save_logs();
@@ -1141,32 +1145,6 @@ impl App {
                 self.flash_err = false;
                 return;
             }
-            // k9s time anchors: `0` re-tails, `1`-`5` re-stream a window.
-            (Some(Action::Anchor0), _) => {
-                self.apply_log_anchor('0');
-                return;
-            }
-            (Some(Action::Anchor1), _) => {
-                self.apply_log_anchor('1');
-                return;
-            }
-            (Some(Action::Anchor2), _) => {
-                self.apply_log_anchor('2');
-                return;
-            }
-            (Some(Action::Anchor3), _) => {
-                self.apply_log_anchor('3');
-                return;
-            }
-            (Some(Action::Anchor4), _) => {
-                self.apply_log_anchor('4');
-                return;
-            }
-            (Some(Action::Anchor5), _) => {
-                self.apply_log_anchor('5');
-                return;
-            }
-
             // Provider logs: `T` changes the lookback period (re-queries).
             (Some(Action::Lookback), _) => {
                 if self.provider_logs_active() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use crate::keymap::{Action, KeyInput, Keymap};
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use futures_util::StreamExt;
@@ -1900,8 +1901,8 @@ pub struct App {
     pub forwards_cfg: Vec<crate::config::Forward>,
     /// `[notify]` delivery options (bell, desktop-notification protocol).
     pub notify_cfg: crate::config::NotifyConfig,
-    /// Compiled `[keys]` palette-completion bindings.
-    pub palette_keys: crate::config::PaletteKeys,
+    /// Effective bindings for all input modes.
+    pub keymap: Keymap,
 
     pub skin_list: Vec<String>,
     pub skin_state: ListState,
@@ -2206,7 +2207,7 @@ impl App {
             pf_picker_state: ListState::default(),
             pf_picker_target: None,
             notify_cfg: crate::config::NotifyConfig::default(),
-            palette_keys: crate::config::PaletteKeys::default(),
+            keymap: Keymap::default(),
             pf_state: ListState::default(),
             skin_list: crate::theme::BUILTIN_NAMES
                 .iter()

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -82,7 +82,15 @@ impl App {
     /// One wheel notch = three steps, like most list UIs.
     fn wheel(&mut self, code: KeyCode) -> Result<()> {
         for _ in 0..3 {
-            self.handle_key(KeyEvent::new(code, KeyModifiers::NONE))?;
+            let action = if code == KeyCode::Up {
+                Action::Up
+            } else {
+                Action::Down
+            };
+            self.handle_input(KeyInput::new(
+                Some(action),
+                KeyEvent::new(KeyCode::Null, KeyModifiers::NONE),
+            ))?;
         }
         Ok(())
     }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -82,13 +82,11 @@ impl App {
     /// One wheel notch = three steps, like most list UIs.
     fn wheel(&mut self, code: KeyCode) -> Result<()> {
         for _ in 0..3 {
-            let action = if code == KeyCode::Up {
-                Action::Up
-            } else {
-                Action::Down
-            };
+            let action = self
+                .keymap
+                .wheel_action(self.key_scope(), code == KeyCode::Down);
             self.handle_input(KeyInput::new(
-                Some(action),
+                action,
                 KeyEvent::new(KeyCode::Null, KeyModifiers::NONE),
             ))?;
         }

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -2,13 +2,13 @@ use super::actions::forward_target;
 use super::*;
 
 impl App {
-    pub(super) fn key_containers(&mut self, key: KeyEvent) {
+    pub(super) fn key_containers(&mut self, key: KeyInput) {
         let len = self.container_list.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.container_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.container_state, len, false),
-            KeyCode::Enter | KeyCode::Char('l') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.container_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.container_state, len, false),
+            (Some(Action::Logs), _) => {
                 if let Some(i) = self.container_state.selected()
                     && let Some(c) = self.container_list.get(i).cloned()
                     && let Some((ns, name)) = self.container_pod.clone()
@@ -24,7 +24,7 @@ impl App {
                     );
                 }
             }
-            KeyCode::Char('p') => {
+            (Some(Action::PreviousLogs), _) => {
                 if let Some(i) = self.container_state.selected()
                     && let Some(c) = self.container_list.get(i).cloned()
                     && let Some((ns, name)) = self.container_pod.clone()
@@ -40,7 +40,7 @@ impl App {
                     );
                 }
             }
-            KeyCode::Char('s') => {
+            (Some(Action::Shell), _) => {
                 if let Some(i) = self.container_state.selected()
                     && let Some(c) = self.container_list.get(i).cloned()
                     && let Some((ns, name)) = self.container_pod.clone()
@@ -48,7 +48,7 @@ impl App {
                     self.exec_into(ns, name, Some(c));
                 }
             }
-            KeyCode::Char('L') => {
+            (Some(Action::ProviderLogs), _) => {
                 if let Some(i) = self.container_state.selected()
                     && let Some(c) = self.container_list.get(i).cloned()
                     && let Some((ns, name)) = self.container_pod.clone()
@@ -57,7 +57,7 @@ impl App {
                 }
             }
             // Transfer files to/from this container (`kubectl cp -c`).
-            KeyCode::Char('t') => {
+            (Some(Action::Transfer), _) => {
                 if let Some(i) = self.container_state.selected()
                     && let Some(c) = self.container_list.get(i).cloned()
                     && let Some((ns, name)) = self.container_pod.clone()
@@ -68,7 +68,7 @@ impl App {
             // Debug an ephemeral container targeting this container's namespace
             // (`kubectl debug --target`). The picker's pod is the selected row,
             // so request_debug reads it back from the table selection.
-            KeyCode::Char('d') => {
+            (Some(Action::Debug), _) => {
                 if let Some(i) = self.container_state.selected()
                     && let Some(c) = self.container_list.get(i).cloned()
                 {
@@ -171,9 +171,9 @@ impl App {
         }
     }
 
-    pub(super) fn key_confirm(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+    pub(super) fn key_confirm(&mut self, key: KeyInput) {
+        match (key.action, key.code) {
+            (Some(Action::Accept), _) => {
                 let back = self.overlay_return();
                 if let Some(action) = self.confirm_action.take() {
                     self.run_confirm_action(action);
@@ -186,7 +186,7 @@ impl App {
                 }
                 self.confirm_return = Mode::Table;
             }
-            KeyCode::Char('f') | KeyCode::Char('F') => {
+            (Some(Action::Force), _) => {
                 let update = match self.confirm_action.as_mut() {
                     Some(ConfirmAction::Delete {
                         targets,
@@ -209,7 +209,7 @@ impl App {
                     );
                 }
             }
-            KeyCode::Char('c') | KeyCode::Char('C') => {
+            (Some(Action::Cascade), _) => {
                 let update = match self.confirm_action.as_mut() {
                     Some(ConfirmAction::Delete {
                         targets,
@@ -232,7 +232,7 @@ impl App {
                     );
                 }
             }
-            _ => {
+            (Some(Action::Back), _) => {
                 // A cancelled PVC shell leaves state (possibly a helper pod)
                 // that only the suspend-and-return path would have cleaned up.
                 let cancelled = self.confirm_action.take();
@@ -242,15 +242,16 @@ impl App {
                 self.mode = self.overlay_return();
                 self.confirm_return = Mode::Table;
             }
+            _ => {}
         }
     }
 
-    pub(super) fn key_prompt(&mut self, key: KeyEvent) {
-        if edit_chord(&key, &mut self.prompt_input) {
+    pub(super) fn key_prompt(&mut self, key: KeyInput) {
+        if edit_action(key.action, &mut self.prompt_input) {
             return;
         }
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 // Most prompts start at (and return to) the table; the
                 // lookback and rename-context prompts return to the view
                 // they were opened from.
@@ -273,7 +274,7 @@ impl App {
                 }
                 self.confirm_return = Mode::Table;
             }
-            KeyCode::Enter => {
+            (Some(Action::Accept), _) => {
                 let input = self.prompt_input.trim().to_string();
                 self.mode = if self.prompt_over_logs() {
                     Mode::Logs
@@ -392,10 +393,10 @@ impl App {
                 // has nothing to do with it.
                 self.confirm_return = Mode::Table;
             }
-            KeyCode::Backspace => {
+            (Some(Action::Backspace), _) => {
                 self.prompt_input.pop();
             }
-            KeyCode::Char(c) => self.prompt_input.push(c),
+            (None, KeyCode::Char(c)) => self.prompt_input.push(c),
             _ => {}
         }
     }
@@ -403,13 +404,13 @@ impl App {
     /// Port-forward picker (`f` on a pod/service): single-select over the
     /// object's declared ports, plus a "Custom…" entry that falls through to
     /// the typed prompt.
-    pub(super) fn key_port_forward_picker(&mut self, key: KeyEvent) {
+    pub(super) fn key_port_forward_picker(&mut self, key: KeyInput) {
         let len = self.pf_picker_items.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.pf_picker_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.pf_picker_state, len, false),
-            KeyCode::Enter => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.pf_picker_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.pf_picker_state, len, false),
+            (Some(Action::Accept), _) => {
                 let Some(i) = self.pf_picker_state.selected() else {
                     return;
                 };

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -249,14 +249,14 @@ impl App {
         value
     }
 
-    pub(super) fn key_sort_picker(&mut self, key: KeyEvent) {
-        if edit_chord(&key, &mut self.sort_picker_filter) {
+    pub(super) fn key_sort_picker(&mut self, key: KeyInput) {
+        if edit_action(key.action, &mut self.sort_picker_filter) {
             self.select_best_sort_match();
             return;
         }
         let len = self.filtered_sort_entries().len();
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 // First esc clears the filter, second closes the picker.
                 if self.sort_picker_filter.is_empty() {
                     self.mode = Mode::Table;
@@ -265,15 +265,9 @@ impl App {
                     self.select_best_sort_match();
                 }
             }
-            KeyCode::Down => list_step(&mut self.sort_picker_state, len, true),
-            KeyCode::Up => list_step(&mut self.sort_picker_state, len, false),
-            KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
-                list_step(&mut self.sort_picker_state, len, true)
-            }
-            KeyCode::Char('p') if key.modifiers == KeyModifiers::CONTROL => {
-                list_step(&mut self.sort_picker_state, len, false)
-            }
-            KeyCode::Enter => {
+            (Some(Action::Down), _) => list_step(&mut self.sort_picker_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.sort_picker_state, len, false),
+            (Some(Action::Accept), _) => {
                 if let Some(entry) = self
                     .sort_picker_state
                     .selected()
@@ -282,11 +276,11 @@ impl App {
                     self.apply_sort_choice(&entry);
                 }
             }
-            KeyCode::Backspace => {
+            (Some(Action::Backspace), _) => {
                 self.sort_picker_filter.pop();
                 self.select_best_sort_match();
             }
-            KeyCode::Char(c) => {
+            (None, KeyCode::Char(c)) => {
                 self.sort_picker_filter.push(c);
                 self.select_best_sort_match();
             }
@@ -392,14 +386,14 @@ impl App {
         value
     }
 
-    pub(super) fn key_copy_picker(&mut self, key: KeyEvent) {
-        if edit_chord(&key, &mut self.copy_picker_filter) {
+    pub(super) fn key_copy_picker(&mut self, key: KeyInput) {
+        if edit_action(key.action, &mut self.copy_picker_filter) {
             self.select_best_copy_match();
             return;
         }
         let len = self.filtered_copy_entries().len();
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 // First esc clears the filter, second closes the picker.
                 if self.copy_picker_filter.is_empty() {
                     self.mode = Mode::Table;
@@ -408,15 +402,9 @@ impl App {
                     self.select_best_copy_match();
                 }
             }
-            KeyCode::Down => list_step(&mut self.copy_picker_state, len, true),
-            KeyCode::Up => list_step(&mut self.copy_picker_state, len, false),
-            KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
-                list_step(&mut self.copy_picker_state, len, true)
-            }
-            KeyCode::Char('p') if key.modifiers == KeyModifiers::CONTROL => {
-                list_step(&mut self.copy_picker_state, len, false)
-            }
-            KeyCode::Enter => {
+            (Some(Action::Down), _) => list_step(&mut self.copy_picker_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.copy_picker_state, len, false),
+            (Some(Action::Accept), _) => {
                 if let Some((header, value)) = self
                     .copy_picker_state
                     .selected()
@@ -425,11 +413,11 @@ impl App {
                     self.copy_field(&header, value);
                 }
             }
-            KeyCode::Backspace => {
+            (Some(Action::Backspace), _) => {
                 self.copy_picker_filter.pop();
                 self.select_best_copy_match();
             }
-            KeyCode::Char(c) => {
+            (None, KeyCode::Char(c)) => {
                 self.copy_picker_filter.push(c);
                 self.select_best_copy_match();
             }
@@ -460,14 +448,14 @@ impl App {
         );
     }
 
-    pub(super) fn key_namespaces(&mut self, key: KeyEvent) {
-        if edit_chord(&key, &mut self.ns_filter) {
+    pub(super) fn key_namespaces(&mut self, key: KeyInput) {
+        if edit_action(key.action, &mut self.ns_filter) {
             self.select_best_namespace_match();
             return;
         }
         let len = self.filtered_namespaces().len();
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 // First esc clears the filter and jumps back to the top
                 // (`<all>`); a second esc closes the switcher.
                 if self.ns_filter.is_empty() {
@@ -477,9 +465,9 @@ impl App {
                     self.ns_state.select(Some(0));
                 }
             }
-            KeyCode::Down => list_step(&mut self.ns_state, len, true),
-            KeyCode::Up => list_step(&mut self.ns_state, len, false),
-            KeyCode::Enter => {
+            (Some(Action::Down), _) => list_step(&mut self.ns_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.ns_state, len, false),
+            (Some(Action::Accept), _) => {
                 let filtered = self.filtered_namespaces();
                 let has_real_match = filtered.iter().any(|n| n != "<all>");
                 let chosen = if !self.ns_filter.trim().is_empty() && !has_real_match {
@@ -495,11 +483,11 @@ impl App {
                     self.set_namespace(ns);
                 }
             }
-            KeyCode::Backspace => {
+            (Some(Action::Backspace), _) => {
                 self.ns_filter.pop();
                 self.select_best_namespace_match();
             }
-            KeyCode::Char(c) => {
+            (None, KeyCode::Char(c)) => {
                 self.ns_filter.push(c);
                 self.select_best_namespace_match();
             }
@@ -615,27 +603,27 @@ impl App {
     /// Contexts type-to-filter like the namespace picker. Existing action keys
     /// remain available while browsing; `/` explicitly starts filter input
     /// when a context name begins with one of those keys.
-    pub(super) fn key_contexts(&mut self, key: KeyEvent) {
+    pub(super) fn key_contexts(&mut self, key: KeyInput) {
         let len = self.filtered_contexts().len();
         if self.ctx_filtering {
-            if edit_chord(&key, &mut self.ctx_filter) {
+            if edit_action(key.action, &mut self.ctx_filter) {
                 self.select_best_context_match();
                 return;
             }
-            match key.code {
-                KeyCode::Esc => {
+            match (key.action, key.code) {
+                (Some(Action::Back), _) => {
                     self.ctx_filter.clear();
                     self.ctx_filtering = false;
                     self.select_current_context();
                 }
-                KeyCode::Enter => self.switch_selected_context(),
-                KeyCode::Down => list_step(&mut self.ctx_state, len, true),
-                KeyCode::Up => list_step(&mut self.ctx_state, len, false),
-                KeyCode::Backspace => {
+                (Some(Action::Accept), _) => self.switch_selected_context(),
+                (Some(Action::Down), _) => list_step(&mut self.ctx_state, len, true),
+                (Some(Action::Up), _) => list_step(&mut self.ctx_state, len, false),
+                (Some(Action::Backspace), _) => {
                     self.ctx_filter.pop();
                     self.select_best_context_match();
                 }
-                KeyCode::Char(c) => {
+                (None, KeyCode::Char(c)) => {
                     self.ctx_filter.push(c);
                     self.select_best_context_match();
                 }
@@ -643,8 +631,8 @@ impl App {
             }
             return;
         }
-        match key.code {
-            KeyCode::Esc => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) => {
                 if self.ctx_filter.is_empty() {
                     self.mode = Mode::Table;
                 } else {
@@ -652,11 +640,11 @@ impl App {
                     self.select_current_context();
                 }
             }
-            KeyCode::Char('/') => self.ctx_filtering = true,
-            KeyCode::Char('r') | KeyCode::Char('R') => self.open_rename_context(),
+            (Some(Action::Filter), _) => self.ctx_filtering = true,
+            (Some(Action::Rename), _) => self.open_rename_context(),
             // Space toggles the highlighted context in/out of the `:fleet`
             // dashboard for this session (the bulk-mark idiom).
-            KeyCode::Char(' ') => {
+            (Some(Action::FleetMark), _) => {
                 if let Some(name) = self
                     .ctx_state
                     .selected()
@@ -665,10 +653,10 @@ impl App {
                     self.toggle_fleet_context(&name);
                 }
             }
-            KeyCode::Down | KeyCode::Char('j') => list_step(&mut self.ctx_state, len, true),
-            KeyCode::Up | KeyCode::Char('k') => list_step(&mut self.ctx_state, len, false),
-            KeyCode::Enter => self.switch_selected_context(),
-            KeyCode::Char(c) => {
+            (Some(Action::Down), _) => list_step(&mut self.ctx_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.ctx_state, len, false),
+            (Some(Action::Accept), _) => self.switch_selected_context(),
+            (None, KeyCode::Char(c)) => {
                 self.ctx_filtering = true;
                 self.ctx_filter.push(c);
                 self.select_best_context_match();
@@ -848,10 +836,7 @@ impl App {
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         plugin_warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
         plugin_warnings.extend(crate::config::pvc_explore_warnings(&self.pvc_cfg));
-        let (palette_keys, key_warnings) =
-            crate::config::compile_palette_keys(&resolved.config.keys);
-        self.palette_keys = palette_keys;
-        plugin_warnings.extend(key_warnings);
+        plugin_warnings.extend(self.configure_keys(&resolved.config.keys));
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -836,7 +836,6 @@ impl App {
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         plugin_warnings.extend(crate::config::guardrail_warnings(&self.guardrails));
         plugin_warnings.extend(crate::config::pvc_explore_warnings(&self.pvc_cfg));
-        plugin_warnings.extend(self.configure_keys(&resolved.config.keys));
         let (views, view_warnings) = crate::views::compile(&resolved.config.views);
         self.user_views = views;
         let (thresholds, threshold_warnings) =
@@ -865,6 +864,7 @@ impl App {
             .or(resolved.config.default_namespace)
             .unwrap_or_else(|| cluster.default_namespace.clone());
         self.cluster = *cluster;
+        plugin_warnings.extend(self.configure_keys(&resolved.config.keys));
         self.stack.clear();
         // View history references the old cluster's kinds and namespaces.
         self.history.clear();

--- a/src/app/pvcexplore.rs
+++ b/src/app/pvcexplore.rs
@@ -1042,21 +1042,21 @@ impl App {
 
     // ----- input ---------------------------------------------------------
 
-    pub(super) fn key_pvc_explore(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.close_pvc_explore(),
-            KeyCode::Tab | KeyCode::BackTab => self.pvc.focus = self.other_pane(),
-            KeyCode::Left => self.pvc.focus = Pane::Local,
-            KeyCode::Right => self.pvc.focus = Pane::Remote,
-            KeyCode::Char('j') | KeyCode::Down => self.step_pane(true),
-            KeyCode::Char('k') | KeyCode::Up => self.step_pane(false),
-            KeyCode::Char('g') | KeyCode::Home => self.jump_pane(true),
-            KeyCode::Char('G') | KeyCode::End => self.jump_pane(false),
-            KeyCode::Enter => self.descend_pane(),
-            KeyCode::Backspace | KeyCode::Char('-') => self.ascend_pane(),
-            KeyCode::Char('c') => self.copy_across(),
-            KeyCode::Char('r') => self.refresh_pvc_panes(),
-            KeyCode::Char('s') => self.pvc_shell_here(),
+    pub(super) fn key_pvc_explore(&mut self, key: KeyInput) {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.close_pvc_explore(),
+            (Some(Action::SwitchPane), _) => self.pvc.focus = self.other_pane(),
+            (Some(Action::Left), _) => self.pvc.focus = Pane::Local,
+            (Some(Action::Right), _) => self.pvc.focus = Pane::Remote,
+            (Some(Action::Down), _) => self.step_pane(true),
+            (Some(Action::Up), _) => self.step_pane(false),
+            (Some(Action::First), _) => self.jump_pane(true),
+            (Some(Action::Last), _) => self.jump_pane(false),
+            (Some(Action::Accept), _) => self.descend_pane(),
+            (Some(Action::Parent), _) => self.ascend_pane(),
+            (Some(Action::Copy), _) => self.copy_across(),
+            (Some(Action::Refresh), _) => self.refresh_pvc_panes(),
+            (Some(Action::Shell), _) => self.pvc_shell_here(),
             _ => {}
         }
     }

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -128,14 +128,14 @@ impl App {
             .collect();
     }
 
-    pub(super) fn key_snapshots(&mut self, key: KeyEvent) {
+    pub(super) fn key_snapshots(&mut self, key: KeyInput) {
         let len = self.snapshot_list.len();
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => self.mode = Mode::Table,
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.snapshot_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.snapshot_state, len, false),
-            KeyCode::Enter => self.open_selected_snapshot(),
-            KeyCode::Char('d') => self.delete_selected_snapshot(),
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
+            (Some(Action::Down), _) => list_step(&mut self.snapshot_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.snapshot_state, len, false),
+            (Some(Action::Accept), _) => self.open_selected_snapshot(),
+            (Some(Action::Delete), _) => self.delete_selected_snapshot(),
             _ => {}
         }
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6494,9 +6494,9 @@ async fn palette_completion_accepts_minus_chords() {
     let (mut app, _rx) = test_app();
     let config: crate::config::Config = toml::from_str(
         r#"
-        [keys]
-        palette_next = "ctrl--"
-        palette_prev = "alt--"
+        [keys.command]
+        down = "ctrl--"
+        up = "alt--"
         "#,
     )
     .unwrap();
@@ -6520,14 +6520,13 @@ async fn palette_shifted_minus_uses_the_resulting_character() {
         let (mut app, _rx) = test_app();
         let config: crate::config::Config = toml::from_str(
             r#"
-            [keys]
-            palette_next = ["shift--", "_"]
+            [keys.command]
+            down = "_"
             "#,
         )
         .unwrap();
         let warnings = app.configure_keys(&config.keys);
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("bind the resulting character"));
+        assert!(warnings.is_empty(), "{warnings:?}");
 
         app.handle_key(press(KeyCode::Char(':'))).unwrap();
         app.handle_key(press(KeyCode::Char('-'))).unwrap();
@@ -6548,10 +6547,10 @@ async fn palette_completion_keys_are_rebindable() {
     let (mut app, _rx) = test_app();
     let keys_cfg: crate::config::Config = toml::from_str(
         r#"
-        [keys]
-        palette_next = "ctrl-n"
-        palette_prev = "ctrl-p"
-        palette_accept = ["ctrl-y", "enter"]
+        [keys.command]
+        down = "ctrl-n"
+        up = "ctrl-p"
+        accept = ["ctrl-y", "enter"]
     "#,
     )
     .unwrap();
@@ -21669,61 +21668,152 @@ async fn explicit_shifted_navigation_bindings_remain_distinct() {
 }
 
 #[tokio::test]
-async fn legacy_palette_errors_keep_valid_chords_and_scoped_overrides() {
-    for spec in ["['shift--', '_']", "['ctrl-c', '_']", "['_', 5]"] {
-        let (mut app, _rx) = key_action_fixture("table");
-        let cfg: crate::config::Config = toml::from_str(&format!(
-            "[keys]\npalette_next = {spec}\n[keys.table]\npage_down = 'f8'"
-        ))
-        .unwrap();
-        let warnings = app.configure_keys(&cfg.keys);
-        assert!(!warnings.is_empty(), "{spec}");
-        assert!(warnings[0].contains("keys.palette_next"), "{warnings:?}");
-        app.handle_key(press(KeyCode::F(8))).unwrap();
-        assert_eq!(app.table_state.selected(), Some(7), "{spec}");
-        app.handle_key(press(KeyCode::Char(':'))).unwrap();
-        assert!(app.cmd_suggestions.len() > 1);
-        app.handle_key(press(KeyCode::Char('_'))).unwrap();
-        assert_eq!(app.cmd_sel, 1, "{spec}");
-        assert!(app.command.is_empty());
-        app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
-        assert!(app.should_quit);
-    }
-    for spec in ["[]", "['shift--', 'ctrl-c']", "5"] {
-        let (mut app, _rx) = test_app();
-        let cfg: crate::config::Config =
-            toml::from_str(&format!("[keys]\npalette_next = {spec}")).unwrap();
-        let warnings = app.configure_keys(&cfg.keys);
-        assert!(
-            warnings.iter().any(|w| w.contains("using default")),
-            "{warnings:?}"
-        );
-        app.handle_key(press(KeyCode::Char(':'))).unwrap();
-        app.handle_key(press(KeyCode::Tab)).unwrap();
-        assert_eq!(app.cmd_sel, 1, "{spec}");
-    }
-}
-
-#[tokio::test]
-async fn legacy_palette_overlaps_keep_the_original_priority() {
-    let (mut app, _rx) = test_app();
-    let cfg: crate::config::Config =
-        toml::from_str("[keys]\npalette_next = 'enter'\npalette_prev = 'enter'").unwrap();
-    let warnings = app.configure_keys(&cfg.keys);
-    assert!(
-        warnings
-            .iter()
-            .any(|w| w.contains("handled by palette_next")),
-        "{warnings:?}"
+async fn palette_config_reload_migrates_with_a_backup() {
+    let dir = std::env::temp_dir().join(format!("sofka-palette-migrate-{}", std::process::id()));
+    let original = "# Keep this comment\nhide_header = true\n[keys]\n# Next suggestion\npalette_next = 'ctrl-n' # next\npalette_prev = 'ctrl-p'\npalette_accept = ['ctrl-y', 'enter']\n[keys.table]\npage_down = 'f8'\n";
+    write_config(&dir, original);
+    let (mut app, _rx) = key_action_fixture("table");
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "reload");
+    assert!(app.hide_header);
+    let updated = std::fs::read_to_string(dir.join("config.toml")).unwrap();
+    assert!(updated.contains("# Keep this comment"));
+    assert!(updated.contains("# Next suggestion"));
+    assert!(updated.contains("# next"));
+    assert!(!updated.contains("palette_next"));
+    assert!(updated.contains("[keys.command]"));
+    assert_eq!(
+        std::fs::read_to_string(dir.join("config.toml.bak")).unwrap(),
+        original
     );
+    assert!(app.config_warnings.iter().any(|w| w.contains("backup:")));
+    app.handle_key(press(KeyCode::F(8))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(7));
     app.handle_key(press(KeyCode::Char(':'))).unwrap();
-    app.handle_key(press(KeyCode::Enter)).unwrap();
-    assert_eq!(app.mode, Mode::Command);
+    app.handle_key(ctrl(KeyCode::Char('n'))).unwrap();
     assert_eq!(app.cmd_sel, 1);
+    app.handle_key(ctrl(KeyCode::Char('p'))).unwrap();
+    assert_eq!(app.cmd_sel, 0);
+    for c in "services".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(ctrl(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.kind_plural, "services");
+    palette(&mut app, "reload");
+    assert!(app.config_warnings.is_empty(), "{:?}", app.config_warnings);
+    assert_eq!(
+        std::fs::read_to_string(dir.join("config.toml")).unwrap(),
+        updated
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("config.toml.bak")).unwrap(),
+        original
+    );
+    std::fs::remove_dir_all(dir).unwrap();
 }
 
 #[tokio::test]
-async fn legacy_and_scoped_palette_bindings_have_the_same_effect() {
+async fn invalid_palette_migrations_warn_without_changing_the_file() {
+    let dir = std::env::temp_dir().join(format!("sofka-palette-invalid-{}", std::process::id()));
+    for settings in [
+        "palette_next = ['shift--', '_']",
+        "palette_next = ['ctrl-c', '_']",
+        "palette_next = ['_', 5]",
+        "palette_next = 5",
+        "palette_next = 'enter'\npalette_prev = 'enter'",
+        "palette_next = 'f7'\n[keys.command]\ndown = 'f8'",
+    ] {
+        let original = format!("hide_header = true\n[keys]\n{settings}\n");
+        write_config(&dir, &original);
+        let (mut app, _rx) = test_app();
+        app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+        palette(&mut app, "reload");
+        assert!(app.hide_header);
+        assert!(!app.config_warnings.is_empty(), "{settings}");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("config.toml")).unwrap(),
+            original
+        );
+        assert!(!dir.join("config.toml.bak").exists());
+        if settings.contains("[keys.command]") {
+            app.handle_key(press(KeyCode::Char(':'))).unwrap();
+            app.handle_key(press(KeyCode::F(8))).unwrap();
+            assert_eq!(app.cmd_sel, 1);
+            app.handle_key(press(KeyCode::F(7))).unwrap();
+            assert_eq!(app.cmd_sel, 1);
+        }
+    }
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[tokio::test]
+async fn empty_legacy_palette_binding_migrates_without_default_fallback() {
+    let dir = std::env::temp_dir().join(format!("sofka-palette-empty-{}", std::process::id()));
+    write_config(&dir, "[keys]\npalette_next = []");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "reload");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    assert_eq!(app.cmd_sel, 0);
+    assert!(app.keymap.chords("command", Action::Down).is_empty());
+    assert!(dir.join("config.toml.bak").exists());
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn managed_palette_config_warns_and_uses_migrated_bindings_in_memory() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    let dir = std::env::temp_dir().join(format!("sofka-palette-managed-{}", std::process::id()));
+    for linked in [false, true] {
+        let original = "[keys]\npalette_next = 'ctrl-n'";
+        write_config(&dir, original);
+        let path = dir.join("config.toml");
+        let source = dir.join("managed.toml");
+        if linked {
+            std::fs::rename(&path, &source).unwrap();
+            symlink(&source, &path).unwrap();
+        } else {
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444)).unwrap();
+        }
+        let (mut app, _rx) = test_app();
+        app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+        palette(&mut app, "reload");
+        let warnings = app.config_warnings.join("\n");
+        assert!(
+            warnings.contains("cannot save config migration"),
+            "{warnings}"
+        );
+        assert!(
+            warnings.contains("using migrated keys in memory"),
+            "{warnings}"
+        );
+        assert!(warnings.contains("Update [keys.command]"), "{warnings}");
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        app.handle_key(ctrl(KeyCode::Char('n'))).unwrap();
+        assert_eq!(app.cmd_sel, 1);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+        assert!(!dir.join("config.toml.bak").exists());
+        if linked {
+            assert!(
+                std::fs::symlink_metadata(&path)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink()
+            );
+        } else {
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn migrated_and_scoped_palette_bindings_have_the_same_effect() {
+    let dir = std::env::temp_dir().join(format!("sofka-palette-equivalent-{}", std::process::id()));
     for (legacy, action, binding, event) in [
         ("palette_next", "down", "ctrl-w", ctrl(KeyCode::Char('w'))),
         ("palette_accept", "accept", "esc", press(KeyCode::Esc)),
@@ -21736,7 +21826,11 @@ async fn legacy_and_scoped_palette_bindings_have_the_same_effect() {
     ] {
         let (mut old, _rx1) = test_app();
         let (mut new, _rx2) = test_app();
-        use_keys(&mut old, &format!("[keys]\n{legacy} = '{binding}'"));
+        write_config(&dir, &format!("[keys]\n{legacy} = '{binding}'"));
+        old.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+        palette(&mut old, "reload");
+        old.flash.clear();
+        new.flash.clear();
         use_keys(&mut new, &format!("[keys.command]\n{action} = '{binding}'"));
         for app in [&mut old, &mut new] {
             app.handle_key(press(KeyCode::Char(':'))).unwrap();
@@ -21752,7 +21846,47 @@ async fn legacy_and_scoped_palette_bindings_have_the_same_effect() {
         } else {
             assert_eq!(new.command, "services");
         }
+        std::fs::remove_dir_all(&dir).unwrap();
     }
+}
+
+#[tokio::test]
+async fn palette_migration_preserves_config_layer_precedence() {
+    let dir = std::env::temp_dir().join(format!("sofka-palette-layers-{}", std::process::id()));
+    write_config(&dir, "[keys]\npalette_next = 'f7'");
+    let cluster = dir.join("clusters/test-cluster");
+    write_config(&cluster, "[keys]\npalette_next = 'f8'");
+    let context = cluster.join("new");
+    write_config(
+        &context,
+        "[keys]\npalette_prev = 'f10'\n[keys.command]\ndown = 'f9'",
+    );
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "reload");
+    palette(&mut app, "ctx new");
+    land_context(&mut app, "new");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for key in [KeyCode::F(7), KeyCode::F(8)] {
+        app.handle_key(press(key)).unwrap();
+        assert_eq!(app.cmd_sel, 0);
+    }
+    app.handle_key(press(KeyCode::F(9))).unwrap();
+    assert_eq!(app.cmd_sel, 1);
+    app.handle_key(press(KeyCode::F(10))).unwrap();
+    assert_eq!(app.cmd_sel, 0);
+    for source in [&dir, &cluster, &context] {
+        assert!(source.join("config.toml.bak").exists());
+        let text = std::fs::read_to_string(source.join("config.toml")).unwrap();
+        assert!(!text.contains("palette_"), "{text}");
+    }
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    palette(&mut app, "ctx other");
+    land_context(&mut app, "other");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    app.handle_key(press(KeyCode::F(8))).unwrap();
+    assert_eq!(app.cmd_sel, 1);
+    std::fs::remove_dir_all(dir).unwrap();
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6521,11 +6521,13 @@ async fn palette_shifted_minus_uses_the_resulting_character() {
         let config: crate::config::Config = toml::from_str(
             r#"
             [keys]
-            palette_next = "_"
+            palette_next = ["shift--", "_"]
             "#,
         )
         .unwrap();
-        app.keymap = Keymap::compile(&config.keys).unwrap();
+        let warnings = app.configure_keys(&config.keys);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("bind the resulting character"));
 
         app.handle_key(press(KeyCode::Char(':'))).unwrap();
         app.handle_key(press(KeyCode::Char('-'))).unwrap();
@@ -21591,4 +21593,319 @@ async fn key_warnings_report_hidden_bindings_without_blocking_released_keys() {
     assert!(app.configure_keys(&cfg.keys).is_empty());
     app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
     assert_eq!(app.kind_plural, "services");
+}
+
+#[tokio::test]
+async fn shifted_navigation_keeps_default_list_behavior() {
+    let defaults = Keymap::default();
+    let mut scopes = std::collections::BTreeSet::new();
+    for (scope, _, _) in defaults.entries() {
+        scopes.insert(scope);
+    }
+    for scope in scopes {
+        // Palette completion already used exact chord matching before this PR.
+        if scope == "command" {
+            continue;
+        }
+        for code in [
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::PageUp,
+            KeyCode::PageDown,
+            KeyCode::Home,
+            KeyCode::End,
+        ] {
+            if defaults.action(scope, &press(code)).is_none() {
+                continue;
+            }
+            let (mut plain, _rx1) = key_action_fixture(scope);
+            let (mut shifted, _rx2) = key_action_fixture(scope);
+            plain.handle_key(press(code)).unwrap();
+            shifted
+                .handle_key(KeyEvent::new(code, KeyModifiers::SHIFT))
+                .unwrap();
+            assert_eq!(
+                key_action_state(&plain),
+                key_action_state(&shifted),
+                "{scope}: {code:?}"
+            );
+        }
+    }
+    let (mut app, _rx) = key_action_fixture("table");
+    for (code, row) in [
+        (KeyCode::Down, 5),
+        (KeyCode::Up, 4),
+        (KeyCode::PageDown, 7),
+        (KeyCode::PageUp, 4),
+        (KeyCode::Home, 0),
+        (KeyCode::End, 11),
+    ] {
+        app.handle_key(KeyEvent::new(code, KeyModifiers::SHIFT))
+            .unwrap();
+        assert_eq!(app.table_state.selected(), Some(row), "{code:?}");
+    }
+}
+
+#[tokio::test]
+async fn explicit_shifted_navigation_bindings_remain_distinct() {
+    let (mut app, _rx) = key_action_fixture("table");
+    use_keys(
+        &mut app,
+        "[keys.table]\ndown = 'down'\nup = ['up', 'shift-down']",
+    );
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    assert_eq!(app.table_state.selected(), Some(5));
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::SHIFT))
+        .unwrap();
+    assert_eq!(app.table_state.selected(), Some(4));
+    use_keys(&mut app, "[keys.table]\ndown = ['down', 'shift-down']");
+    for modifiers in [KeyModifiers::NONE, KeyModifiers::SHIFT] {
+        app.handle_key(KeyEvent::new(KeyCode::Down, modifiers))
+            .unwrap();
+    }
+    assert_eq!(app.table_state.selected(), Some(6));
+}
+
+#[tokio::test]
+async fn legacy_palette_errors_keep_valid_chords_and_scoped_overrides() {
+    for spec in ["['shift--', '_']", "['ctrl-c', '_']", "['_', 5]"] {
+        let (mut app, _rx) = key_action_fixture("table");
+        let cfg: crate::config::Config = toml::from_str(&format!(
+            "[keys]\npalette_next = {spec}\n[keys.table]\npage_down = 'f8'"
+        ))
+        .unwrap();
+        let warnings = app.configure_keys(&cfg.keys);
+        assert!(!warnings.is_empty(), "{spec}");
+        assert!(warnings[0].contains("keys.palette_next"), "{warnings:?}");
+        app.handle_key(press(KeyCode::F(8))).unwrap();
+        assert_eq!(app.table_state.selected(), Some(7), "{spec}");
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        assert!(app.cmd_suggestions.len() > 1);
+        app.handle_key(press(KeyCode::Char('_'))).unwrap();
+        assert_eq!(app.cmd_sel, 1, "{spec}");
+        assert!(app.command.is_empty());
+        app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
+        assert!(app.should_quit);
+    }
+    for spec in ["[]", "['shift--', 'ctrl-c']", "5"] {
+        let (mut app, _rx) = test_app();
+        let cfg: crate::config::Config =
+            toml::from_str(&format!("[keys]\npalette_next = {spec}")).unwrap();
+        let warnings = app.configure_keys(&cfg.keys);
+        assert!(
+            warnings.iter().any(|w| w.contains("using default")),
+            "{warnings:?}"
+        );
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        app.handle_key(press(KeyCode::Tab)).unwrap();
+        assert_eq!(app.cmd_sel, 1, "{spec}");
+    }
+}
+
+#[tokio::test]
+async fn legacy_palette_overlaps_keep_the_original_priority() {
+    let (mut app, _rx) = test_app();
+    let cfg: crate::config::Config =
+        toml::from_str("[keys]\npalette_next = 'enter'\npalette_prev = 'enter'").unwrap();
+    let warnings = app.configure_keys(&cfg.keys);
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("handled by palette_next")),
+        "{warnings:?}"
+    );
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Command);
+    assert_eq!(app.cmd_sel, 1);
+}
+
+#[tokio::test]
+async fn legacy_and_scoped_palette_bindings_have_the_same_effect() {
+    for (legacy, action, binding, event) in [
+        ("palette_next", "down", "ctrl-w", ctrl(KeyCode::Char('w'))),
+        ("palette_accept", "accept", "esc", press(KeyCode::Esc)),
+        (
+            "palette_accept",
+            "accept",
+            "backspace",
+            press(KeyCode::Backspace),
+        ),
+    ] {
+        let (mut old, _rx1) = test_app();
+        let (mut new, _rx2) = test_app();
+        use_keys(&mut old, &format!("[keys]\n{legacy} = '{binding}'"));
+        use_keys(&mut new, &format!("[keys.command]\n{action} = '{binding}'"));
+        for app in [&mut old, &mut new] {
+            app.handle_key(press(KeyCode::Char(':'))).unwrap();
+            for c in "services".chars() {
+                app.handle_key(press(KeyCode::Char(c))).unwrap();
+            }
+            app.handle_key(event).unwrap();
+        }
+        assert_eq!(key_action_state(&old), key_action_state(&new), "{legacy}");
+        if action == "accept" {
+            assert_eq!(new.mode, Mode::Table);
+            assert_eq!(new.kind_plural, "services");
+        } else {
+            assert_eq!(new.command, "services");
+        }
+    }
+}
+
+#[tokio::test]
+async fn wheel_and_keyboard_arrows_cancel_default_confirmations() {
+    use crossterm::event::{MouseEvent, MouseEventKind};
+    for (code, kind) in [
+        (KeyCode::Up, MouseEventKind::ScrollUp),
+        (KeyCode::Down, MouseEventKind::ScrollDown),
+    ] {
+        for settings in [
+            "",
+            "[keys.navigation]\nback = ['esc', 'ctrl-g']",
+            "[keys.confirm]\nback = []",
+        ] {
+            let (mut keyboard, _rx1) = key_action_fixture("table");
+            let (mut wheel, _rx2) = key_action_fixture("table");
+            for app in [&mut keyboard, &mut wheel] {
+                app.readonly = false;
+                use_keys(app, settings);
+                app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+                assert_eq!(app.mode, Mode::Confirm);
+            }
+            for _ in 0..3 {
+                keyboard.handle_key(press(code)).unwrap();
+            }
+            wheel
+                .handle_mouse(MouseEvent {
+                    kind,
+                    column: 0,
+                    row: 0,
+                    modifiers: KeyModifiers::NONE,
+                })
+                .unwrap();
+            assert_eq!(
+                key_action_state(&keyboard),
+                key_action_state(&wheel),
+                "{settings}: {code:?}"
+            );
+            assert_eq!(
+                wheel.mode,
+                if settings.contains("back = []") {
+                    Mode::Confirm
+                } else {
+                    Mode::Table
+                }
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn shared_navigation_back_keeps_confirmation_cancel_keys() {
+    let (mut app, _rx) = key_action_fixture("table");
+    app.readonly = false;
+    use_keys(&mut app, "[keys.navigation]\nback = ['esc', 'ctrl-g']");
+    for event in [
+        press(KeyCode::Char('n')),
+        press(KeyCode::Char('q')),
+        ctrl(KeyCode::Char('g')),
+    ] {
+        app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+        assert_eq!(app.mode, Mode::Confirm);
+        app.handle_key(event).unwrap();
+        assert_eq!(app.mode, Mode::Table);
+        assert!(app.confirm_action.is_none());
+    }
+}
+
+#[tokio::test]
+async fn malformed_key_settings_do_not_discard_other_configuration() {
+    let dir = std::env::temp_dir().join(format!("sofka-key-shapes-{}", std::process::id()));
+    let other_settings = r#"
+hide_header = true
+[skin]
+name = "catppuccin-mocha"
+[[bookmarks]]
+name = "services"
+key = "alt-b"
+resource = "services"
+[[plugins]]
+name = "example"
+key = "alt-p"
+command = "true"
+mutating = false
+[views.pods]
+columns = [{ name = "NAME", path = "/metadata/name" }]
+"#;
+    for bad in [
+        "[keys]\npalette_nxt = 'ctrl-n'",
+        "[keys.table]\ndelete = 5",
+        "[keys.table]\ndelete = ['alt-d', 5]",
+        "[keys]\ntable = 5",
+    ] {
+        write_config(&dir, &format!("{other_settings}\n{bad}"));
+        let (mut app, _rx) = test_app();
+        app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+        palette(&mut app, "reload");
+        palette(&mut app, "ctx new");
+        land_context(&mut app, "new");
+        assert!(app.hide_header, "{bad}");
+        assert!(app.plugins.iter().any(|p| p.name == "example"), "{bad}");
+        assert!(app.user_views.contains_key("pods"), "{bad}");
+        assert_eq!(app.active_skin.as_deref(), Some("catppuccin-mocha"));
+        assert!(app.keymap.is_default(), "{bad}");
+        let warnings = app.config_warnings.join("\n");
+        assert!(warnings.contains("keys."), "{warnings}");
+        assert!(warnings.contains("default keymap kept"), "{warnings}");
+        app.handle_key(alt(KeyCode::Char('b'))).unwrap();
+        assert_eq!(app.kind_plural, "services");
+    }
+    // A later key shape error retains the existing keymap but applies other settings.
+    write_config(&dir, "[keys.table]\npage_down = 'f8'");
+    let (mut app, _rx) = key_action_fixture("table");
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "reload");
+    write_config(&dir, "hide_header = true\n[keys.table]\ndelete = 5");
+    palette(&mut app, "reload");
+    assert!(app.hide_header);
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::F(8))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(3));
+    assert!(
+        app.config_warnings
+            .iter()
+            .any(|w| w.contains("previous keymap kept"))
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[tokio::test]
+async fn context_key_errors_name_the_destination_config() {
+    let dir = std::env::temp_dir().join(format!("sofka-key-paths-{}", std::process::id()));
+    write_config(&dir, "");
+    write_config(
+        &dir.join("clusters/test-cluster/old"),
+        "[keys.table]\npage_down = 'f8'",
+    );
+    write_config(
+        &dir.join("clusters/test-cluster/new"),
+        "[keys.table]\ndelete = 5",
+    );
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "ctx old");
+    land_context(&mut app, "old");
+    assert_eq!(app.keymap.label("table", Action::PageDown), "f8");
+    palette(&mut app, "ctx new");
+    land_context(&mut app, "new");
+    let warnings = app.config_warnings.join("\n");
+    assert!(warnings.contains("new/config.toml"), "{warnings}");
+    assert!(!warnings.contains("old/config.toml"), "{warnings}");
+    assert!(warnings.contains("keys.table.delete"), "{warnings}");
+    assert!(warnings.contains("previous keymap kept"), "{warnings}");
+    assert_eq!(app.keymap.label("table", Action::PageDown), "f8");
+    std::fs::remove_dir_all(dir).unwrap();
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1810,7 +1810,7 @@ async fn saved_forwards_show_as_stopped_until_running() {
     // the entry reappears in the stopped tail.
     app.open_port_forwards();
     assert_eq!(app.pf_state.selected(), Some(0));
-    app.key_port_forwards(press(KeyCode::Char('x')));
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
     assert!(app.port_forwards.is_empty());
     assert_eq!(app.stopped_configured_forwards().len(), 2);
     assert_eq!(app.pf_state.selected(), Some(0), "clamped to combined list");
@@ -3204,7 +3204,7 @@ async fn find_opens_picker_and_enter_navigates_to_the_object() {
     assert_eq!(app.find_state.selected(), Some(0));
     assert!(app.flash.contains("2 hit(s)"), "{}", app.flash);
 
-    app.key_find(press(KeyCode::Enter));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Table);
     assert_eq!(app.kind_plural, "pods");
     assert_eq!(app.fields.as_deref(), Some("metadata.name=web-1"));
@@ -6411,12 +6411,12 @@ async fn namespace_picker_edit_chords() {
 #[test]
 fn edit_chord_leaves_plain_keys_alone() {
     let mut buf = "abc".to_string();
-    assert!(!edit_chord(&press(KeyCode::Char('u')), &mut buf));
-    assert!(!edit_chord(&press(KeyCode::Backspace), &mut buf));
+    assert!(!edit_action(None, &mut buf));
+    assert!(!edit_action(Some(Action::Backspace), &mut buf));
     assert_eq!(buf, "abc");
     // Word rubout trims trailing spaces before the word, readline-style.
     let mut buf = "one two   ".to_string();
-    assert!(edit_chord(&alt(KeyCode::Backspace), &mut buf));
+    assert!(edit_action(Some(Action::DeleteWord), &mut buf));
     assert_eq!(buf, "one ");
 }
 
@@ -6470,9 +6470,9 @@ async fn crd_plural_outranks_builtin_command() {
     // collides with the `:snapshots` built-in — the CRD must win.
     app.mode = Mode::Command;
     for c in "snapshots".chars() {
-        app.key_command(press(KeyCode::Char(c)));
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
-    app.key_command(press(KeyCode::Enter));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Table);
     assert!(
         app.flash.contains("snapshots.kopiur.home-operations.com"),
@@ -6483,9 +6483,9 @@ async fn crd_plural_outranks_builtin_command() {
     // `:kind namespace` still works for the shadowed plural.
     app.mode = Mode::Command;
     for c in "snapshots media".chars() {
-        app.key_command(press(KeyCode::Char(c)));
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
-    app.key_command(press(KeyCode::Enter));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.namespace, "media");
 }
 
@@ -6500,9 +6500,7 @@ async fn palette_completion_accepts_minus_chords() {
         "#,
     )
     .unwrap();
-    let (palette_keys, warnings) = crate::config::compile_palette_keys(&config.keys);
-    assert!(warnings.is_empty(), "{warnings:?}");
-    app.palette_keys = palette_keys;
+    app.keymap = Keymap::compile(&config.keys).unwrap();
 
     app.handle_key(press(KeyCode::Char(':'))).unwrap();
     assert_eq!(app.mode, Mode::Command);
@@ -6523,14 +6521,11 @@ async fn palette_shifted_minus_uses_the_resulting_character() {
         let config: crate::config::Config = toml::from_str(
             r#"
             [keys]
-            palette_next = ["shift--", "_"]
+            palette_next = "_"
             "#,
         )
         .unwrap();
-        let (palette_keys, warnings) = crate::config::compile_palette_keys(&config.keys);
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("bind the resulting character"));
-        app.palette_keys = palette_keys;
+        app.keymap = Keymap::compile(&config.keys).unwrap();
 
         app.handle_key(press(KeyCode::Char(':'))).unwrap();
         app.handle_key(press(KeyCode::Char('-'))).unwrap();
@@ -6558,9 +6553,7 @@ async fn palette_completion_keys_are_rebindable() {
     "#,
     )
     .unwrap();
-    let (palette_keys, warnings) = crate::config::compile_palette_keys(&keys_cfg.keys);
-    assert!(warnings.is_empty(), "{warnings:?}");
-    app.palette_keys = palette_keys;
+    app.keymap = Keymap::compile(&keys_cfg.keys).unwrap();
 
     app.mode = Mode::Command;
     app.update_suggestions();
@@ -6568,28 +6561,28 @@ async fn palette_completion_keys_are_rebindable() {
     assert_eq!(app.cmd_sel, 0);
 
     // ctrl-n / ctrl-p move the highlight; the overridden tab/arrows don't.
-    app.key_command(ctrl(KeyCode::Char('n')));
+    app.handle_key(ctrl(KeyCode::Char('n'))).unwrap();
     assert_eq!(app.cmd_sel, 1);
-    app.key_command(press(KeyCode::Tab));
-    app.key_command(press(KeyCode::Down));
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
     assert_eq!(app.cmd_sel, 1, "tab/down were overridden away");
-    app.key_command(ctrl(KeyCode::Char('p')));
+    app.handle_key(ctrl(KeyCode::Char('p'))).unwrap();
     assert_eq!(app.cmd_sel, 0);
 
     // ctrl-y runs the command line exactly like enter does by default.
     for c in "snapshots media".chars() {
-        app.key_command(press(KeyCode::Char(c)));
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
-    app.key_command(ctrl(KeyCode::Char('y')));
+    app.handle_key(ctrl(KeyCode::Char('y'))).unwrap();
     assert_eq!(app.mode, Mode::Table);
     assert_eq!(app.namespace, "media");
 
     // Enter stays usable because the config listed it too.
     app.mode = Mode::Command;
     for c in "pods".chars() {
-        app.key_command(press(KeyCode::Char(c)));
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
-    app.key_command(press(KeyCode::Enter));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Table);
 }
 
@@ -6635,9 +6628,9 @@ async fn typed_qualified_name_opens_the_kind() {
     let (mut app, _rx) = test_app();
     app.mode = Mode::Command;
     for c in "snapshots.kopiur.home-operations.com".chars() {
-        app.key_command(press(KeyCode::Char(c)));
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
-    app.key_command(press(KeyCode::Enter));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Table);
     assert!(
         app.flash.contains("snapshots.kopiur.home-operations.com"),
@@ -9126,14 +9119,14 @@ async fn context_rename_prompt_opens_prefilled_and_returns_to_picker() {
         list: vec!["prod".into(), "test".into()],
     });
 
-    app.key_contexts(press(KeyCode::Char('r')));
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
     assert_eq!(app.mode, Mode::Prompt);
     assert!(app.prompt_over_contexts());
     assert_eq!(app.prompt_input, "test", "prefilled with the selected name");
     assert!(app.prompt_label.contains("Rename context test"));
 
     // Esc abandons the rename and lands back in the picker.
-    app.key_prompt(press(KeyCode::Esc));
+    app.handle_key(press(KeyCode::Esc)).unwrap();
     assert_eq!(app.mode, Mode::Contexts);
     assert!(!app.prompt_over_contexts());
 }
@@ -9147,9 +9140,9 @@ async fn context_rename_to_existing_name_warns() {
         list: vec!["prod".into(), "test".into()],
     });
 
-    app.key_contexts(press(KeyCode::Char('r')));
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
     app.prompt_input = "prod".into();
-    app.key_prompt(press(KeyCode::Enter));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Contexts);
     assert!(app.flash_err);
     assert!(app.flash.contains("already exists"), "{}", app.flash);
@@ -10894,8 +10887,8 @@ async fn resource_cycle_hint_is_visible_and_changes_for_a_workspace() {
         ..Default::default()
     }];
     for (key, expected) in [
-        (press(KeyCode::Tab), "Tab/⇧Tab: resources"),
-        (ctrl(KeyCode::Char('w')), "Tab/⇧Tab: workspace"),
+        (press(KeyCode::Tab), "tab/backtab: resources"),
+        (ctrl(KeyCode::Char('w')), "tab/backtab: workspace"),
     ] {
         app.handle_key(key).unwrap();
         for width in [60, 160] {
@@ -11279,7 +11272,7 @@ async fn help_scrolls_and_resets_on_reopen() {
     app.handle_key(press(KeyCode::End)).unwrap();
     app.handle_key(press(KeyCode::Char('/'))).unwrap();
     assert_eq!(app.help_scroll, 0);
-    for c in "help".chars() {
+    for c in "cascade".chars() {
         app.handle_key(press(KeyCode::Char(c))).unwrap();
     }
     app.handle_key(press(KeyCode::Enter)).unwrap();
@@ -11349,7 +11342,7 @@ async fn help_paging_updates_after_resize_and_compact_mode() {
     app.handle_key(press(KeyCode::PageDown)).unwrap();
     assert_eq!(app.help_scroll, 21);
 
-    term.backend_mut().resize(120, 200);
+    term.backend_mut().resize(120, 800);
     term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
     assert_eq!(app.help_scroll, 0);
     assert_eq!(app.help_max_scroll, 0);
@@ -12150,23 +12143,23 @@ async fn fleet_toggle_in_context_switcher_edits_marks() {
     app.ctx_list = vec!["prod".into(), "staging".into()];
     app.ctx_state.select(Some(1));
     app.mode = Mode::Contexts;
-    app.key_contexts(press(KeyCode::Char(' ')));
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
     assert_eq!(app.fleet_contexts(), vec!["prod", "staging"]);
     assert!(app.is_fleet_context("staging"));
     assert!(app.flash.contains("fleet + staging"), "{}", app.flash);
     assert_eq!(app.mode, Mode::Contexts, "toggling stays in the switcher");
 
     // Space again removes it.
-    app.key_contexts(press(KeyCode::Char(' ')));
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
     assert_eq!(app.fleet_contexts(), vec!["prod"]);
     assert!(app.flash.contains("fleet − staging"), "{}", app.flash);
 
     // A config-listed context can be masked out for the session too…
     app.ctx_state.select(Some(0));
-    app.key_contexts(press(KeyCode::Char(' ')));
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
     assert!(app.fleet_contexts().is_empty());
     // …and re-added.
-    app.key_contexts(press(KeyCode::Char(' ')));
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
     assert_eq!(app.fleet_contexts(), vec!["prod"]);
 }
 
@@ -12193,7 +12186,7 @@ async fn fleet_marks_persist_across_restarts() {
     app.ctx_list = vec!["prod".into(), "staging".into()];
     app.ctx_state.select(Some(1));
     app.mode = Mode::Contexts;
-    app.key_contexts(press(KeyCode::Char(' ')));
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
     assert!(path.exists(), "marks file written on toggle");
     assert!(!app.flash_err, "{}", app.flash);
 
@@ -21200,4 +21193,402 @@ async fn image_tag_columns_render_selected_paths_and_filter_by_tag() {
     let (_, rows) = app.snapshot_table();
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|row| row[2] == "1.2.3"));
+}
+
+const PAGING_KEYS: &str = r#"
+[keys.navigation]
+page_up = ["pageup", "ctrl-b", "ctrl-u"]
+page_down = ["pagedown", "ctrl-f", "ctrl-d"]
+[keys.table]
+delete = "alt-d"
+"#;
+
+fn use_keys(app: &mut App, text: &str) {
+    let cfg: crate::config::Config = toml::from_str(text).unwrap();
+    app.keymap = Keymap::compile(&cfg.keys).unwrap();
+}
+
+#[tokio::test]
+async fn configured_paging_releases_delete_and_keeps_its_confirmation() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in 0..25 {
+        apply(
+            &mut app,
+            json!({"apiVersion":"v1", "kind":"Pod",
+            "metadata":{"name":format!("p{n:02}"), "namespace":"default"}}),
+        );
+    }
+    app.table_state.select(Some(0));
+    app.table_page_rows = 8;
+    use_keys(&mut app, PAGING_KEYS);
+    app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(8));
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.confirm_action.is_none());
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    assert_eq!(app.table_state.selected(), Some(0));
+    app.handle_key(press(KeyCode::PageDown)).unwrap();
+    assert_eq!(app.table_state.selected(), Some(8));
+    app.handle_key(alt(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+    assert!(matches!(
+        app.confirm_action,
+        Some(ConfirmAction::Delete { force: false, .. })
+    ));
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.readonly = true;
+    app.handle_key(alt(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.flash.contains("read-only"), "{}", app.flash);
+    assert!(app.confirm_action.is_none());
+}
+
+#[tokio::test]
+async fn configured_paging_preserves_view_behavior_and_text_input() {
+    let (mut app, _rx) = test_app();
+    use_keys(&mut app, PAGING_KEYS);
+    for mode in [Mode::Detail, Mode::Diff, Mode::Events] {
+        app.mode = mode;
+        app.detail = Scrollable {
+            lines: (0..100).map(|n| n.to_string()).collect(),
+            ..Default::default()
+        };
+        app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+        assert_eq!(app.detail.scroll, 20, "{mode:?}");
+        app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+        assert_eq!(app.detail.scroll, 0, "{mode:?}");
+    }
+    app.mode = Mode::Logs;
+    app.logs.viewport_h = 7;
+    app.logs.viewport_rows = 100;
+    app.logs.follow = true;
+    app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.logs.view.scroll, 7);
+    assert!(!app.logs.follow);
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    assert_eq!(app.logs.view.scroll, 0);
+    app.mode = Mode::Help;
+    app.help_viewport_h = 9;
+    app.help_max_scroll = 100;
+    app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.help_scroll, 9);
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    assert_eq!(app.help_scroll, 0);
+    app.mode = Mode::Prompt;
+    app.prompt_input = "keep text editing".into();
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    assert!(app.prompt_input.is_empty());
+    assert_eq!(app.mode, Mode::Prompt);
+}
+
+#[tokio::test]
+async fn released_keys_reach_bookmarks_and_wheel_uses_actions() {
+    use crossterm::event::{MouseEvent, MouseEventKind};
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for n in 0..8 {
+        apply(
+            &mut app,
+            json!({"apiVersion":"v1", "kind":"Pod",
+            "metadata":{"name":format!("p{n}"), "namespace":"default"}}),
+        );
+    }
+    app.table_state.select(Some(0));
+    use_keys(&mut app, "[keys.table]\ndown = []\ndelete = 'down'\n");
+    app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    })
+    .unwrap();
+    assert_eq!(app.table_state.selected(), Some(3));
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.confirm_action.is_none());
+    app.bookmarks.push(crate::config::Bookmark {
+        name: "services".into(),
+        key: Some("j".into()),
+        resource: "services".into(),
+        ..Default::default()
+    });
+    app.handle_key(press(KeyCode::Char('j'))).unwrap();
+    assert_eq!(app.kind_plural, "services");
+}
+
+#[tokio::test]
+async fn global_and_confirmation_bindings_can_be_replaced_or_disabled() {
+    let (mut app, _rx) = test_app();
+    use_keys(
+        &mut app,
+        r#"
+        [keys.global]
+        quit = "alt-q"
+        compact = "f6"
+        [keys.confirm]
+        accept = []
+        back = "f7"
+        force = "f8"
+    "#,
+    );
+    app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
+    assert!(!app.should_quit);
+    app.handle_key(ctrl(KeyCode::Char('e'))).unwrap();
+    assert!(!app.compact);
+    app.handle_key(press(KeyCode::F(6))).unwrap();
+    assert!(app.compact);
+    app.mode = Mode::Confirm;
+    for key in [KeyCode::Enter, KeyCode::Char('y'), KeyCode::Esc] {
+        app.handle_key(press(key)).unwrap();
+        assert_eq!(app.mode, Mode::Confirm);
+    }
+    app.handle_key(press(KeyCode::F(7))).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    app.handle_key(alt(KeyCode::Char('q'))).unwrap();
+    assert!(app.should_quit);
+}
+
+#[tokio::test]
+async fn keymap_reload_is_atomic_and_context_overrides_apply() {
+    let dir = std::env::temp_dir().join(format!("sofka-keymap-{}", std::process::id()));
+    write_config(&dir, PAGING_KEYS);
+    write_config(
+        &dir.join("clusters/test-cluster/dev"),
+        "[keys.table]\npage_down = 'f8'\n",
+    );
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    palette(&mut app, "reload");
+    assert!(app.config_warnings.is_empty(), "{:?}", app.config_warnings);
+    assert!(
+        app.keymap
+            .label("table", Action::PageDown)
+            .contains("ctrl-d")
+    );
+    let good = app.keymap.clone();
+    write_config(&dir, "[keys.navigation]\npage_down = 'ctrl-d'\n");
+    palette(&mut app, "reload");
+    assert_eq!(app.keymap, good);
+    let warnings = app.config_warnings.join("\n");
+    assert!(warnings.contains("config.toml"), "{warnings}");
+    assert!(warnings.contains("conflicts"), "{warnings}");
+    write_config(&dir, PAGING_KEYS);
+    palette(&mut app, "reload");
+    palette(&mut app, "ctx dev");
+    land_context(&mut app, "dev");
+    assert_eq!(app.keymap.label("table", Action::PageDown), "f8");
+    assert!(
+        app.keymap
+            .label("logs", Action::PageDown)
+            .contains("ctrl-d")
+    );
+    palette(&mut app, "ctx prod");
+    land_context(&mut app, "prod");
+    assert!(
+        app.keymap
+            .label("table", Action::PageDown)
+            .contains("ctrl-d")
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+fn key_action_fixture(scope: &str) -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    app.switch_kind("pods");
+    for n in 0..12 {
+        apply(
+            &mut app,
+            json!({"apiVersion":"v1", "kind":"Pod",
+            "metadata":{"name":format!("p{n:02}"), "namespace":"default"},
+            "spec":{"containers":[{"name":"main", "image":"example:1"}]}}),
+        );
+    }
+    app.readonly = true;
+    app.table_page_rows = 3;
+    app.table_state.select(Some(4));
+    app.detail = Scrollable {
+        lines: (0..60).map(|n| format!("line {n}")).collect(),
+        scroll: 5,
+        ..Default::default()
+    };
+    app.logs.viewport_rows = 60;
+    app.logs.viewport_h = 5;
+    app.logs.view.scroll = 10;
+    app.help_scroll = 5;
+    app.help_max_scroll = 60;
+    app.help_viewport_h = 5;
+    app.command = "pods default".into();
+    app.prompt_input = "two words".into();
+    app.ns_list = vec!["default".into(), "tools".into(), "test".into()];
+    app.ns_state.select(Some(1));
+    app.ctx_list = vec!["test".into(), "dev".into(), "prod".into()];
+    app.ctx_state.select(Some(1));
+    app.container_list = vec!["main".into(), "sidecar".into(), "agent".into()];
+    app.container_state.select(Some(1));
+    app.mode = match scope {
+        "table" => Mode::Table,
+        "command" => Mode::Command,
+        "filter" => Mode::Filter,
+        "detail" => Mode::Detail,
+        "diff" => Mode::Diff,
+        "events" => Mode::Events,
+        "logs" => Mode::Logs,
+        "log_filter" => Mode::LogFilter,
+        "doc_filter" => Mode::DocFilter,
+        "help" => Mode::Help,
+        "namespaces" => Mode::Namespaces,
+        "contexts" | "context_filter" => Mode::Contexts,
+        "sort_picker" => Mode::SortPicker,
+        "copy_picker" => Mode::CopyPicker,
+        "containers" => Mode::Containers,
+        "set_image" => Mode::SetImage,
+        "confirm" => Mode::Confirm,
+        "prompt" => Mode::Prompt,
+        "pulse" => Mode::Pulse,
+        "xray" => Mode::Xray,
+        "explain" => Mode::Explain,
+        "timeline" => Mode::Timeline,
+        "gitops" => Mode::Gitops,
+        "adjacent" => Mode::Adjacent,
+        "flux_menu" => Mode::FluxMenu,
+        "transfer_menu" => Mode::TransferMenu,
+        "port_forwards" => Mode::PortForwards,
+        "skins" => Mode::Skins,
+        "snapshots" => Mode::Snapshots,
+        "fleet" => Mode::Fleet,
+        "find" => Mode::Find,
+        "pvc_explore" => Mode::PvcExplore,
+        "port_forward_picker" => Mode::PortForwardPicker,
+        _ => panic!("missing fixture for {scope}"),
+    };
+    app.ctx_filtering = scope == "context_filter";
+    (app, rx)
+}
+
+fn key_action_state(app: &App) -> serde_json::Value {
+    json!({
+        "navigation": {
+            "mode": format!("{:?}", app.mode), "kind": app.kind_plural,
+            "namespace": app.namespace, "selected": app.table_state.selected(),
+            "quit": app.should_quit, "compact": app.compact, "wide": app.wide,
+            "marked": app.marked, "sort": app.sort_column, "desc": app.sort_desc,
+            "faults": app.faults_only, "flash": app.flash,
+        },
+        "input": {
+            "command": app.command, "suggestion": app.cmd_sel, "filter": app.filter,
+            "prompt": app.prompt_input, "prompt_label": app.prompt_label,
+            "confirm": app.confirm_label, "confirm_pending": app.confirm_action.is_some(),
+            "suspend": app.pending.is_some(), "namespaces": app.ns_state.selected(),
+            "namespace_filter": app.ns_filter, "contexts": app.ctx_state.selected(),
+            "context_filter": app.ctx_filter, "context_filtering": app.ctx_filtering,
+            "container": app.container_state.selected(),
+            "sort_picker": app.sort_picker_state.selected(), "copy_picker": app.copy_picker_state.selected(),
+        },
+        "document": {
+            "title": app.detail.title, "scroll": app.detail.scroll,
+            "horizontal": app.detail.hscroll, "wrap": app.detail.wrap,
+            "filter": app.detail.filter, "match": app.detail.match_idx,
+            "help_scroll": app.help_scroll, "help_filter": app.help_filter,
+        },
+        "logs": {
+            "scroll": app.logs.view.scroll, "follow": app.logs.follow, "wrap": app.logs.wrap,
+            "fullscreen": app.logs.fullscreen, "timestamps": app.logs.timestamps,
+            "stopped": app.logs.stopped, "since": app.logs.since_anchor, "filter": app.logs.filter,
+        },
+        "lists": [app.xray_state.selected(), app.timeline_state.selected(), app.explain_state.selected(),
+            app.gitops_state.selected(), app.adjacent_state.selected(), app.find_state.selected(),
+            app.fleet_state.selected(), app.snapshot_state.selected(), app.skin_state.selected(),
+            app.flux_menu_state.selected(), app.transfer_menu_state.selected(), app.pf_state.selected()],
+    })
+}
+
+#[tokio::test]
+async fn every_builtin_action_has_the_same_effect_after_rebinding() {
+    let defaults = Keymap::default();
+    for (scope, action, chords) in defaults.entries() {
+        let cfg: crate::config::Config =
+            toml::from_str(&format!("[keys.{scope}]\n{} = 'f24'\n", action.name())).unwrap();
+        let configured = Keymap::compile(&cfg.keys).unwrap();
+        for chord in chords {
+            let (mut original, _rx1) = key_action_fixture(scope);
+            let (mut changed, _rx2) = key_action_fixture(scope);
+            changed.keymap = configured.clone();
+            let mut modifiers = KeyModifiers::NONE;
+            modifiers.set(KeyModifiers::CONTROL, chord.ctrl);
+            modifiers.set(KeyModifiers::ALT, chord.alt);
+            modifiers.set(KeyModifiers::SHIFT, chord.shift);
+            original
+                .handle_key(KeyEvent::new(chord.code, modifiers))
+                .unwrap();
+            changed.handle_key(press(KeyCode::F(24))).unwrap();
+            assert_eq!(
+                key_action_state(&original),
+                key_action_state(&changed),
+                "keys.{scope}.{} with {}",
+                action.name(),
+                chord.label()
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn custom_keys_are_visible_in_help_header_and_footer() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    use_keys(&mut app, &format!("{PAGING_KEYS}\nyaml = []\n"));
+    let mut terminal = Terminal::new(TestBackend::new(180, 30)).unwrap();
+    let screen = |app: &mut App, terminal: &mut Terminal<TestBackend>| {
+        terminal.draw(|f| crate::ui::draw(f, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>()
+    };
+    // The header shows the reassigned delete key and disabled YAML action.
+    let text = screen(&mut app, &mut terminal);
+    assert!(text.contains("alt-d"), "{text}");
+    assert!(text.contains("unbound yaml"), "{text}");
+    app.hide_header = true;
+    let text = screen(&mut app, &mut terminal);
+    assert!(text.contains("alt-d:delete"), "{text}");
+    assert!(text.contains("unbound:yaml"), "{text}");
+    app.handle_key(press(KeyCode::Char('?'))).unwrap();
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "page down".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    let text = screen(&mut app, &mut terminal);
+    assert!(text.contains("ctrl-d"), "{text}");
+    assert!(text.contains("pagedown"), "{text}");
+}
+
+#[tokio::test]
+async fn key_warnings_report_hidden_bindings_without_blocking_released_keys() {
+    let (mut app, _rx) = test_app();
+    app.plugins = vec![crate::config::Plugin {
+        name: "pod-inspect".into(),
+        key: "x".into(),
+        scopes: vec!["pods".into()],
+        ..Default::default()
+    }];
+    app.bookmarks = vec![crate::config::Bookmark {
+        name: "services".into(),
+        key: Some("ctrl-d".into()),
+        resource: "services".into(),
+        ..Default::default()
+    }];
+    let warnings = app.configure_keys(&Default::default());
+    assert_eq!(warnings.len(), 1, "{warnings:?}");
+    assert!(warnings[0].contains("services"));
+    assert!(warnings[0].contains("keys.table.delete"));
+    let cfg: crate::config::Config = toml::from_str("[keys.table]\ndelete = []").unwrap();
+    assert!(app.configure_keys(&cfg.keys).is_empty());
+    app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+    assert_eq!(app.kind_plural, "services");
 }

--- a/src/app/timeline.rs
+++ b/src/app/timeline.rs
@@ -28,26 +28,24 @@ impl App {
         self.mode = Mode::Timeline;
     }
 
-    pub(super) fn key_timeline(&mut self, key: KeyEvent) {
+    pub(super) fn key_timeline(&mut self, key: KeyInput) {
         let len = self
             .timeline_target
             .as_ref()
             .and_then(|(p, rk)| self.timeline.entries(p, rk))
             .map(|e| e.len())
             .unwrap_or(0);
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+        match (key.action, key.code) {
+            (Some(Action::Back), _) | (Some(Action::Close), _) => {
                 self.mode = self.return_mode;
                 if self.return_mode == Mode::Table {
                     self.restore_selection();
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => list_step(&mut self.timeline_state, len, true),
-            KeyCode::Char('k') | KeyCode::Up => list_step(&mut self.timeline_state, len, false),
-            KeyCode::Char('g') | KeyCode::Home if len > 0 => self.timeline_state.select(Some(0)),
-            KeyCode::Char('G') | KeyCode::End if len > 0 => {
-                self.timeline_state.select(Some(len - 1))
-            }
+            (Some(Action::Down), _) => list_step(&mut self.timeline_state, len, true),
+            (Some(Action::Up), _) => list_step(&mut self.timeline_state, len, false),
+            (Some(Action::First), _) if len > 0 => self.timeline_state.select(Some(0)),
+            (Some(Action::Last), _) if len > 0 => self.timeline_state.select(Some(len - 1)),
             _ => {}
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,10 +34,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crossterm::event::KeyCode;
 use serde::Deserialize;
-
-use crate::keys::KeyChord;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
@@ -108,8 +105,7 @@ pub struct Config {
     pub remember_sort: Option<bool>,
     /// How `:notify` events are delivered — see [`NotifyConfig`].
     pub notify: NotifyConfig,
-    /// Command-palette completion key rebinds — see [`KeysConfig`]. Compiled
-    /// and validated by [`compile_palette_keys`].
+    /// Built-in keyboard bindings, validated by [`crate::keymap::Keymap::compile`].
     pub keys: KeysConfig,
     /// Structured application logging — see [`LoggingConfig`].
     pub logging: LoggingConfig,
@@ -179,20 +175,9 @@ pub fn notify_warnings(cfg: &NotifyConfig) -> Vec<String> {
     warnings
 }
 
-/// Key overrides for the `:` command-palette completion popup — emacs/cmp
-/// style rebinds, for example:
-///
-/// ```toml
-/// [keys]
-/// palette_next   = "ctrl-n"            # default: ["tab", "down"]
-/// palette_prev   = "ctrl-p"            # default: ["backtab", "up"]
-/// palette_accept = ["ctrl-y", "enter"] # default: ["enter"]
-/// ```
-///
-/// Each value is one key chord (see [`crate::keys::KeyChord`]) or a list of
-/// them, and *replaces* the default set for that action — include a default
-/// chord in the list to keep it too. Compiled and validated by
-/// [`compile_palette_keys`].
+/// Built-in key bindings. Scope tables replace bindings by action name.
+/// The three palette fields remain aliases for command down, up, and accept.
+/// See [`crate::keymap::Keymap::compile`] for validation.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct KeysConfig {
@@ -202,6 +187,8 @@ pub struct KeysConfig {
     pub palette_prev: Option<Chords>,
     /// Run the highlighted suggestion (or the typed text).
     pub palette_accept: Option<Chords>,
+    #[serde(flatten)]
+    pub scopes: std::collections::BTreeMap<String, std::collections::BTreeMap<String, Chords>>,
 }
 
 /// One key chord, or a list of chords that all trigger the same action.
@@ -213,81 +200,12 @@ pub enum Chords {
 }
 
 impl Chords {
-    fn as_slice(&self) -> &[String] {
+    pub(crate) fn as_slice(&self) -> &[String] {
         match self {
             Chords::One(s) => std::slice::from_ref(s),
             Chords::Many(v) => v,
         }
     }
-}
-
-/// Compiled `[keys]` palette bindings, with defaults filled in.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PaletteKeys {
-    pub next: Vec<KeyChord>,
-    pub prev: Vec<KeyChord>,
-    pub accept: Vec<KeyChord>,
-}
-
-impl Default for PaletteKeys {
-    fn default() -> Self {
-        let plain = |code| KeyChord {
-            code,
-            ctrl: false,
-            alt: false,
-            shift: false,
-        };
-        Self {
-            next: vec![plain(KeyCode::Tab), plain(KeyCode::Down)],
-            prev: vec![plain(KeyCode::BackTab), plain(KeyCode::Up)],
-            accept: vec![plain(KeyCode::Enter)],
-        }
-    }
-}
-
-impl PaletteKeys {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
-}
-
-/// Compile `[keys]` palette bindings. A chord that doesn't parse, or that
-/// collides with a reserved global (`ctrl-c` quit, `ctrl-e` compact toggle),
-/// warns and is dropped; an action left with no usable chord falls back to
-/// its default so the palette never becomes unusable.
-pub fn compile_palette_keys(cfg: &KeysConfig) -> (PaletteKeys, Vec<String>) {
-    let mut warnings = Vec::new();
-    let defaults = PaletteKeys::default();
-    let mut action = |name: &str, spec: &Option<Chords>, default: &[KeyChord]| {
-        let Some(spec) = spec else {
-            return default.to_vec();
-        };
-        let mut out = Vec::new();
-        for s in spec.as_slice() {
-            match KeyChord::parse(s) {
-                Ok(c) if c.ctrl && matches!(c.code, KeyCode::Char('c' | 'e')) => {
-                    warnings.push(format!(
-                        "keys: {name}: {} is reserved by a built-in; ignored",
-                        c.label()
-                    ));
-                }
-                Ok(c) => out.push(c),
-                Err(e) => warnings.push(format!("keys: {name}: {e}")),
-            }
-        }
-        if out.is_empty() {
-            warnings.push(format!("keys: {name} has no usable chord; using default"));
-            default.to_vec()
-        } else {
-            out
-        }
-    };
-    let keys = PaletteKeys {
-        next: action("palette_next", &cfg.palette_next, &defaults.next),
-        prev: action("palette_prev", &cfg.palette_prev, &defaults.prev),
-        accept: action("palette_accept", &cfg.palette_accept, &defaults.accept),
-    };
-    (keys, warnings)
 }
 
 /// A named, saved port-forward. Shows up in `:pf` even when stopped, so one
@@ -1540,63 +1458,6 @@ mod tests {
             assert_eq!(cfg.compact_mode, expected);
         }
         assert!(toml::from_str::<Config>("compact_mode = 'true'").is_err());
-    }
-
-    #[test]
-    fn palette_keys_default_when_unset() {
-        let cfg: Config = toml::from_str("").unwrap();
-        let (keys, warnings) = compile_palette_keys(&cfg.keys);
-        assert!(warnings.is_empty());
-        assert!(keys.is_default());
-    }
-
-    #[test]
-    fn palette_keys_accept_string_or_list() {
-        let toml = r#"
-            [keys]
-            palette_next = "ctrl-n"
-            palette_prev = "ctrl-p"
-            palette_accept = ["ctrl-y", "enter"]
-        "#;
-        let cfg: Config = toml::from_str(toml).unwrap();
-        let (keys, warnings) = compile_palette_keys(&cfg.keys);
-        assert!(warnings.is_empty(), "{warnings:?}");
-        assert_eq!(keys.next, vec![KeyChord::parse("ctrl-n").unwrap()]);
-        assert_eq!(keys.prev, vec![KeyChord::parse("ctrl-p").unwrap()]);
-        assert_eq!(
-            keys.accept,
-            vec![
-                KeyChord::parse("ctrl-y").unwrap(),
-                KeyChord::parse("enter").unwrap()
-            ]
-        );
-        assert!(!keys.is_default());
-    }
-
-    #[test]
-    fn palette_keys_bad_chord_warns_and_falls_back() {
-        let toml = r#"
-            [keys]
-            palette_next = "hyper-n"
-        "#;
-        let cfg: Config = toml::from_str(toml).unwrap();
-        let (keys, warnings) = compile_palette_keys(&cfg.keys);
-        assert_eq!(warnings.len(), 2, "{warnings:?}"); // parse error + fallback
-        assert!(warnings[0].contains("palette_next"), "{warnings:?}");
-        assert_eq!(keys.next, PaletteKeys::default().next);
-    }
-
-    #[test]
-    fn palette_keys_reserved_chord_is_dropped() {
-        let toml = r#"
-            [keys]
-            palette_accept = ["ctrl-c", "ctrl-y"]
-        "#;
-        let cfg: Config = toml::from_str(toml).unwrap();
-        let (keys, warnings) = compile_palette_keys(&cfg.keys);
-        assert_eq!(warnings.len(), 1, "{warnings:?}");
-        assert!(warnings[0].contains("reserved"), "{warnings:?}");
-        assert_eq!(keys.accept, vec![KeyChord::parse("ctrl-y").unwrap()]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+mod key_migration;
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -1287,10 +1289,20 @@ impl ConfigLoader {
             .clone()
             .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
         let mut overlay = toml::Value::Table(toml::map::Map::new());
+        let mut migrations = Vec::new();
+        if let Some(path) = self.base_path()
+            && let Some(migration) = key_migration::prepare(&mut merged, &path, &mut warnings)
+        {
+            migrations.push(migration);
+        }
+        let base = merged.clone();
 
         for path in self.override_paths(context, cluster) {
             match read_value(&path) {
-                Ok(Some(v)) => {
+                Ok(Some(mut v)) => {
+                    if let Some(migration) = key_migration::prepare(&mut v, &path, &mut warnings) {
+                        migrations.push(migration);
+                    }
                     merge(&mut merged, v.clone());
                     merge(&mut overlay, v);
                 }
@@ -1301,13 +1313,19 @@ impl ConfigLoader {
 
         // A type mismatch introduced by an override drops back to the base
         // config (validated at load time) rather than losing everything.
+        let mut valid_config = true;
         let mut config: Config = merged.try_into().unwrap_or_else(|e| {
+            valid_config = false;
             warnings.push(format!("ignoring cluster overrides: {e}"));
-            self.base
-                .clone()
-                .and_then(|b| b.try_into().ok())
-                .unwrap_or_default()
+            base.try_into().unwrap_or_default()
         });
+        if !migrations.is_empty() {
+            key_migration::finish(
+                migrations,
+                valid_config && crate::keymap::Keymap::compile(&config.keys).is_ok(),
+                &mut warnings,
+            );
+        }
         if let Some(dir) = &self.dir {
             crate::plugins::load_packages(&dir.join("plugins"), &mut config.plugins, &mut warnings);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,36 +175,14 @@ pub fn notify_warnings(cfg: &NotifyConfig) -> Vec<String> {
     warnings
 }
 
-/// Built-in key bindings. Scope tables replace bindings by action name.
-/// The three palette fields remain aliases for command down, up, and accept.
-/// See [`crate::keymap::Keymap::compile`] for validation.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default)]
-pub struct KeysConfig {
-    /// Move the suggestion highlight down.
-    pub palette_next: Option<Chords>,
-    /// Move the suggestion highlight up.
-    pub palette_prev: Option<Chords>,
-    /// Run the highlighted suggestion (or the typed text).
-    pub palette_accept: Option<Chords>,
-    #[serde(flatten)]
-    pub scopes: std::collections::BTreeMap<String, std::collections::BTreeMap<String, Chords>>,
-}
-
-/// One key chord, or a list of chords that all trigger the same action.
+/// Keep key settings as TOML values so key errors cannot discard other settings.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged)]
-pub enum Chords {
-    One(String),
-    Many(Vec<String>),
-}
+#[serde(transparent)]
+pub struct KeysConfig(pub toml::Value);
 
-impl Chords {
-    pub(crate) fn as_slice(&self) -> &[String] {
-        match self {
-            Chords::One(s) => std::slice::from_ref(s),
-            Chords::Many(v) => v,
-        }
+impl Default for KeysConfig {
+    fn default() -> Self {
+        Self(toml::Value::Table(toml::Table::new()))
     }
 }
 

--- a/src/config/key_migration.rs
+++ b/src/config/key_migration.rs
@@ -1,0 +1,293 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use crate::keymap::LEGACY_PALETTE_KEYS;
+
+pub(super) struct Migration {
+    path: PathBuf,
+    original: String,
+    updated: String,
+}
+
+/// Convert each source before merging so context bindings retain precedence.
+pub(super) fn prepare(
+    value: &mut toml::Value,
+    path: &Path,
+    warnings: &mut Vec<String>,
+) -> Option<Migration> {
+    let keys = value.get("keys")?.as_table()?;
+    let moves: Vec<_> = LEGACY_PALETTE_KEYS
+        .iter()
+        .filter_map(|&(old, action)| keys.get(old).map(|v| (old, action.name(), v.clone())))
+        .collect();
+    if moves.is_empty() {
+        return None;
+    }
+    let mut errors = Vec::new();
+    for (old, _, spec) in &moves {
+        crate::keymap::parse_chords(spec, &format!("keys.{old}"), &mut errors);
+    }
+    if !errors.is_empty() {
+        warnings.push(format!(
+            "{}: cannot migrate palette keys: {}; correct the values and move them to [keys.command]",
+            path.display(), errors.join("; ")
+        ));
+        return None;
+    }
+    if let Some(command) = keys.get("command") {
+        for &(old, new, _) in &moves {
+            if !command.is_table() || command.get(new).is_some() {
+                warnings.push(format!(
+                    "{}: cannot migrate keys.{old}; check keys.command.{new} and remove the legacy field",
+                    path.display()
+                ));
+                return None;
+            }
+        }
+    }
+    let before = value.clone();
+    let keys = value.get_mut("keys").unwrap().as_table_mut().unwrap();
+    for (old, new, v) in moves {
+        keys.remove(old);
+        keys.entry("command")
+            .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+            .as_table_mut()
+            .unwrap()
+            .insert(new.into(), v);
+    }
+    let prepared = (|| -> Result<Migration, String> {
+        let original = fs::read_to_string(path).map_err(|e| e.to_string())?;
+        // A prior resolve may already have updated this cached base source.
+        let current = super::parse_doc(&original).map_err(|e| e.to_string())?;
+        if current == *value {
+            return Ok(Migration {
+                path: path.into(),
+                original: original.clone(),
+                updated: original,
+            });
+        }
+        if current != before {
+            return Err("config changed since it was loaded; reload it before migration".into());
+        }
+        let updated = edit_document(&original)?;
+        if super::parse_doc(&updated).map_err(|e| e.to_string())? != *value {
+            return Err("migration changed other settings; update the config manually".into());
+        }
+        Ok(Migration {
+            path: path.into(),
+            original,
+            updated,
+        })
+    })();
+    match prepared {
+        Ok(migration) => Some(migration),
+        Err(e) => {
+            warnings.push(failure(path, &e));
+            None
+        }
+    }
+}
+
+fn edit_document(text: &str) -> Result<String, String> {
+    let mut doc = text
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|e| e.to_string())?;
+    let keys = doc
+        .get_mut("keys")
+        .and_then(toml_edit::Item::as_table_like_mut)
+        .ok_or("keys is not a table")?;
+    let mut moves = Vec::new();
+    for &(old, action) in LEGACY_PALETTE_KEYS {
+        if let Some(key) = keys.key(old).cloned() {
+            let new = toml_edit::Key::new(action.name())
+                .with_leaf_decor(key.leaf_decor().clone())
+                .with_dotted_decor(key.dotted_decor().clone());
+            moves.push((new, keys.remove(old).unwrap()));
+        }
+    }
+    let command = keys
+        .entry("command")
+        .or_insert(toml_edit::Item::Table(toml_edit::Table::new()))
+        .as_table_like_mut()
+        .ok_or("keys.command is not a table")?;
+    for (key, item) in moves {
+        command.entry_format(&key).or_insert(item);
+    }
+    Ok(doc.to_string())
+}
+
+pub(super) fn finish(migrations: Vec<Migration>, valid: bool, warnings: &mut Vec<String>) {
+    for migration in migrations {
+        if migration.original == migration.updated {
+            continue;
+        }
+        if !valid {
+            warnings.push(format!(
+                "{}: config migration was not saved; correct the config errors, then reload",
+                migration.path.display()
+            ));
+            continue;
+        }
+        match migration.save() {
+            Ok(backup) => warnings.push(format!(
+                "{}: moved legacy palette keys to [keys.command]; backup: {}",
+                migration.path.display(),
+                backup.display()
+            )),
+            Err(e) => warnings.push(failure(&migration.path, &e.to_string())),
+        }
+    }
+}
+
+fn failure(path: &Path, error: &str) -> String {
+    format!(
+        "{}: cannot save config migration: {error}; using migrated keys in memory. Update [keys.command] in the config source: palette_next -> down, palette_prev -> up, palette_accept -> accept",
+        path.display()
+    )
+}
+
+impl Migration {
+    fn save(&self) -> io::Result<PathBuf> {
+        let metadata = fs::symlink_metadata(&self.path)?;
+        if !metadata.is_file() || metadata.permissions().readonly() {
+            return Err(io::Error::other("config is read-only or a symlink"));
+        }
+        self.check_source()?;
+        let backup = self.path.with_extension("toml.bak");
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut backup_file = options.open(&backup).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("cannot create backup {}: {e}", backup.display()),
+            )
+        })?;
+        if let Err(e) = backup_file
+            .write_all(self.original.as_bytes())
+            .and_then(|_| backup_file.sync_all())
+            .and_then(|_| backup_file.set_permissions(metadata.permissions()))
+        {
+            let _ = fs::remove_file(&backup);
+            return Err(e);
+        }
+        let temporary = self.path.with_extension("toml.migration.tmp");
+        let mut file = options.open(&temporary)?;
+        let saved = (|| {
+            file.write_all(self.updated.as_bytes())?;
+            file.set_permissions(metadata.permissions())?;
+            file.sync_all()?;
+            self.check_source()?;
+            fs::rename(&temporary, &self.path)
+        })();
+        if saved.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        saved.map(|_| backup)
+    }
+
+    fn check_source(&self) -> io::Result<()> {
+        if fs::symlink_metadata(&self.path)?.file_type().is_symlink()
+            || fs::read_to_string(&self.path)? != self.original
+        {
+            return Err(io::Error::other("config changed during migration"));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn document_migration_handles_toml_forms_without_changing_other_values() {
+        for text in [
+            "# heading\n[keys]\n# move me\npalette_next = ['ctrl-n', 'down'] # next\n[aliases]\nx = 'palette_next'\n",
+            "keys.palette_next = 'ctrl-n'\n",
+            "keys = { palette_next = 'ctrl-n' }\n",
+            "[keys]\ncommand = { up = 'ctrl-p' }\npalette_next = 'ctrl-n'\n",
+            "[keys]\n'palette_next' = '''ctrl-n'''\n",
+            "[keys]\npalette_next = [\n  'ctrl-n', # first\n  'down',\n]\n",
+        ] {
+            let updated = edit_document(text).unwrap();
+            let parsed = super::super::parse_doc(&updated).unwrap();
+            let before = super::super::parse_doc(text).unwrap();
+            assert_eq!(
+                parsed["keys"]["command"]["down"], before["keys"]["palette_next"],
+                "{updated}"
+            );
+            assert!(parsed["keys"].get("palette_next").is_none());
+            assert_eq!(parsed.get("aliases"), before.get("aliases"));
+            for comment in ["# heading", "# move me", "# next", "# first"] {
+                if text.contains(comment) {
+                    assert!(updated.contains(comment), "{updated}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn migration_preserves_existing_backups_and_detects_changed_sources() {
+        let dir = std::env::temp_dir().join(format!("sofka-migrate-save-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        let backup = dir.join("config.toml.bak");
+        let temporary = dir.join("config.toml.migration.tmp");
+        let migration = Migration {
+            path: path.clone(),
+            original: "[keys]\npalette_next = 'ctrl-n'\n".into(),
+            updated: "[keys.command]\ndown = 'ctrl-n'\n".into(),
+        };
+        fs::write(&path, &migration.original).unwrap();
+        fs::write(&backup, "previous backup").unwrap();
+        assert!(migration.save().is_err());
+        assert_eq!(fs::read_to_string(&backup).unwrap(), "previous backup");
+        assert_eq!(fs::read_to_string(&path).unwrap(), migration.original);
+        fs::remove_file(&backup).unwrap();
+
+        fs::write(&path, "hide_header = true\n").unwrap();
+        assert!(migration.save().is_err());
+        assert_eq!(fs::read_to_string(&path).unwrap(), "hide_header = true\n");
+        assert!(!backup.exists());
+
+        fs::write(&path, &migration.original).unwrap();
+        fs::write(&temporary, "another migration").unwrap();
+        assert!(migration.save().is_err());
+        assert_eq!(fs::read_to_string(&temporary).unwrap(), "another migration");
+        assert_eq!(fs::read_to_string(&path).unwrap(), migration.original);
+        assert_eq!(fs::read_to_string(&backup).unwrap(), migration.original);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migration_preserves_file_and_backup_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("sofka-migrate-mode-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        let migration = Migration {
+            path: path.clone(),
+            original: "[keys]\npalette_next = 'ctrl-n'\n".into(),
+            updated: "[keys.command]\ndown = 'ctrl-n'\n".into(),
+        };
+        fs::write(&path, &migration.original).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+        let backup = migration.save().unwrap();
+        for file in [&path, &backup] {
+            assert_eq!(
+                fs::metadata(file).unwrap().permissions().mode() & 0o777,
+                0o640
+            );
+        }
+        assert_eq!(fs::read_to_string(&path).unwrap(), migration.updated);
+        assert_eq!(fs::read_to_string(&backup).unwrap(), migration.original);
+        fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -161,7 +161,7 @@ struct KeyLabels {
     all: String,
 }
 
-const LEGACY: &[(&str, Action)] = &[
+pub(crate) const LEGACY_PALETTE_KEYS: &[(&str, Action)] = &[
     ("palette_next", Action::Down),
     ("palette_prev", Action::Up),
     ("palette_accept", Action::Accept),
@@ -590,7 +590,11 @@ impl Keymap {
         let mut errors = Vec::new();
         let mut overrides = BTreeMap::new();
         for (scope, value) in settings {
-            if LEGACY.iter().any(|(name, _)| scope == name) {
+            if let Some((_, action)) = LEGACY_PALETTE_KEYS.iter().find(|(name, _)| scope == name) {
+                map.warnings.push(format!(
+                    "keys.{scope}: legacy setting ignored; move its value to [keys.command] {}",
+                    action.name()
+                ));
                 continue;
             }
             if !matches!(scope.as_str(), "global" | "navigation" | "input")
@@ -630,56 +634,14 @@ impl Keymap {
         let command_settings = settings.get("command").and_then(toml::Value::as_table);
         let scoped =
             |action: Action| command_settings.is_some_and(|c| c.contains_key(action.name()));
-        let legacy = |action: Action| {
-            LEGACY
-                .iter()
-                .any(|&(name, a)| a == action && settings.contains_key(name))
-        };
-        let defaults = Self::default();
-        for &(name, action) in LEGACY {
-            let Some(spec) = settings.get(name) else {
-                continue;
-            };
-            if scoped(action) {
-                errors.push(format!(
-                    "keys.{name}: also set as keys.command.{}",
-                    action.name()
-                ));
-            }
-            let path = format!("keys.{name}");
-            let mut chords = parse_chords(spec, &path, &mut map.warnings);
-            chords.retain(|c| {
-                let reserved = (c.ctrl && matches!(c.code, KeyCode::Char('c' | 'e')))
-                    || GLOBAL.iter().any(|&(global, _)| {
-                        map.chords("command", global).iter().any(|g| overlaps(c, g))
-                    });
-                if reserved {
-                    map.warnings.push(format!(
-                        "{path}: {} is reserved by a built-in; ignored",
-                        c.label()
-                    ));
-                }
-                !reserved
-            });
-            if chords.is_empty() {
-                map.warnings
-                    .push(format!("{path}: no usable chord; using default"));
-                chords = defaults.chords("command", action).to_vec();
-            }
-            map.bindings
-                .get_mut("command")
-                .unwrap()
-                .insert(action, chords);
-        }
-        // Both configuration forms give explicit completion keys priority over
-        // text editing and cancellation, as the original palette handler did.
-        for &(_, action) in LEGACY {
-            if !legacy(action) && !scoped(action) {
+        // Explicit completion keys take priority over text editing and cancellation.
+        for &(_, action) in LEGACY_PALETTE_KEYS {
+            if !scoped(action) {
                 continue;
             }
             let chords = map.chords("command", action).to_vec();
             for &(edit, _) in INPUT {
-                if LEGACY.iter().any(|&(_, a)| a == edit) {
+                if LEGACY_PALETTE_KEYS.iter().any(|&(_, a)| a == edit) {
                     continue;
                 }
                 map.bindings
@@ -688,33 +650,6 @@ impl Keymap {
                     .get_mut(&edit)
                     .unwrap()
                     .retain(|c| !chords.iter().any(|other| overlaps(c, other)));
-            }
-        }
-        // Legacy completion fields used ordered dispatch: next, previous, accept.
-        // Preserve that order when legacy fields overlap each other or defaults.
-        for (i, &(higher_name, higher)) in LEGACY.iter().enumerate() {
-            for &(lower_name, lower) in &LEGACY[i + 1..] {
-                if scoped(higher) || scoped(lower) || !(legacy(higher) || legacy(lower)) {
-                    continue;
-                }
-                let chords = map.chords("command", higher).to_vec();
-                let lower_chords = map
-                    .bindings
-                    .get_mut("command")
-                    .unwrap()
-                    .get_mut(&lower)
-                    .unwrap();
-                lower_chords.retain(|c| {
-                    if chords.iter().any(|other| overlaps(c, other)) {
-                        map.warnings.push(format!(
-                            "keys.{lower_name}: {} is handled by {higher_name}; ignored",
-                            c.label()
-                        ));
-                        false
-                    } else {
-                        true
-                    }
-                });
             }
         }
         map.cancel_any = !settings
@@ -848,7 +783,11 @@ impl Keymap {
     }
 }
 
-fn parse_chords(spec: &toml::Value, path: &str, errors: &mut Vec<String>) -> Vec<KeyChord> {
+pub(crate) fn parse_chords(
+    spec: &toml::Value,
+    path: &str,
+    errors: &mut Vec<String>,
+) -> Vec<KeyChord> {
     let values = match spec {
         toml::Value::String(_) => std::slice::from_ref(spec),
         toml::Value::Array(values) => values,
@@ -1001,22 +940,10 @@ mod tests {
     }
 
     #[test]
-    fn legacy_palette_fields_remain_valid_and_take_priority_over_editing() {
-        let map = compile(
-            r#"
-            [keys]
-            palette_next = "ctrl-w"
-            palette_prev = "ctrl-p"
-            palette_accept = ["ctrl-y", "enter"]
-        "#,
-        )
-        .unwrap();
-        assert_eq!(map.label("command", Action::Down), "ctrl-w");
-        assert_eq!(map.label("command", Action::Accept), "ctrl-y / enter");
-        assert!(!map.label("command", Action::DeleteWord).contains("ctrl-w"));
-        assert!(
-            compile("[keys]\npalette_next = 'ctrl-n'\n[keys.command]\ndown = 'ctrl-n'").is_err()
-        );
+    fn unmigrated_palette_fields_warn_and_keep_scoped_settings() {
+        let map = compile("[keys]\npalette_next = 'ctrl-n'\n[keys.command]\ndown = 'f8'").unwrap();
+        assert_eq!(map.label("command", Action::Down), "f8");
+        assert!(map.warnings()[0].contains("[keys.command] down"));
     }
 
     #[test]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -113,6 +113,20 @@ actions! {
     Yaml => ("yaml", "yaml"),
 }
 
+impl Action {
+    pub(crate) fn log_anchor(self) -> Option<char> {
+        match self {
+            Self::Anchor0 => Some('0'),
+            Self::Anchor1 => Some('1'),
+            Self::Anchor2 => Some('2'),
+            Self::Anchor3 => Some('3'),
+            Self::Anchor4 => Some('4'),
+            Self::Anchor5 => Some('5'),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct KeyInput {
     pub action: Option<Action>,
@@ -136,8 +150,15 @@ impl KeyInput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Keymap {
     bindings: BTreeMap<&'static str, BTreeMap<Action, Vec<KeyChord>>>,
+    labels: BTreeMap<&'static str, BTreeMap<Action, KeyLabels>>,
     cancel_any: bool,
     warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct KeyLabels {
+    first: String,
+    all: String,
 }
 
 const LEGACY: &[(&str, Action)] = &[
@@ -547,11 +568,14 @@ impl Default for Keymap {
                         chords.extend(shifted);
                     }
                 }
-                Keymap {
+                let mut map = Keymap {
                     bindings,
+                    labels: BTreeMap::new(),
                     cancel_any: true,
                     warnings: Vec::new(),
-                }
+                };
+                map.cache_labels();
+                map
             })
             .clone()
     }
@@ -716,6 +740,7 @@ impl Keymap {
             }
         }
         if errors.is_empty() {
+            map.cache_labels();
             Ok(map)
         } else {
             Err(errors)
@@ -777,17 +802,41 @@ impl Keymap {
             .unwrap_or_default()
     }
 
-    pub fn label(&self, scope: &str, action: Action) -> String {
-        let chords = self.chords(scope, action);
-        if chords.is_empty() {
-            "unbound".into()
-        } else {
-            chords
-                .iter()
-                .map(KeyChord::label)
-                .collect::<Vec<_>>()
-                .join(" / ")
-        }
+    fn cache_labels(&mut self) {
+        self.labels = self
+            .bindings
+            .iter()
+            .map(|(&scope, bindings)| {
+                let labels = bindings
+                    .iter()
+                    .map(|(&action, chords)| {
+                        let labels: Vec<_> = chords.iter().map(KeyChord::label).collect();
+                        let first = labels.first().cloned().unwrap_or_else(|| "unbound".into());
+                        let all = if labels.is_empty() {
+                            first.clone()
+                        } else {
+                            labels.join(" / ")
+                        };
+                        (action, KeyLabels { first, all })
+                    })
+                    .collect();
+                (scope, labels)
+            })
+            .collect();
+    }
+
+    pub fn label(&self, scope: &str, action: Action) -> &str {
+        self.labels
+            .get(scope)
+            .and_then(|labels| labels.get(&action))
+            .map_or("unbound", |labels| labels.all.as_str())
+    }
+
+    pub fn first_label(&self, scope: &str, action: Action) -> &str {
+        self.labels
+            .get(scope)
+            .and_then(|labels| labels.get(&action))
+            .map_or("unbound", |labels| labels.first.as_str())
     }
 
     pub fn entries(&self) -> impl Iterator<Item = (&'static str, Action, &[KeyChord])> {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,9 +1,6 @@
 //! Built-in actions and their effective keyboard bindings.
 
-use crate::{
-    config::{Chords, KeysConfig},
-    keys::KeyChord,
-};
+use crate::{config::KeysConfig, keys::KeyChord};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
@@ -140,10 +137,20 @@ impl KeyInput {
 pub struct Keymap {
     bindings: BTreeMap<&'static str, BTreeMap<Action, Vec<KeyChord>>>,
     cancel_any: bool,
+    warnings: Vec<String>,
 }
+
+const LEGACY: &[(&str, Action)] = &[
+    ("palette_next", Action::Down),
+    ("palette_prev", Action::Up),
+    ("palette_accept", Action::Accept),
+];
 
 const GLOBAL: &[(Action, &[&str])] = &[(Action::Quit, &["ctrl-c"]), (Action::Compact, &["ctrl-e"])];
 const INPUT: &[(Action, &[&str])] = &[
+    (Action::Back, &["esc"]),
+    (Action::Backspace, &["backspace"]),
+    (Action::Accept, &["enter"]),
     (Action::ClearLine, &["ctrl-u"]),
     (
         Action::DeleteWord,
@@ -187,9 +194,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("adjacent", Action::Refresh, &["r"]),
     ("adjacent", Action::Up, &["k", "up"]),
     ("adjacent", Action::Yaml, &["y"]),
-    ("command", Action::Accept, &["enter"]),
-    ("command", Action::Back, &["esc"]),
-    ("command", Action::Backspace, &["backspace"]),
     ("command", Action::Down, &["tab", "down"]),
     ("command", Action::Up, &["backtab", "up"]),
     ("confirm", Action::Accept, &["y", "Y", "enter"]),
@@ -206,9 +210,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("containers", Action::Shell, &["s"]),
     ("containers", Action::Transfer, &["t"]),
     ("containers", Action::Up, &["k", "up"]),
-    ("context_filter", Action::Accept, &["enter"]),
-    ("context_filter", Action::Back, &["esc"]),
-    ("context_filter", Action::Backspace, &["backspace"]),
     ("context_filter", Action::Down, &["down"]),
     ("context_filter", Action::Up, &["up"]),
     ("contexts", Action::Accept, &["enter"]),
@@ -218,9 +219,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("contexts", Action::FleetMark, &["space"]),
     ("contexts", Action::Rename, &["r", "R"]),
     ("contexts", Action::Up, &["up", "k"]),
-    ("copy_picker", Action::Accept, &["enter"]),
-    ("copy_picker", Action::Back, &["esc"]),
-    ("copy_picker", Action::Backspace, &["backspace"]),
     ("copy_picker", Action::Down, &["down", "ctrl-n"]),
     ("copy_picker", Action::Up, &["up", "ctrl-p"]),
     ("detail", Action::AutoRefresh, &["r"]),
@@ -255,9 +253,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("diff", Action::Right, &["l", "right"]),
     ("diff", Action::Up, &["k", "up"]),
     ("diff", Action::Wrap, &["w"]),
-    ("doc_filter", Action::Accept, &["enter"]),
-    ("doc_filter", Action::Back, &["esc"]),
-    ("doc_filter", Action::Backspace, &["backspace"]),
     ("events", Action::Back, &["esc"]),
     ("events", Action::Close, &["q"]),
     ("events", Action::Copy, &["c"]),
@@ -283,9 +278,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("explain", Action::Logs, &["l"]),
     ("explain", Action::Refresh, &["r"]),
     ("explain", Action::Up, &["k", "up"]),
-    ("filter", Action::Accept, &["enter"]),
-    ("filter", Action::Back, &["esc"]),
-    ("filter", Action::Backspace, &["backspace"]),
     ("find", Action::Accept, &["enter"]),
     ("find", Action::Back, &["esc"]),
     ("find", Action::Close, &["q"]),
@@ -321,9 +313,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("help", Action::PageDown, &["pagedown", "space", "ctrl-f"]),
     ("help", Action::PageUp, &["pageup", "ctrl-b"]),
     ("help", Action::Up, &["k", "up"]),
-    ("log_filter", Action::Accept, &["enter"]),
-    ("log_filter", Action::Back, &["esc"]),
-    ("log_filter", Action::Backspace, &["backspace"]),
     ("logs", Action::Anchor0, &["0"]),
     ("logs", Action::Anchor1, &["1"]),
     ("logs", Action::Anchor2, &["2"]),
@@ -348,9 +337,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("logs", Action::Timestamps, &["t"]),
     ("logs", Action::Up, &["k", "up"]),
     ("logs", Action::Wrap, &["w"]),
-    ("namespaces", Action::Accept, &["enter"]),
-    ("namespaces", Action::Back, &["esc"]),
-    ("namespaces", Action::Backspace, &["backspace"]),
     ("namespaces", Action::Down, &["down"]),
     ("namespaces", Action::Up, &["up"]),
     ("port_forward_picker", Action::Accept, &["enter"]),
@@ -364,9 +350,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("port_forwards", Action::Start, &["enter"]),
     ("port_forwards", Action::Toggle, &["x", "s"]),
     ("port_forwards", Action::Up, &["k", "up"]),
-    ("prompt", Action::Accept, &["enter"]),
-    ("prompt", Action::Back, &["esc"]),
-    ("prompt", Action::Backspace, &["backspace"]),
     ("pulse", Action::Back, &["esc"]),
     ("pulse", Action::Close, &["q"]),
     ("pulse", Action::Refresh, &["r"]),
@@ -400,9 +383,6 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("snapshots", Action::Delete, &["d"]),
     ("snapshots", Action::Down, &["j", "down"]),
     ("snapshots", Action::Up, &["k", "up"]),
-    ("sort_picker", Action::Accept, &["enter"]),
-    ("sort_picker", Action::Back, &["esc"]),
-    ("sort_picker", Action::Backspace, &["backspace"]),
     ("sort_picker", Action::Down, &["down", "ctrl-n"]),
     ("sort_picker", Action::Up, &["up", "ctrl-p"]),
     ("table", Action::ActionMenu, &["t"]),
@@ -515,6 +495,9 @@ impl Default for Keymap {
                             .collect(),
                     );
                 }
+                for &scope in TEXT_SCOPES {
+                    bindings.entry(scope).or_default();
+                }
                 for (&scope, actions) in &mut bindings {
                     for &(action, chords) in GLOBAL
                         .iter()
@@ -535,9 +518,39 @@ impl Default for Keymap {
                         }
                     }
                 }
+                // Raw navigation matches previously accepted Shift in these modes.
+                // Keep explicit aliases in the defaults; user chords remain exact.
+                for (&scope, actions) in &mut bindings {
+                    if scope == "command" {
+                        continue;
+                    }
+                    for chords in actions.values_mut() {
+                        let shifted: Vec<_> = chords
+                            .iter()
+                            .filter(|c| {
+                                !c.ctrl
+                                    && !c.alt
+                                    && matches!(
+                                        c.code,
+                                        KeyCode::Up
+                                            | KeyCode::Down
+                                            | KeyCode::Left
+                                            | KeyCode::Right
+                                            | KeyCode::PageUp
+                                            | KeyCode::PageDown
+                                            | KeyCode::Home
+                                            | KeyCode::End
+                                    )
+                            })
+                            .map(|c| KeyChord { shift: true, ..*c })
+                            .collect();
+                        chords.extend(shifted);
+                    }
+                }
                 Keymap {
                     bindings,
                     cancel_any: true,
+                    warnings: Vec::new(),
                 }
             })
             .clone()
@@ -546,112 +559,144 @@ impl Default for Keymap {
 
 impl Keymap {
     pub fn compile(cfg: &KeysConfig) -> Result<Self, Vec<String>> {
+        let Some(settings) = cfg.0.as_table() else {
+            return Err(vec!["keys: expected a table".into()]);
+        };
         let mut map = Self::default();
         let mut errors = Vec::new();
-        for (scope, actions) in &cfg.scopes {
-            if actions.is_empty()
-                && !matches!(scope.as_str(), "global" | "navigation" | "input")
+        let mut overrides = BTreeMap::new();
+        for (scope, value) in settings {
+            if LEGACY.iter().any(|(name, _)| scope == name) {
+                continue;
+            }
+            if !matches!(scope.as_str(), "global" | "navigation" | "input")
                 && !map.bindings.contains_key(scope.as_str())
             {
                 errors.push(format!("keys.{scope}: unknown scope"));
+                continue;
             }
+            let Some(actions) = value.as_table() else {
+                errors.push(format!("keys.{scope}: expected a table of actions"));
+                continue;
+            };
             for (name, spec) in actions {
-                let targets: Vec<_> = map
-                    .bindings
-                    .iter()
-                    .filter_map(|(&target, bindings)| {
-                        let eligible = match scope.as_str() {
-                            "global" => true,
-                            "navigation" => !TEXT_SCOPES.contains(&target),
-                            "input" => TEXT_SCOPES.contains(&target),
-                            _ => target == scope,
-                        };
-                        eligible
-                            .then(|| bindings.keys().find(|a| a.name() == name).copied())
-                            .flatten()
-                            .filter(|a| match scope.as_str() {
-                                "global" => matches!(a, Action::Quit | Action::Compact),
-                                "navigation" => NAVIGATION_ACTIONS.contains(a),
-                                "input" => matches!(
-                                    a,
-                                    Action::ClearLine
-                                        | Action::DeleteWord
-                                        | Action::Backspace
-                                        | Action::Back
-                                        | Action::Accept
-                                ),
-                                _ => true,
-                            })
-                            .map(|action| (target, action))
-                    })
-                    .collect();
+                let targets = map.targets(scope, name);
                 if targets.is_empty() {
-                    errors.push(format!(
-                        "keys.{scope}.{name}: unknown scope or unsupported action"
-                    ));
+                    errors.push(format!("keys.{scope}.{name}: unsupported action"));
                     continue;
                 }
                 let chords = parse_chords(spec, &format!("keys.{scope}.{name}"), &mut errors);
-                // Shared groups are applied first below, independent of TOML order.
-                if matches!(scope.as_str(), "global" | "navigation" | "input") {
-                    for (target, action) in targets {
-                        map.bindings
-                            .get_mut(target)
-                            .unwrap()
-                            .insert(action, chords.clone());
-                    }
+                overrides.insert((scope.as_str(), name.as_str()), (targets, chords));
+            }
+        }
+        // Apply groups first, then explicit mode settings, regardless of file order.
+        for shared in [true, false] {
+            for (&(scope, _), (targets, chords)) in &overrides {
+                if matches!(scope, "global" | "navigation" | "input") != shared {
+                    continue;
+                }
+                for &(target, action) in targets {
+                    map.bindings
+                        .get_mut(target)
+                        .unwrap()
+                        .insert(action, chords.clone());
                 }
             }
         }
-        // Legacy palette fields remain aliases for the command scope.
-        for (name, action, spec) in [
-            ("palette_next", Action::Down, &cfg.palette_next),
-            ("palette_prev", Action::Up, &cfg.palette_prev),
-            ("palette_accept", Action::Accept, &cfg.palette_accept),
-        ] {
-            if let Some(spec) = spec {
-                if cfg
-                    .scopes
-                    .get("command")
-                    .is_some_and(|s| s.contains_key(action.name()))
-                {
-                    errors.push(format!(
-                        "keys.{name}: also set as keys.command.{}",
-                        action.name()
+        let command_settings = settings.get("command").and_then(toml::Value::as_table);
+        let scoped =
+            |action: Action| command_settings.is_some_and(|c| c.contains_key(action.name()));
+        let legacy = |action: Action| {
+            LEGACY
+                .iter()
+                .any(|&(name, a)| a == action && settings.contains_key(name))
+        };
+        let defaults = Self::default();
+        for &(name, action) in LEGACY {
+            let Some(spec) = settings.get(name) else {
+                continue;
+            };
+            if scoped(action) {
+                errors.push(format!(
+                    "keys.{name}: also set as keys.command.{}",
+                    action.name()
+                ));
+            }
+            let path = format!("keys.{name}");
+            let mut chords = parse_chords(spec, &path, &mut map.warnings);
+            chords.retain(|c| {
+                let reserved = (c.ctrl && matches!(c.code, KeyCode::Char('c' | 'e')))
+                    || GLOBAL.iter().any(|&(global, _)| {
+                        map.chords("command", global).iter().any(|g| overlaps(c, g))
+                    });
+                if reserved {
+                    map.warnings.push(format!(
+                        "{path}: {} is reserved by a built-in; ignored",
+                        c.label()
                     ));
                 }
-                let chords = parse_chords(spec, &format!("keys.{name}"), &mut errors);
-                // Existing palette bindings take priority over line editing.
-                if let Some(bindings) = map.bindings.get_mut("command") {
-                    for edit in [Action::ClearLine, Action::DeleteWord] {
-                        bindings
-                            .get_mut(&edit)
-                            .unwrap()
-                            .retain(|c| !chords.iter().any(|other| overlaps(c, other)));
-                    }
-                    bindings.insert(action, chords);
+                !reserved
+            });
+            if chords.is_empty() {
+                map.warnings
+                    .push(format!("{path}: no usable chord; using default"));
+                chords = defaults.chords("command", action).to_vec();
+            }
+            map.bindings
+                .get_mut("command")
+                .unwrap()
+                .insert(action, chords);
+        }
+        // Both configuration forms give explicit completion keys priority over
+        // text editing and cancellation, as the original palette handler did.
+        for &(_, action) in LEGACY {
+            if !legacy(action) && !scoped(action) {
+                continue;
+            }
+            let chords = map.chords("command", action).to_vec();
+            for &(edit, _) in INPUT {
+                if LEGACY.iter().any(|&(_, a)| a == edit) {
+                    continue;
                 }
+                map.bindings
+                    .get_mut("command")
+                    .unwrap()
+                    .get_mut(&edit)
+                    .unwrap()
+                    .retain(|c| !chords.iter().any(|other| overlaps(c, other)));
             }
         }
-        for (scope, actions) in &cfg.scopes {
-            if let Some(bindings) = map.bindings.get_mut(scope.as_str()) {
-                for (name, spec) in actions {
-                    if let Some(action) = bindings.keys().find(|a| a.name() == name).copied() {
-                        // Parsing was already checked in the first pass.
-                        let chords = parse_chords(spec, "", &mut Vec::new());
-                        bindings.insert(action, chords);
-                    }
+        // Legacy completion fields used ordered dispatch: next, previous, accept.
+        // Preserve that order when legacy fields overlap each other or defaults.
+        for (i, &(higher_name, higher)) in LEGACY.iter().enumerate() {
+            for &(lower_name, lower) in &LEGACY[i + 1..] {
+                if scoped(higher) || scoped(lower) || !(legacy(higher) || legacy(lower)) {
+                    continue;
                 }
+                let chords = map.chords("command", higher).to_vec();
+                let lower_chords = map
+                    .bindings
+                    .get_mut("command")
+                    .unwrap()
+                    .get_mut(&lower)
+                    .unwrap();
+                lower_chords.retain(|c| {
+                    if chords.iter().any(|other| overlaps(c, other)) {
+                        map.warnings.push(format!(
+                            "keys.{lower_name}: {} is handled by {higher_name}; ignored",
+                            c.label()
+                        ));
+                        false
+                    } else {
+                        true
+                    }
+                });
             }
         }
-        map.cancel_any = !cfg
-            .scopes
+        map.cancel_any = !settings
             .get("confirm")
-            .is_some_and(|s| s.contains_key("back"))
-            && !cfg
-                .scopes
-                .get("navigation")
-                .is_some_and(|s| s.contains_key("back"));
+            .and_then(toml::Value::as_table)
+            .is_some_and(|s| s.contains_key("back"));
         for (scope, bindings) in &map.bindings {
             let entries: Vec<_> = bindings.iter().collect();
             for (i, (action, chords)) in entries.iter().enumerate() {
@@ -674,6 +719,45 @@ impl Keymap {
             Ok(map)
         } else {
             Err(errors)
+        }
+    }
+
+    fn targets(&self, scope: &str, name: &str) -> Vec<(&'static str, Action)> {
+        self.bindings
+            .iter()
+            .filter_map(|(&target, bindings)| {
+                let action = bindings.keys().find(|a| a.name() == name).copied()?;
+                let applies = match scope {
+                    "global" => GLOBAL.iter().any(|&(a, _)| a == action),
+                    "input" => {
+                        TEXT_SCOPES.contains(&target) && INPUT.iter().any(|&(a, _)| a == action)
+                    }
+                    "navigation" => {
+                        !TEXT_SCOPES.contains(&target)
+                            && NAVIGATION_ACTIONS.contains(&action)
+                            && !(target == "confirm" && action == Action::Back)
+                    }
+                    _ => scope == target,
+                };
+                applies.then_some((target, action))
+            })
+            .collect()
+    }
+
+    pub fn is_default(&self) -> bool {
+        let defaults = Self::default();
+        self.bindings == defaults.bindings && self.cancel_any == defaults.cancel_any
+    }
+
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
+    }
+
+    pub(crate) fn wheel_action(&self, scope: &str, down: bool) -> Option<Action> {
+        if scope == "confirm" {
+            self.cancel_any.then_some(Action::Back)
+        } else {
+            Some(if down { Action::Down } else { Action::Up })
         }
     }
 
@@ -715,9 +799,26 @@ impl Keymap {
     }
 }
 
-fn parse_chords(spec: &Chords, path: &str, errors: &mut Vec<String>) -> Vec<KeyChord> {
+fn parse_chords(spec: &toml::Value, path: &str, errors: &mut Vec<String>) -> Vec<KeyChord> {
+    let values = match spec {
+        toml::Value::String(_) => std::slice::from_ref(spec),
+        toml::Value::Array(values) => values,
+        _ => {
+            errors.push(format!(
+                "{path}: expected a key string or an array of key strings"
+            ));
+            return Vec::new();
+        }
+    };
     let mut out = Vec::new();
-    for value in spec.as_slice() {
+    for value in values {
+        let Some(value) = value.as_str() else {
+            errors.push(format!(
+                "{path}: expected a key string, got {}",
+                value.type_str()
+            ));
+            continue;
+        };
         match KeyChord::parse(value) {
             Ok(chord) => {
                 if !out.iter().any(|other| overlaps(&chord, other)) {
@@ -835,7 +936,7 @@ mod tests {
         for (text, path) in [
             ("[keys.table]\npaeg_up = 'f8'", "keys.table.paeg_up"),
             ("[keys.unknown]", "keys.unknown"),
-            ("[keys.unknown]\npage_up = 'f8'", "keys.unknown.page_up"),
+            ("[keys.unknown]\npage_up = 'f8'", "keys.unknown"),
             ("[keys.input]\npage_up = 'f8'", "keys.input.page_up"),
             ("[keys.table]\npage_up = 'hyper-u'", "keys.table.page_up"),
             (

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,0 +1,888 @@
+//! Built-in actions and their effective keyboard bindings.
+
+use crate::{
+    config::{Chords, KeysConfig},
+    keys::KeyChord,
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+macro_rules! actions {
+    ($($variant:ident => ($name:literal, $description:literal)),* $(,)?) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        pub enum Action { $($variant),* }
+        impl Action {
+            pub fn name(self) -> &'static str {
+                match self { $(Self::$variant => $name),* }
+            }
+            pub fn description(self) -> &'static str {
+                match self { $(Self::$variant => $description),* }
+            }
+        }
+    };
+}
+
+actions! {
+    Accept => ("accept", "accept selection or input"),
+    ActionMenu => ("action_menu", "resource action menu"),
+    Adjacent => ("adjacent", "adjacent"),
+    AllNamespaces => ("all_namespaces", "all namespaces"),
+    Anchor0 => ("anchor_0", "tail logs"),
+    Anchor1 => ("anchor_1", "logs from last minute"),
+    Anchor2 => ("anchor_2", "logs from last 5 minutes"),
+    Anchor3 => ("anchor_3", "logs from last 15 minutes"),
+    Anchor4 => ("anchor_4", "logs from last 30 minutes"),
+    Anchor5 => ("anchor_5", "logs from last hour"),
+    Attach => ("attach", "attach"),
+    AutoRefresh => ("auto_refresh", "auto refresh"),
+    Back => ("back", "back or clear search"),
+    Backspace => ("backspace", "backspace"),
+    Cascade => ("cascade", "cascade"),
+    Clear => ("clear", "clear"),
+    ClearLine => ("clear_line", "clear line"),
+    Close => ("close", "close view"),
+    Command => ("command", "command palette"),
+    Compact => ("compact", "toggle compact mode"),
+    Copy => ("copy", "copy"),
+    CopyCell => ("copy_cell", "copy cell"),
+    CopyName => ("copy_name", "copy name"),
+    Cordon => ("cordon", "cordon"),
+    Debug => ("debug", "debug"),
+    DecodeSecret => ("decode_secret", "decode secret"),
+    Delete => ("delete", "delete"),
+    DeleteWord => ("delete_word", "delete word"),
+    Describe => ("describe", "describe"),
+    DiscoverChildren => ("discover_children", "discover children"),
+    Down => ("down", "down"),
+    Drain => ("drain", "drain"),
+    Edit => ("edit", "edit"),
+    Events => ("events", "events"),
+    Exit => ("exit", "quit from table"),
+    Explain => ("explain", "explain"),
+    Faults => ("faults", "faults"),
+    Filter => ("filter", "filter"),
+    First => ("first", "first row"),
+    FleetMark => ("fleet_mark", "fleet mark"),
+    Follow => ("follow", "follow"),
+    Force => ("force", "force"),
+    ForceDelete => ("force_delete", "force delete"),
+    Fullscreen => ("fullscreen", "fullscreen"),
+    Help => ("help", "help"),
+    HistoryBack => ("history_back", "history back"),
+    HistoryForward => ("history_forward", "history forward"),
+    Inspect => ("inspect", "decode secret or browse PVC"),
+    InvertSort => ("invert_sort", "invert sort"),
+    Last => ("last", "last row"),
+    Left => ("left", "left"),
+    Logs => ("logs", "logs"),
+    Lookback => ("lookback", "lookback"),
+    Mark => ("mark", "mark"),
+    Namespaces => ("namespaces", "namespaces"),
+    NextMatch => ("next_match", "next match"),
+    NextView => ("next_view", "next view"),
+    Node => ("node", "node"),
+    Open => ("open", "open selection"),
+    Owner => ("owner", "owner"),
+    PageDown => ("page_down", "page down"),
+    PageUp => ("page_up", "page up"),
+    Parent => ("parent", "parent"),
+    PortForward => ("port_forward", "port forward"),
+    PreviousLogs => ("previous_logs", "previous logs"),
+    PreviousMatch => ("previous_match", "previous match"),
+    PreviousView => ("previous_view", "previous view"),
+    ProviderLogs => ("provider_logs", "provider logs"),
+    Quit => ("quit", "quit"),
+    Refresh => ("refresh", "refresh"),
+    Rename => ("rename", "rename"),
+    RestartOrRefresh => ("restart_or_refresh", "restart, sync, rollback, or refresh"),
+    Right => ("right", "right"),
+    Save => ("save", "save"),
+    SetImage => ("set_image", "set image"),
+    Shell => ("shell", "shell"),
+    ShellOrScale => ("shell_or_scale", "shell or scale"),
+    Sort => ("sort", "sort"),
+    Start => ("start", "start"),
+    Stream => ("stream", "stream"),
+    SwitchPane => ("switch_pane", "switch pane"),
+    Timeline => ("timeline", "timeline"),
+    Timestamps => ("timestamps", "timestamps"),
+    Toggle => ("toggle", "toggle"),
+    Transfer => ("transfer", "transfer"),
+    Uncordon => ("uncordon", "uncordon"),
+    Up => ("up", "up"),
+    Wide => ("wide", "wide"),
+    Wrap => ("wrap", "wrap"),
+    Yaml => ("yaml", "yaml"),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct KeyInput {
+    pub action: Option<Action>,
+    pub code: KeyCode,
+    pub modifiers: KeyModifiers,
+}
+
+impl KeyInput {
+    pub fn new(action: Option<Action>, key: KeyEvent) -> Self {
+        Self {
+            action,
+            code: key.code,
+            modifiers: key.modifiers,
+        }
+    }
+    pub fn event(self) -> KeyEvent {
+        KeyEvent::new(self.code, self.modifiers)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Keymap {
+    bindings: BTreeMap<&'static str, BTreeMap<Action, Vec<KeyChord>>>,
+    cancel_any: bool,
+}
+
+const GLOBAL: &[(Action, &[&str])] = &[(Action::Quit, &["ctrl-c"]), (Action::Compact, &["ctrl-e"])];
+const INPUT: &[(Action, &[&str])] = &[
+    (Action::ClearLine, &["ctrl-u"]),
+    (
+        Action::DeleteWord,
+        &["ctrl-w", "alt-backspace", "ctrl-backspace"],
+    ),
+];
+const VIEW_SCOPES: &[&str] = &[
+    "table",
+    "detail",
+    "logs",
+    "help",
+    "containers",
+    "confirm",
+    "pulse",
+    "xray",
+    "explain",
+    "timeline",
+    "gitops",
+    "adjacent",
+    "diff",
+    "events",
+    "flux_menu",
+    "transfer_menu",
+    "port_forwards",
+    "skins",
+    "snapshots",
+    "fleet",
+    "find",
+    "pvc_explore",
+];
+
+const DEFAULTS: &[(&str, Action, &[&str])] = &[
+    ("adjacent", Action::Accept, &["enter"]),
+    ("adjacent", Action::Back, &["esc"]),
+    ("adjacent", Action::Close, &["q"]),
+    ("adjacent", Action::Describe, &["d"]),
+    ("adjacent", Action::DiscoverChildren, &["c"]),
+    ("adjacent", Action::Down, &["j", "down"]),
+    ("adjacent", Action::First, &["g", "home"]),
+    ("adjacent", Action::Last, &["G", "end"]),
+    ("adjacent", Action::Refresh, &["r"]),
+    ("adjacent", Action::Up, &["k", "up"]),
+    ("adjacent", Action::Yaml, &["y"]),
+    ("command", Action::Accept, &["enter"]),
+    ("command", Action::Back, &["esc"]),
+    ("command", Action::Backspace, &["backspace"]),
+    ("command", Action::Down, &["tab", "down"]),
+    ("command", Action::Up, &["backtab", "up"]),
+    ("confirm", Action::Accept, &["y", "Y", "enter"]),
+    ("confirm", Action::Back, &["esc", "n", "N", "q"]),
+    ("confirm", Action::Cascade, &["c", "C"]),
+    ("confirm", Action::Force, &["f", "F"]),
+    ("containers", Action::Back, &["esc"]),
+    ("containers", Action::Close, &["q"]),
+    ("containers", Action::Debug, &["d"]),
+    ("containers", Action::Down, &["j", "down"]),
+    ("containers", Action::Logs, &["enter", "l"]),
+    ("containers", Action::PreviousLogs, &["p"]),
+    ("containers", Action::ProviderLogs, &["L"]),
+    ("containers", Action::Shell, &["s"]),
+    ("containers", Action::Transfer, &["t"]),
+    ("containers", Action::Up, &["k", "up"]),
+    ("context_filter", Action::Accept, &["enter"]),
+    ("context_filter", Action::Back, &["esc"]),
+    ("context_filter", Action::Backspace, &["backspace"]),
+    ("context_filter", Action::Down, &["down"]),
+    ("context_filter", Action::Up, &["up"]),
+    ("contexts", Action::Accept, &["enter"]),
+    ("contexts", Action::Back, &["esc"]),
+    ("contexts", Action::Down, &["down", "j"]),
+    ("contexts", Action::Filter, &["/"]),
+    ("contexts", Action::FleetMark, &["space"]),
+    ("contexts", Action::Rename, &["r", "R"]),
+    ("contexts", Action::Up, &["up", "k"]),
+    ("copy_picker", Action::Accept, &["enter"]),
+    ("copy_picker", Action::Back, &["esc"]),
+    ("copy_picker", Action::Backspace, &["backspace"]),
+    ("copy_picker", Action::Down, &["down", "ctrl-n"]),
+    ("copy_picker", Action::Up, &["up", "ctrl-p"]),
+    ("detail", Action::AutoRefresh, &["r"]),
+    ("detail", Action::Back, &["esc"]),
+    ("detail", Action::Close, &["q"]),
+    ("detail", Action::Copy, &["c"]),
+    ("detail", Action::DecodeSecret, &["x"]),
+    ("detail", Action::Down, &["j", "down"]),
+    ("detail", Action::Filter, &["/"]),
+    ("detail", Action::First, &["g", "home"]),
+    ("detail", Action::Last, &["G", "end"]),
+    ("detail", Action::Left, &["h", "left"]),
+    ("detail", Action::NextMatch, &["n"]),
+    ("detail", Action::PageDown, &["pagedown", "space", "ctrl-f"]),
+    ("detail", Action::PageUp, &["pageup", "ctrl-b"]),
+    ("detail", Action::PreviousMatch, &["N"]),
+    ("detail", Action::Right, &["l", "right"]),
+    ("detail", Action::Up, &["k", "up"]),
+    ("detail", Action::Wrap, &["w"]),
+    ("diff", Action::Back, &["esc"]),
+    ("diff", Action::Close, &["q"]),
+    ("diff", Action::Copy, &["c"]),
+    ("diff", Action::Down, &["j", "down"]),
+    ("diff", Action::Filter, &["/"]),
+    ("diff", Action::First, &["g", "home"]),
+    ("diff", Action::Last, &["G", "end"]),
+    ("diff", Action::Left, &["h", "left"]),
+    ("diff", Action::NextMatch, &["n"]),
+    ("diff", Action::PageDown, &["pagedown", "space", "ctrl-f"]),
+    ("diff", Action::PageUp, &["pageup", "ctrl-b"]),
+    ("diff", Action::PreviousMatch, &["N"]),
+    ("diff", Action::Right, &["l", "right"]),
+    ("diff", Action::Up, &["k", "up"]),
+    ("diff", Action::Wrap, &["w"]),
+    ("doc_filter", Action::Accept, &["enter"]),
+    ("doc_filter", Action::Back, &["esc"]),
+    ("doc_filter", Action::Backspace, &["backspace"]),
+    ("events", Action::Back, &["esc"]),
+    ("events", Action::Close, &["q"]),
+    ("events", Action::Copy, &["c"]),
+    ("events", Action::Down, &["j", "down"]),
+    ("events", Action::Filter, &["/"]),
+    ("events", Action::First, &["g", "home"]),
+    ("events", Action::Last, &["G", "end"]),
+    ("events", Action::Left, &["h", "left"]),
+    ("events", Action::NextMatch, &["n"]),
+    ("events", Action::PageDown, &["pagedown", "space", "ctrl-f"]),
+    ("events", Action::PageUp, &["pageup", "ctrl-b"]),
+    ("events", Action::PreviousMatch, &["N"]),
+    ("events", Action::Right, &["l", "right"]),
+    ("events", Action::Up, &["k", "up"]),
+    ("events", Action::Wrap, &["w"]),
+    ("explain", Action::Accept, &["enter"]),
+    ("explain", Action::Back, &["esc"]),
+    ("explain", Action::Close, &["q"]),
+    ("explain", Action::Down, &["j", "down"]),
+    ("explain", Action::Events, &["E"]),
+    ("explain", Action::First, &["g", "home"]),
+    ("explain", Action::Last, &["G", "end"]),
+    ("explain", Action::Logs, &["l"]),
+    ("explain", Action::Refresh, &["r"]),
+    ("explain", Action::Up, &["k", "up"]),
+    ("filter", Action::Accept, &["enter"]),
+    ("filter", Action::Back, &["esc"]),
+    ("filter", Action::Backspace, &["backspace"]),
+    ("find", Action::Accept, &["enter"]),
+    ("find", Action::Back, &["esc"]),
+    ("find", Action::Close, &["q"]),
+    ("find", Action::Down, &["j", "down"]),
+    ("find", Action::First, &["g", "home"]),
+    ("find", Action::Last, &["G", "end"]),
+    ("find", Action::Up, &["k", "up"]),
+    ("fleet", Action::Accept, &["enter"]),
+    ("fleet", Action::Back, &["esc"]),
+    ("fleet", Action::Close, &["q"]),
+    ("fleet", Action::Down, &["j", "down"]),
+    ("fleet", Action::Refresh, &["r"]),
+    ("fleet", Action::Up, &["k", "up"]),
+    ("flux_menu", Action::Accept, &["enter"]),
+    ("flux_menu", Action::Back, &["esc"]),
+    ("flux_menu", Action::Close, &["q"]),
+    ("flux_menu", Action::Down, &["j", "down"]),
+    ("flux_menu", Action::Up, &["k", "up"]),
+    ("gitops", Action::Accept, &["enter"]),
+    ("gitops", Action::Back, &["esc"]),
+    ("gitops", Action::Close, &["q"]),
+    ("gitops", Action::Down, &["j", "down"]),
+    ("gitops", Action::First, &["g", "home"]),
+    ("gitops", Action::Last, &["G", "end"]),
+    ("gitops", Action::Refresh, &["r"]),
+    ("gitops", Action::Up, &["k", "up"]),
+    ("help", Action::Back, &["esc"]),
+    ("help", Action::Close, &["q", "?"]),
+    ("help", Action::Down, &["j", "down"]),
+    ("help", Action::Filter, &["/"]),
+    ("help", Action::First, &["g", "home"]),
+    ("help", Action::Last, &["G", "end"]),
+    ("help", Action::PageDown, &["pagedown", "space", "ctrl-f"]),
+    ("help", Action::PageUp, &["pageup", "ctrl-b"]),
+    ("help", Action::Up, &["k", "up"]),
+    ("log_filter", Action::Accept, &["enter"]),
+    ("log_filter", Action::Back, &["esc"]),
+    ("log_filter", Action::Backspace, &["backspace"]),
+    ("logs", Action::Anchor0, &["0"]),
+    ("logs", Action::Anchor1, &["1"]),
+    ("logs", Action::Anchor2, &["2"]),
+    ("logs", Action::Anchor3, &["3"]),
+    ("logs", Action::Anchor4, &["4"]),
+    ("logs", Action::Anchor5, &["5"]),
+    ("logs", Action::Back, &["esc"]),
+    ("logs", Action::Clear, &["z"]),
+    ("logs", Action::Close, &["q"]),
+    ("logs", Action::Copy, &["c"]),
+    ("logs", Action::Down, &["j", "down"]),
+    ("logs", Action::Filter, &["/"]),
+    ("logs", Action::First, &["g", "home"]),
+    ("logs", Action::Follow, &["s", "f"]),
+    ("logs", Action::Fullscreen, &["F"]),
+    ("logs", Action::Last, &["G", "end"]),
+    ("logs", Action::Lookback, &["T"]),
+    ("logs", Action::PageDown, &["pagedown", "space"]),
+    ("logs", Action::PageUp, &["pageup"]),
+    ("logs", Action::Save, &["ctrl-s"]),
+    ("logs", Action::Stream, &["x"]),
+    ("logs", Action::Timestamps, &["t"]),
+    ("logs", Action::Up, &["k", "up"]),
+    ("logs", Action::Wrap, &["w"]),
+    ("namespaces", Action::Accept, &["enter"]),
+    ("namespaces", Action::Back, &["esc"]),
+    ("namespaces", Action::Backspace, &["backspace"]),
+    ("namespaces", Action::Down, &["down"]),
+    ("namespaces", Action::Up, &["up"]),
+    ("port_forward_picker", Action::Accept, &["enter"]),
+    ("port_forward_picker", Action::Back, &["esc"]),
+    ("port_forward_picker", Action::Close, &["q"]),
+    ("port_forward_picker", Action::Down, &["j", "down"]),
+    ("port_forward_picker", Action::Up, &["k", "up"]),
+    ("port_forwards", Action::Back, &["esc"]),
+    ("port_forwards", Action::Close, &["q"]),
+    ("port_forwards", Action::Down, &["j", "down"]),
+    ("port_forwards", Action::Start, &["enter"]),
+    ("port_forwards", Action::Toggle, &["x", "s"]),
+    ("port_forwards", Action::Up, &["k", "up"]),
+    ("prompt", Action::Accept, &["enter"]),
+    ("prompt", Action::Back, &["esc"]),
+    ("prompt", Action::Backspace, &["backspace"]),
+    ("pulse", Action::Back, &["esc"]),
+    ("pulse", Action::Close, &["q"]),
+    ("pulse", Action::Refresh, &["r"]),
+    ("pvc_explore", Action::Accept, &["enter"]),
+    ("pvc_explore", Action::Back, &["esc"]),
+    ("pvc_explore", Action::Close, &["q"]),
+    ("pvc_explore", Action::Copy, &["c"]),
+    ("pvc_explore", Action::Down, &["j", "down"]),
+    ("pvc_explore", Action::First, &["g", "home"]),
+    ("pvc_explore", Action::Last, &["G", "end"]),
+    ("pvc_explore", Action::Left, &["left"]),
+    ("pvc_explore", Action::Parent, &["backspace", "-"]),
+    ("pvc_explore", Action::Refresh, &["r"]),
+    ("pvc_explore", Action::Right, &["right"]),
+    ("pvc_explore", Action::Shell, &["s"]),
+    ("pvc_explore", Action::SwitchPane, &["tab", "backtab"]),
+    ("pvc_explore", Action::Up, &["k", "up"]),
+    ("set_image", Action::Accept, &["enter"]),
+    ("set_image", Action::Back, &["esc"]),
+    ("set_image", Action::Close, &["q"]),
+    ("set_image", Action::Down, &["j", "down"]),
+    ("set_image", Action::Up, &["k", "up"]),
+    ("skins", Action::Accept, &["enter"]),
+    ("skins", Action::Back, &["esc"]),
+    ("skins", Action::Close, &["q"]),
+    ("skins", Action::Down, &["j", "down"]),
+    ("skins", Action::Up, &["k", "up"]),
+    ("snapshots", Action::Accept, &["enter"]),
+    ("snapshots", Action::Back, &["esc"]),
+    ("snapshots", Action::Close, &["q"]),
+    ("snapshots", Action::Delete, &["d"]),
+    ("snapshots", Action::Down, &["j", "down"]),
+    ("snapshots", Action::Up, &["k", "up"]),
+    ("sort_picker", Action::Accept, &["enter"]),
+    ("sort_picker", Action::Back, &["esc"]),
+    ("sort_picker", Action::Backspace, &["backspace"]),
+    ("sort_picker", Action::Down, &["down", "ctrl-n"]),
+    ("sort_picker", Action::Up, &["up", "ctrl-p"]),
+    ("table", Action::ActionMenu, &["t"]),
+    ("table", Action::Adjacent, &["u"]),
+    ("table", Action::AllNamespaces, &["0"]),
+    ("table", Action::Attach, &["a"]),
+    ("table", Action::Back, &["esc"]),
+    ("table", Action::CopyCell, &["Y"]),
+    ("table", Action::CopyName, &["c"]),
+    ("table", Action::Cordon, &["C"]),
+    ("table", Action::Delete, &["ctrl-d"]),
+    ("table", Action::Describe, &["d"]),
+    ("table", Action::Down, &["j", "down"]),
+    ("table", Action::Drain, &["D"]),
+    ("table", Action::Edit, &["e"]),
+    ("table", Action::Events, &["E"]),
+    ("table", Action::Exit, &["q"]),
+    ("table", Action::Explain, &["X"]),
+    ("table", Action::Faults, &["ctrl-z"]),
+    ("table", Action::Filter, &["/"]),
+    ("table", Action::First, &["g", "home"]),
+    ("table", Action::ForceDelete, &["ctrl-k"]),
+    ("table", Action::HistoryBack, &["["]),
+    ("table", Action::HistoryForward, &["]"]),
+    ("table", Action::Inspect, &["x"]),
+    ("table", Action::InvertSort, &["I"]),
+    ("table", Action::Last, &["G", "end"]),
+    ("table", Action::Left, &["left"]),
+    ("table", Action::Logs, &["l"]),
+    ("table", Action::Mark, &["space"]),
+    ("table", Action::Namespaces, &["n"]),
+    ("table", Action::NextView, &["tab"]),
+    ("table", Action::Node, &["o"]),
+    ("table", Action::Open, &["enter"]),
+    ("table", Action::Owner, &["J"]),
+    ("table", Action::PageDown, &["pagedown", "ctrl-f"]),
+    ("table", Action::PageUp, &["pageup", "ctrl-b"]),
+    ("table", Action::PortForward, &["f", "F"]),
+    ("table", Action::PreviousLogs, &["p"]),
+    ("table", Action::PreviousView, &["backtab"]),
+    ("table", Action::ProviderLogs, &["L"]),
+    ("table", Action::Refresh, &["ctrl-r"]),
+    ("table", Action::RestartOrRefresh, &["r"]),
+    ("table", Action::Right, &["right"]),
+    ("table", Action::SetImage, &["i"]),
+    ("table", Action::ShellOrScale, &["s"]),
+    ("table", Action::Sort, &["S"]),
+    ("table", Action::Timeline, &["T"]),
+    ("table", Action::Uncordon, &["U"]),
+    ("table", Action::Up, &["k", "up"]),
+    ("table", Action::Wide, &["w"]),
+    ("table", Action::Yaml, &["y"]),
+    ("timeline", Action::Back, &["esc"]),
+    ("timeline", Action::Close, &["q"]),
+    ("timeline", Action::Down, &["j", "down"]),
+    ("timeline", Action::First, &["g", "home"]),
+    ("timeline", Action::Last, &["G", "end"]),
+    ("timeline", Action::Up, &["k", "up"]),
+    ("transfer_menu", Action::Accept, &["enter"]),
+    ("transfer_menu", Action::Back, &["esc"]),
+    ("transfer_menu", Action::Close, &["q"]),
+    ("transfer_menu", Action::Down, &["j", "down"]),
+    ("transfer_menu", Action::Up, &["k", "up"]),
+    ("xray", Action::Back, &["esc"]),
+    ("xray", Action::Close, &["q"]),
+    ("xray", Action::Down, &["j", "down"]),
+    ("xray", Action::First, &["g", "home"]),
+    ("xray", Action::Last, &["G", "end"]),
+    ("xray", Action::Logs, &["enter", "l"]),
+    ("xray", Action::Refresh, &["r"]),
+    ("xray", Action::Up, &["k", "up"]),
+];
+const TEXT_SCOPES: &[&str] = &[
+    "command",
+    "filter",
+    "log_filter",
+    "doc_filter",
+    "prompt",
+    "sort_picker",
+    "copy_picker",
+    "namespaces",
+    "context_filter",
+];
+const NAVIGATION_ACTIONS: &[Action] = &[
+    Action::Up,
+    Action::Down,
+    Action::First,
+    Action::Last,
+    Action::PageUp,
+    Action::PageDown,
+    Action::Left,
+    Action::Right,
+    Action::Back,
+    Action::Close,
+    Action::Command,
+    Action::Help,
+];
+impl Default for Keymap {
+    fn default() -> Self {
+        static DEFAULT: OnceLock<Keymap> = OnceLock::new();
+        DEFAULT
+            .get_or_init(|| {
+                let mut bindings: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
+                for &(scope, action, chords) in DEFAULTS {
+                    bindings.entry(scope).or_default().insert(
+                        action,
+                        chords
+                            .iter()
+                            .map(|s| KeyChord::parse(s).expect("valid default key"))
+                            .collect(),
+                    );
+                }
+                for (&scope, actions) in &mut bindings {
+                    for &(action, chords) in GLOBAL
+                        .iter()
+                        .chain(INPUT.iter().filter(|_| TEXT_SCOPES.contains(&scope)))
+                    {
+                        actions.insert(
+                            action,
+                            chords
+                                .iter()
+                                .map(|s| KeyChord::parse(s).expect("valid default key"))
+                                .collect(),
+                        );
+                    }
+                    if VIEW_SCOPES.contains(&scope) {
+                        actions.insert(Action::Command, vec![KeyChord::parse(":").unwrap()]);
+                        if scope != "help" {
+                            actions.insert(Action::Help, vec![KeyChord::parse("?").unwrap()]);
+                        }
+                    }
+                }
+                Keymap {
+                    bindings,
+                    cancel_any: true,
+                }
+            })
+            .clone()
+    }
+}
+
+impl Keymap {
+    pub fn compile(cfg: &KeysConfig) -> Result<Self, Vec<String>> {
+        let mut map = Self::default();
+        let mut errors = Vec::new();
+        for (scope, actions) in &cfg.scopes {
+            if actions.is_empty()
+                && !matches!(scope.as_str(), "global" | "navigation" | "input")
+                && !map.bindings.contains_key(scope.as_str())
+            {
+                errors.push(format!("keys.{scope}: unknown scope"));
+            }
+            for (name, spec) in actions {
+                let targets: Vec<_> = map
+                    .bindings
+                    .iter()
+                    .filter_map(|(&target, bindings)| {
+                        let eligible = match scope.as_str() {
+                            "global" => true,
+                            "navigation" => !TEXT_SCOPES.contains(&target),
+                            "input" => TEXT_SCOPES.contains(&target),
+                            _ => target == scope,
+                        };
+                        eligible
+                            .then(|| bindings.keys().find(|a| a.name() == name).copied())
+                            .flatten()
+                            .filter(|a| match scope.as_str() {
+                                "global" => matches!(a, Action::Quit | Action::Compact),
+                                "navigation" => NAVIGATION_ACTIONS.contains(a),
+                                "input" => matches!(
+                                    a,
+                                    Action::ClearLine
+                                        | Action::DeleteWord
+                                        | Action::Backspace
+                                        | Action::Back
+                                        | Action::Accept
+                                ),
+                                _ => true,
+                            })
+                            .map(|action| (target, action))
+                    })
+                    .collect();
+                if targets.is_empty() {
+                    errors.push(format!(
+                        "keys.{scope}.{name}: unknown scope or unsupported action"
+                    ));
+                    continue;
+                }
+                let chords = parse_chords(spec, &format!("keys.{scope}.{name}"), &mut errors);
+                // Shared groups are applied first below, independent of TOML order.
+                if matches!(scope.as_str(), "global" | "navigation" | "input") {
+                    for (target, action) in targets {
+                        map.bindings
+                            .get_mut(target)
+                            .unwrap()
+                            .insert(action, chords.clone());
+                    }
+                }
+            }
+        }
+        // Legacy palette fields remain aliases for the command scope.
+        for (name, action, spec) in [
+            ("palette_next", Action::Down, &cfg.palette_next),
+            ("palette_prev", Action::Up, &cfg.palette_prev),
+            ("palette_accept", Action::Accept, &cfg.palette_accept),
+        ] {
+            if let Some(spec) = spec {
+                if cfg
+                    .scopes
+                    .get("command")
+                    .is_some_and(|s| s.contains_key(action.name()))
+                {
+                    errors.push(format!(
+                        "keys.{name}: also set as keys.command.{}",
+                        action.name()
+                    ));
+                }
+                let chords = parse_chords(spec, &format!("keys.{name}"), &mut errors);
+                // Existing palette bindings take priority over line editing.
+                if let Some(bindings) = map.bindings.get_mut("command") {
+                    for edit in [Action::ClearLine, Action::DeleteWord] {
+                        bindings
+                            .get_mut(&edit)
+                            .unwrap()
+                            .retain(|c| !chords.iter().any(|other| overlaps(c, other)));
+                    }
+                    bindings.insert(action, chords);
+                }
+            }
+        }
+        for (scope, actions) in &cfg.scopes {
+            if let Some(bindings) = map.bindings.get_mut(scope.as_str()) {
+                for (name, spec) in actions {
+                    if let Some(action) = bindings.keys().find(|a| a.name() == name).copied() {
+                        // Parsing was already checked in the first pass.
+                        let chords = parse_chords(spec, "", &mut Vec::new());
+                        bindings.insert(action, chords);
+                    }
+                }
+            }
+        }
+        map.cancel_any = !cfg
+            .scopes
+            .get("confirm")
+            .is_some_and(|s| s.contains_key("back"))
+            && !cfg
+                .scopes
+                .get("navigation")
+                .is_some_and(|s| s.contains_key("back"));
+        for (scope, bindings) in &map.bindings {
+            let entries: Vec<_> = bindings.iter().collect();
+            for (i, (action, chords)) in entries.iter().enumerate() {
+                for (other, other_chords) in &entries[i + 1..] {
+                    if let Some(chord) = chords
+                        .iter()
+                        .find(|c| other_chords.iter().any(|o| overlaps(c, o)))
+                    {
+                        errors.push(format!(
+                            "keys.{scope}: {} conflicts between {} and {}",
+                            chord.label(),
+                            action.name(),
+                            other.name()
+                        ));
+                    }
+                }
+            }
+        }
+        if errors.is_empty() {
+            Ok(map)
+        } else {
+            Err(errors)
+        }
+    }
+
+    pub fn action(&self, scope: &str, key: &KeyEvent) -> Option<Action> {
+        self.bindings
+            .get(scope)?
+            .iter()
+            .find_map(|(&action, chords)| chords.iter().any(|c| c.matches(key)).then_some(action))
+            .or_else(|| (scope == "confirm" && self.cancel_any).then_some(Action::Back))
+    }
+
+    pub fn chords(&self, scope: &str, action: Action) -> &[KeyChord] {
+        self.bindings
+            .get(scope)
+            .and_then(|b| b.get(&action))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    pub fn label(&self, scope: &str, action: Action) -> String {
+        let chords = self.chords(scope, action);
+        if chords.is_empty() {
+            "unbound".into()
+        } else {
+            chords
+                .iter()
+                .map(KeyChord::label)
+                .collect::<Vec<_>>()
+                .join(" / ")
+        }
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = (&'static str, Action, &[KeyChord])> {
+        self.bindings.iter().flat_map(|(&scope, bindings)| {
+            bindings
+                .iter()
+                .map(move |(&action, chords)| (scope, action, chords.as_slice()))
+        })
+    }
+}
+
+fn parse_chords(spec: &Chords, path: &str, errors: &mut Vec<String>) -> Vec<KeyChord> {
+    let mut out = Vec::new();
+    for value in spec.as_slice() {
+        match KeyChord::parse(value) {
+            Ok(chord) => {
+                if !out.iter().any(|other| overlaps(&chord, other)) {
+                    out.push(chord);
+                }
+            }
+            Err(error) => errors.push(format!("{path}: {error}")),
+        }
+    }
+    out
+}
+
+pub(crate) fn overlaps(a: &KeyChord, b: &KeyChord) -> bool {
+    let event = |c: &KeyChord| {
+        let mut modifiers = KeyModifiers::NONE;
+        modifiers.set(KeyModifiers::CONTROL, c.ctrl);
+        modifiers.set(KeyModifiers::ALT, c.alt);
+        modifiers.set(KeyModifiers::SHIFT, c.shift);
+        KeyEvent::new(c.code, modifiers)
+    };
+    a.matches(&event(b)) || b.matches(&event(a))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compile(text: &str) -> Result<Keymap, Vec<String>> {
+        let cfg: crate::config::Config = toml::from_str(text).unwrap();
+        Keymap::compile(&cfg.keys)
+    }
+
+    #[test]
+    fn defaults_have_no_conflicts() {
+        assert_eq!(compile("").unwrap(), Keymap::default());
+    }
+
+    #[test]
+    fn paging_requires_releasing_delete_and_keeps_text_editing() {
+        let text = r#"
+            [keys.navigation]
+            page_up = ["pageup", "ctrl-b", "ctrl-u"]
+            page_down = ["pagedown", "ctrl-f", "ctrl-d"]
+        "#;
+        let errors = compile(text).unwrap_err().join("\n");
+        assert!(errors.contains("keys.table"), "{errors}");
+        assert!(errors.contains("ctrl-d"), "{errors}");
+        assert!(errors.contains("delete"), "{errors}");
+        assert!(errors.contains("page_down"), "{errors}");
+        let map = compile(&format!("{text}\n[keys.table]\ndelete = 'alt-d'\n")).unwrap();
+        for scope in ["table", "detail", "diff", "events", "help", "logs"] {
+            assert_eq!(
+                map.action(
+                    scope,
+                    &KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)
+                ),
+                Some(Action::PageDown)
+            );
+        }
+        assert_eq!(
+            map.action(
+                "prompt",
+                &KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL)
+            ),
+            Some(Action::ClearLine)
+        );
+    }
+
+    #[test]
+    fn local_override_replaces_shared_keys_and_empty_array_disables() {
+        let map = compile(
+            r#"
+            [keys.navigation]
+            page_down = "alt-d"
+            [keys.logs]
+            page_down = []
+            [keys.table]
+            page_down = ["f8", "f9"]
+        "#,
+        )
+        .unwrap();
+        assert_eq!(map.label("table", Action::PageDown), "f8 / f9");
+        assert_eq!(map.label("logs", Action::PageDown), "unbound");
+        assert_eq!(map.label("help", Action::PageDown), "alt-d");
+        assert_eq!(
+            map.action(
+                "table",
+                &KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn equivalent_key_spellings_cannot_bypass_conflict_checks() {
+        for text in [
+            "[keys.table]\npage_up = 'ctrl-D'",
+            "[keys.table]\npage_up = 'shift-tab'",
+            "[keys.table]\npage_up = 'shift-g'",
+        ] {
+            assert!(
+                compile(text)
+                    .unwrap_err()
+                    .iter()
+                    .any(|e| e.contains("conflicts")),
+                "{text}"
+            );
+        }
+        let map = compile("[keys.table]\npage_up = ['ctrl-u', 'control-U']").unwrap();
+        assert_eq!(map.chords("table", Action::PageUp).len(), 1);
+    }
+
+    #[test]
+    fn invalid_scopes_actions_and_chords_report_the_path() {
+        for (text, path) in [
+            ("[keys.table]\npaeg_up = 'f8'", "keys.table.paeg_up"),
+            ("[keys.unknown]", "keys.unknown"),
+            ("[keys.unknown]\npage_up = 'f8'", "keys.unknown.page_up"),
+            ("[keys.input]\npage_up = 'f8'", "keys.input.page_up"),
+            ("[keys.table]\npage_up = 'hyper-u'", "keys.table.page_up"),
+            (
+                "[keys.table]\npage_up = ['ctrl-u', 'shift--']",
+                "keys.table.page_up",
+            ),
+        ] {
+            assert!(
+                compile(text).unwrap_err().iter().any(|e| e.contains(path)),
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_palette_fields_remain_valid_and_take_priority_over_editing() {
+        let map = compile(
+            r#"
+            [keys]
+            palette_next = "ctrl-w"
+            palette_prev = "ctrl-p"
+            palette_accept = ["ctrl-y", "enter"]
+        "#,
+        )
+        .unwrap();
+        assert_eq!(map.label("command", Action::Down), "ctrl-w");
+        assert_eq!(map.label("command", Action::Accept), "ctrl-y / enter");
+        assert!(!map.label("command", Action::DeleteWord).contains("ctrl-w"));
+        assert!(
+            compile("[keys]\npalette_next = 'ctrl-n'\n[keys.command]\ndown = 'ctrl-n'").is_err()
+        );
+    }
+
+    #[test]
+    fn global_quit_and_compact_are_reassignable() {
+        let map = compile(
+            r#"
+            [keys.global]
+            quit = "alt-q"
+            compact = []
+            [keys.command]
+            accept = "ctrl-c"
+        "#,
+        )
+        .unwrap();
+        assert_eq!(map.label("table", Action::Quit), "alt-q");
+        assert_eq!(map.label("prompt", Action::Compact), "unbound");
+        assert_eq!(map.label("command", Action::Accept), "ctrl-c");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod gitops;
 pub mod helm;
 pub mod journal;
 pub mod k8s;
+pub mod keymap;
 pub mod keys;
 mod legacy_tls;
 pub mod logfilter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,6 +287,7 @@ async fn run_main(args: Args) -> Result<()> {
     let (tx, mut rx) = mpsc::channel(EVENT_CHANNEL_CAP);
     let panic_tx = tx.clone();
     let mut app = App::new(cluster, tx);
+    app.config = loader;
     match sofka::state_writer::StateWriter::new(app.tx.clone()) {
         Ok(writer) => app.state_writer = Some(writer),
         Err(e) => {
@@ -350,12 +351,11 @@ async fn run_main(args: Args) -> Result<()> {
         eprintln!("warning: {w}");
         config_warnings.push(w);
     }
-    let (palette_keys, key_warnings) = config::compile_palette_keys(&cfg.keys);
+    let key_warnings = app.configure_keys(&cfg.keys);
     for w in key_warnings {
         eprintln!("warning: {w}");
         config_warnings.push(w);
     }
-    app.palette_keys = palette_keys;
     let (user_views, view_warnings) = views::compile(&cfg.views);
     for w in &view_warnings {
         eprintln!("warning: {w}");
@@ -378,7 +378,6 @@ async fn run_main(args: Args) -> Result<()> {
     }
     app.metrics_provider = metrics_provider;
     app.skin_colors = cfg.skin.colors.clone();
-    app.config = loader;
     app.session_skin = Some(session_skin);
     app.active_skin = Some(initial_skin);
     // Keep initial-load validation problems visible in-app (`:config`), not

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -472,12 +472,7 @@ fn key_hint(app: &App, scope: &str, actions: &[(Action, &str)]) -> String {
     actions
         .iter()
         .map(|&(action, label)| {
-            let key = app
-                .keymap
-                .chords(scope, action)
-                .first()
-                .map(|c| c.label())
-                .unwrap_or_else(|| "unbound".into());
+            let key = app.keymap.first_label(scope, action);
             format!("{key}:{label}")
         })
         .collect::<Vec<_>>()
@@ -491,12 +486,7 @@ fn hint_line(app: &App, pairs: &[(Action, &str)]) -> Line<'static> {
     let mut spans = Vec::new();
     let mut width = 0;
     for &(action, label) in pairs {
-        let key = app
-            .keymap
-            .chords("table", action)
-            .first()
-            .map(|c| c.label())
-            .unwrap_or_else(|| "unbound".into());
+        let key = app.keymap.first_label("table", action);
         let cell = format!("{key} {label}");
         let cell_width = cell.chars().count().max(13);
         if width + cell_width > usize::from(HEADER_HINTS_WIDTH) {
@@ -505,7 +495,7 @@ fn hint_line(app: &App, pairs: &[(Action, &str)]) -> Line<'static> {
         if width > 0 {
             spans.push(Span::raw("  "));
         }
-        spans.push(Span::styled(key, key_style));
+        spans.push(Span::styled(key.to_owned(), key_style));
         spans.push(Span::styled(
             format!(
                 " {label:<width$}",
@@ -2426,7 +2416,7 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
             )));
             previous_scope = scope;
         }
-        lines.push(bind(&app.keymap.label(scope, action), action.description()));
+        lines.push(bind(app.keymap.label(scope, action), action.description()));
     }
     lines.push(Line::from(Span::styled(
         "  Commands (enter in the command palette)",
@@ -2571,11 +2561,11 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         theme::title(),
     )));
     lines.push(bind(
-        &app.keymap.label("help", Action::Back),
+        app.keymap.label("help", Action::Back),
         "clear the search or close help",
     ));
     lines.push(bind(
-        &app.keymap.label("help", Action::Close),
+        app.keymap.label("help", Action::Close),
         "close help and return to the previous screen",
     ));
     // `/` search: keep only matching binding lines (section headers and
@@ -4029,17 +4019,10 @@ fn counts_tile(frame: &mut Frame, area: Rect, p: &crate::store::Pulse) {
 fn navigation_hint(app: &App, width: u16) -> String {
     let scope = app.key_scope();
     if scope == "table" {
-        let first = |action| {
-            app.keymap
-                .chords(scope, action)
-                .first()
-                .map(|c| c.label())
-                .unwrap_or_else(|| "unbound".into())
-        };
         let cycle = format!(
             "{}/{}: {}",
-            first(Action::NextView),
-            first(Action::PreviousView),
+            app.keymap.first_label(scope, Action::NextView),
+            app.keymap.first_label(scope, Action::PreviousView),
             if app.active_workspace.is_some() {
                 "workspace"
             } else {
@@ -4069,16 +4052,6 @@ fn navigation_hint(app: &App, width: u16) -> String {
         return format!("{cycle}  {}", key_hint(app, scope, &actions));
     }
     let preferred = match scope {
-        "table" => &[
-            Action::Command,
-            Action::Help,
-            Action::Filter,
-            Action::Sort,
-            Action::Mark,
-            Action::PageUp,
-            Action::PageDown,
-            Action::Back,
-        ][..],
         "logs" => &[
             Action::Back,
             Action::Filter,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 //! All ratatui rendering.
 
+use crate::keymap::Action;
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -466,19 +467,53 @@ fn header_hints_fit(frame_width: u16) -> bool {
     frame_width.saturating_sub(26 + 2) >= HEADER_INFO_MIN + HEADER_HINTS_WIDTH
 }
 
-/// One hint row of fixed-width cells (right-aligned key, padded label) so
-/// consecutive rows line up into a table. Labels must stay ≤ 10 chars.
-fn hint_line(pairs: &[(&str, &str)]) -> Line<'static> {
+/// Show the first effective binding for each action.
+fn key_hint(app: &App, scope: &str, actions: &[(Action, &str)]) -> String {
+    actions
+        .iter()
+        .map(|&(action, label)| {
+            let key = app
+                .keymap
+                .chords(scope, action)
+                .first()
+                .map(|c| c.label())
+                .unwrap_or_else(|| "unbound".into());
+            format!("{key}:{label}")
+        })
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
+fn hint_line(app: &App, pairs: &[(Action, &str)]) -> Line<'static> {
     let key_style = Style::default()
         .fg(theme::sky())
         .add_modifier(Modifier::BOLD);
-    let mut spans = Vec::with_capacity(pairs.len() * 3);
-    for (i, (key, label)) in pairs.iter().enumerate() {
-        if i > 0 {
+    let mut spans = Vec::new();
+    let mut width = 0;
+    for &(action, label) in pairs {
+        let key = app
+            .keymap
+            .chords("table", action)
+            .first()
+            .map(|c| c.label())
+            .unwrap_or_else(|| "unbound".into());
+        let cell = format!("{key} {label}");
+        let cell_width = cell.chars().count().max(13);
+        if width + cell_width > usize::from(HEADER_HINTS_WIDTH) {
+            break;
+        }
+        if width > 0 {
             spans.push(Span::raw("  "));
         }
-        spans.push(Span::styled(format!("{key:>2}"), key_style));
-        spans.push(Span::styled(format!(" {label:<10}"), theme::dim()));
+        spans.push(Span::styled(key, key_style));
+        spans.push(Span::styled(
+            format!(
+                " {label:<width$}",
+                width = cell_width - cell.chars().count() + label.chars().count()
+            ),
+            theme::dim(),
+        ));
+        width += cell_width + 2;
     }
     Line::from(spans)
 }
@@ -509,71 +544,270 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
     }
     let mut lines = match app.kind_plural.as_str() {
         "pods" => vec![
-            hint_line(&[("⏎", "containers"), ("l", "logs"), ("p", "prev logs")]),
-            hint_line(&[("s", "shell"), ("t", "transfer"), ("f", "port-fwd")]),
-            hint_line(&[("y", "yaml"), ("d", "describe"), ("E", "events")]),
-            hint_line(&[("e", "edit"), ("o", "node"), ("J", "owner")]),
-            hint_line(&[("X", "explain"), ("T", "timeline"), ("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "containers"),
+                    (Action::Logs, "logs"),
+                    (Action::PreviousLogs, "prev logs"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::ShellOrScale, "shell"),
+                    (Action::ActionMenu, "transfer"),
+                    (Action::PortForward, "port-fwd"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                    (Action::Events, "events"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Edit, "edit"),
+                    (Action::Node, "node"),
+                    (Action::Owner, "owner"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Explain, "explain"),
+                    (Action::Timeline, "timeline"),
+                    (Action::Delete, "delete"),
+                ],
+            ),
         ],
         "deployments" | "statefulsets" => vec![
-            hint_line(&[("⏎", "pods"), ("l", "logs"), ("E", "events")]),
-            hint_line(&[("s", "scale"), ("r", "restart"), ("i", "image")]),
-            hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
-            hint_line(&[("X", "explain"), ("T", "timeline"), ("f", "port-fwd")]),
-            hint_line(&[("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "pods"),
+                    (Action::Logs, "logs"),
+                    (Action::Events, "events"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::ShellOrScale, "scale"),
+                    (Action::RestartOrRefresh, "restart"),
+                    (Action::SetImage, "image"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                    (Action::Edit, "edit"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Explain, "explain"),
+                    (Action::Timeline, "timeline"),
+                    (Action::PortForward, "port-fwd"),
+                ],
+            ),
+            hint_line(app, &[(Action::Delete, "delete")]),
         ],
         "daemonsets" => vec![
-            hint_line(&[("⏎", "pods"), ("l", "logs"), ("E", "events")]),
-            hint_line(&[("r", "restart"), ("i", "image")]),
-            hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
-            hint_line(&[("X", "explain"), ("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "pods"),
+                    (Action::Logs, "logs"),
+                    (Action::Events, "events"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::RestartOrRefresh, "restart"),
+                    (Action::SetImage, "image"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                    (Action::Edit, "edit"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[(Action::Explain, "explain"), (Action::Delete, "delete")],
+            ),
         ],
         "replicasets" | "jobs" => vec![
-            hint_line(&[("⏎", "pods"), ("l", "logs"), ("E", "events")]),
-            hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
-            hint_line(&[("X", "explain"), ("J", "owner"), ("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "pods"),
+                    (Action::Logs, "logs"),
+                    (Action::Events, "events"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                    (Action::Edit, "edit"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Explain, "explain"),
+                    (Action::Owner, "owner"),
+                    (Action::Delete, "delete"),
+                ],
+            ),
         ],
         "services" => vec![
-            hint_line(&[("⏎", "pods"), ("f", "port-fwd")]),
-            hint_line(&[("y", "yaml"), ("d", "describe"), ("e", "edit")]),
-            hint_line(&[("Y", "copy cell"), ("^d", "delete")]),
+            hint_line(
+                app,
+                &[(Action::Open, "pods"), (Action::PortForward, "port-fwd")],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                    (Action::Edit, "edit"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[(Action::CopyCell, "copy cell"), (Action::Delete, "delete")],
+            ),
         ],
         "nodes" => vec![
-            hint_line(&[("⏎", "pods"), ("y", "yaml"), ("d", "describe")]),
-            hint_line(&[("C", "cordon"), ("U", "uncordon"), ("D", "drain")]),
-            hint_line(&[("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "pods"),
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Cordon, "cordon"),
+                    (Action::Uncordon, "uncordon"),
+                    (Action::Drain, "drain"),
+                ],
+            ),
+            hint_line(app, &[(Action::Delete, "delete")]),
         ],
         "namespaces" => vec![
-            hint_line(&[("⏎", "switch to"), ("y", "yaml"), ("d", "describe")]),
-            hint_line(&[("e", "edit"), ("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "switch to"),
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                ],
+            ),
+            hint_line(app, &[(Action::Edit, "edit"), (Action::Delete, "delete")]),
         ],
         "helm" => vec![
-            hint_line(&[("⏎", "history")]),
-            hint_line(&[("y", "yaml"), ("d", "describe")]),
-            hint_line(&[("^d", "uninstall")]),
+            hint_line(app, &[(Action::Open, "history")]),
+            hint_line(
+                app,
+                &[(Action::Yaml, "yaml"), (Action::Describe, "describe")],
+            ),
+            hint_line(app, &[(Action::Delete, "uninstall")]),
         ],
         "helmhistory" => vec![
-            hint_line(&[("⏎", "values"), ("r", "rollback")]),
-            hint_line(&[("^d", "uninstall")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "values"),
+                    (Action::RestartOrRefresh, "rollback"),
+                ],
+            ),
+            hint_line(app, &[(Action::Delete, "uninstall")]),
         ],
         "customresourcedefinitions" => vec![
-            hint_line(&[("⏎", "resources"), ("y", "yaml"), ("d", "describe")]),
-            hint_line(&[("e", "edit"), ("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "resources"),
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                ],
+            ),
+            hint_line(app, &[(Action::Edit, "edit"), (Action::Delete, "delete")]),
         ],
         "secrets" => vec![
-            hint_line(&[("x", "decode"), ("y", "yaml"), ("d", "describe")]),
-            hint_line(&[("e", "edit"), ("E", "events"), ("c", "copy name")]),
-            hint_line(&[("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Inspect, "decode"),
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Edit, "edit"),
+                    (Action::Events, "events"),
+                    (Action::CopyName, "copy name"),
+                ],
+            ),
+            hint_line(app, &[(Action::Delete, "delete")]),
         ],
         "persistentvolumeclaims" => vec![
-            hint_line(&[("x", "browse"), ("s", "shell"), ("d", "describe")]),
-            hint_line(&[("y", "yaml"), ("E", "events"), ("c", "copy name")]),
-            hint_line(&[("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Inspect, "browse"),
+                    (Action::ShellOrScale, "shell"),
+                    (Action::Describe, "describe"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Yaml, "yaml"),
+                    (Action::Events, "events"),
+                    (Action::CopyName, "copy name"),
+                ],
+            ),
+            hint_line(app, &[(Action::Delete, "delete")]),
         ],
         _ => vec![
-            hint_line(&[("⏎", "yaml"), ("d", "describe"), ("E", "events")]),
-            hint_line(&[("e", "edit"), ("c", "copy name"), ("Y", "copy cell")]),
-            hint_line(&[("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "yaml"),
+                    (Action::Describe, "describe"),
+                    (Action::Events, "events"),
+                ],
+            ),
+            hint_line(
+                app,
+                &[
+                    (Action::Edit, "edit"),
+                    (Action::CopyName, "copy name"),
+                    (Action::CopyCell, "copy cell"),
+                ],
+            ),
+            hint_line(app, &[(Action::Delete, "delete")]),
         ],
     };
     if app.kind_plural == "machinedeployments"
@@ -583,24 +817,31 @@ fn header_hints(app: &App) -> Vec<Line<'static>> {
             .is_some_and(|k| k.ar.group == "cluster.x-k8s.io")
     {
         lines = vec![
-            hint_line(&[("⏎", "machines"), ("y", "yaml"), ("d", "describe")]),
-            hint_line(&[("e", "edit"), ("^d", "delete")]),
+            hint_line(
+                app,
+                &[
+                    (Action::Open, "machines"),
+                    (Action::Yaml, "yaml"),
+                    (Action::Describe, "describe"),
+                ],
+            ),
+            hint_line(app, &[(Action::Edit, "edit"), (Action::Delete, "delete")]),
         ];
     }
     if app.flux_suspendable() {
-        lines.push(hint_line(&[("t", "flux menu")]));
+        lines.push(hint_line(app, &[(Action::ActionMenu, "flux menu")]));
     }
     if app.argocd_kind() {
-        lines.push(hint_line(&[("t", "suspend/sync")]));
+        lines.push(hint_line(app, &[(Action::ActionMenu, "suspend/sync")]));
     }
     if app.kind_plural == "helmreleases" {
-        lines.push(hint_line(&[("⏎", "helm history")]));
+        lines.push(hint_line(app, &[(Action::Open, "helm history")]));
     }
     if app.cronjob_kind() {
-        lines.push(hint_line(&[("t", "trigger/suspend")]));
+        lines.push(hint_line(app, &[(Action::ActionMenu, "trigger/suspend")]));
     }
     if app.external_secret_kind() {
-        lines.push(hint_line(&[("r", "force-sync")]));
+        lines.push(hint_line(app, &[(Action::RestartOrRefresh, "force-sync")]));
     }
     // The header box has 5 inner rows.
     lines.truncate(5);
@@ -2174,234 +2415,95 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
             Span::styled(d.to_string(), theme::dim()),
         ])
     };
-    let mut lines = vec![
-        Line::from(Span::styled("  Navigation", theme::title())),
-        bind(
-            ":<resource>",
-            "global command palette — fuzzy over kinds + commands (tab/↑↓)",
-        ),
-        bind(
-            ":<res> <ns>",
-            "switch kind and namespace at once (all/* = all namespaces)",
-        ),
-        bind("[ · ]", "view history — back · forward"),
-        bind(
-            "Tab · ⇧Tab",
-            "next · previous resource in this namespace (workspace views when open)",
-        ),
-        bind(":ctx · :pulse", "switch context · cluster-health dashboard"),
-        bind(
-            ":fleet",
-            "cross-context health dashboard ([fleet] contexts or space in :ctx; ⏎ switches)",
-        ),
-        bind(
-            ":xray · :diff",
-            "hierarchical tree · live-vs-last-applied diff",
-        ),
-        bind(
-            ":events · E",
-            "browse all events · events for the selected object",
-        ),
-        bind(":pf", "view/stop background port-forwards"),
-        bind(":skin", "switch color skin live"),
-        bind(
-            ":reload · :config · :info",
-            "reload config · config sources + warnings · runtime diagnostics",
-        ),
-        bind(
-            ":can-i",
-            "what you can do here · :can-i <verb> <resource> [ns] checks one action",
-        ),
-        bind(
-            "enter",
-            "drill down (deploy→pods, pod→containers, ns→re-scope)",
-        ),
-        bind("shift-j", "jump to owner (controller)"),
-        bind("o", "show node hosting the pod"),
-        bind(
-            "←/→",
-            "scroll sideways (5 cells; NAMESPACE/NAME stay fixed)",
-        ),
-        bind("esc", "go back / pop view / clear filter"),
-        bind("j/k g/G", "move · top/bottom"),
-        bind(
-            "ctrl-f/ctrl-b",
-            "page tables and documents forward/back (also PgDn/PgUp)",
-        ),
-        bind("S · I", "sort by column (fuzzy picker) · invert direction"),
-        bind(
-            "w",
-            "toggle wide columns (kubectl -o wide), including node labels",
-        ),
-        bind(
-            "ctrl-e",
-            "compact mode: collapse header + footer (for tiled panes)",
-        ),
-        bind(
-            "/",
-            "filter: fuzzy · \"exact\" · /regex/ · !inverse · -l/-f selectors (server-side on ⏎) · col=val cpu>500m age<2h · && || !(...)",
-        ),
-        bind(
-            ":resource -n ns --context ctx /filter",
-            "query resource, namespace, context and filter together",
-        ),
-        bind(
-            ":resource @context [namespace]",
-            "switch context and resource (context fuzzy-completes; kubeconfig unchanged)",
-        ),
-        bind(
-            "ctrl-u · ctrl-w",
-            "text inputs: clear line (cmd-⌫) · delete word (opt-⌫)",
-        ),
-        bind("n · 0", "namespace switcher · 0 = all namespaces"),
-        bind("ctrl-r", "refresh watch"),
-        bind("ctrl-z", "toggle faults filter (pods only)"),
-        Line::from(""),
-        Line::from(Span::styled("  Inspect", theme::title())),
-        bind("y · d", "view YAML · describe (kubectl)"),
-        bind("r (describe)", "turn automatic refresh on/off (5s)"),
-        bind("l · p", "logs (workload = all pods) · previous logs"),
-        bind(
-            "shift-l · :vlogs",
-            "VictoriaLogs history (autodiscovered or [providers.logs]) — pods/workloads/ns",
-        ),
-        bind("c", "copy resource name · in doc views: copy the document"),
-        bind(
-            "shift-y",
-            "copy any cell of the selected row (picker: type to match a column or value)",
-        ),
-        bind(
-            "/ · n/N",
-            "search within YAML/describe/diff/events (highlight in place, n/N to jump); filters help",
-        ),
-        bind(
-            "x",
-            "secrets: show data base64-decoded (also inside YAML/describe) · PVCs: browse the volume",
-        ),
-        bind(
-            "shift-x · :explain",
-            "explain why the selection is unhealthy (evidence-backed)",
-        ),
-        bind(
-            "shift-t · :timeline",
-            "session-local state-change history for the selection",
-        ),
-        bind(
-            "u · :adjacent",
-            "adjacent view: owners, children, and references (⏎ opens one; c discovers direct children of a namespaced custom resource)",
-        ),
-        bind(
-            ":rightsize",
-            "historical right-sizing: P50/P95/P99 usage → suggested requests + patch (needs [providers.metrics])",
-        ),
-        bind(
-            ":gitops · :flux",
-            "Flux owner, source, revisions & reconciliation chain (⏎ to jump)",
-        ),
-        bind(
-            ":journal · :audit",
-            "session-local log of the mutating actions you've taken",
-        ),
-        Line::from(""),
-        Line::from(Span::styled("  Act", theme::title())),
-        bind("e", "edit in $EDITOR (kubectl edit)"),
-        bind("s", "shell into pod / PVC volume · scale workload"),
-        bind("a", "attach to pod"),
-        bind(
-            ":debug",
-            "pod: ephemeral debug container (d in picker targets one) · node: privileged debug pod",
-        ),
-        bind(
-            ":debug-clean",
-            "delete the node debugger pods launched this session",
-        ),
-        bind(
-            ":bundle · :bundle-save",
-            "assemble a redacted diagnostic bundle for the selection · write it to a file",
-        ),
-        bind(
-            ":snapshot [fmt] · :snapshots",
-            "capture the current view (text/json/yaml) · browse saved snapshots",
-        ),
-        bind("i", "set container image"),
-        bind(
-            "r",
-            "rollout restart (deploy/sts/ds) · force-sync (external secrets)",
-        ),
-        bind(
-            "f / shift-f",
-            "port-forward (pod/svc) — runs in the background",
-        ),
-        bind(
-            "t",
-            "pods: file transfer (kubectl cp, in picker targets a container) · flux: suspend/resume/reconcile · argocd apps: suspend/resume/sync, appsets: suspend/resume · cronjobs: trigger/suspend/resume",
-        ),
-        bind("C · U · D", "nodes: cordon · uncordon · drain"),
-        bind("space", "mark/unmark row for bulk actions (esc clears)"),
-        bind(
-            "ctrl-d · ctrl-k",
-            "delete · force-delete (in confirm: f force, c cascade)",
-        ),
-        Line::from(""),
-        Line::from(Span::styled("  PVC explore (x on a PVC)", theme::title())),
-        bind(
-            "x · s · :pvc-explore",
-            "browse the volume (local left, PVC right; also :pvc-browse) · shell into it at the mount point",
-        ),
-        bind(
-            "tab · ←/→",
-            "switch pane · j/k g/G move · ⏎ open directory · ⌫ or - go up (stops at the mount)",
-        ),
-        bind(
-            "esc · q",
-            "close the browser (and delete the helper pod, if any)",
-        ),
-        bind(
-            "c · r",
-            "copy the selection into the other pane (download or upload) · refresh both",
-        ),
-        bind(
-            ":pvc-clean",
-            "delete helper pods left behind by a session that exited uncleanly (:pvc-cleanup)",
-        ),
-        Line::from(""),
-        Line::from(Span::styled("  Logs view", theme::title())),
-        bind(
-            "/ · s · w · t",
-            "filter (text · /regex/ · !invert) · autoscroll · wrap · timestamps",
-        ),
-        bind(
-            "x · z · c · ctrl-s",
-            "stop/resume · clear buffer · copy · save to file",
-        ),
-        bind("shift-f", "fullscreen (no borders — easy terminal copying)"),
-        bind(
-            "0 – 5",
-            "time anchor: tail · 1m · 5m · 15m · 30m · 1h (re-streams)",
-        ),
-        bind(
-            "shift-t",
-            "provider logs: change lookback period (30m, 4h, 2d)",
-        ),
-        Line::from(""),
-        bind(
-            ":plugin-cancel",
-            "cancel the active plugin and its temporary forward",
-        ),
-        bind(":q / ctrl-c", "quit"),
-        Line::from(""),
-        Line::from(Span::styled("  Help view", theme::title())),
-        bind("j/k · ↑/↓", "scroll one line"),
-        bind("ctrl-f · PgDn", "next page (space also moves forward)"),
-        bind("ctrl-b · PgUp", "previous page"),
-        bind("g/G · Home/End", "go to the top/bottom"),
-        bind("/", "filter help bindings"),
-        bind(
-            "esc",
-            "clear the filter, or close help if no filter is active",
-        ),
-        bind("q · ?", "close help and return to the previous screen"),
-    ];
+    let mut lines = Vec::new();
+    let mut previous_scope = "";
+    for (scope, action, _) in app.keymap.entries() {
+        if scope != previous_scope {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                format!("  Keys: {scope}"),
+                theme::title(),
+            )));
+            previous_scope = scope;
+        }
+        lines.push(bind(&app.keymap.label(scope, action), action.description()));
+    }
+    lines.push(Line::from(Span::styled(
+        "  Commands (enter in the command palette)",
+        theme::title(),
+    )));
+    lines.push(bind(
+        ":<resource>",
+        "global command palette - fuzzy over kinds + commands",
+    ));
+    lines.push(bind(
+        ":<res> <ns>",
+        "switch kind and namespace at once (all/* = all namespaces)",
+    ));
+    lines.push(bind(
+        ":ctx · :pulse",
+        "switch context · cluster-health dashboard",
+    ));
+    lines.push(bind(
+        ":fleet",
+        "cross-context health dashboard for configured contexts",
+    ));
+    lines.push(bind(
+        ":xray · :diff",
+        "hierarchical tree · live-vs-last-applied diff",
+    ));
+    lines.push(bind(":events", "browse all events"));
+    lines.push(bind(":pf", "view/stop background port-forwards"));
+    lines.push(bind(":skin", "switch color skin live"));
+    lines.push(bind(
+        ":reload · :config · :info",
+        "reload config · config sources + warnings · runtime diagnostics",
+    ));
+    lines.push(bind(
+        ":can-i",
+        "what you can do here · :can-i <verb> <resource> [ns] checks one action",
+    ));
+    lines.push(bind(
+        ":resource -n ns --context ctx /filter",
+        "query resource, namespace, context and filter together",
+    ));
+    lines.push(bind(
+        ":resource @context [namespace]",
+        "switch context and resource (context fuzzy-completes; kubeconfig unchanged)",
+    ));
+    lines.push(bind(":rightsize", "historical right-sizing: P50/P95/P99 usage → suggested requests + patch (needs [providers.metrics])"));
+    lines.push(bind(
+        ":gitops · :flux",
+        "Flux owner, source, revisions & reconciliation chain",
+    ));
+    lines.push(bind(
+        ":journal · :audit",
+        "session-local log of the mutating actions you've taken",
+    ));
+    lines.push(bind(
+        ":debug",
+        "pod: ephemeral debug container · node: privileged debug pod",
+    ));
+    lines.push(bind(
+        ":debug-clean",
+        "delete the node debugger pods launched this session",
+    ));
+    lines.push(bind(
+        ":bundle · :bundle-save",
+        "assemble a redacted diagnostic bundle for the selection · write it to a file",
+    ));
+    lines.push(bind(
+        ":snapshot [fmt] · :snapshots",
+        "capture the current view (text/json/yaml) · browse saved snapshots",
+    ));
+    lines.push(bind(
+        ":pvc-clean",
+        "delete helper pods left behind by a session that exited uncleanly (:pvc-cleanup)",
+    ));
+    lines.push(bind(
+        ":plugin-cancel",
+        "cancel the active plugin and its temporary forward",
+    ));
     // Config-defined plugins, with their (possibly modified) key chords.
     if !app.plugins.is_empty() {
         lines.push(Line::from(""));
@@ -2464,6 +2566,18 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
             ));
         }
     }
+    lines.push(Line::from(Span::styled(
+        "  Help navigation",
+        theme::title(),
+    )));
+    lines.push(bind(
+        &app.keymap.label("help", Action::Back),
+        "clear the search or close help",
+    ));
+    lines.push(bind(
+        &app.keymap.label("help", Action::Close),
+        "close help and return to the previous screen",
+    ));
     // `/` search: keep only matching binding lines (section headers and
     // spacers match like any other text), highlighting the matched runs.
     let needle = app.help_filter.to_lowercase();
@@ -2486,7 +2600,14 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
     let scroll = app.help_scroll.min(max_scroll);
     app.help_scroll = scroll;
     let title = if max_scroll > 0 {
-        format!("{title}· j/k scroll · / search ")
+        format!(
+            "{title} {} ",
+            key_hint(
+                app,
+                "help",
+                &[(Action::Down, "scroll"), (Action::Filter, "search")]
+            )
+        )
     } else {
         title
     };
@@ -2530,7 +2651,7 @@ fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     // Show the type-to-filter buffer in the title so it reads like an input.
     let title = if app.ns_filter.is_empty() {
-        " Namespaces (★ fav · recent · ⏎ switch) ".to_string()
+        " Namespaces (★ favorites and recent) ".to_string()
     } else {
         format!(" Namespaces · /{}_ ", app.ns_filter)
     };
@@ -2578,7 +2699,7 @@ fn draw_contexts(frame: &mut Frame, app: &mut App, area: Rect) {
     } else if !app.ctx_filter.is_empty() {
         format!(" Contexts · /{} ", app.ctx_filter)
     } else {
-        " Contexts (type to filter · r rename · space fleet · ⏎ switch) ".to_string()
+        " Contexts (type to filter) ".to_string()
     };
     render_popup_list(
         frame,
@@ -2619,7 +2740,7 @@ fn draw_sort_picker(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     // Show the type-to-filter buffer in the title so it reads like an input.
     let title = if app.sort_picker_filter.is_empty() {
-        " Sort by (⏎ again inverts) ".to_string()
+        " Sort by ".to_string()
     } else {
         format!(" Sort by · /{}_ ", app.sort_picker_filter)
     };
@@ -2655,7 +2776,7 @@ fn draw_copy_picker(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     // Show the type-to-filter buffer in the title so it reads like an input.
     let title = if app.copy_picker_filter.is_empty() {
-        " Copy (⏎ copies the value) ".to_string()
+        " Copy ".to_string()
     } else {
         format!(" Copy · /{}_ ", app.copy_picker_filter)
     };
@@ -2806,10 +2927,7 @@ fn draw_port_forwards(frame: &mut Frame, app: &mut App, area: Rect) {
             ),
         ])));
     }
-    let title = format!(
-        " Port-forwards [{}]  (x/s stop · ⏎ start · esc close) ",
-        app.port_forwards.len()
-    );
+    let title = format!(" Port-forwards [{}] ", app.port_forwards.len());
     render_framed_list(
         frame,
         area,
@@ -2835,11 +2953,7 @@ fn draw_find(frame: &mut Frame, app: &mut App, area: Rect) {
             ]))
         })
         .collect();
-    let title = format!(
-        " Find '{}' [{}]  (⏎ open · esc close) ",
-        app.find_query,
-        app.find_items.len()
-    );
+    let title = format!(" Find '{}' [{}] ", app.find_query, app.find_items.len());
     render_framed_list(
         frame,
         area,
@@ -2965,7 +3079,7 @@ fn draw_skins(frame: &mut Frame, app: &mut App, area: Rect) {
         42,
         58,
         items,
-        Span::styled(" Skins (enter apply · esc close) ", theme::title()),
+        Span::styled(" Skins ", theme::title()),
         &mut app.skin_state,
     );
 }
@@ -2987,10 +3101,7 @@ fn draw_snapshots(frame: &mut Frame, app: &mut App, area: Rect) {
         70,
         70,
         items,
-        Span::styled(
-            " Snapshots (⏎ open · d delete · esc close) ",
-            theme::title(),
-        ),
+        Span::styled(" Snapshots ", theme::title()),
         &mut app.snapshot_state,
     );
 }
@@ -3126,7 +3237,18 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         format!(" · {}", app.container_qos)
     };
     let title = format!(" Containers{qos} ");
-    let footer = " ⏎ logs · p previous · s shell · t transfer · d debug · L provider ";
+    let footer = key_hint(
+        app,
+        "containers",
+        &[
+            (Action::Logs, "logs"),
+            (Action::PreviousLogs, "previous"),
+            (Action::Shell, "shell"),
+            (Action::Transfer, "transfer"),
+            (Action::Debug, "debug"),
+            (Action::ProviderLogs, "provider"),
+        ],
+    );
 
     // Size the box to its contents: header + rows + borders, and wide enough
     // for the columns, the title, or the footer — whichever needs the most.
@@ -3191,7 +3313,14 @@ fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("█", Style::default().fg(theme::peach())),
         ]),
         Line::from(""),
-        Line::from(Span::styled("  enter: apply    esc: cancel", theme::dim())),
+        Line::from(Span::styled(
+            key_hint(
+                app,
+                "prompt",
+                &[(Action::Accept, "apply"), (Action::Back, "cancel")],
+            ),
+            theme::dim(),
+        )),
     ];
     frame.render_widget(
         Paragraph::new(lines).block(
@@ -3225,7 +3354,7 @@ fn draw_set_image(frame: &mut Frame, app: &mut App, area: Rect) {
         70,
         60,
         items,
-        Span::styled(" Set Image (⏎ to edit container) ", theme::title()),
+        Span::styled(" Set Image ", theme::title()),
         &mut app.container_state,
     );
 }
@@ -3241,7 +3370,7 @@ fn draw_confirm(frame: &mut Frame, app: &App, area: Rect) {
         )),
         Line::from(""),
         Line::from(Span::styled(
-            confirm_action_hint(app.confirm_allows_force_toggle(), ConfirmHintStyle::Popup),
+            confirm_action_hint(app, app.confirm_allows_force_toggle()),
             Style::default().fg(theme::yellow()),
         )),
     ];
@@ -3312,21 +3441,18 @@ fn draw_palette(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     let mut state = ListState::default();
     state.select(Some(app.cmd_sel));
-    // The hint mirrors the user's `[keys]` rebinds (first chord of each
-    // action); the default set keeps its compact symbols.
-    let hint = if app.palette_keys.is_default() {
-        " commands & resources (tab/↑↓ · ⏎) ".to_string()
-    } else {
-        let first = |chords: &[crate::keys::KeyChord]| {
-            chords.first().map(|c| c.label()).unwrap_or_default()
-        };
-        format!(
-            " commands & resources ({}/{} · {}) ",
-            first(&app.palette_keys.next),
-            first(&app.palette_keys.prev),
-            first(&app.palette_keys.accept),
+    let hint = format!(
+        " commands & resources ({}) ",
+        key_hint(
+            app,
+            "command",
+            &[
+                (Action::Down, "next"),
+                (Action::Up, "previous"),
+                (Action::Accept, "run")
+            ]
         )
-    };
+    );
     render_framed_list(
         frame,
         rect,
@@ -3369,10 +3495,7 @@ fn draw_xray(frame: &mut Frame, app: &mut App, area: Rect) {
             ListItem::new(Line::from(spans))
         })
         .collect();
-    let title = format!(
-        " Xray [{}]  (⏎ logs · r refresh · esc back) ",
-        app.xray_items.len()
-    );
+    let title = format!(" Xray [{}] ", app.xray_items.len());
     render_framed_list(
         frame,
         area,
@@ -3456,10 +3579,7 @@ fn draw_fleet(frame: &mut Frame, app: &mut App, area: Rect) {
             ListItem::new(Line::from(spans))
         })
         .collect();
-    let title = format!(
-        " Fleet [{}]  (⏎ switch · r refresh · esc back) ",
-        app.fleet_rows.len()
-    );
+    let title = format!(" Fleet [{}] ", app.fleet_rows.len());
     render_framed_list(
         frame,
         area,
@@ -3532,7 +3652,7 @@ fn draw_explain(frame: &mut Frame, app: &mut App, area: Rect) {
         format!(" {} ", app.explain_title)
     } else {
         format!(
-            " {}  ({} findings · ⏎/E/l evidence · r refresh) ",
+            " {} ({} findings) ",
             app.explain_title,
             app.explain_items.len()
         )
@@ -3548,11 +3668,7 @@ fn draw_explain(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_gitops(frame: &mut Frame, app: &mut App, area: Rect) {
-    let title = if app.gitops_items.is_empty() {
-        format!(" {} ", app.gitops_title)
-    } else {
-        format!(" {}  (⏎ jump · r refresh · esc back) ", app.gitops_title)
-    };
+    let title = format!(" {} ", app.gitops_title);
     draw_findings(
         frame,
         area,
@@ -3910,6 +4026,126 @@ fn counts_tile(frame: &mut Frame, area: Rect, p: &crate::store::Pulse) {
     );
 }
 
+fn navigation_hint(app: &App, width: u16) -> String {
+    let scope = app.key_scope();
+    if scope == "table" {
+        let first = |action| {
+            app.keymap
+                .chords(scope, action)
+                .first()
+                .map(|c| c.label())
+                .unwrap_or_else(|| "unbound".into())
+        };
+        let cycle = format!(
+            "{}/{}: {}",
+            first(Action::NextView),
+            first(Action::PreviousView),
+            if app.active_workspace.is_some() {
+                "workspace"
+            } else {
+                "resources"
+            }
+        );
+        let mut actions = vec![
+            (Action::Command, "command"),
+            (Action::Help, "help"),
+            (Action::Filter, "filter"),
+        ];
+        if app.hide_header || !header_hints_fit(width) {
+            actions.extend([
+                (Action::Yaml, "yaml"),
+                (Action::Describe, "describe"),
+                (Action::Logs, "logs"),
+                (Action::Edit, "edit"),
+                (Action::ShellOrScale, "shell/scale"),
+                (Action::Delete, "delete"),
+            ]);
+        }
+        actions.extend([
+            (Action::Sort, "sort"),
+            (Action::Mark, "mark"),
+            (Action::Back, "back"),
+        ]);
+        return format!("{cycle}  {}", key_hint(app, scope, &actions));
+    }
+    let preferred = match scope {
+        "table" => &[
+            Action::Command,
+            Action::Help,
+            Action::Filter,
+            Action::Sort,
+            Action::Mark,
+            Action::PageUp,
+            Action::PageDown,
+            Action::Back,
+        ][..],
+        "logs" => &[
+            Action::Back,
+            Action::Filter,
+            Action::Follow,
+            Action::Wrap,
+            Action::Stream,
+            Action::Copy,
+            Action::Save,
+            Action::PageUp,
+            Action::PageDown,
+        ][..],
+        "detail" | "diff" | "events" => &[
+            Action::Back,
+            Action::Filter,
+            Action::NextMatch,
+            Action::PreviousMatch,
+            Action::Wrap,
+            Action::Copy,
+            Action::PageUp,
+            Action::PageDown,
+        ][..],
+        "pvc_explore" => &[
+            Action::Back,
+            Action::SwitchPane,
+            Action::Accept,
+            Action::Parent,
+            Action::Copy,
+            Action::Shell,
+            Action::Refresh,
+        ][..],
+        "port_forwards" => &[
+            Action::Back,
+            Action::Up,
+            Action::Down,
+            Action::Start,
+            Action::Toggle,
+        ][..],
+        "contexts" => &[
+            Action::Back,
+            Action::Accept,
+            Action::Rename,
+            Action::FleetMark,
+        ][..],
+        _ => &[
+            Action::Back,
+            Action::Up,
+            Action::Down,
+            Action::Accept,
+            Action::Logs,
+            Action::Refresh,
+            Action::Filter,
+            Action::Delete,
+            Action::Help,
+        ][..],
+    };
+    let available: Vec<_> = preferred
+        .iter()
+        .filter(|&&action| {
+            app.keymap
+                .entries()
+                .any(|(s, a, _)| s == scope && a == action)
+        })
+        .map(|&action| (action, action.description()))
+        .collect();
+    key_hint(app, scope, &available)
+}
+
 fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
     let line = match app.mode {
         Mode::Command => Line::from(vec![
@@ -3943,7 +4179,10 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
                 ));
             } else if app.filter_selectors_pending() {
                 spans.push(Span::styled(
-                    "  ⏎ apply server-side",
+                    format!(
+                        "  {} apply server-side",
+                        app.keymap.label("filter", Action::Accept)
+                    ),
                     Style::default().fg(theme::yellow()),
                 ));
             } else {
@@ -3979,104 +4218,13 @@ fn draw_prompt(frame: &mut Frame, app: &App, area: Rect) {
             ])
         }
         Mode::Confirm => Line::from(Span::styled(
-            confirm_action_hint(app.confirm_allows_force_toggle(), ConfirmHintStyle::Prompt),
+            confirm_action_hint(app, app.confirm_allows_force_toggle()),
             Style::default().fg(theme::yellow()),
         )),
-        Mode::Logs => {
-            let hint = if app.provider_logs_active() {
-                "  /filter  s:autoscroll  w:wrap  t:timestamps  F:fullscreen  0-5:since  T:period  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
-            } else {
-                "  /filter  s:autoscroll  w:wrap  t:timestamps  F:fullscreen  0-5:since  x:stop/resume  z:clear  c:copy  ^s:save  esc:back"
-            };
-            Line::from(Span::styled(hint, theme::dim()))
-        }
-        Mode::Detail | Mode::Events | Mode::Diff => {
-            // The `x` decode binding only applies to a secret's document view.
-            let hint = if app.mode == Mode::Detail && app.kind_plural == "secrets" {
-                "  j/k:scroll  ^f/^b:page  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  x:decode  esc:back"
-            } else {
-                "  j/k:scroll  ^f/^b:page  h/l:← →  g/G:top/bottom  /:search  n/N:next/prev  w:wrap  c:copy  esc:back"
-            };
-            let hint = if app.mode == Mode::Detail && app.describe_source.is_some() {
-                format!(
-                    "{hint}  r:refresh {}",
-                    if app.describe_refresh_task.is_some() {
-                        "on"
-                    } else {
-                        "off"
-                    }
-                )
-            } else {
-                hint.to_string()
-            };
-            Line::from(Span::styled(hint, theme::dim()))
-        }
-        Mode::Help => Line::from(Span::styled("  /:search  ?/esc:back", theme::dim())),
-        Mode::Explain => Line::from(Span::styled(
-            "  j/k: move   ⏎: go to resource   E: events   l: logs   r: refresh   esc: back",
+        _ => Line::from(Span::styled(
+            navigation_hint(app, frame.area().width),
             theme::dim(),
         )),
-        Mode::Timeline => Line::from(Span::styled(
-            "  j/k: move   g/G: top/bottom   esc: back",
-            theme::dim(),
-        )),
-        Mode::Gitops => Line::from(Span::styled(
-            "  j/k: move   ⏎: jump to owner/source   r: refresh   esc: back",
-            theme::dim(),
-        )),
-        Mode::Adjacent => Line::from(Span::styled(
-            "  j/k: move   ⏎: open the object   y: yaml   d: describe   c: discover children   r: refresh   esc: back",
-            theme::dim(),
-        )),
-        Mode::FluxMenu => Line::from(Span::styled(
-            "  j/k: move   enter: confirm   esc: cancel",
-            theme::dim(),
-        )),
-        Mode::PortForwardPicker => Line::from(Span::styled(
-            "  j/k: move   ⏎: forward this port   esc: cancel",
-            theme::dim(),
-        )),
-        Mode::PortForwards => Line::from(Span::styled(
-            "  j/k: move   x/s: stop   esc: close (others keep running)",
-            theme::dim(),
-        )),
-        Mode::Snapshots => Line::from(Span::styled(
-            "  j/k: move   ⏎: open   d: delete   esc: close",
-            theme::dim(),
-        )),
-        Mode::Fleet => Line::from(Span::styled(
-            "  j/k: move   ⏎: switch to context   r: refresh   esc: back",
-            theme::dim(),
-        )),
-        Mode::Find => Line::from(Span::styled(
-            "  j/k: move   ⏎: open the object   esc: close",
-            theme::dim(),
-        )),
-        Mode::PvcExplore => Line::from(Span::styled(
-            "  tab/←→: pane   j/k: move   ⏎: open   ⌫/-: up   c: copy to other pane   s: shell   r: refresh   esc: back",
-            theme::dim(),
-        )),
-        _ => {
-            // Per-resource verbs live in the header hint column when it
-            // fits; only repeat the full line when the header dropped it.
-            let cycle = if app.mode != Mode::Table {
-                ""
-            } else if app.active_workspace.is_some() {
-                "Tab/⇧Tab: workspace  "
-            } else {
-                "Tab/⇧Tab: resources  "
-            };
-            let hint = if !app.hide_header && header_hints_fit(frame.area().width) {
-                format!(
-                    "  {cycle}:resource  /filter  S:sort I:invert  w:wide  space:mark  [ ]:history  0:all-ns  ?:help"
-                )
-            } else {
-                format!(
-                    "  {cycle}:resource  /filter  S:sort I:invert  w:wide  ⏎drill  y:yaml d:describe l:logs e:edit s:shell/scale i:image r:restart f:fwd ^d:del  ?:help"
-                )
-            };
-            Line::from(Span::styled(hint, theme::dim()))
-        }
     };
     frame.render_widget(Paragraph::new(line), area);
 }
@@ -4136,23 +4284,15 @@ fn draw_status(frame: &mut Frame, app: &App, area: Rect) {
     );
 }
 
-#[derive(Clone, Copy)]
-enum ConfirmHintStyle {
-    Popup,
-    Prompt,
-}
-
-fn confirm_action_hint(allows_force: bool, style: ConfirmHintStyle) -> &'static str {
-    match (allows_force, style) {
-        (true, ConfirmHintStyle::Popup) => {
-            "  [y] confirm    [f] toggle force    [c] cascade    [n] cancel"
-        }
-        (false, ConfirmHintStyle::Popup) => "  [y] confirm    [n] cancel",
-        (true, ConfirmHintStyle::Prompt) => {
-            "  y/enter: confirm   f: toggle force   c: cascade   n/esc: cancel"
-        }
-        (false, ConfirmHintStyle::Prompt) => "  y/enter: confirm   n/esc: cancel",
+fn confirm_action_hint(app: &App, allows_force: bool) -> String {
+    let mut actions = vec![(Action::Accept, "confirm"), (Action::Back, "cancel")];
+    if allows_force {
+        actions.extend([
+            (Action::Force, "toggle force"),
+            (Action::Cascade, "cascade"),
+        ]);
     }
+    key_hint(app, "confirm", &actions)
 }
 
 /// Clear a popup region before drawing on top of it. `Clear` resets the cells
@@ -4480,16 +4620,14 @@ mod tests {
         assert_eq!(centered_rect_with_min(50, 20, 56, 7, tiny), tiny);
     }
 
-    #[test]
-    fn confirm_hint_mentions_force_only_when_supported() {
-        assert!(confirm_action_hint(true, ConfirmHintStyle::Popup).contains("toggle force"));
-        assert!(confirm_action_hint(true, ConfirmHintStyle::Prompt).contains("toggle force"));
-        assert!(!confirm_action_hint(false, ConfirmHintStyle::Popup).contains("toggle force"));
-        assert!(!confirm_action_hint(false, ConfirmHintStyle::Prompt).contains("toggle force"));
-        assert!(confirm_action_hint(true, ConfirmHintStyle::Popup).contains("cascade"));
-        assert!(confirm_action_hint(true, ConfirmHintStyle::Prompt).contains("cascade"));
-        assert!(!confirm_action_hint(false, ConfirmHintStyle::Popup).contains("cascade"));
-        assert!(!confirm_action_hint(false, ConfirmHintStyle::Prompt).contains("cascade"));
+    #[tokio::test]
+    async fn confirm_hint_mentions_force_only_when_supported() {
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let app = App::new(crate::k8s::Cluster::fake(), tx);
+        assert!(confirm_action_hint(&app, true).contains("toggle force"));
+        assert!(!confirm_action_hint(&app, false).contains("toggle force"));
+        assert!(confirm_action_hint(&app, true).contains("cascade"));
+        assert!(!confirm_action_hint(&app, false).contains("cascade"));
     }
 
     #[test]


### PR DESCRIPTION
Allow users to configure every built-in keyboard action through `[keys]` scopes. Users can assign Ctrl+U and Ctrl+D to paging after moving the table's delete binding. Deletion keeps the existing confirmation and read-only checks.

- Resolve named actions before input dispatch. Support global, navigation, text input, and mode settings, multiple bindings, and empty arrays to disable scoped bindings.
- Preserve default keys, including shifted list navigation. Explicit palette completion keys take priority over text editing.
- Automatically migrate legacy palette settings to `[keys.command]` before merging config layers. Preserve comments and file permissions, save `config.toml.bak`, and replace the file only after validation. Do not overwrite existing backups or managed symlinks. If saving fails, warn and use the converted settings in memory. Remove the old per-key fallback.
- Validate key settings after loading the config. Invalid key values retain the default or previous keymap without discarding other settings. Error messages identify the active context's config paths.
- Keep default confirmation cancellation for keyboard and mouse wheel input. Shared navigation settings do not change confirmation cancellation.
- Show effective bindings in help, header hints, and footer hints. Cache key labels when the map changes. Document all actions, validation rules, and recovery behavior.
- Keep mouse scrolling independent of keyboard assignments. Report user bindings hidden by built-in actions.

Closes #398

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/397

Validation: `just check` and required pre-commit checks pass, with 1,164 tests passed and 2 ignored. Tests cover every built-in action before and after rebinding, shifted navigation, palette migration, backups, managed config warnings, key value errors, reload and context changes, confirmation cancellation, mouse scrolling, help, and hints. Tests do not require a live cluster.
