### PR TITLE
fix: keep the current view when switching namespace by name

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -60,6 +60,16 @@ impl App {
     pub fn switch_kind_ns(&mut self, input: &str, ns: Option<&str>) {
         match self.cluster.resolve(input) {
             Some(kind) => {
+                if let Some(name) = ns
+                    && kind.ar.plural.eq_ignore_ascii_case("namespaces")
+                {
+                    if self.kind_plural == "namespaces" {
+                        self.set_namespace_and_return(name);
+                    } else {
+                        self.set_namespace(name.to_string());
+                    }
+                    return;
+                }
                 self.save_history_filter();
                 if let Some(ns) = ns {
                     self.namespace = normalize_ns(ns);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -9789,6 +9789,32 @@ async fn command_with_unlisted_namespace_is_freeform() {
 }
 
 #[tokio::test]
+async fn ns_command_stays_on_current_view() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "namespaces social".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    assert_eq!(app.namespace, "social");
+}
+
+#[tokio::test]
+async fn ns_command_from_namespaces_list_falls_back_to_pods() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("namespaces");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "namespaces social".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.namespace, "social");
+}
+
+#[tokio::test]
 async fn command_completes_context_argument() {
     let (mut app, _rx) = test_app();
     app.all_contexts = vec!["prod-eu".into(), "staging".into(), "dev".into()];


### PR DESCRIPTION
## Summary

`:ns <name>` (and any alias for the namespaces kind) went through the
generic `:kind namespace` path, which navigates to the Namespaces list
view instead of staying on whatever view was open. Two other entry
points to "pick a namespace" already do the right thing:

- The namespace switcher's `enter` action stays on the current view
  (`App::set_namespace`).
- Pressing `enter` on a row while browsing the Namespaces list itself
  falls back to Pods when there's no previous view to return to
  (`App::set_namespace_and_return`).

`switch_kind_ns` now detects a namespaces-kind target and routes it
through those same two paths instead of treating it as a plain kind
switch, so `:ns <name>` behaves consistently with the rest of the app.

Related: #410 (filed as an idea, but this turned out to be a plain
inconsistency between two existing code paths rather than new
behavior, so no feature discussion was needed per AGENTS.md.)

## Test plan

- [x] Added `ns_command_stays_on_current_view` and
      `ns_command_from_namespaces_list_falls_back_to_pods`, both driven
      through `handle_key`.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked` (1180 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)