### PR TITLE
feat: show scroll position on view borders

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,11 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Scroll position** appears on the borders of long resource tables, document
+  views, logs, and pickers. Tables and unwrapped documents also show horizontal
+  position. Wrapped views use display rows. Scrollbars disappear when content
+  fits. Fullscreen logs keep their borderless layout for text selection.
+
 - **Terminal title** shows `sofka: <context>/<namespace>` and follows navigation.
   The namespace is `all` when all namespaces are selected. Set
   `terminal_title = false` to disable title changes. Sofka clears the title on exit.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -535,6 +535,7 @@ struct MatchCache {
 }
 
 struct DocumentViewport {
+    widest: usize,
     width: usize,
     height: usize,
     wrap: bool,
@@ -781,11 +782,13 @@ impl Scrollable {
                 || viewport.line_count != self.lines.len()
         });
         if stale {
+            let mut widest = 0usize;
             let mut rows = 0usize;
             let ends = self
                 .lines
                 .iter()
                 .map(|line| {
+                    widest = widest.max(line.chars().count());
                     let line_rows = if self.wrap {
                         crate::ui::wrapped_height(line, width)
                     } else {
@@ -796,6 +799,7 @@ impl Scrollable {
                 })
                 .collect();
             self.viewport = Some(DocumentViewport {
+                widest,
                 width,
                 height,
                 wrap: self.wrap,
@@ -827,6 +831,12 @@ impl Scrollable {
             .saturating_add(1)
             .min(self.lines.len());
         (start, end, row_offset)
+    }
+
+    pub(crate) fn scroll_dimensions(&self) -> (usize, usize) {
+        self.viewport
+            .as_ref()
+            .map_or((self.lines.len(), 0), |v| (v.total_rows(), v.widest))
     }
 
     fn max_scroll(&self) -> usize {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23635,3 +23635,82 @@ async fn explain_refresh_clears_a_removed_selection_and_blocks_implicit_root_act
     assert!(app.detail.title.starts_with("web"));
     app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
 }
+
+#[tokio::test]
+async fn scrollbars_follow_keys_and_disappear_when_content_fits() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.compact = true;
+    let mut terminal = Terminal::new(TestBackend::new(60, 16)).unwrap();
+    let thumb_rows = |terminal: &Terminal<TestBackend>| -> Vec<u16> {
+        (0..16)
+            .filter(|&y| terminal.backend().buffer()[(59, y)].symbol() == "█")
+            .collect()
+    };
+    for i in 0..80 {
+        apply(
+            &mut app,
+            json!({"apiVersion":"v1", "kind":"Pod",
+            "metadata":{"name":format!("pod-{i:03}"), "namespace":"default"}}),
+        );
+    }
+    for mode in [
+        Mode::Table,
+        Mode::Detail,
+        Mode::Diff,
+        Mode::Logs,
+        Mode::Help,
+    ] {
+        app.mode = mode;
+        app.detail = Scrollable {
+            lines: (0..80).map(|i| format!("line {i}")).collect(),
+            ..Default::default()
+        };
+        app.logs.view = Scrollable {
+            lines: (0..80).map(|i| format!("line {i}")).collect(),
+            ..Default::default()
+        };
+        app.logs.follow = false;
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let top = thumb_rows(&terminal);
+        assert!(!top.is_empty(), "{mode:?}");
+        app.handle_key(press(KeyCode::End)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let bottom = thumb_rows(&terminal);
+        assert!(bottom[0] > top[0], "{mode:?}: {top:?} -> {bottom:?}");
+    }
+    app.mode = Mode::Detail;
+    for lines in [VecDeque::new(), VecDeque::from(["short".into()])] {
+        app.detail = Scrollable {
+            lines,
+            ..Default::default()
+        };
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert!(thumb_rows(&terminal).is_empty());
+    }
+    app.detail = Scrollable {
+        lines: VecDeque::from(["x".repeat(4000)]),
+        ..Default::default()
+    };
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    app.handle_key(press(KeyCode::Right)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert!(app.detail.hscroll > 0);
+    assert!((1..59).any(|x| terminal.backend().buffer()[(x, 15)].symbol() == "█"));
+    app.detail = Scrollable {
+        lines: VecDeque::from(["x".repeat(4000)]),
+        wrap: true,
+        ..Default::default()
+    };
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    app.handle_key(press(KeyCode::End)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    assert!(thumb_rows(&terminal)[0] > 2);
+    for width in [1, 2, 3, 120] {
+        terminal.backend_mut().resize(width, 16);
+        crate::ui::resize(&mut terminal, &mut app).unwrap();
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,7 +7,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
-    Paragraph, Row, Table,
+    Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -1229,6 +1229,26 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
         },
         inner,
     );
+    draw_border_scrollbar(
+        frame,
+        Rect {
+            y: area.y.saturating_add(1),
+            height: area.height.saturating_sub(1),
+            ..area
+        },
+        offset,
+        count.saturating_sub(visible_rows),
+        visible_rows,
+        false,
+    );
+    draw_border_scrollbar(
+        frame,
+        area,
+        col_offset,
+        app.col_scroll_max,
+        usize::from(inner.width),
+        true,
+    );
 }
 
 /// Positions in the full table, measured from the selection marker.
@@ -1575,6 +1595,7 @@ fn draw_scrollable(
         p.scroll((0, view.hscroll.min(u16::MAX as usize) as u16))
     };
     frame.render_widget(p, area);
+    draw_document_scrollbars(frame, view, area);
 }
 
 fn visible_wrapped_rows(
@@ -1740,6 +1761,9 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
             .title(Span::styled(title, theme::title()))
     };
     frame.render_widget(Paragraph::new(rows).block(block), area);
+    if !fullscreen {
+        draw_border_scrollbar(frame, area, scroll, max_scroll, inner_h, false);
+    }
 }
 
 /// Display rows `raw` occupies when char-wrapped to `width` columns: ANSI
@@ -2278,6 +2302,7 @@ fn draw_diff(frame: &mut Frame, view: &mut crate::app::Scrollable, area: Rect) {
         p.scroll((0, view.hscroll.min(u16::MAX as usize) as u16))
     };
     frame.render_widget(p, area);
+    draw_document_scrollbars(frame, view, area);
 }
 
 /// Doc-view title, extended with the active search query and the current
@@ -2723,6 +2748,14 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
                 .title(Span::styled(title, theme::title())),
         ),
         area,
+    );
+    draw_border_scrollbar(
+        frame,
+        area,
+        usize::from(scroll),
+        usize::from(max_scroll),
+        usize::from(inner_h),
+        false,
     );
 }
 
