### PR TITLE
feat: make mouse wheel scroll distance configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ hide_header = false # true hides the header and logo
 compact_mode = false # true starts with a one-line header and no footer
 mouse             = true   # false keeps the terminal's native mouse behavior
                            # (text selection) instead of scroll/click/sort
+mouse_scroll_lines = 3     # rows moved per wheel notch; 1 for line-by-line
 terminal_title = true # false disables terminal title changes
 remember_sort     = true   # save and restore sort choices per resource kind
                            # false makes sort changes temporary
@@ -54,6 +55,12 @@ namespace, context, and live status, with the footer hidden. The default is
 overrides are resolved at startup; `:reload` and subsequent context switches do
 not reset the current compact mode. With `hide_header = true`, the compact
 header is hidden too. Command and filter input still appears when needed.
+
+`mouse_scroll_lines` sets how many rows one mouse wheel notch moves in every
+view (table, logs, documents, pickers). The default is `3`. Set it to `1` if
+your terminal or trackpad already sends several wheel events per gesture and
+scrolling overshoots. `0` behaves like `1`. The option supports cluster and
+context overrides and `:reload`.
 
 `remember_sort` is enabled by default. Set it to `false` to stop saving and
 restoring sort choices from `S`, `I`, and column header clicks. Existing saved

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,7 @@ header is hidden too. Command and filter input still appears when needed.
 event triggers in views with mouse capture enabled (tables and pickers). The
 default is `3`. Set it to `1` if your terminal or trackpad already sends several
 wheel events per gesture and scrolling overshoots. `0` is treated as `1` and
-reported as a config warning. Logs and document views release mouse capture and
+values above `100` are capped at `100`, each reported as a config warning. Logs and document views release mouse capture and
 receive terminal-generated arrow keys instead, so this setting does not control
 their scroll speed. The option supports cluster and context overrides and
 `:reload`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ hide_header = false # true hides the header and logo
 compact_mode = false # true starts with a one-line header and no footer
 mouse             = true   # false keeps the terminal's native mouse behavior
                            # (text selection) instead of scroll/click/sort
-mouse_scroll_lines = 3     # rows moved per wheel notch; 1 for line-by-line
+mouse_scroll_lines = 3     # steps per wheel event in captured views; 1 for one step
 terminal_title = true # false disables terminal title changes
 remember_sort     = true   # save and restore sort choices per resource kind
                            # false makes sort changes temporary
@@ -56,11 +56,14 @@ overrides are resolved at startup; `:reload` and subsequent context switches do
 not reset the current compact mode. With `hide_header = true`, the compact
 header is hidden too. Command and filter input still appears when needed.
 
-`mouse_scroll_lines` sets how many rows one mouse wheel notch moves in every
-view (table, logs, documents, pickers). The default is `3`. Set it to `1` if
-your terminal or trackpad already sends several wheel events per gesture and
-scrolling overshoots. `0` behaves like `1`. The option supports cluster and
-context overrides and `:reload`.
+`mouse_scroll_lines` sets how many navigation steps one received mouse wheel
+event triggers in views with mouse capture enabled (tables and pickers). The
+default is `3`. Set it to `1` if your terminal or trackpad already sends several
+wheel events per gesture and scrolling overshoots. `0` is treated as `1` and
+reported as a config warning. Logs and document views release mouse capture and
+receive terminal-generated arrow keys instead, so this setting does not control
+their scroll speed. The option supports cluster and context overrides and
+`:reload`.
 
 `remember_sort` is enabled by default. Set it to `false` to stop saving and
 restoring sort choices from `S`, `I`, and column header clicks. Existing saved

