### PR TITLE
feat: keep the resource view when switching namespace by command

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -34,6 +34,14 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   extension API server is down, or it sends an `apiVersion` that is not `v1`.
   Sofka does not load that group. It shows a warning at startup and a flash
   on the first screen. `:info` shows the group and the reason.
+- **Namespace commands**: `:ns <name>` changes namespace and keeps the current
+  resource view, as the namespace switcher does. `:namespace` and `:namespaces`
+  accept the same argument; `all` and `*` select all namespaces. From the
+  Namespaces list, the command returns to the previous view, or opens Pods if
+  there is no previous view. Other cluster-scoped views stay open; the namespace
+  selection applies to the next namespaced resource view. Filters follow the
+  namespace switcher's rules, and resource ownership scope is cleared.
+  Without an argument, `:ns` opens the Namespaces list.
 - **Live watch** of any kind through `kube::runtime::watcher`, streamed into an
   in-memory store. Watch requests use uncompressed responses to avoid gzip
   stream errors. List requests retain gzip compression.

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -25,6 +25,7 @@ for the grammar and selector persistence rules.
 | `:resource @context [namespace]`              | switch context and resource; context names fuzzy-complete                                                                                                           |
 | `:<resource>`                                 | command palette - fuzzy over kinds and built-in commands                                                                                                            |
 | `:<resource> <ns>`                            | switch kind and namespace at once (`:deploy social`; `all`/`*` = all namespaces; the namespace tab-completes)                                                       |
