### PR TITLE
feat: add theme-aware popup shadows

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Popup shadows** use the active skin colors to separate confirmation boxes,
+  the command palette, and pickers from the content below. Shadows stay within
+  the terminal bounds and disappear when the popup closes.
+
 - **Terminal title** shows `sofka: <context>/<namespace>` and follows navigation.
   The namespace is `all` when all namespaces are selected. Set
   `terminal_title = false` to disable title changes. Sofka clears the title on exit.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23635,3 +23635,40 @@ async fn explain_refresh_clears_a_removed_selection_and_blocks_implicit_root_act
     assert!(app.detail.title.starts_with("web"));
     app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
 }
+
+#[tokio::test]
+async fn popup_shadows_follow_open_close_and_resize() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.compact = true;
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"web", "namespace":"default"}}),
+    );
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    let mut terminal = Terminal::new(TestBackend::new(100, 24)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let original = terminal.backend().buffer().clone();
+    for key in [ctrl(KeyCode::Char('d')), press(KeyCode::Char('S'))] {
+        app.handle_key(key).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let corner = (1..23)
+            .find_map(|y| (1..99).find_map(|x| (buffer[(x, y)].symbol() == "╮").then_some((x, y))))
+            .unwrap();
+        let shadow = &buffer[(corner.0 + 1, corner.1 + 1)];
+        assert_eq!(shadow.bg, crate::theme::surface0());
+        assert_eq!(shadow.fg, crate::theme::overlay1());
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert_eq!(terminal.backend().buffer(), &original);
+    }
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for (width, height) in [(3, 3), (20, 8), (80, 24)] {
+        terminal.backend_mut().resize(width, height);
+        crate::ui::resize(&mut terminal, &mut app).unwrap();
+    }
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,7 +7,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
-    Paragraph, Row, Table,
+    Paragraph, Row, Shadow, Table,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -4396,6 +4396,9 @@ fn confirm_action_hint(app: &App, allows_force: bool) -> String {
 /// to the terminal default; with the skin background enabled that would punch a
 /// transparent hole through the fill, so repaint `base` over the cleared cells.
 fn clear_region(frame: &mut Frame, area: Rect) {
+    let shadow =
+        Shadow::overlay().style(Style::default().fg(theme::overlay1()).bg(theme::surface0()));
+    frame.render_widget(&shadow, area);
     frame.render_widget(Clear, area);
     if let Some(bg) = theme::background() {
         frame.buffer_mut().set_style(area, Style::default().bg(bg));


### PR DESCRIPTION
Add a one-cell shadow to confirmation boxes, picker popups, and the command palette. The shadow uses the active skin colors and leaves the underlying symbols intact. Ratatui clips it to the terminal bounds.

Validation: formatter, Clippy, and the full test suite passed in the commit hooks. Keyboard tests check popup open and close, restored screen content, and resize to small terminal sizes.

Closes #436