--- a/docs/features.md
+++ b/docs/features.md
@@ -164,7 +164,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   backup; managed files produce a warning and use the converted keys in memory.
   See [Configure key bindings](keybindings.md).
 - **Mouse support** - the wheel scrolls every view (one notch is three steps of
-  that view's own up/down), clicking a row selects it, clicking a column header
+  that view's own up/down; tune with `mouse_scroll_lines`), clicking a row
+  selects it, clicking a column header
   sorts by it (click again to flip). Document views (YAML/describe, diff,
   events, logs, help) release the mouse automatically so click-drag selects
   text natively; the wheel still scrolls them in terminals that translate it to

--- a/docs/features.md
+++ b/docs/features.md
@@ -163,13 +163,14 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   the previous keymap. Legacy palette settings are migrated with a config
   backup; managed files produce a warning and use the converted keys in memory.
   See [Configure key bindings](keybindings.md).
-- **Mouse support** - the wheel scrolls every view (one notch is three steps of
-  that view's own up/down; tune with `mouse_scroll_lines`), clicking a row
-  selects it, clicking a column header
+- **Mouse support** - the wheel scrolls every view (one wheel event is three
+  steps of that view's own up/down; `mouse_scroll_lines` tunes this in views
+  with mouse capture), clicking a row selects it, clicking a column header
   sorts by it (click again to flip). Document views (YAML/describe, diff,
   events, logs, help) release the mouse automatically so click-drag selects
   text natively; the wheel still scrolls them in terminals that translate it to
-  arrow keys in the alternate screen (kitty, Ghostty, iTerm2, ...). Set
+  arrow keys in the alternate screen (kitty, Ghostty, iTerm2, ...), at the
+  terminal's own speed, not `mouse_scroll_lines`. Set
   `mouse = false` to keep the terminal's native mouse behavior everywhere.
   sofka also releases the mouse while a suspended command (`kubectl exec`,
   `$EDITOR`) runs.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1451,6 +1451,7 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
+        self.mouse_scroll_lines = resolved.config.mouse_scroll_lines.unwrap_or(3).max(1);
         self.hide_header = resolved.config.hide_header;
         self.terminal_title = resolved.config.terminal_title.unwrap_or(true);
         self.plugins = resolved.config.plugins;

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1451,7 +1451,8 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
-        self.mouse_scroll_lines = resolved.config.mouse_scroll_lines.unwrap_or(3).max(1);
+        self.mouse_scroll_lines =
+            crate::config::mouse_scroll_lines(resolved.config.mouse_scroll_lines, &mut warnings);
         self.hide_header = resolved.config.hide_header;
         self.terminal_title = resolved.config.terminal_title.unwrap_or(true);
         self.plugins = resolved.config.plugins;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1819,7 +1819,7 @@ pub struct App {
     /// view start. Persisted to `sort_memory_path` on every change.
     pub sort_memory: crate::sortmem::SortMemory,
     pub remember_sort: bool,
-    /// Rows moved per mouse wheel notch (`mouse_scroll_lines`, default 3).
+    /// Steps per received mouse wheel event (`mouse_scroll_lines`, default 3).
     pub mouse_scroll_lines: u16,
     /// Where remembered sorts persist (`<state-dir>/sort.toml`, set at
     /// startup); `None` (tests) keeps them in memory only.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1819,6 +1819,8 @@ pub struct App {
     /// view start. Persisted to `sort_memory_path` on every change.
     pub sort_memory: crate::sortmem::SortMemory,
     pub remember_sort: bool,
+    /// Rows moved per mouse wheel notch (`mouse_scroll_lines`, default 3).
+    pub mouse_scroll_lines: u16,
     /// Where remembered sorts persist (`<state-dir>/sort.toml`, set at
     /// startup); `None` (tests) keeps them in memory only.
     pub sort_memory_path: Option<std::path::PathBuf>,
@@ -2182,6 +2184,7 @@ impl App {
             fleet_marks_path: None,
             sort_memory: crate::sortmem::SortMemory::default(),
             remember_sort: true,
+            mouse_scroll_lines: 3,
             sort_memory_path: None,
             namespace_memory: crate::nsmem::NamespaceMemory::default(),
             namespace_memory_path: None,

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -79,9 +79,10 @@ impl App {
         }
     }
 
-    /// One wheel notch = three steps, like most list UIs.
+    /// One wheel notch = `mouse_scroll_lines` steps (default three, like most
+    /// list UIs).
     fn wheel(&mut self, code: KeyCode) -> Result<()> {
-        for _ in 0..3 {
+        for _ in 0..self.mouse_scroll_lines {
             let action = self
                 .keymap
                 .wheel_action(self.key_scope(), code == KeyCode::Down);

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -79,13 +79,19 @@ impl App {
         }
     }
 
-    /// One wheel notch = `mouse_scroll_lines` steps (default three, like most
-    /// list UIs).
+    /// One wheel event = `mouse_scroll_lines` steps (default three, like most
+    /// list UIs). The action is resolved once and the loop stops as soon as
+    /// the mode changes, so a wheel event that dismisses an overlay does not
+    /// keep scrolling the view underneath it.
     fn wheel(&mut self, code: KeyCode) -> Result<()> {
+        let mode = self.mode;
+        let action = self
+            .keymap
+            .wheel_action(self.key_scope(), code == KeyCode::Down);
         for _ in 0..self.mouse_scroll_lines {
-            let action = self
-                .keymap
-                .wheel_action(self.key_scope(), code == KeyCode::Down);
+            if self.mode != mode {
+                break;
+            }
             self.handle_input(KeyInput::new(
                 action,
                 KeyEvent::new(KeyCode::Null, KeyModifiers::NONE),

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -818,7 +818,6 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
-        self.mouse_scroll_lines = resolved.config.mouse_scroll_lines.unwrap_or(3).max(1);
         self.hide_header = resolved.config.hide_header;
         self.terminal_title = resolved.config.terminal_title.unwrap_or(true);
         self.plugins = resolved.config.plugins;
@@ -833,6 +832,10 @@ impl App {
         // Tracked debuggers belong to the previous cluster/context.
         self.launched_node_debuggers.clear();
         let mut plugin_warnings = crate::config::plugin_warnings(&self.plugins);
+        self.mouse_scroll_lines = crate::config::mouse_scroll_lines(
+            resolved.config.mouse_scroll_lines,
+            &mut plugin_warnings,
+        );
         plugin_warnings.extend(crate::config::bookmark_warnings(&self.bookmarks));
         plugin_warnings.extend(crate::config::workspace_warnings(&self.workspaces));
         plugin_warnings.extend(crate::config::guardrail_warnings(&self.guardrails));

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -818,6 +818,7 @@ impl App {
         self.user_aliases = resolved.config.aliases;
         self.namespace_favorites = resolved.config.favorite_namespaces;
         self.remember_sort = resolved.config.remember_sort.unwrap_or(true);
+        self.mouse_scroll_lines = resolved.config.mouse_scroll_lines.unwrap_or(3).max(1);
         self.hide_header = resolved.config.hide_header;
         self.terminal_title = resolved.config.terminal_title.unwrap_or(true);
         self.plugins = resolved.config.plugins;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14349,14 +14349,20 @@ async fn mouse_scroll_lines_sets_rows_per_wheel_notch() {
     app.handle_mouse(notch).unwrap();
     assert_eq!(app.table_state.selected(), Some(1), "one row per notch");
 
-    // `0` is clamped to one row; an unset value restores the default of three.
+    // `0` is treated as one row and reported as a config warning; an unset
+    // value restores the default of three and clears the warning.
     write_config(&dir, "mouse_scroll_lines = 0\n");
     app.reload_config();
+    assert_eq!(
+        app.config_warnings,
+        vec!["mouse_scroll_lines: 0 is not allowed — using 1".to_string()]
+    );
     app.handle_mouse(notch).unwrap();
     assert_eq!(app.table_state.selected(), Some(2));
 
     write_config(&dir, "");
     app.reload_config();
+    assert!(app.config_warnings.is_empty());
     app.table_state.select(Some(0));
     app.handle_mouse(notch).unwrap();
     assert_eq!(

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14360,6 +14360,18 @@ async fn mouse_scroll_lines_sets_rows_per_wheel_notch() {
     app.handle_mouse(notch).unwrap();
     assert_eq!(app.table_state.selected(), Some(2));
 
+    // Values above the maximum are capped so one wheel event cannot stall
+    // the UI; the list boundary still stops the selection.
+    write_config(&dir, "mouse_scroll_lines = 65535\n");
+    app.reload_config();
+    assert_eq!(
+        app.config_warnings,
+        vec!["mouse_scroll_lines: 65535 is above the maximum of 100 — using 100".to_string()]
+    );
+    assert_eq!(app.mouse_scroll_lines, 100);
+    app.handle_mouse(notch).unwrap();
+    assert_eq!(app.table_state.selected(), Some(4), "stops at the last row");
+
     write_config(&dir, "");
     app.reload_config();
     assert!(app.config_warnings.is_empty());
@@ -14372,6 +14384,40 @@ async fn mouse_scroll_lines_sets_rows_per_wheel_notch() {
     );
 
     std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn wheel_that_dismisses_a_confirm_does_not_scroll_the_table_beneath() {
+    use crossterm::event::{MouseEvent, MouseEventKind};
+
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    for name in ["a", "b", "c", "d", "e"] {
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": name, "namespace": "default"},
+                "status": {"phase": "Running"}
+            }),
+        );
+    }
+    app.table_state.select(Some(0));
+    app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert_eq!(app.mode, Mode::Confirm);
+
+    // With the default of three steps, the first step cancels the confirm and
+    // the remaining two must not move the selection in the table.
+    app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    })
+    .unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.table_state.selected(), Some(0));
 }
 
 #[tokio::test]
@@ -22496,9 +22542,9 @@ async fn wheel_and_keyboard_arrows_cancel_default_confirmations() {
                 app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
                 assert_eq!(app.mode, Mode::Confirm);
             }
-            for _ in 0..3 {
-                keyboard.handle_key(press(code)).unwrap();
-            }
+            // One wheel event cancels the confirm and stops there, so it
+            // matches a single arrow press, not three.
+            keyboard.handle_key(press(code)).unwrap();
             wheel
                 .handle_mouse(MouseEvent {
                     kind,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -14317,6 +14317,58 @@ async fn reload_applies_config_changes_live() {
 }
 
 #[tokio::test]
+async fn mouse_scroll_lines_sets_rows_per_wheel_notch() {
+    use crossterm::event::{MouseEvent, MouseEventKind};
+
+    let dir = std::env::temp_dir().join(format!("sofka-app-wheel-{}", std::process::id()));
+    write_config(&dir, "mouse_scroll_lines = 1\n");
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    app.reload_config();
+    assert!(app.config_warnings.is_empty());
+
+    app.switch_kind("pods");
+    for name in ["a", "b", "c", "d", "e"] {
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": name, "namespace": "default"},
+                "status": {"phase": "Running"}
+            }),
+        );
+    }
+    app.table_state.select(Some(0));
+    let notch = MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    };
+
+    app.handle_mouse(notch).unwrap();
+    assert_eq!(app.table_state.selected(), Some(1), "one row per notch");
+
+    // `0` is clamped to one row; an unset value restores the default of three.
+    write_config(&dir, "mouse_scroll_lines = 0\n");
+    app.reload_config();
+    app.handle_mouse(notch).unwrap();
+    assert_eq!(app.table_state.selected(), Some(2));
+
+    write_config(&dir, "");
+    app.reload_config();
+    app.table_state.select(Some(0));
+    app.handle_mouse(notch).unwrap();
+    assert_eq!(
+        app.table_state.selected(),
+        Some(3),
+        "default three per notch"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
 async fn failed_reload_keeps_last_known_good_config() {
     let dir = std::env::temp_dir().join(format!("sofka-app-reload-bad-{}", std::process::id()));
     write_config(&dir, "readonly = true\n[aliases]\ndep = \"deployments\"\n");

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,8 @@ pub struct Config {
     /// behavior (text selection) everywhere. Document views release capture
     /// on their own regardless — see [`crate::app::App::wants_mouse_capture`].
     pub mouse: Option<bool>,
-    /// Rows moved per mouse wheel notch. Defaults to 3; `0` behaves like 1.
+    /// Navigation steps per received mouse wheel event in views with mouse
+    /// capture. Defaults to 3; `0` is treated as 1 with a warning.
     pub mouse_scroll_lines: Option<u16>,
     /// Set the terminal title to the context and namespace. Defaults to true.
     pub terminal_title: Option<bool>,
@@ -1096,6 +1097,19 @@ pub struct Guardrail {
     pub max_bulk: Option<usize>,
     /// Human note shown when the guardrail blocks or confirms.
     pub reason: Option<String>,
+}
+
+/// Resolves `mouse_scroll_lines`: unset means 3, `0` is treated as 1 with a
+/// warning pushed onto `warnings`.
+pub fn mouse_scroll_lines(value: Option<u16>, warnings: &mut Vec<String>) -> u16 {
+    match value {
+        None => 3,
+        Some(0) => {
+            warnings.push("mouse_scroll_lines: 0 is not allowed — using 1".into());
+            1
+        }
+        Some(n) => n,
+    }
 }
 
 /// Validation warnings for guardrails: an unknown `confirmation` mode.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1099,14 +1099,25 @@ pub struct Guardrail {
     pub reason: Option<String>,
 }
 
-/// Resolves `mouse_scroll_lines`: unset means 3, `0` is treated as 1 with a
-/// warning pushed onto `warnings`.
+/// Upper bound for `mouse_scroll_lines`; each step is a full input dispatch,
+/// so a huge value would stall the UI on a single wheel event.
+pub const MAX_MOUSE_SCROLL_LINES: u16 = 100;
+
+/// Resolves `mouse_scroll_lines`: unset means 3, `0` is treated as 1 and values
+/// above [`MAX_MOUSE_SCROLL_LINES`] are capped, each with a warning pushed onto
+/// `warnings`.
 pub fn mouse_scroll_lines(value: Option<u16>, warnings: &mut Vec<String>) -> u16 {
     match value {
         None => 3,
         Some(0) => {
             warnings.push("mouse_scroll_lines: 0 is not allowed — using 1".into());
             1
+        }
+        Some(n) if n > MAX_MOUSE_SCROLL_LINES => {
+            warnings.push(format!(
+                "mouse_scroll_lines: {n} is above the maximum of {MAX_MOUSE_SCROLL_LINES} — using {MAX_MOUSE_SCROLL_LINES}"
+            ));
+            MAX_MOUSE_SCROLL_LINES
         }
         Some(n) => n,
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,8 @@ pub struct Config {
     /// behavior (text selection) everywhere. Document views release capture
     /// on their own regardless — see [`crate::app::App::wants_mouse_capture`].
     pub mouse: Option<bool>,
+    /// Rows moved per mouse wheel notch. Defaults to 3; `0` behaves like 1.
+    pub mouse_scroll_lines: Option<u16>,
     /// Set the terminal title to the context and namespace. Defaults to true.
     pub terminal_title: Option<bool>,
     /// Save and restore sort choices per kind. Defaults to true.

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,7 @@ async fn run_main(args: Args) -> Result<()> {
     app.sort_memory = sortmem::SortMemory::load(&sort_memory_path);
     app.sort_memory_path = Some(sort_memory_path);
     app.remember_sort = cfg.remember_sort.unwrap_or(true);
+    app.mouse_scroll_lines = cfg.mouse_scroll_lines.unwrap_or(3).max(1);
     app.hide_header = cfg.hide_header;
     app.compact = cfg.compact_mode;
     app.terminal_title = cfg.terminal_title.unwrap_or(true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,8 @@ async fn run_main(args: Args) -> Result<()> {
     app.sort_memory = sortmem::SortMemory::load(&sort_memory_path);
     app.sort_memory_path = Some(sort_memory_path);
     app.remember_sort = cfg.remember_sort.unwrap_or(true);
-    app.mouse_scroll_lines = cfg.mouse_scroll_lines.unwrap_or(3).max(1);
+    app.mouse_scroll_lines =
+        config::mouse_scroll_lines(cfg.mouse_scroll_lines, &mut config_warnings);
     app.hide_header = cfg.hide_header;
     app.compact = cfg.compact_mode;
     app.terminal_title = cfg.terminal_title.unwrap_or(true);


### PR DESCRIPTION
## Summary

Every mouse wheel notch currently moves the selection three rows (hard-coded in `src/app/mouse.rs`). On high-resolution mice and trackpads that overshoots, and there was no way to tune it.

This adds a `mouse_scroll_lines` option to the config:

```toml
mouse_scroll_lines = 3
```

- Default stays `3`, so behaviour is unchanged for existing users.
- Values below `1` are treated as `1`.
- Applied at startup, on config reload, and on context switch, in the same places `remember_sort` is handled.

Proposed in discussion #416. Opened as a draft so we can settle the naming/design there first.

## Changes

- `src/config.rs`: new `mouse_scroll_lines: Option<u16>`
- `src/app/mod.rs`, `src/main.rs`, `src/app/actions.rs`, `src/app/pickers.rs`: carry the value on `App` and populate it wherever config is loaded
- `src/app/mouse.rs`: `wheel()` uses the configured count
- `src/app/tests.rs`: `mouse_scroll_lines_sets_rows_per_wheel_notch` covers 1, 0 (clamped) and unset (back to 3) via `reload_config` + `handle_mouse`
- `docs/configuration.md`, `docs/features.md`: document the option

## Testing

- `rustfmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked` all pass locally (1179 tests).

Closes #424