@@ -3409,6 +3442,20 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         .highlight_symbol("▌ ")
         .highlight_spacing(HighlightSpacing::Always);
     frame.render_stateful_widget(list, list_area, &mut app.container_state);
+    draw_border_scrollbar(
+        frame,
+        Rect {
+            y: popup.y.saturating_add(1),
+            height: popup.height.saturating_sub(1),
+            ..popup
+        },
+        app.container_state.offset(),
+        app.container_list
+            .len()
+            .saturating_sub(usize::from(list_area.height)),
+        usize::from(list_area.height),
+        false,
+    );
 }
 
 fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {
@@ -4392,6 +4439,64 @@ fn confirm_action_hint(app: &App, allows_force: bool) -> String {
     key_hint(app, "confirm", &actions)
 }
 
+fn draw_border_scrollbar(
+    frame: &mut Frame,
+    area: Rect,
+    position: usize,
+    max_offset: usize,
+    visible: usize,
+    horizontal: bool,
+) {
+    if max_offset == 0 || visible == 0 || area.width < 3 || area.height < 3 {
+        return;
+    }
+    let (orientation, track) = if horizontal {
+        (
+            ScrollbarOrientation::HorizontalBottom,
+            Rect::new(area.x + 1, area.bottom() - 1, area.width - 2, 1),
+        )
+    } else {
+        (
+            ScrollbarOrientation::VerticalRight,
+            Rect::new(area.right() - 1, area.y + 1, 1, area.height - 2),
+        )
+    };
+    // Ratatui maps the last state position to the end of the track.
+    let mut state = ScrollbarState::new(max_offset.saturating_add(1))
+        .position(position.min(max_offset))
+        .viewport_content_length(visible);
+    let scrollbar = Scrollbar::new(orientation)
+        .begin_symbol(None)
+        .end_symbol(None)
+        .thumb_style(theme::border_focused())
+        .track_style(theme::dim());
+    frame.render_stateful_widget(scrollbar, track, &mut state);
+}
+
+fn draw_document_scrollbars(frame: &mut Frame, view: &crate::app::Scrollable, area: Rect) {
+    let (rows, widest) = view.scroll_dimensions();
+    let height = usize::from(area.height.saturating_sub(2));
+    let width = usize::from(area.width.saturating_sub(2));
+    draw_border_scrollbar(
+        frame,
+        area,
+        view.scroll,
+        rows.saturating_sub(height),
+        height,
+        false,
+    );
+    if !view.wrap && (widest > width || view.hscroll > 0) {
+        draw_border_scrollbar(
+            frame,
+            area,
+            view.hscroll,
+            widest.saturating_sub(1),
+            width,
+            true,
+        );
+    }
+}
+
 /// Clear a popup region before drawing on top of it. `Clear` resets the cells
 /// to the terminal default; with the skin background enabled that would punch a
 /// transparent hole through the fill, so repaint `base` over the cleared cells.
@@ -4427,6 +4532,8 @@ fn render_framed_list<'a, T>(
 ) where
     T: Into<Line<'a>>,
 {
+    let heights: Vec<_> = items.iter().map(ListItem::height).collect();
+    let total: usize = heights.iter().sum();
     let list = List::new(items)
         .highlight_style(theme::selected_row())
         .highlight_symbol("▌ ")
@@ -4439,6 +4546,16 @@ fn render_framed_list<'a, T>(
                 .title(title.into()),
         );
     frame.render_stateful_widget(list, area, state);
+    let visible = usize::from(area.height.saturating_sub(2));
+    let position = heights.iter().take(state.offset()).sum();
+    draw_border_scrollbar(
+        frame,
+        area,
+        position,
+        total.saturating_sub(visible),
+        visible,
+        false,
+    );
 }
 
 /// Center a fixed-size rectangle within `r`, clamped to `r`'s bounds. Used by


### PR DESCRIPTION
Show scroll position on the borders of long tables, documents, logs, and picker lists. Wrapped text uses display rows. Tables and unwrapped documents also show horizontal position. Fullscreen logs stay borderless for text selection.

Cache document width with the existing layout data. Keep the table header and popup titles clear of the scrollbar.

Validation: formatter, Clippy, and the full test suite passed in the commit hooks. Keyboard tests cover top and bottom positions, short and empty content, wrapping, horizontal scrolling, and resize.

Closes #435
