### PR TITLE
fix: recompute time-dependent sort keys on every rebuild

### DIFF
--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -467,23 +467,29 @@ impl App {
             return;
         }
         let parsed = self.parsed_filter();
+        let headers = self.display_headers();
+        let sort_header = self
+            .sort_column
+            .and_then(|i| headers.get(i).map(String::as_str));
+        // AGE and other time-dependent sort keys move without a new
+        // resourceVersion, so they can never be cached and the cache must
+        // rebuild once per second even without a watch event.
+        let time_dependent_sort =
+            sort_header.is_some_and(|h| self.spec.is_time_sort(h, &self.kind_plural));
         cache.time_sensitive = match &*parsed {
             crate::filter::ParsedFilter::Structured(s) => {
                 s.terms.iter().any(crate::filter::Term::time_sensitive)
             }
             _ => false,
-        };
+        } || time_dependent_sort;
         cache.filter_second = now;
         cache.column_widths = None;
 
-        let headers = self.display_headers();
-        let sort_header = self
-            .sort_column
-            .and_then(|i| headers.get(i).map(String::as_str));
         // CPU/MEM (and the node capacity percentages and pod counts) sort by
         // live poll snapshots, which move without a new resourceVersion, so
         // those keys can never be cached.
-        let volatile_sort = sort_header.is_some_and(|h| self.spec.metric(h).is_some());
+        let volatile_sort =
+            sort_header.is_some_and(|h| self.spec.metric(h).is_some()) || time_dependent_sort;
         // The aggregated Helm release list (`helm list` semantics) shows only
         // the latest revision per release; `helmhistory` (one release's full
         // history) shows every revision, so it skips this.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7167,6 +7167,110 @@ async fn sorted_order_updates_when_an_object_changes() {
 }
 
 #[tokio::test]
+async fn age_sort_new_pod_not_lost_among_stale_cached_keys() {
+    // AGE sort keys are cached by (header, resourceVersion), but depend on
+    // `now`. A new pod triggers a rebuild at a later `now`; unchanged pods
+    // reuse stale keys with a smaller age, so the new pod sorts after them.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let age_idx = app
+        .display_headers()
+        .to_vec()
+        .iter()
+        .position(|h| h == "AGE")
+        .unwrap();
+
+    let pod = |name: &str, created: &str, rv: &str| {
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {
+                "name": name, "namespace": "default",
+                "resourceVersion": rv, "creationTimestamp": created
+            },
+            "status": {"phase": "Running"}
+        })
+    };
+
+    // Two pods created years ago.
+    apply(&mut app, pod("old-a", "2020-01-01T00:00:00Z", "1"));
+    apply(&mut app, pod("old-b", "2021-01-01T00:00:00Z", "1"));
+    app.sort_column = Some(age_idx);
+    app.invalidate_rows();
+    assert_eq!(row_names(&app), ["old-b", "old-a"]);
+
+    // Inject stale sort keys: simulate a cache built at an earlier `now`.
+    {
+        let mut cache = app.rows_cache.borrow_mut();
+        cache.sort_keys.insert(
+            Rc::from("default/old-a"),
+            SortKeyEntry {
+                header: "AGE".into(),
+                resource_version: Some("1".into()),
+                key: SortKey::Num(10.0),
+            },
+        );
+        cache.sort_keys.insert(
+            Rc::from("default/old-b"),
+            SortKeyEntry {
+                header: "AGE".into(),
+                resource_version: Some("1".into()),
+                key: SortKey::Num(10.0),
+            },
+        );
+    }
+
+    // A new pod created 30 s ago: its fresh age (30) is larger than the stale
+    // cached age (10), so with the bug it sorts after the old pods.
+    let now = Timestamp::now().as_second();
+    let created = Timestamp::from_second(now - 30).unwrap().to_string();
+    apply(&mut app, pod("new-pod", &created, "1"));
+
+    // Correct ascending order: new-pod (30 s) before old-b (5 y) before
+    // old-a (6 y).
+    assert_eq!(row_names(&app), ["new-pod", "old-b", "old-a"]);
+}
+
+#[tokio::test]
+async fn age_sort_rebuilds_periodically_without_watch_events() {
+    // AGE sort keys change every second without a watch event; the cache
+    // must rebuild once per second to keep them fresh.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "p", "namespace": "default",
+                            "creationTimestamp": "2020-01-01T00:00:00Z"}}),
+    );
+    let age_idx = app
+        .display_headers()
+        .to_vec()
+        .iter()
+        .position(|h| h == "AGE")
+        .unwrap();
+    app.sort_column = Some(age_idx);
+    app.invalidate_rows();
+    let _ = row_names(&app);
+
+    // Simulate one second passing without a watch event.
+    let stale;
+    {
+        let mut cache = app.rows_cache.borrow_mut();
+        cache.filter_second -= 1;
+        stale = cache.filter_second;
+        assert!(!cache.dirty);
+    }
+
+    let _ = row_names(&app);
+
+    assert_ne!(
+        app.rows_cache.borrow().filter_second,
+        stale,
+        "AGE sort should rebuild once per second"
+    );
+}
+
+#[tokio::test]
 async fn sort_picker_picks_toggles_and_clears() {
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -602,6 +602,24 @@ impl ViewSpec {
         Some(&self.columns.get(idx)?.original_header)
     }
 
+    /// Whether `header`'s sort key depends on `now` (AGE, running-job
+    /// DURATION, user `time` columns) and so can't be cached by
+    /// resourceVersion alone.
+    pub fn is_time_sort(&self, header: &str, plural: &str) -> bool {
+        let idx = match self.header_index(header) {
+            Some(i) => i,
+            None => return false,
+        };
+        if let SpecSource::User(uc) = &self.columns[idx].source {
+            return uc.kind == crate::views::ColumnKind::Time;
+        }
+        match self.canonical_header(idx) {
+            Some("AGE") => true,
+            Some("DURATION") if plural == "jobs" => true,
+            _ => false,
+        }
+    }
+
     pub fn headers(&self) -> Vec<String> {
         self.columns.iter().map(|c| c.header.clone()).collect()
     }


### PR DESCRIPTION
## What

Sorting pods by AGE (ascending, newest first) could land a brand-new pod in the middle of the table instead of at the top. The same applies to running-job DURATION and user `time` columns.

## Why

AGE sort keys are `now - creationTimestamp`, but the sort-key cache validates by `(header, resourceVersion)` and `now` is not part of the key. When a new pod arrived and triggered a rebuild at a later `now`, unchanged pods reused stale keys computed with an earlier `now`. Their cached ages were artificially small, so the new pod's fresh (larger) age sorted after them.

This was especially visible in all-namespaces mode: more pods means more stale cached keys, increasing the chance a new pod's fresh age falls between stale values.

## Fix

- `ViewSpec::is_time_sort` identifies sort columns whose keys depend on `now`: AGE, running-job DURATION, user `time` columns.
- `volatile_sort` extended to include these columns: their sort keys bypass the cache and are always freshly computed (same path as CPU/MEM metrics).
- `time_sensitive` extended so the cache rebuilds once per second even without a watch event.

## Proof of the bug

Two tests that fail on `main` and pass with the fix:

1. `age_sort_new_pod_not_lost_among_stale_cached_keys` - injects stale sort keys (age=10s) for old pods, then applies a new pod (age=30s). Before the fix: `[old-a, old-b, new-pod]` (new pod last). After: `[new-pod, old-b, old-a]`.

2. `age_sort_rebuilds_periodically_without_watch_events` - simulates time passing without a watch event. Before the fix: the cache does not rebuild (time_sensitive was false for sort-only). After: it rebuilds once per second.
