### PR TITLE
fix: keep section headings in help search results

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11194,6 +11194,62 @@ async fn help_search_uses_own_buffer() {
 }
 
 #[tokio::test]
+async fn help_search_keeps_section_headings_with_matching_bindings() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    for filter in ["enter", "Keys: detail", "no-such-help-entry"] {
+        let (mut app, _rx) = test_app();
+        app.handle_key(press(KeyCode::Char('?'))).unwrap();
+        app.handle_key(press(KeyCode::Char('/'))).unwrap();
+        for c in filter.chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(120, 120)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let rows: Vec<String> = terminal
+            .backend()
+            .buffer()
+            .content
+            .chunks(120)
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect())
+            .collect();
+        let text = rows.join("\n");
+        if filter == "enter" {
+            let mut matches = 1; // The command section heading also matches.
+            for (scope, action, _) in app.keymap.entries() {
+                let label = app.keymap.label(scope, action);
+                if !label.contains("enter") {
+                    continue;
+                }
+                matches += 1;
+                let heading = format!("Keys: {scope}");
+                let positions: Vec<_> = rows
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, row)| row.contains(&heading))
+                    .map(|(i, _)| i)
+                    .collect();
+                assert_eq!(positions.len(), 1, "{heading}: {text}");
+                let binding = &rows[positions[0] + 1];
+                assert!(binding.contains(label), "{heading}: {binding}");
+                assert!(binding.contains(action.description()), "{binding}");
+            }
+            assert!(text.contains(&format!("/enter [{matches}]")), "{text}");
+            assert!(!text.contains("Keys: detail"), "{text}");
+            assert!(!text.contains("decode secret"), "{text}");
+        } else if filter == "Keys: detail" {
+            assert!(text.contains("/Keys: detail [1]"), "{text}");
+            assert!(rows.iter().any(|row| row.contains("  Keys: detail")));
+            assert!(!text.contains("decode secret"), "{text}");
+        } else {
+            assert!(text.contains("/no-such-help-entry [0]"), "{text}");
+            assert!(!text.contains("Keys:"), "{text}");
+        }
+    }
+}
+
+#[tokio::test]
 async fn help_pages_use_the_rendered_height() {
     use ratatui::{Terminal, backend::TestBackend};
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2612,17 +2612,40 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         .unwrap_or(14)
         .min(width.saturating_sub(4) / 2)
         .max(1);
-    // `/` search: keep only matching binding lines (section headers and
-    // spacers match like any other text), highlighting the matched runs.
+    // Keep section headings with matching entries so each binding has context.
     let needle = app.help_filter.to_lowercase();
     let (lines, title) = if needle.is_empty() {
         (lines, " Help ".to_string())
     } else {
-        let shown: Vec<Line> = lines
-            .into_iter()
-            .filter(|l| line_text(l).to_lowercase().contains(&needle))
-            .collect();
-        let title = format!(" Help · /{} [{}] ", app.help_filter, shown.len());
+        let mut shown = Vec::new();
+        let mut heading = None;
+        let mut matches = 0;
+        for line in lines {
+            let text = line_text(&line);
+            if text.is_empty() {
+                continue;
+            }
+            let matched = text.to_lowercase().contains(&needle);
+            let binding = if line.spans.len() != 2 {
+                heading = Some(line);
+                None
+            } else {
+                Some(line)
+            };
+            if matched {
+                matches += 1;
+                if let Some(heading) = heading.take() {
+                    if !shown.is_empty() {
+                        shown.push(Line::default());
+                    }
+                    shown.push(heading);
+                }
+                if let Some(binding) = binding {
+                    shown.push(binding);
+                }
+            }
+        }
+        let title = format!(" Help · /{} [{}] ", app.help_filter, matches);
         (shown, title)
     };
     let lines: Vec<Line> = lines


### PR DESCRIPTION
Searching help for `enter` showed repeated bindings without their view headings. Search results now keep each matching binding under its section heading, with a blank row between sections.

The result count excludes headings added only for context. Searches that match a heading still show that heading. Sections with no match remain hidden.

Validation: `just check` and commit hooks passed. Keyboard tests cover `enter` bindings and their headings, result counts, heading searches, and searches with no matches.
