### PR TITLE
fix: respect Kubernetes proxy exclusions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,6 +3044,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
+ "ipnet",
  "k8s-openapi",
  "kube",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper = { version = "1.10.1", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27.9", default-features = false, features = ["http1", "native-tokio", "ring", "tls12"] }
 hyper-timeout = "0.5.2"
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
+ipnet = "2.12.2"
 k8s-openapi = { version = "0.28", features = ["latest"] }
 kube = { version = "4.2.0", features = ["runtime", "client", "derive", "ws", "http-proxy", "socks5", "gzip"] }
 memchr = "2.8.3"

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -326,6 +326,34 @@ For a certificate file, use `openssl x509 -in client.crt -noout -text`.
 flag, have the cluster administrator issue a v3 client certificate and update
 your kubeconfig. Keep the existing identity and required permissions.
 
+## HTTPS proxy exclusions
+
+If the API server must use a direct connection, include its host name or IP
+address in `NO_PROXY` or `no_proxy`. For example:
+
+```sh
+NO_PROXY=rke2-server sofka --check
+```
+
+The first nonempty value takes priority: `NO_PROXY`, then `no_proxy`. Separate
+entries with commas. A domain such as `example.com` matches that domain and its
+subdomains. A leading dot or `*.` matches subdomains only. Entries can also be IP
+addresses, CIDR ranges, or host names and IP addresses with a port. Use brackets
+for an IPv6 address with a port, such as `[2001:db8::1]:6443`. A single `*` excludes
+all servers. CIDR entries match literal server IP addresses; sofka does not
+resolve host names to test these entries.
+
+These exclusions apply to the environment proxy on startup and context changes.
+Servers without a matching exclusion keep using the proxy. An explicit
+`proxy-url` in the selected kubeconfig cluster takes priority over exclusions.
+
+To test whether the environment proxy causes a connection failure, remove its
+settings for one run:
+
+```sh
+env -u HTTPS_PROXY -u https_proxy sofka --check
+```
+
 ## Teleport local Kubernetes proxy certificates
 
 `tsh proxy kube` can serve a CA certificate as its server certificate. Some TLS

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -335,7 +335,8 @@ address in `NO_PROXY` or `no_proxy`. For example:
 NO_PROXY=rke2-server sofka --check
 ```
 
-The first nonempty value takes priority: `NO_PROXY`, then `no_proxy`. Separate
+The first value with non-whitespace text takes priority: `NO_PROXY`, then
+`no_proxy`. Values that contain only whitespace are ignored. Separate
 entries with commas. A domain such as `example.com` matches that domain and its
 subdomains. A leading dot or `*.` matches subdomains only. Entries can also be IP
 addresses, CIDR ranges, or host names and IP addresses with a port. Use brackets

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5,6 +5,8 @@ use serde_json::json;
 use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver};
 
+mod proxy;
+
 fn obj(v: serde_json::Value) -> DynamicObject {
     serde_json::from_value(v).unwrap()
 }

--- a/src/app/tests/proxy.rs
+++ b/src/app/tests/proxy.rs
@@ -1,0 +1,225 @@
+use super::*;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+async fn read_headers(stream: &mut (impl tokio::io::AsyncRead + Unpin)) -> Option<String> {
+    let mut bytes = Vec::new();
+    while !bytes.ends_with(b"\r\n\r\n") {
+        bytes.push(stream.read_u8().await.ok()?);
+        assert!(bytes.len() < 16384);
+    }
+    String::from_utf8(bytes).ok()
+}
+
+#[tokio::test]
+async fn proxy_exclusions_apply_on_startup_and_context_switch() {
+    const CHILD: &str = "SOFKA_TEST_PROXY_CONNECTION";
+    if let Ok(phase) = std::env::var(CHILD) {
+        let (mut app, mut rx) = test_app();
+        if phase == "startup" {
+            app.cluster = Cluster::connect(false).await.expect("connect at startup");
+            app.kind = app.cluster.resolve("pods");
+            app.kind_plural = "pods".into();
+            app.handle_key(press(KeyCode::Char('r'))).unwrap();
+        } else {
+            type_resource_query(&mut app, "pods --context target");
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let msg = rx.recv().await.expect("context result");
+                    let switched = matches!(&msg, Msg::ContextSwitched { .. });
+                    if let Msg::ContextSwitched { result, .. } = &msg {
+                        assert!(
+                            result.is_ok(),
+                            "context connection failed: {:?}",
+                            result.as_ref().err()
+                        );
+                    }
+                    app.handle_msg(msg);
+                    if switched {
+                        break;
+                    }
+                }
+            })
+            .await
+            .expect("context switch timeout");
+            assert_eq!(app.cluster.context, "target");
+        }
+        sync_selector_view(&mut app, &mut rx).await;
+        assert_eq!(row_names(&app), ["direct-pod"]);
+        app.handle_key(press(KeyCode::Char('q'))).unwrap();
+        return;
+    }
+
+    let certificate = include_bytes!("../../../tests/fixtures/tls/proxy-ca.pem");
+    let tls = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![CertificateDer::from_pem_slice(certificate).unwrap()],
+            PrivateKeyDer::from_pem_slice(include_bytes!("../../../tests/fixtures/tls/server.key"))
+                .unwrap(),
+        )
+        .unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let api = tokio::spawn(async move {
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(tls));
+        let mut connections = tokio::task::JoinSet::new();
+        loop {
+            let (socket, _) = listener.accept().await.unwrap();
+            let acceptor = acceptor.clone();
+            connections.spawn(async move {
+                let Ok(mut stream) = acceptor.accept(socket).await else { return };
+                let Some(request) = read_headers(&mut stream).await else { return };
+                let path = request.split_whitespace().nth(1).unwrap();
+                let body = match path {
+                    "/apis" => json!({"kind":"APIGroupList", "apiVersion":"v1", "groups":[]}),
+                    "/api" => json!({"kind":"APIVersions", "apiVersion":"v1", "versions":["v1"], "serverAddressByClientCIDRs":[]}),
+                    "/api/v1" => json!({"kind":"APIResourceList", "apiVersion":"v1", "groupVersion":"v1", "resources":[{"name":"pods", "singularName":"pod", "namespaced":true, "kind":"Pod", "verbs":["get","list","watch"]}]}),
+                    "/version" => json!({"major":"1", "minor":"35", "gitVersion":"v1.35.0", "gitCommit":"", "gitTreeState":"clean", "buildDate":"", "goVersion":"", "compiler":"", "platform":"linux/amd64"}),
+                    _ if path.contains("/pods?") => {
+                        let body = concat!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n",
+                            "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"name\":\"direct-pod\",\"namespace\":\"default\",\"resourceVersion\":\"1\"}}}\n",
+                            "{\"type\":\"BOOKMARK\",\"object\":{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"resourceVersion\":\"1\",\"annotations\":{\"k8s.io/initial-events-end\":\"true\"}}}}\n",
+                        );
+                        let _ = stream.write_all(body.as_bytes()).await;
+                        std::future::pending::<()>().await;
+                        return;
+                    }
+                    _ => {
+                        let _ = stream.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").await;
+                        return;
+                    }
+                }.to_string();
+                let response = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len());
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_url = format!("http://{}", listener.local_addr().unwrap());
+    let proxy_connections = Arc::new(AtomicUsize::new(0));
+    let seen = proxy_connections.clone();
+    let proxy = tokio::spawn(async move {
+        let mut connections = tokio::task::JoinSet::new();
+        loop {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            seen.fetch_add(1, Ordering::SeqCst);
+            connections.spawn(async move {
+                let Some(request) = read_headers(&mut socket).await else {
+                    return;
+                };
+                assert!(
+                    request.starts_with(&format!("CONNECT {address} ")),
+                    "{request}"
+                );
+                let mut upstream = tokio::net::TcpStream::connect(address).await.unwrap();
+                socket
+                    .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                    .await
+                    .unwrap();
+                let _ = tokio::io::copy_bidirectional(&mut socket, &mut upstream).await;
+            });
+        }
+    });
+    let directory = std::env::temp_dir().join(format!(
+        "sofka-no-proxy-{}-{}",
+        std::process::id(),
+        address.port()
+    ));
+    std::fs::create_dir(&directory).unwrap();
+    let config_path = directory.join("kubeconfig");
+    for (upper, lower, explicit, use_proxy) in [
+        (Some("127.0.0.1"), None, false, false),
+        (None, Some("127.0.0.1"), false, false),
+        (Some(""), Some("127.0.0.1"), false, false),
+        (Some("unmatched.invalid"), Some("127.0.0.1"), false, true),
+        (Some("*"), None, false, false),
+        (Some("127.0.0.0/8"), None, false, false),
+        (None, None, false, true),
+        (Some("*"), None, true, true),
+    ] {
+        for phase in ["startup", "context"] {
+            let mut cluster =
+                json!({"server":format!("https://{address}"), "tls-server-name":"localhost"});
+            // Cover both the standard TLS client and the configured CA transport.
+            if phase == "startup" {
+                cluster["insecure-skip-tls-verify"] = true.into();
+            } else {
+                cluster["certificate-authority-data"] = STANDARD.encode(certificate).into();
+            }
+            let mut other = cluster.clone();
+            if explicit {
+                cluster["proxy-url"] = proxy_url.clone().into();
+            }
+            if !explicit {
+                other["proxy-url"] = proxy_url.clone().into();
+            }
+            let document = json!({
+                "apiVersion":"v1", "kind":"Config", "current-context":"startup",
+                "clusters":[{"name":"selected", "cluster":cluster}, {"name":"other", "cluster":other}],
+                "contexts":[
+                    {"name":"startup", "context":{"cluster":if phase == "startup" {"selected"} else {"other"}}},
+                    {"name":"target", "context":{"cluster":"selected"}}
+                ]
+            });
+            std::fs::write(&config_path, document.to_string()).unwrap();
+            let before = proxy_connections.load(Ordering::SeqCst);
+            let mut command = tokio::process::Command::new(std::env::current_exe().unwrap());
+            command
+                .args([
+                    "--exact",
+                    "app::tests::proxy::proxy_exclusions_apply_on_startup_and_context_switch",
+                    "--nocapture",
+                ])
+                .env(CHILD, phase)
+                .env("KUBECONFIG", &config_path)
+                .env_remove("HTTPS_PROXY")
+                .env_remove("https_proxy")
+                .env_remove("NO_PROXY")
+                .env_remove("no_proxy")
+                .env_remove("HTTP_PROXY")
+                .env_remove("http_proxy")
+                .env_remove("ALL_PROXY")
+                .env_remove("all_proxy")
+                .env_remove("KUBE_RS_DEBUG_IMPERSONATE_USER")
+                .env_remove("KUBE_RS_DEBUG_IMPERSONATE_GROUP")
+                .env_remove("KUBE_RS_DEBUG_OVERRIDE_URL")
+                .env(
+                    if phase == "startup" {
+                        "HTTPS_PROXY"
+                    } else {
+                        "https_proxy"
+                    },
+                    &proxy_url,
+                )
+                .kill_on_drop(true);
+            if let Some(value) = upper {
+                command.env("NO_PROXY", value);
+            }
+            if let Some(value) = lower {
+                command.env("no_proxy", value);
+            }
+            let output = tokio::time::timeout(Duration::from_secs(15), command.output())
+                .await
+                .expect("child timeout")
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{phase}, {upper:?}, {lower:?}, explicit={explicit}:\n{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                proxy_connections.load(Ordering::SeqCst) > before,
+                use_proxy,
+                "{phase}, {upper:?}, {lower:?}, explicit={explicit}"
+            );
+        }
+    }
+    std::fs::remove_dir_all(directory).unwrap();
+    proxy.abort();
+    api.abort();
+}

--- a/src/app/tests/proxy.rs
+++ b/src/app/tests/proxy.rs
@@ -135,6 +135,8 @@ async fn proxy_exclusions_apply_on_startup_and_context_switch() {
         (Some("127.0.0.1"), None, false, false),
         (None, Some("127.0.0.1"), false, false),
         (Some(""), Some("127.0.0.1"), false, false),
+        (Some(" \t\n"), Some("127.0.0.1"), false, false),
+        (Some(" \t"), Some("\n "), false, true),
         (Some("unmatched.invalid"), Some("127.0.0.1"), false, true),
         (Some("*"), None, false, false),
         (Some("127.0.0.0/8"), None, false, false),

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -24,6 +24,7 @@ use crate::diagnostics::Op;
 use crate::store::{Msg, row_key};
 
 mod discovery;
+mod proxy;
 
 pub(crate) fn build_client(config: Config, allow_v1_client_cert: bool) -> Result<Client> {
     let builder = crate::legacy_tls::client_builder(config, allow_v1_client_cert)?;
@@ -276,12 +277,16 @@ fn sanitize_server_version(version: &str) -> String {
 
 impl Cluster {
     pub async fn connect(allow_v1_client_cert: bool) -> Result<Self> {
-        let config = Config::infer()
+        let mut config = Config::infer()
             .await
             .context("loading kubeconfig (is KUBECONFIG / ~/.kube/config present?)")?;
         // The real kubeconfig current-context (if any) is what kubectl uses by
         // default; pass it explicitly so shell-outs can't drift from us.
-        let cli_context = current_context_name();
+        let kubeconfig = Kubeconfig::read().ok();
+        if let Some(kubeconfig) = &kubeconfig {
+            proxy::configure(&mut config, kubeconfig, None);
+        }
+        let cli_context = kubeconfig.and_then(|config| config.current_context);
         let context = cli_context.clone().unwrap_or_else(|| "default".into());
         Self::from_config(config, context, cli_context, allow_v1_client_cert).await
     }
@@ -294,9 +299,10 @@ impl Cluster {
             cluster: None,
             user: None,
         };
-        let config = Config::from_custom_kubeconfig(kubeconfig, &opts)
+        let mut config = Config::from_custom_kubeconfig(kubeconfig.clone(), &opts)
             .await
             .with_context(|| format!("building config for context '{name}'"))?;
+        proxy::configure(&mut config, &kubeconfig, Some(name));
         Self::from_config(
             config,
             name.to_string(),
@@ -836,12 +842,6 @@ fn group_priority(group: &str) -> u8 {
         "metrics.k8s.io" => 0, // virtual metrics API — never shadow real kinds
         _ => 50,
     }
-}
-
-fn current_context_name() -> Option<String> {
-    // Config::infer() doesn't surface the context name, so read it directly.
-    let kubeconfig = kube::config::Kubeconfig::read().ok()?;
-    kubeconfig.current_context
 }
 
 /// A requested kubeconfig context (or the current one when none was requested),

--- a/src/k8s/proxy.rs
+++ b/src/k8s/proxy.rs
@@ -37,8 +37,8 @@ pub(super) fn configure(config: &mut Config, kubeconfig: &Kubeconfig, context: O
 
 fn first_nonempty(upper: Option<String>, lower: Option<String>) -> Option<String> {
     upper
-        .filter(|value| !value.is_empty())
-        .or(lower.filter(|value| !value.is_empty()))
+        .filter(|value| !value.trim().is_empty())
+        .or(lower.filter(|value| !value.trim().is_empty()))
 }
 
 fn matches(server: &Uri, exclusions: &str) -> bool {
@@ -177,10 +177,14 @@ mod tests {
         for (upper, lower, expected) in [
             (Some("upper"), Some("lower"), Some("upper")),
             (Some(""), Some("lower"), Some("lower")),
+            (Some(" \t\n"), Some("lower"), Some("lower")),
+            (Some(" upper "), Some("lower"), Some(" upper ")),
             (None, Some("lower"), Some("lower")),
             (Some("upper"), None, Some("upper")),
             (None, None, None),
             (Some(""), Some(""), None),
+            (Some(" \t"), Some("\n "), None),
+            (None, Some(" \t\n"), None),
         ] {
             assert_eq!(
                 first_nonempty(upper.map(str::to_owned), lower.map(str::to_owned)).as_deref(),

--- a/src/k8s/proxy.rs
+++ b/src/k8s/proxy.rs
@@ -1,0 +1,191 @@
+use std::net::IpAddr;
+
+use http::Uri;
+use kube::{Config, config::Kubeconfig};
+
+pub(super) fn configure(config: &mut Config, kubeconfig: &Kubeconfig, context: Option<&str>) {
+    let context = context.or(kubeconfig.current_context.as_deref());
+    let cluster = kubeconfig
+        .contexts
+        .iter()
+        .find(|entry| Some(entry.name.as_str()) == context)
+        .and_then(|entry| entry.context.as_ref())
+        .and_then(|context| {
+            kubeconfig
+                .clusters
+                .iter()
+                .find(|entry| entry.name == context.cluster)
+        })
+        .and_then(|entry| entry.cluster.as_ref());
+    // An explicit kubeconfig proxy takes priority over environment exclusions.
+    let Some(cluster) = cluster else { return };
+    if cluster
+        .proxy_url
+        .as_ref()
+        .is_some_and(|url| !url.is_empty())
+    {
+        return;
+    }
+    let exclusions = first_nonempty(
+        std::env::var("NO_PROXY").ok(),
+        std::env::var("no_proxy").ok(),
+    );
+    if exclusions.is_some_and(|value| matches(&config.cluster_url, &value)) {
+        config.proxy_url = None;
+    }
+}
+
+fn first_nonempty(upper: Option<String>, lower: Option<String>) -> Option<String> {
+    upper
+        .filter(|value| !value.is_empty())
+        .or(lower.filter(|value| !value.is_empty()))
+}
+
+fn matches(server: &Uri, exclusions: &str) -> bool {
+    let Some(host) = server.host() else {
+        return false;
+    };
+    let host = host
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_ascii_lowercase();
+    let address = host.parse::<IpAddr>().ok();
+    let port = server.port_u16().or_else(|| match server.scheme_str() {
+        Some("http") => Some(80),
+        Some("https") => Some(443),
+        _ => None,
+    });
+    exclusions
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .any(|entry| {
+            if entry == "*" {
+                return true;
+            }
+            if let Ok(network) = entry.parse::<ipnet::IpNet>() {
+                return address.is_some_and(|address| network.contains(&address));
+            }
+            if let Ok(ip) = entry.parse::<IpAddr>() {
+                return address == Some(ip);
+            }
+            let (entry_host, entry_port) = if let Some(rest) = entry.strip_prefix('[') {
+                let Some((host, suffix)) = rest.split_once(']') else {
+                    return false;
+                };
+                if suffix.is_empty() {
+                    (host, None)
+                } else if let Some(port) = suffix.strip_prefix(':') {
+                    (host, Some(port))
+                } else {
+                    return false;
+                }
+            } else if let Some((host, port)) = entry.split_once(':') {
+                (host, Some(port))
+            } else {
+                (entry, None)
+            };
+            if let Some(entry_port) = entry_port
+                && (entry_port.is_empty() || entry_port.parse::<u16>().ok() != port)
+            {
+                return false;
+            }
+            if let Ok(ip) = entry_host.parse::<IpAddr>() {
+                return address == Some(ip);
+            }
+            if address.is_some() {
+                return false;
+            }
+            let entry_host = entry_host.to_ascii_lowercase();
+            let domain = if entry_host.starts_with("*.") {
+                &entry_host[1..]
+            } else {
+                &entry_host
+            };
+            if domain.is_empty() || domain == "." {
+                return false;
+            }
+            if domain.starts_with('.') {
+                host.ends_with(domain)
+            } else {
+                host == domain
+                    || host
+                        .strip_suffix(domain)
+                        .is_some_and(|prefix| prefix.ends_with('.'))
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusions_match_hosts_addresses_networks_and_ports() {
+        for (server, exclusions, expected) in [
+            ("https://rke2-server:6443", "rke2-server", true),
+            ("https://rke2-server:6443", " other, RKE2-SERVER , ", true),
+            ("https://rke2-server:6443", "other", false),
+            ("https://rke2-server:6443", "", false),
+            ("https://rke2-server:6443", " , , ", false),
+            ("https://api.example.com:6443", "example.com", true),
+            ("https://example.com", "example.com", true),
+            ("https://notexample.com", "example.com", false),
+            ("https://example.com.evil", "example.com", false),
+            ("https://api.example.com", ".example.com", true),
+            ("https://example.com", ".example.com", false),
+            ("https://api.example.com", "*.example.com", true),
+            ("https://example.com", "*.example.com", false),
+            ("https://api.example.com", "*example.com", false),
+            ("https://rke2-server:6443", "rke2-server:6443", true),
+            ("https://rke2-server:6443", "rke2-server:443", false),
+            ("https://rke2-server", "rke2-server:443", true),
+            ("http://rke2-server", "rke2-server:80", true),
+            ("https://rke2-server", "rke2-server:", false),
+            ("https://rke2-server", "rke2-server:invalid", false),
+            ("https://10.20.30.40:6443", "10.20.30.40", true),
+            ("https://10.20.30.40:6443", "10.20.30.40:6443", true),
+            ("https://10.20.30.40:6443", "10.20.30.40:443", false),
+            ("https://10.20.30.40", "10.20.0.0/16", true),
+            ("https://10.21.30.40", "10.20.0.0/16", false),
+            ("https://10.20.30.40", "10.20.0.0/99", false),
+            ("https://10.20.30.40", "30.40", false),
+            ("https://rke2-server", "10.20.0.0/16", false),
+            ("https://[2001:db8::1]:6443", "2001:db8::1", true),
+            ("https://[2001:db8::1]:6443", "[2001:db8::1]", true),
+            ("https://[2001:db8::1]:6443", "[2001:db8::1]:6443", true),
+            ("https://[2001:db8::1]:6443", "[2001:db8::1]:443", false),
+            ("https://[2001:db8::1]", "2001:db8::/32", true),
+            ("https://[2001:db9::1]", "2001:db8::/32", false),
+            ("https://[2001:db8::1]", "[2001:db8::1", false),
+            ("https://[2001:db8::1]", "[2001:db8::1]invalid", false),
+            ("https://rke2-server", "*", true),
+            ("https://10.20.30.40", "*", true),
+            ("https://[2001:db8::1]", "*", true),
+            ("https://rke2-server", "https://rke2-server", false),
+        ] {
+            assert_eq!(
+                matches(&server.parse().unwrap(), exclusions),
+                expected,
+                "{server}, {exclusions}"
+            );
+        }
+    }
+
+    #[test]
+    fn uppercase_exclusions_take_priority_unless_empty() {
+        for (upper, lower, expected) in [
+            (Some("upper"), Some("lower"), Some("upper")),
+            (Some(""), Some("lower"), Some("lower")),
+            (None, Some("lower"), Some("lower")),
+            (Some("upper"), None, Some("upper")),
+            (None, None, None),
+            (Some(""), Some(""), None),
+        ] {
+            assert_eq!(
+                first_nonempty(upper.map(str::to_owned), lower.map(str::to_owned)).as_deref(),
+                expected
+            );
+        }
+    }
+}


### PR DESCRIPTION
When an HTTPS proxy is set, sofka can send requests through it even when the API server is listed in `NO_PROXY`. The reporter in discussion #419 could connect only after removing the HTTPS proxy variables.

Apply `NO_PROXY` and `no_proxy` exclusions on startup and context changes. Keep proxy use for servers without a matching exclusion, and preserve an explicit kubeconfig `proxy-url`. Support host names, domain suffixes, IP addresses, CIDR ranges, ports, and `*`. Add troubleshooting instructions.

Validation: `just check` passed with formatting, Clippy, and 1,193 passing tests. The regression tests use local TLS and proxy servers to check startup, keyboard-driven context changes, uppercase and lowercase variables, and explicit proxy priority. No live cluster test was run.

Closes #428.

Related discussion: https://github.com/nklmilojevic/sofka/discussions/419

Reporter confirmation: https://github.com/nklmilojevic/sofka/discussions/419#discussioncomment-18367911
