### PR TITLE
fix: keep help keys separate from descriptions

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -21637,6 +21637,53 @@ async fn help_keeps_long_key_lists_separate_from_descriptions() {
 }
 
 #[tokio::test]
+async fn help_highlights_search_phrases_across_wrapped_rows() {
+    use ratatui::{Terminal, backend::TestBackend, style::Modifier};
+
+    for filter in [
+        "switch kind and namespace at once",
+        "pagedown / space / ctrl-f / shift-pagedown",
+        "hierarchical tree · live-vs-last-applied diff",
+    ] {
+        for width in [40, 60] {
+            let (mut app, _rx) = test_app();
+            app.handle_key(press(KeyCode::Char('?'))).unwrap();
+            app.handle_key(press(KeyCode::Char('/'))).unwrap();
+            for c in filter.chars() {
+                app.handle_key(press(KeyCode::Char(c))).unwrap();
+            }
+            app.handle_key(press(KeyCode::Enter)).unwrap();
+            let mut terminal = Terminal::new(TestBackend::new(width, 40)).unwrap();
+            terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+            let highlighted: Vec<String> = terminal
+                .backend()
+                .buffer()
+                .content
+                .chunks(usize::from(width))
+                .map(|row| {
+                    row.iter()
+                        .filter(|cell| {
+                            cell.bg == crate::theme::yellow()
+                                && cell.modifier.contains(Modifier::BOLD)
+                        })
+                        .map(|cell| cell.symbol())
+                        .collect::<String>()
+                })
+                .filter(|row| !row.is_empty())
+                .collect();
+            assert!(highlighted.len() >= 2, "{filter}: {highlighted:?}");
+            let matched: String = highlighted
+                .concat()
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect();
+            let expected: String = filter.chars().filter(|c| !c.is_whitespace()).collect();
+            assert!(matched.starts_with(&expected), "{filter}: {highlighted:?}");
+        }
+    }
+}
+
+#[tokio::test]
 async fn custom_keys_are_visible_in_help_header_and_footer() {
     use ratatui::{Terminal, backend::TestBackend};
     let (mut app, _rx) = test_app();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -21595,6 +21595,48 @@ async fn every_builtin_action_has_the_same_effect_after_rebinding() {
 }
 
 #[tokio::test]
+async fn help_keeps_long_key_lists_separate_from_descriptions() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    for width in [60, 100, 180] {
+        let (mut app, _rx) = test_app();
+        app.handle_key(press(KeyCode::Char('?'))).unwrap();
+        app.handle_key(press(KeyCode::Char('/'))).unwrap();
+        for c in "page down".chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(width, 40)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let rows: Vec<String> = terminal
+            .backend()
+            .buffer()
+            .content
+            .chunks(usize::from(width))
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect())
+            .collect();
+        let descriptions: Vec<_> = rows
+            .iter()
+            .filter(|row| row.contains("page down"))
+            .filter(|row| row.contains("pagedown"))
+            .collect();
+        assert!(!descriptions.is_empty(), "{rows:#?}");
+        let column = descriptions[0].find("page down").unwrap();
+        for row in descriptions {
+            assert_eq!(row.find("page down"), Some(column), "{row}");
+            assert_eq!(&row[column - 2..column], "  ", "{row}");
+        }
+        assert!(
+            rows.iter().any(|row| row.contains("shift-pagedown")),
+            "{rows:#?}"
+        );
+        app.handle_key(press(KeyCode::End)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert_eq!(app.help_scroll, app.help_max_scroll);
+    }
+}
+
+#[tokio::test]
 async fn custom_keys_are_visible_in_help_header_and_footer() {
     use ratatui::{Terminal, backend::TestBackend};
     let (mut app, _rx) = test_app();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2398,10 +2398,29 @@ fn value_style(value: &str) -> Style {
     Style::default().fg(theme::text())
 }
 
+fn wrap_help_span(span: Span<'static>, width: usize) -> Vec<Line<'static>> {
+    let mut rows = Vec::new();
+    let mut text = String::new();
+    for word in span.content.split_whitespace() {
+        if !text.is_empty() && text.width() + 1 + word.width() > width {
+            rows.extend(wrap_line(
+                Line::from(Span::styled(std::mem::take(&mut text), span.style)),
+                width,
+            ));
+        }
+        if !text.is_empty() {
+            text.push(' ');
+        }
+        text.push_str(word);
+    }
+    rows.extend(wrap_line(Line::from(Span::styled(text, span.style)), width));
+    rows
+}
+
 fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
     let bind = |k: &str, d: &str| {
         Line::from(vec![
-            Span::styled(format!("  {k:<14}"), Style::default().fg(theme::yellow())),
+            Span::styled(k.to_string(), Style::default().fg(theme::yellow())),
             Span::styled(d.to_string(), theme::dim()),
         ])
     };
@@ -2568,6 +2587,15 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         app.keymap.label("help", Action::Close),
         "close help and return to the previous screen",
     ));