+| `:ns <name>`                                  | change namespace and keep the resource view; from Namespaces, return to the previous view or Pods (`all`/`*` = all namespaces)                                      |
 | `[` / `]`                                     | view history - back / forward through visited kind+namespace views                                                                                                  |
 | `Tab` / `shift-Tab`                           | next / previous common resource in the current namespace; cycle workspace views when one is open                                                                    |
 | `enter`                                       | drill down (workload/svc → pods, machinedeployment → machines, cronjob → jobs, node → pods, pod → containers, ns → re-scope, CRD → resources, or [views](views.md)) |

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -60,6 +60,16 @@ impl App {
     pub fn switch_kind_ns(&mut self, input: &str, ns: Option<&str>) {
         match self.cluster.resolve(input) {
             Some(kind) => {
+                if let Some(name) = ns
+                    && kind.ar.plural.eq_ignore_ascii_case("namespaces")
+                {
+                    if self.kind_plural == "namespaces" {
+                        self.set_namespace_and_return(name);
+                    } else {
+                        self.set_namespace(name.to_string());
+                    }
+                    return;
+                }
                 self.save_history_filter();
                 if let Some(ns) = ns {
                     self.namespace = normalize_ns(ns);

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -381,11 +381,6 @@ impl App {
     }
 
     pub(super) fn set_namespace_and_return(&mut self, name: &str) {
-        let ns = if name == "<all>" {
-            String::new()
-        } else {
-            name.to_string()
-        };
         // Return to the view we came from if there is one; otherwise (a `:ns`
         // root switch clears the stack) drop into pods scoped to the chosen
         // namespace — namespaces aren't namespaced, so staying on the list would
@@ -403,11 +398,6 @@ impl App {
             self.reset_sort();
             self.table_state.select(Some(0));
         }
-        self.namespace = ns;
-        self.note_recent_namespace(name);
-        self.remember_namespace();
-        self.set_flash(format!("namespace: {}", self.namespace_label()));
-        self.record_history();
-        self.start_watch();
+        self.set_namespace(name.to_string());
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -9995,29 +9995,91 @@ async fn command_with_unlisted_namespace_is_freeform() {
 }
 
 #[tokio::test]
-async fn ns_command_stays_on_current_view() {
-    let (mut app, _rx) = test_app();
-    app.switch_kind("deployments");
-    app.handle_key(press(KeyCode::Char(':'))).unwrap();
-    for c in "namespaces social".chars() {
-        app.handle_key(press(KeyCode::Char(c))).unwrap();
+async fn ns_command_preserves_resource_and_normalizes_namespace() {
+    for resource in ["deployments", "nodes", "namespaces"] {
+        for alias in ["ns", "namespace", "namespaces"] {
+            for (name, expected) in [("social", "social"), ("all", ""), ("*", "")] {
+                let (mut app, _rx) = test_app();
+                app.cluster
+                    .add_aliases(&HashMap::from([("ns".into(), "namespaces".into())]));
+                palette(&mut app, resource);
+                palette(&mut app, &format!("{alias} {name}"));
+                let expected_resource = if resource == "namespaces" {
+                    "pods"
+                } else {
+                    resource
+                };
+                assert_eq!(
+                    app.kind_plural, expected_resource,
+                    "{resource}: {alias} {name}"
+                );
+                assert_eq!(app.namespace, expected, "{resource}: {alias} {name}");
+                assert_eq!(app.mode, Mode::Table);
+                if resource == "nodes" {
+                    palette(&mut app, "pods");
+                    assert_eq!(app.namespace, expected);
+                }
+            }
+        }
     }
-    app.handle_key(press(KeyCode::Enter)).unwrap();
-    assert_eq!(app.kind_plural, "deployments");
-    assert_eq!(app.namespace, "social");
 }
 
 #[tokio::test]
-async fn ns_command_from_namespaces_list_falls_back_to_pods() {
-    let (mut app, _rx) = test_app();
-    app.switch_kind("namespaces");
-    app.handle_key(press(KeyCode::Char(':'))).unwrap();
-    for c in "namespaces social".chars() {
-        app.handle_key(press(KeyCode::Char(c))).unwrap();
+async fn ns_command_without_argument_opens_namespaces() {
+    for alias in ["ns", "namespace", "namespaces"] {
+        let (mut app, _rx) = test_app();
+        app.cluster
+            .add_aliases(&HashMap::from([("ns".into(), "namespaces".into())]));
+        palette(&mut app, "deployments social");
+        palette(&mut app, alias);
+        assert_eq!(app.kind_plural, "namespaces");
+        assert_eq!(app.namespace, "social");
+        assert_eq!(app.mode, Mode::Table);
     }
-    app.handle_key(press(KeyCode::Enter)).unwrap();
-    assert_eq!(app.kind_plural, "pods");
-    assert_eq!(app.namespace, "social");
+}
+
+#[tokio::test]
+async fn ns_command_matches_picker_for_filters_and_owner_scope() {
+    for return_from_list in [false, true] {
+        for name in ["social", "all", "*"] {
+            let (mut app, _rx) = test_app();
+            app.cluster
+                .add_aliases(&HashMap::from([("ns".into(), "namespaces".into())]));
+            palette(&mut app, "jobs");
+            app.filter = "backup -l app=backup".into();
+            app.owner = Some(OwnerScope {
+                kind: "CronJob".into(),
+                name: "backup".into(),
+                uid: Some("old-owner".into()),
+            });
+            app.scope_label = Some("cronjob/backup".into());
+            if return_from_list {
+                app.push_frame();
+                app.kind = app.cluster.resolve("namespaces");
+                app.kind_plural = "namespaces".into();
+                app.filter.clear();
+                app.owner = None;
+                app.scope_label = None;
+            }
+            palette(&mut app, &format!("ns {name}"));
+            assert_eq!(app.kind_plural, "jobs");
+            assert_eq!(app.namespace, if name == "social" { "social" } else { "" });
+            assert_eq!(app.filter, "backup -l app=backup");
+            assert_eq!(app.owner, None);
+            assert_eq!(app.scope_label, None);
+            assert!(app.stack.is_empty());
+            assert_eq!(app.mode, Mode::Table);
+            apply(
+                &mut app,
+                json!({
+                    "apiVersion": "batch/v1", "kind": "Job",
+                    "metadata": {"name": "backup-new", "namespace": "social", "labels": {"app": "backup"}},
+                    "spec": {}
+                }),
+            );
+            assert_eq!(row_names(&app), ["backup-new"]);
+        }
+    }
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -9995,6 +9995,32 @@ async fn command_with_unlisted_namespace_is_freeform() {
 }
 
 #[tokio::test]
+async fn ns_command_stays_on_current_view() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("deployments");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "namespaces social".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "deployments");
+    assert_eq!(app.namespace, "social");
+}
+
+#[tokio::test]
+async fn ns_command_from_namespaces_list_falls_back_to_pods() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("namespaces");
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "namespaces social".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.namespace, "social");
+}
+
+#[tokio::test]
 async fn command_completes_context_argument() {
     let (mut app, _rx) = test_app();
     app.all_contexts = vec!["prod-eu".into(), "staging".into(), "dev".into()];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2474,6 +2474,10 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         "switch kind and namespace at once (all/* = all namespaces)",
     ));
     lines.push(bind(
+        ":ns <name>",
+        "change namespace, keep resource (all/* = all); from Namespaces, return or open Pods",
+    ));
+    lines.push(bind(
         ":ctx · :pulse",
         "switch context · cluster-health dashboard",
     ));


### PR DESCRIPTION
`:ns <name>` currently opens the Namespaces list even when the user is viewing another resource. This change keeps the current resource type while selecting the requested namespace. For example, `:ns production` from Deployments shows Deployments in `production`.

Namespace aliases use the same behavior. From the Namespaces list, the command returns to the previous view or opens Pods if no previous view exists. Both paths accept `all` and `*`, use the existing namespace filter rules, and clear stale resource ownership scope. The command without an argument still opens Namespaces. Other cluster-scoped views stay open and retain the namespace selection for later use.

Tests through `handle_key` cover aliases, named and all-namespace selections, Nodes, the command without an argument, previous-view restoration, the Pods fallback, and filter and ownership behavior. Command documentation and help text describe the exception.

Validation: `just check` (format check, clippy with warnings denied, and the full test suite).

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/410
Closes #422

Replaces #420. This PR retains the original contribution from @Alhiane and adds the corrections, tests, and documentation required by #422. A new PR is needed because maintainer edits are disabled on the original fork branch.
