### PR TITLE
feat: switch to favourite namespaces with number keys

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ remember_sort     = true   # save and restore sort choices per resource kind
                            # false makes sort changes temporary
 
 # Namespaces pinned to the top of the `n` switcher (★); session recents (·)
-# follow them.
+# follow them. Keys 1 to 9 select the first nine entries in this fixed order.
 favorite_namespaces = ["kube-system", "monitoring"]
 
 [aliases]
@@ -79,6 +79,19 @@ under `[aliases]`. Use a group-qualified target when resource names overlap:
 ```toml
 [aliases]
 md = "machinedeployments.cluster.x-k8s.io"
+```
+
+The resource table actions `favorite_namespace_1` through
+`favorite_namespace_9` select entries from `favorite_namespaces` in configuration
+order. Recent namespace changes do not change these assignments. Extra entries
+remain available through `n`. Empty or unconfigured slots do nothing.
+
+To change or disable a shortcut, use the existing key configuration:
+
+```toml
+[keys.table]
+favorite_namespace_1 = "f1"
+favorite_namespace_2 = []
 ```
 
 ## Skins

--- a/docs/features.md
+++ b/docs/features.md
@@ -147,7 +147,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `list`. An explicit search checks the full discovery catalog, because some
   delegated authorizers return incomplete rule reviews.
 - **Namespace switcher** (`n`) with pinned favourites (★) and per-context
-  session recents (·) above the rest, plus a context switcher (`:ctx`). The
+  session recents (·) above the rest, plus a context switcher (`:ctx`). In the
+  resource table, `1` to `9` select the first nine configured favourites in fixed
+  configuration order. The picker shows these shortcuts beside favourites.
+  Unconfigured slots do nothing. `0` selects all namespaces. The
   last namespace picked in each context is remembered across restarts
   (`<state-dir>/namespaces.toml`); `-n`/`-A` override it for a session.
 - **Default sort** - `[views."*"].sort` sets a global initial sort, with

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -37,6 +37,7 @@ for the grammar and selector persistence rules.
 | `/`                                           | filter: fuzzy text · `"exact"` · `/regex/` · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                                   |
 | `Ctrl+Z`                                      | toggle faults filter in pod views; configured actions take precedence; combine with `/`; press again to turn off                                                    |
 | `n` / `0`                                     | namespace switcher / all namespaces                                                                                                                                 |