+    let width = usize::from(area.width.saturating_sub(2)).max(1);
+    let key_width = lines
+        .iter()
+        .filter(|line| line.spans.len() == 2)
+        .map(|line| line.spans[0].width())
+        .max()
+        .unwrap_or(14)
+        .min(width.saturating_sub(4) / 2)
+        .max(1);
     // `/` search: keep only matching binding lines (section headers and
     // spacers match like any other text), highlighting the matched runs.
     let needle = app.help_filter.to_lowercase();
@@ -2577,11 +2605,39 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         let shown: Vec<Line> = lines
             .into_iter()
             .filter(|l| line_text(l).to_lowercase().contains(&needle))
-            .map(|l| highlight_matches(l, &app.help_filter))
             .collect();
         let title = format!(" Help · /{} [{}] ", app.help_filter, shown.len());
         (shown, title)
     };
+    let lines: Vec<Line> = lines
+        .into_iter()
+        .flat_map(|line| {
+            if line.spans.len() != 2 {
+                return wrap_line(line, width);
+            }
+            let mut spans = line.spans.into_iter();
+            let keys = wrap_help_span(spans.next().unwrap(), key_width);
+            let descriptions = wrap_help_span(
+                spans.next().unwrap(),
+                width.saturating_sub(key_width + 4).max(1),
+            );
+            (0..keys.len().max(descriptions.len()))
+                .map(|i| {
+                    let mut row = vec![Span::raw("  ")];
+                    let used = keys.get(i).map_or(0, Line::width);
+                    if let Some(key) = keys.get(i) {
+                        row.extend(key.spans.clone());
+                    }
+                    row.push(Span::raw(" ".repeat(key_width.saturating_sub(used) + 2)));
+                    if let Some(description) = descriptions.get(i) {
+                        row.extend(description.spans.clone());
+                    }
+                    Line::from(row)
+                })
+                .collect()
+        })
+        .map(|line| highlight_matches(line, &app.help_filter))
+        .collect();
     // Record the content height for paging and clamp the offset after layout changes.
     let inner_h = area.height.saturating_sub(2);
     app.help_viewport_h = inner_h;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2398,22 +2398,38 @@ fn value_style(value: &str) -> Style {
     Style::default().fg(theme::text())
 }
 
-fn wrap_help_span(span: Span<'static>, width: usize) -> Vec<Line<'static>> {
+fn wrap_help_span(span: Span<'static>, width: usize, needle: &str) -> Vec<Line<'static>> {
+    let highlighted = highlight_matches(Line::from(span.clone()), needle);
+    let render = |start: usize, end: usize| {
+        let mut offset = 0;
+        let mut spans = Vec::new();
+        for part in &highlighted.spans {
+            let part_end = offset + part.content.len();
+            let from = start.max(offset);
+            let to = end.min(part_end);
+            if from < to {
+                spans.push(Span::styled(
+                    part.content[from - offset..to - offset].to_string(),
+                    part.style,
+                ));
+            }
+            offset = part_end;
+        }
+        wrap_line(Line::from(spans), width)
+    };
     let mut rows = Vec::new();
-    let mut text = String::new();
+    let mut start = 0;
+    let mut end = 0;
     for word in span.content.split_whitespace() {
-        if !text.is_empty() && text.width() + 1 + word.width() > width {
-            rows.extend(wrap_line(
-                Line::from(Span::styled(std::mem::take(&mut text), span.style)),
-                width,
-            ));
+        let word_start = end + span.content[end..].find(word).unwrap();
+        let word_end = word_start + word.len();
+        if start < end && span.content[start..word_end].width() > width {
+            rows.extend(render(start, end));
+            start = word_start;
         }
-        if !text.is_empty() {
-            text.push(' ');
-        }
-        text.push_str(word);
+        end = word_end;
     }
-    rows.extend(wrap_line(Line::from(Span::styled(text, span.style)), width));
+    rows.extend(render(start, end));
     rows
 }
 
@@ -2613,13 +2629,14 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         .into_iter()
         .flat_map(|line| {
             if line.spans.len() != 2 {
-                return wrap_line(line, width);
+                return wrap_line(highlight_matches(line, &app.help_filter), width);
             }
             let mut spans = line.spans.into_iter();
-            let keys = wrap_help_span(spans.next().unwrap(), key_width);
+            let keys = wrap_help_span(spans.next().unwrap(), key_width, &app.help_filter);
             let descriptions = wrap_help_span(
                 spans.next().unwrap(),
                 width.saturating_sub(key_width + 4).max(1),
+                &app.help_filter,
             );
             (0..keys.len().max(descriptions.len()))
                 .map(|i| {
@@ -2636,7 +2653,6 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
                 })
                 .collect()
         })
-        .map(|line| highlight_matches(line, &app.help_filter))
         .collect();
     // Record the content height for paging and clamp the offset after layout changes.
     let inner_h = area.height.saturating_sub(2);


### PR DESCRIPTION
Long key lists, including Shift navigation keys, exceeded the fixed 14-character help column and ran into their descriptions. Help now sizes the columns to fit the terminal and wraps each column separately, with a clear gap between keys and descriptions.

Search filters complete entries before wrapping. Scrolling uses the rendered row count. A regression test opens help through keyboard input and checks spacing, Shift key visibility, search, and scrolling at terminal widths of 60, 100, and 180 columns.

Validation: `just check` passed. The commit hook also passed Rust formatting, Clippy, and the test suite.
