### PR TITLE
perf: render table cells without nested tables

### DIFF
--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -455,6 +455,7 @@ fn custom_columns(c: &mut Criterion) {
         width: None,
         align: None,
         condition_field: None,
+        condition_match: sofka::views::ConditionMatch::Type,
     };
     let now = columns::now_secs();
 
@@ -627,8 +628,29 @@ fn dependencies(c: &mut Criterion) {
     g.finish();
 }
 
+fn table_frames(c: &mut Criterion) {
+    let mut group = c.benchmark_group("table_frames");
+    for (width, height, count) in [(80, 24, 500), (160, 48, 2000)] {
+        let (mut app, _rx) = bs::pods_app(count);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| sofka::ui::draw(frame, &mut app))
+            .unwrap();
+        group.bench_function(format!("{width}x{height}/{count}"), |b| {
+            b.iter(|| {
+                terminal
+                    .draw(|frame| sofka::ui::draw(frame, &mut app))
+                    .unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
+    table_frames,
     rows_cache,
     filter,
     filter_cmp,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,8 +6,8 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
-    Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
-    Paragraph, Row, Table,
+    Block, BorderType, Borders, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
+    Paragraph,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -15,6 +15,37 @@ use crate::app::{App, DEFAULT_SORT_LABEL, Mode, Pane, SuggestKind, TRANSFER_MENU
 use crate::{columns, theme};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+struct RenderCell<'a> {
+    content: Text<'a>,
+    style: Style,
+}
+
+impl<'a, T: Into<Text<'a>>> From<T> for RenderCell<'a> {
+    fn from(content: T) -> Self {
+        Self {
+            content: content.into(),
+            style: Style::default(),
+        }
+    }
+}
+
+impl RenderCell<'_> {
+    fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    fn render(&self, area: Rect, buf: &mut ratatui::buffer::Buffer, row: Style, selected: bool) {
+        use ratatui::widgets::Widget;
+        buf.set_style(area, row);
+        buf.set_style(area, self.style);
+        (&self.content).render(area, buf);
+        if selected {
+            buf.set_style(area, theme::selected_row());
+        }
+    }
+}
 
 enum TableCellText<'a> {
     Borrowed(&'a str),
@@ -29,21 +60,21 @@ impl<'a> TableCellText<'a> {
         }
     }
 
-    fn into_cell(self) -> Cell<'a> {
+    fn into_cell(self) -> RenderCell<'a> {
         match self {
-            TableCellText::Borrowed(value) => Cell::from(value),
-            TableCellText::Owned(value) => Cell::from(value),
+            TableCellText::Borrowed(value) => RenderCell::from(value),
+            TableCellText::Owned(value) => RenderCell::from(value),
         }
     }
 
     /// Like [`Self::into_cell`], honoring a custom column's alignment.
-    fn into_cell_aligned(self, align: Option<Alignment>) -> Cell<'a> {
+    fn into_cell_aligned(self, align: Option<Alignment>) -> RenderCell<'a> {
         let Some(align) = align else {
             return self.into_cell();
         };
         match self {
-            TableCellText::Borrowed(value) => Cell::from(Text::from(value).alignment(align)),
-            TableCellText::Owned(value) => Cell::from(Text::from(value).alignment(align)),
+            TableCellText::Borrowed(value) => RenderCell::from(Text::from(value).alignment(align)),
+            TableCellText::Owned(value) => RenderCell::from(Text::from(value).alignment(align)),
         }
     }
 }
@@ -883,11 +914,11 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
                 if let Some(a) = align_of(i) {
                     line = line.alignment(a);
                 }
-                Cell::from(line)
+                RenderCell::from(line)
             } else {
                 match align_of(i) {
-                    Some(a) => Cell::from(Text::from(h.clone()).alignment(a)),
-                    None => Cell::from(h.clone()),
+                    Some(a) => RenderCell::from(Text::from(h.clone()).alignment(a)),
+                    None => RenderCell::from(h.clone()),
                 }
             }
         })
@@ -1043,7 +1074,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
     app.ensure_table_cell_cache_at(&visible_objects, now);
     let cell_cache = app.table_cell_cache();
 