+| `1` to `9`                                    | select a configured favourite namespace in fixed configuration order                                                                                                |
 | `shift-j`                                     | jump to owner/controller                                                                                                                                            |
 | `o`                                           | show the node the selected row names (pods built in; other kinds via `[views."…"].node`)                                                                            |
 | `ctrl-r`                                      | refresh the watch                                                                                                                                                   |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -251,6 +251,20 @@ impl App {
     }
 
     pub(super) fn key_table(&mut self, key: KeyInput) {
+        if let Some(index) = Action::FAVORITE_NAMESPACES
+            .iter()
+            .position(|action| Some(*action) == key.action)
+        {
+            if let Some(namespace) = self
+                .namespace_favorites
+                .get(index)
+                .filter(|n| !n.is_empty())
+                .cloned()
+            {
+                self.set_namespace(namespace);
+            }
+            return;
+        }
         match (key.action, key.code) {
             (Some(Action::Delete), _) => self.request_delete(false),
             (Some(Action::ForceDelete), _) => self.request_delete(true),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -22104,3 +22104,128 @@ async fn context_key_errors_name_the_destination_config() {
     assert_eq!(app.keymap.label("table", Action::PageDown), "f8");
     std::fs::remove_dir_all(dir).unwrap();
 }
+
+#[tokio::test]
+async fn favorite_namespace_keys_keep_config_order_and_record_history() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind("pods");
+    app.namespace_favorites = (1..=10).map(|i| format!("team-{i}")).collect();
+    for digit in ['9', '1', '4', '2', '3', '5', '6', '7', '8', '1'] {
+        app.handle_key(press(KeyCode::Char(digit))).unwrap();
+        let expected = format!("team-{digit}");
+        assert_eq!(app.namespace, expected);
+        assert_eq!(app.namespace_memory.get("test"), Some(expected.clone()));
+        assert!(app.is_recent_namespace(&expected));
+        assert_eq!(app.kind_plural, "pods");
+    }
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(app.namespace, "team-8");
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    assert_eq!(app.namespace, "team-1");
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    assert!(app.all_namespaces());
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.mode, Mode::Namespaces);
+    assert!(app.filtered_namespaces().contains(&"team-10".to_string()));
+}
+
+#[tokio::test]
+async fn favorite_namespace_keys_ignore_empty_slots_and_preserve_text_input() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind("pods");
+    for digit in '1'..='9' {
+        app.handle_key(press(KeyCode::Char(digit))).unwrap();
+        assert_eq!(app.namespace, "default");
+    }
+    app.namespace_favorites = vec![String::new(), "team-2".into()];
+    app.handle_key(press(KeyCode::Char('1'))).unwrap();
+    assert_eq!(app.namespace, "default");
+    app.handle_key(press(KeyCode::Char('2'))).unwrap();
+    assert_eq!(app.namespace, "team-2");
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    app.handle_key(press(KeyCode::Char('1'))).unwrap();
+    assert_eq!(app.ns_filter, "1");
+    assert_eq!(app.namespace, "team-2");
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    app.handle_key(press(KeyCode::Char('9'))).unwrap();
+    assert_eq!(app.filter, "9");
+    assert_eq!(app.namespace, "team-2");
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    app.handle_key(press(KeyCode::Char('1'))).unwrap();
+    assert_eq!(app.command, "1");
+    assert_eq!(app.namespace, "team-2");
+}
+
+#[tokio::test]
+async fn favorite_namespace_key_clears_drill_scope() {
+    let (mut app, _rx) = test_app();
+    app.namespace_favorites = vec!["target".into()];
+    app.switch_kind("cronjobs");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "batch/v1", "kind": "CronJob",
+            "metadata": {"name": "backup", "namespace": "ops"},
+            "spec": {"schedule": "* * * * *", "jobTemplate": {"spec": {}}}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(app.owner.is_some());
+    app.handle_key(press(KeyCode::Char('1'))).unwrap();
+    assert_eq!(app.namespace, "target");
+    assert_eq!(app.kind_plural, "jobs");
+    assert_eq!(app.owner, None);
+    assert_eq!(app.scope_label, None);
+    assert_eq!(app.table_state.selected(), Some(0));
+}
+
+#[tokio::test]
+async fn favorite_namespace_shortcuts_follow_key_configuration_in_picker_and_help() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.namespace = "default".into();
+    app.switch_kind("pods");
+    app.namespace_favorites = vec!["production".into(), "staging".into()];
+    use_keys(
+        &mut app,
+        "[keys.table]\nfavorite_namespace_1 = 'f1'\nfavorite_namespace_2 = []\n",
+    );
+    app.handle_key(press(KeyCode::Char('1'))).unwrap();
+    app.handle_key(press(KeyCode::Char('2'))).unwrap();
+    assert_eq!(app.namespace, "default");
+    app.handle_key(press(KeyCode::F(1))).unwrap();
+    assert_eq!(app.namespace, "production");
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    let mut terminal = Terminal::new(TestBackend::new(180, 40)).unwrap();
+    let screen = |app: &mut App, terminal: &mut Terminal<TestBackend>| {
+        terminal.draw(|f| crate::ui::draw(f, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>()
+    };
+    let text = screen(&mut app, &mut terminal);
+    assert!(text.contains("production [f1]"), "{text}");
+    assert!(text.contains("staging [unbound]"), "{text}");
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Char('?'))).unwrap();
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "favourite namespace".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    let text = screen(&mut app, &mut terminal);
+    assert!(
+        text.contains("select configured favourite namespace 1"),
+        "{text}"
+    );
+    assert!(text.contains("f1"), "{text}");
+}

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -58,6 +58,15 @@ actions! {
     Exit => ("exit", "quit from table"),
     Explain => ("explain", "explain"),
     Faults => ("faults", "faults"),
+    FavoriteNamespace1 => ("favorite_namespace_1", "select configured favourite namespace 1"),
+    FavoriteNamespace2 => ("favorite_namespace_2", "select configured favourite namespace 2"),
+    FavoriteNamespace3 => ("favorite_namespace_3", "select configured favourite namespace 3"),
+    FavoriteNamespace4 => ("favorite_namespace_4", "select configured favourite namespace 4"),
+    FavoriteNamespace5 => ("favorite_namespace_5", "select configured favourite namespace 5"),
+    FavoriteNamespace6 => ("favorite_namespace_6", "select configured favourite namespace 6"),
+    FavoriteNamespace7 => ("favorite_namespace_7", "select configured favourite namespace 7"),
+    FavoriteNamespace8 => ("favorite_namespace_8", "select configured favourite namespace 8"),
+    FavoriteNamespace9 => ("favorite_namespace_9", "select configured favourite namespace 9"),
     Filter => ("filter", "filter"),
     First => ("first", "first row"),
     FleetMark => ("fleet_mark", "fleet mark"),
@@ -125,6 +134,18 @@ impl Action {
             _ => None,
         }
     }
