### PR TITLE
feat: select adjacent rows with Shift+Arrow keys

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -138,6 +138,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   rank by fuzzy score, `⏎` jumps to the object. When a kind can't be listed
   (RBAC), the result says it's incomplete instead of pretending otherwise.
 - **Multiselect** (`space`) for bulk delete/kill/suspend/resume/reconcile.
+  `Shift+ArrowUp` / `Shift+ArrowDown` extend or reduce a range from a fixed
+  starting row. Separate marks remain selected when the range contracts.
+  Range marks also work with combined pod logs.
 - **Copy to clipboard** - `c` copies the selected resource's name; `Y` opens a
   field picker over the selected row's displayed columns (full values, never
   the width-truncated cell text) - type to match a column name or its value

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -34,6 +34,7 @@ for the grammar and selector persistence rules.
 | `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction; saved per kind by default (`remember_sort = false` disables this)               |
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                                                            |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                                                    |
+| `shift-up` / `shift-down`                     | extend or reduce the marked range from the starting row                                                                                                             |
 | `/`                                           | filter: fuzzy text · `"exact"` · `/regex/` · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                                   |
 | `Ctrl+Z`                                      | toggle faults filter in pod views; configured actions take precedence; combine with `/`; press again to turn off                                                    |
 | `n` / `0`                                     | namespace switcher / all namespaces                                                                                                                                 |
@@ -80,6 +81,11 @@ for the grammar and selector persistence rules.
 | `:q`, `ctrl-c`                                | quit                                                                                                                                                                |
 | `?`                                           | help                                                                                                                                                                |
 | _(config)_                                    | plugin / bookmark / workspace key chords — `ctrl-`/`alt-`/`shift-`/`fN`; listed in `?` help                                                                         |
+
+Shift+Arrow selects a range in the visible row order. Reversing direction reduces
+the range and keeps separate marks made with `space`. Other keys end the range
+operation. Normal movement keeps marked rows. Filtering, sorting, view changes,
+and changes to the row order reset the range before the next Shift+Arrow press.
 
 ## PVC explore (`x` on a PVC)
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -9,6 +9,9 @@ impl App {
     }
 
     pub(super) fn handle_input(&mut self, key: KeyInput) -> Result<()> {
+        if !matches!(key.action, Some(Action::RangeUp | Action::RangeDown)) {
+            self.range_selection = None;
+        }
         let before = match self.mode {
             Mode::Command => self.palette_return,
             Mode::Help => self.help_return,
@@ -295,6 +298,8 @@ impl App {
                     // at root, nothing to pop
                 }
             }
+            (Some(Action::RangeDown), _) => self.extend_selection(1),
+            (Some(Action::RangeUp), _) => self.extend_selection(-1),
             (Some(Action::Down), _) => self.move_selection(1),
             (Some(Action::Up), _) => self.move_selection(-1),
             (Some(Action::First), _) => self.table_state.select(Some(0)),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -351,6 +351,7 @@ impl App {
         self.container_metrics.clear();
         self.node_pods = None;
         self.marked.clear();
+        self.range_selection = None;
         self.clear_rows_cache();
         if self.table_state.selected().is_none() {
             self.table_state.select(Some(0));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1661,6 +1661,7 @@ pub struct App {
     /// the view is (re)watched. Bulk actions target this set if non-empty, else
     /// the current selection.
     pub marked: HashSet<String>,
+    range_selection: Option<RangeSelection>,
     /// Column index (into the displayed headers) to sort the table by, or
     /// `None` for the natural namespace/name order.
     pub sort_column: Option<usize>,
@@ -2102,6 +2103,7 @@ impl App {
             table_state: TableState::default(),
             table_page_rows: 10,
             marked: HashSet::new(),
+            range_selection: None,
             sort_column: None,
             sort_origin: SortOrigin::Unset,
             sort_desc: false,
@@ -2400,4 +2402,10 @@ mod tests;
 /// Built-ins retain ownership of their command names when loading packages.
 pub(crate) fn plugin_command_reserved(name: &str) -> bool {
     name == "plugin-cancel" || PALETTE_COMMANDS.iter().any(|c| c.names.contains(&name))
+}
+
+struct RangeSelection {
+    anchor: usize,
+    rows: Vec<(String, Option<String>)>,
+    previous_marks: HashSet<String>,
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -72,6 +72,7 @@ impl App {
             MouseEventKind::ScrollUp => self.wheel(KeyCode::Up),
             MouseEventKind::ScrollDown => self.wheel(KeyCode::Down),
             MouseEventKind::Down(MouseButton::Left) if self.mode == Mode::Table => {
+                self.range_selection = None;
                 self.table_click(m.column, m.row);
                 Ok(())
             }

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -1258,6 +1258,40 @@ impl App {
             .collect()
     }
 
+    pub(super) fn extend_selection(&mut self, delta: i32) {
+        let rows: Vec<_> = self
+            .rows()
+            .iter()
+            .map(|obj| (row_key(obj), obj.metadata.uid.clone()))
+            .collect();
+        if rows.is_empty() {
+            self.range_selection = None;
+            return;
+        }
+        let current = self.table_state.selected().unwrap_or(0).min(rows.len() - 1);
+        // A changed row order ends the old range before another row is marked.
+        if self
+            .range_selection
+            .as_ref()
+            .is_none_or(|range| range.rows != rows)
+        {
+            self.range_selection = Some(RangeSelection {
+                anchor: current,
+                rows,
+                previous_marks: self.marked.clone(),
+            });
+        }
+        let range = self.range_selection.as_ref().unwrap();
+        let next = current
+            .saturating_add_signed(delta as isize)
+            .min(range.rows.len() - 1);
+        self.marked.clone_from(&range.previous_marks);
+        for (key, _) in &range.rows[range.anchor.min(next)..=range.anchor.max(next)] {
+            self.marked.insert(key.clone());
+        }
+        self.table_state.select(Some(next));
+    }
+
     pub(super) fn move_selection(&mut self, delta: i32) {
         let len = self.row_count() as i32;
         if len == 0 {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4797,6 +4797,212 @@ async fn delete_message_updates_rows() {
     assert_eq!(rows[0].metadata.name.as_deref(), Some("keep"));
 }
 
+fn range_app() -> (App, Receiver<Msg>) {
+    let (mut app, rx) = test_app();
+    app.switch_kind("pods");
+    for name in ["a", "b", "c", "d", "e"] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": name, "namespace": "default", "uid": name},
+            "spec": {"containers": [{"name": "app"}]}}),
+        );
+    }
+    (app, rx)
+}
+
+fn range_key(app: &mut App, code: KeyCode) {
+    app.handle_key(KeyEvent::new(code, KeyModifiers::SHIFT))
+        .unwrap();
+}
+
+fn assert_marks(app: &App, names: &[&str]) {
+    assert_eq!(
+        app.marked,
+        names.iter().map(|name| format!("default/{name}")).collect()
+    );
+}
+
+#[tokio::test]
+async fn range_selection_extends_contracts_and_crosses_anchor() {
+    let (mut app, _rx) = range_app();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    for (key, names, cursor) in [
+        (KeyCode::Down, vec!["c", "d"], 3),
+        (KeyCode::Down, vec!["c", "d", "e"], 4),
+        (KeyCode::Down, vec!["c", "d", "e"], 4),
+        (KeyCode::Up, vec!["c", "d"], 3),
+        (KeyCode::Up, vec!["c"], 2),
+        (KeyCode::Up, vec!["b", "c"], 1),
+        (KeyCode::Up, vec!["a", "b", "c"], 0),
+        (KeyCode::Up, vec!["a", "b", "c"], 0),
+    ] {
+        range_key(&mut app, key);
+        assert_marks(&app, &names);
+        assert_eq!(app.table_state.selected(), Some(cursor));
+    }
+}
+
+#[tokio::test]
+async fn range_selection_keeps_separate_marks_and_space_ends_range() {
+    let (mut app, _rx) = range_app();
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
+    range_key(&mut app, KeyCode::Up);
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &["a", "c", "d"]);
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
+    assert_marks(&app, &["a", "c"]);
+    assert_eq!(app.table_state.selected(), Some(4));
+    range_key(&mut app, KeyCode::Up);
+    assert_marks(&app, &["a", "c", "d", "e"]);
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &["a", "c", "e"]);
+}
+
+#[tokio::test]
+async fn range_selection_navigation_and_escape_end_range() {
+    for key in [
+        KeyCode::Up,
+        KeyCode::Down,
+        KeyCode::Char('j'),
+        KeyCode::Char('k'),
+        KeyCode::Home,
+        KeyCode::End,
+        KeyCode::PageUp,
+        KeyCode::PageDown,
+    ] {
+        let (mut app, _rx) = range_app();
+        range_key(&mut app, KeyCode::Down);
+        app.handle_key(press(key)).unwrap();
+        assert_marks(&app, &["a", "b"]);
+        let current = app.table_state.selected().unwrap();
+        range_key(&mut app, KeyCode::Up);
+        let names = ["a", "b", "c", "d", "e"];
+        let mut expected = vec!["a", "b", names[current]];
+        expected.push(names[current.saturating_sub(1)]);
+        assert_marks(&app, &expected);
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        assert_marks(&app, &[]);
+        range_key(&mut app, KeyCode::Down);
+        assert_eq!(app.marked.len(), 2);
+    }
+}
+
+#[tokio::test]
+async fn range_selection_handles_empty_single_and_unselected_tables() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &[]);
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "a", "namespace": "default"}}),
+    );
+    range_key(&mut app, KeyCode::Up);
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &["a"]);
+    let (mut app, _rx) = range_app();
+    app.table_state.select(None);
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &["a", "b"]);
+    assert_eq!(app.table_state.selected(), Some(1));
+}
+
+#[tokio::test]
+async fn range_selection_resets_after_filter_sort_and_view_changes() {
+    let (mut app, _rx) = range_app();
+    range_key(&mut app, KeyCode::Down);
+    type_filter(&mut app, "!/^a$/");
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &["a", "b", "c"]);
+    range_key(&mut app, KeyCode::Up);
+    assert_marks(&app, &["a", "b"]);
+    select_sort_with_keys(&mut app, "NAME");
+    app.handle_key(press(KeyCode::Char('I'))).unwrap();
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &["a", "b", "d", "e"]);
+    palette(&mut app, "services");
+    assert_marks(&app, &[]);
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &[]);
+}
+
+#[tokio::test]
+async fn range_selection_resets_on_membership_or_identity_changes() {
+    for change in ["insert", "delete", "replace"] {
+        let (mut app, _rx) = range_app();
+        range_key(&mut app, KeyCode::Down);
+        range_key(&mut app, KeyCode::Down);
+        match change {
+            "insert" => apply(
+                &mut app,
+                json!({"apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": "z", "namespace": "default", "uid": "z"}}),
+            ),
+            "delete" => app.handle_msg(Msg::Deleted {
+                generation: app.generation,
+                key: "default/e".into(),
+            }),
+            _ => apply(
+                &mut app,
+                json!({"apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": "e", "namespace": "default", "uid": "replacement"}}),
+            ),
+        }
+        range_key(&mut app, KeyCode::Up);
+        assert_marks(&app, &["a", "b", "c"]);
+    }
+    let (mut app, _rx) = range_app();
+    range_key(&mut app, KeyCode::Down);
+    range_key(&mut app, KeyCode::Down);
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "e", "namespace": "default", "uid": "e"},
+        "status": {"phase": "Running"}}),
+    );
+    range_key(&mut app, KeyCode::Up);
+    assert_marks(&app, &["a", "b"]);
+}
+
+#[tokio::test]
+async fn range_selection_uses_keymap_and_existing_bulk_actions() {
+    let (mut app, _rx) = range_app();
+    let cfg: crate::config::Config =
+        toml::from_str("[keys.table]\nrange_down = 'alt-j'\nrange_up = 'alt-k'").unwrap();
+    app.keymap = Keymap::compile(&cfg.keys).unwrap();
+    range_key(&mut app, KeyCode::Down);
+    assert_marks(&app, &[]);
+    app.handle_key(alt(KeyCode::Char('j'))).unwrap();
+    app.handle_key(alt(KeyCode::Char('j'))).unwrap();
+    app.handle_key(alt(KeyCode::Char('k'))).unwrap();
+    assert_marks(&app, &["a", "b"]);
+    app.handle_key(ctrl(KeyCode::Char('d'))).unwrap();
+    let Some(ConfirmAction::Delete { targets, .. }) = &app.confirm_action else {
+        panic!("expected delete confirmation");
+    };
+    assert_eq!(
+        targets,
+        &vec![
+            ("a".into(), "default".into()),
+            ("b".into(), "default".into())
+        ]
+    );
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Char('l'))).unwrap();
+    let Some(LogSource::Pods(pods)) = &app.logs.source else {
+        panic!("expected marked pod logs");
+    };
+    assert_eq!(
+        pods.iter().map(|pod| pod.name.as_str()).collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+}
+
 #[tokio::test]
 async fn space_marks_rows_for_bulk_delete() {
     let (mut app, _rx) = test_app();
@@ -21912,7 +22118,7 @@ fn key_action_state(app: &App) -> serde_json::Value {
             "mode": format!("{:?}", app.mode), "kind": app.kind_plural,
             "namespace": app.namespace, "selected": app.table_state.selected(),
             "quit": app.should_quit, "compact": app.compact, "wide": app.wide,
-            "marked": app.marked, "sort": app.sort_column, "desc": app.sort_desc,
+            "marked": app.marked.iter().collect::<std::collections::BTreeSet<_>>(), "sort": app.sort_column, "desc": app.sort_desc,
             "faults": app.faults_only, "flash": app.flash,
         },
         "input": {
@@ -22145,7 +22351,9 @@ async fn shifted_navigation_keeps_default_list_behavior() {
             KeyCode::Home,
             KeyCode::End,
         ] {
-            if defaults.action(scope, &press(code)).is_none() {
+            if (scope == "table" && matches!(code, KeyCode::Up | KeyCode::Down))
+                || defaults.action(scope, &press(code)).is_none()
+            {
                 continue;
             }
             let (mut plain, _rx1) = key_action_fixture(scope);
@@ -22181,14 +22389,17 @@ async fn explicit_shifted_navigation_bindings_remain_distinct() {
     let (mut app, _rx) = key_action_fixture("table");
     use_keys(
         &mut app,
-        "[keys.table]\ndown = 'down'\nup = ['up', 'shift-down']",
+        "[keys.table]\nrange_down = []\ndown = 'down'\nup = ['up', 'shift-down']",
     );
     app.handle_key(press(KeyCode::Down)).unwrap();
     assert_eq!(app.table_state.selected(), Some(5));
     app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::SHIFT))
         .unwrap();
     assert_eq!(app.table_state.selected(), Some(4));
-    use_keys(&mut app, "[keys.table]\ndown = ['down', 'shift-down']");
+    use_keys(
+        &mut app,
+        "[keys.table]\nrange_down = []\ndown = ['down', 'shift-down']",
+    );
     for modifiers in [KeyModifiers::NONE, KeyModifiers::SHIFT] {
         app.handle_key(KeyEvent::new(KeyCode::Down, modifiers))
             .unwrap();

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -84,6 +84,8 @@ actions! {
     Logs => ("logs", "logs"),
     Lookback => ("lookback", "lookback"),
     Mark => ("mark", "mark"),
+    RangeDown => ("range_down", "extend or reduce selection down"),
+    RangeUp => ("range_up", "extend or reduce selection up"),
     Namespaces => ("namespaces", "namespaces"),
     NextMatch => ("next_match", "next match"),
     NextView => ("next_view", "next view"),
@@ -464,6 +466,8 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("table", Action::Left, &["left"]),
     ("table", Action::Logs, &["l"]),
     ("table", Action::Mark, &["space"]),
+    ("table", Action::RangeDown, &["shift-down"]),
+    ("table", Action::RangeUp, &["shift-up"]),
     ("table", Action::Namespaces, &["n"]),
     ("table", Action::NextView, &["tab"]),
     ("table", Action::Node, &["o"]),
@@ -570,7 +574,7 @@ impl Default for Keymap {
                     }
                 }
                 // Raw navigation matches previously accepted Shift in these modes.
-                // Keep explicit aliases in the defaults; user chords remain exact.
+                // Table Shift+Up/Down select ranges. Other aliases stay unchanged.
                 for (&scope, actions) in &mut bindings {
                     if scope == "command" {
                         continue;
@@ -581,6 +585,9 @@ impl Default for Keymap {
                             .filter(|c| {
                                 !c.ctrl
                                     && !c.alt
+                                    && !c.shift
+                                    && !(scope == "table"
+                                        && matches!(c.code, KeyCode::Up | KeyCode::Down))
                                     && matches!(
                                         c.code,
                                         KeyCode::Up

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2458,6 +2458,9 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         };
         lines.push(bind(app.keymap.label(scope, action), description));
     }
+    lines.push(Line::from(
+        "  Range selection keeps separate marks; other keys end the range.",
+    ));
     lines.push(Line::from(Span::styled(
         "  Commands (enter in the command palette)",
         theme::title(),


### PR DESCRIPTION
Select adjacent resources with Shift+ArrowUp and Shift+ArrowDown. The first press marks the starting row and the next row. Reversing direction reduces the range while keeping earlier marks made with Space. The marks work with existing bulk actions, including delete and pod logs.

Other keys end the range operation. Normal movement keeps the marks. View changes and changes to visible row order or resource identity reset the range. Add `range_up` and `range_down` to the shared key map and update the help and key documentation. Users who assign Shift+Arrow to another table action must first disable or reassign the matching range action.

Validation: `just check` (formatting, Clippy with warnings denied, and the full test suite). Seven new keyboard tests cover range behavior, resets, custom shortcuts, and bulk targets. Existing keyboard tests now account for the new defaults and compare marked sets in a stable order.

Discussion: https://github.com/nklmilojevic/sofka/discussions/418

Closes #421


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added range selection for table rows using Shift+Arrow Up/Down.
  * Extend or reduce selections from a fixed starting row while preserving separate marks.
  * Range selection works with filtered, sorted, and combined pod logs, and supports bulk actions.
  * Selections reset after unrelated key presses, clicks, view changes, or refreshed data.

* **Documentation**
  * Added keyboard reference and help content describing range selection behavior and key bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->