-    let rows: Vec<Vec<Cell>> = visible_objects
+    let rows: Vec<Vec<RenderCell>> = visible_objects
         .iter()
         .map(|obj| {
             let row_key = crate::store::row_key(obj);
@@ -1098,7 +1129,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
             };
             let row_color = theme::row_color(status_key);
             let status_badge = theme::status_color(status_key);
-            let render_cells: Vec<Cell> = cells
+            let render_cells: Vec<RenderCell> = cells
                 .into_iter()
                 .enumerate()
                 .map(|(i, c)| {
@@ -1294,8 +1325,8 @@ impl TableViewport {
 }
 
 struct ScrollingTable<'a> {
-    header: Vec<Cell<'a>>,
-    rows: Vec<Vec<Cell<'a>>>,
+    header: Vec<RenderCell<'a>>,
+    rows: Vec<Vec<RenderCell<'a>>>,
     widths: Vec<u16>,
     viewport: TableViewport,
     offset: usize,
@@ -1304,8 +1335,6 @@ struct ScrollingTable<'a> {
 
 impl ratatui::widgets::Widget for ScrollingTable<'_> {
     fn render(self, area: Rect, buf: &mut ratatui::buffer::Buffer) {
-        use ratatui::widgets::StatefulWidget;
-
         let ranges = self.viewport.ranges(self.offset);
         let max_width = ranges
             .iter()
@@ -1338,14 +1367,7 @@ impl ratatui::widgets::Widget for ScrollingTable<'_> {
                     source.set_style(source.area, Style::default().bg(bg));
                 }
                 let cell_area = Rect::new(0, 0, self.widths[index], 1);
-                let mut state = ratatui::widgets::TableState::default();
-                state.select(selected.then_some(0));
-                let table = Table::new(
-                    [Row::new([cells[index].clone()]).style(style)],
-                    [Constraint::Length(self.widths[index])],
-                )
-                .row_highlight_style(theme::selected_row());
-                StatefulWidget::render(table, cell_area, &mut source, &mut state);
+                cells[index].render(cell_area, &mut source, style, selected);
                 let source_end = source_start + (end - start);
                 let mut x = 0;
                 while x < source_end {
@@ -1498,7 +1520,7 @@ fn pod_readiness_blocked(obj: &kube::core::DynamicObject) -> bool {
 /// fuzzy row filter (bold yellow) so a scan across many filtered results is
 /// faster — every visible row already matched, this just shows *where*.
 /// Falls back to a flat `base`-colored cell when there's no active filter.
-fn render_name_cell(app: &App, name: &str, base: Color, forwarded: bool) -> Cell<'static> {
+fn render_name_cell(app: &App, name: &str, base: Color, forwarded: bool) -> RenderCell<'static> {
     // A teal ● prepended when a port-forward is active for this row.
     let marker = if forwarded {
         vec![Span::styled("● ", Style::default().fg(theme::teal()))]
@@ -1508,7 +1530,7 @@ fn render_name_cell(app: &App, name: &str, base: Color, forwarded: bool) -> Cell
     let Some(matched) = app.filter_match_indices(name).filter(|idx| !idx.is_empty()) else {
         let mut spans = marker;
         spans.push(Span::styled(name.to_string(), Style::default().fg(base)));
-        return Cell::from(Line::from(spans));
+        return RenderCell::from(Line::from(spans));
     };
     let matched: std::collections::HashSet<usize> = matched.iter().copied().collect();
     let plain = Style::default().fg(base);
@@ -1533,7 +1555,7 @@ fn render_name_cell(app: &App, name: &str, base: Color, forwarded: bool) -> Cell
     if !run.is_empty() {
         spans.push(Span::styled(run, if run_matched { hl } else { plain }));
     }
-    Cell::from(Line::from(spans))
+    RenderCell::from(Line::from(spans))
 }
 
 fn draw_scrollable(
@@ -4495,6 +4517,60 @@ mod tests {
         assert!(clipped.ends_with('…'));
         // No room even for the ellipsis.
         assert_eq!(clip_to_width("abc", 0), "");
+    }
+
+    #[test]
+    fn direct_cells_match_table_rendering() {
+        use ratatui::buffer::Buffer;
+        use ratatui::widgets::{Cell, Row, StatefulWidget, Table, TableState};
+        for width in [0, 1, 2, 5, 20] {
+            for alignment in [Alignment::Left, Alignment::Center, Alignment::Right] {
+                for selected in [false, true] {
+                    for value in [
+                        "",
+                        "plain",
+                        "界e\u{301}界",
+                        "first\nsecond",
+                        "a long clipped value",
+                    ] {
+                        let text = Text::from(Line::from(vec![
+                            Span::styled(value, Style::default().fg(Color::Red)),
+                            Span::styled("!", Style::default().add_modifier(Modifier::BOLD)),
+                        ]))
+                        .alignment(alignment);
+                        let area = Rect::new(0, 0, width, 1);
+                        let mut expected = Buffer::empty(area);
+                        let mut actual = Buffer::empty(area);
+                        let row = theme::header_row();
+                        let cell_style = Style::default().bg(Color::Blue);
+                        let mut state = TableState::default().with_selected(selected.then_some(0));
+                        StatefulWidget::render(
+                            Table::new(
+                                [
+                                    Row::new([Cell::from(text.clone()).style(cell_style)])
+                                        .style(row),
+                                ],
+                                [Constraint::Length(width)],
+                            )
+                            .row_highlight_style(theme::selected_row()),
+                            area,
+                            &mut expected,
+                            &mut state,
+                        );
+                        RenderCell::from(text).style(cell_style).render(
+                            area,
+                            &mut actual,
+                            row,
+                            selected,
+                        );
+                        assert_eq!(
+                            actual, expected,
+                            "{width} {alignment:?} {selected} {value:?}"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// A describe/YAML/diff document is a snapshot — the status bar must not


### PR DESCRIPTION
Table frames previously created a one-cell Ratatui table and cloned its content for each visible cell. Render styled text directly into the existing row buffer. Fixed columns, alignment, selection styles, and wide-character clipping stay the same.

Validation:
- `just check` passed. The commit hooks also passed.
- Added an output comparison against Ratatui Table.
- Added full-frame TestBackend benchmarks. At 80×24 with 500 pods, mean frame time fell from 105.52 µs to 82.46 µs. At 160×48 with 2,000 pods, it fell from 373.27 µs to 276.96 µs.
- These measurements exclude a live terminal and cluster.
- Fixed a missing field in an existing benchmark fixture so the benchmarks build.

Closes #434