+
+    pub const FAVORITE_NAMESPACES: [Self; 9] = [
+        Self::FavoriteNamespace1,
+        Self::FavoriteNamespace2,
+        Self::FavoriteNamespace3,
+        Self::FavoriteNamespace4,
+        Self::FavoriteNamespace5,
+        Self::FavoriteNamespace6,
+        Self::FavoriteNamespace7,
+        Self::FavoriteNamespace8,
+        Self::FavoriteNamespace9,
+    ];
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -409,6 +430,15 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("table", Action::ActionMenu, &["t"]),
     ("table", Action::Adjacent, &["u"]),
     ("table", Action::AllNamespaces, &["0"]),
+    ("table", Action::FavoriteNamespace1, &["1"]),
+    ("table", Action::FavoriteNamespace2, &["2"]),
+    ("table", Action::FavoriteNamespace3, &["3"]),
+    ("table", Action::FavoriteNamespace4, &["4"]),
+    ("table", Action::FavoriteNamespace5, &["5"]),
+    ("table", Action::FavoriteNamespace6, &["6"]),
+    ("table", Action::FavoriteNamespace7, &["7"]),
+    ("table", Action::FavoriteNamespace8, &["8"]),
+    ("table", Action::FavoriteNamespace9, &["9"]),
     ("table", Action::Attach, &["a"]),
     ("table", Action::Back, &["esc"]),
     ("table", Action::CopyCell, &["Y"]),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2633,9 +2633,20 @@ fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 ("", theme::text())
             };
+            let shortcut = if browsing {
+                app.namespace_favorites
+                    .iter()
+                    .position(|favorite| favorite == n)
+                    .and_then(|index| Action::FAVORITE_NAMESPACES.get(index))
+                    .map(|action| format!(" [{}]", app.keymap.label("table", *action)))
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
             ListItem::new(Line::from(vec![
                 Span::styled(tag.to_string(), theme::dim()),
                 Span::styled(n.clone(), Style::default().fg(color)),
+                Span::styled(shortcut, theme::dim()),
             ]))
         })
         .collect();


### PR DESCRIPTION
Users can now press `1` to `9` in the resource table to select the first nine configured `favorite_namespaces`. Assignments stay in configuration order when recent history changes. `0` still selects all namespaces, and `n` opens the full picker.

The picker shows effective shortcuts beside favourites. Each shortcut can be changed or disabled through `keys.table.favorite_namespace_1` to `favorite_namespace_9`. Empty or unconfigured slots do nothing. Numeric text input keeps its existing behaviour.

Scope agreed in https://github.com/nklmilojevic/sofka/discussions/396.

Validation: `just check` passed, including formatting, Clippy with warnings denied, and the full test suite. Added tests through `handle_key` for fixed assignments, history and namespace memory, empty slots, text input, drill scope, custom bindings, picker labels, and help.

Closes #403
