### PR TITLE
feat: show compact gauges for the selected container

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Container gauges** show CPU and memory for the selected container when space
+  is available. The bars use a positive limit, or a positive request when no
+  limit is set. Labels keep the numeric usage and percentages above 100%.
+  Missing metrics and missing denominators are shown explicitly. A failed
+  metrics poll marks the retained values as stale.
+
 - **Terminal title** shows `sofka: <context>/<namespace>` and follows navigation.
   The namespace is `all` when all namespaces are selected. Set
   `terminal_title = false` to disable title changes. Sofka clears the title on exit.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23682,17 +23682,39 @@ async fn container_gauges_follow_selection_and_missing_metrics() {
         "{text}"
     );
     assert!(text.contains("no request or limit"));
+    app.handle_msg(Msg::MetricsError {
+        generation: app.generation,
+        error: "offline".into(),
+    });
+    let text = render(&mut terminal, &mut app);
+    assert!(text.contains("CPU 0m / request 50m (0%) [stale]"), "{text}");
+    assert!(
+        text.contains("MEM 0B / no request or limit [stale]"),
+        "{text}"
+    );
+    app.handle_key(press(KeyCode::Up)).unwrap();
+    let text = render(&mut terminal, &mut app);
+    assert!(
+        text.contains("CPU 250m / limit 100m (250%) [stale]"),
+        "{text}"
+    );
     app.handle_msg(Msg::Metrics {
         generation: app.generation,
         data: HashMap::new(),
         containers: HashMap::new(),
     });
-    assert!(render(&mut terminal, &mut app).contains("CPU unavailable"));
+    let text = render(&mut terminal, &mut app);
+    assert!(text.contains("CPU unavailable"), "{text}");
+    assert!(text.contains("MEM unavailable"), "{text}");
+    assert!(!text.contains("[stale]"), "{text}");
     app.handle_msg(Msg::MetricsError {
         generation: app.generation,
         error: "offline".into(),
     });
-    assert!(render(&mut terminal, &mut app).contains("[stale]"));
+    let text = render(&mut terminal, &mut app);
+    assert!(text.contains("CPU unavailable"), "{text}");
+    assert!(text.contains("MEM unavailable"), "{text}");
+    assert!(!text.contains("[stale]"), "{text}");
     for (width, height) in [(1, 1), (20, 8), (80, 24)] {
         terminal.backend_mut().resize(width, height);
         crate::ui::resize(&mut terminal, &mut app).unwrap();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23635,3 +23635,66 @@ async fn explain_refresh_clears_a_removed_selection_and_blocks_implicit_root_act
     assert!(app.detail.title.starts_with("web"));
     app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
 }
+
+#[tokio::test]
+async fn container_gauges_follow_selection_and_missing_metrics() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"api", "namespace":"default"},
+        "spec":{"containers":[
+            {"name":"app", "resources":{"limits":{"cpu":"100m", "memory":"64Mi"}}},
+            {"name":"sidecar", "resources":{"requests":{"cpu":"50m"}, "limits":{"cpu":"0"}}}
+        ]}}),
+    );
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::new(),
+        containers: HashMap::from([
+            ("default/api/app".into(), (250, 32 * 1024 * 1024)),
+            ("default/api/sidecar".into(), (0, 0)),
+        ]),
+    });
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Containers);
+    let mut terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
+    let render = |terminal: &mut Terminal<TestBackend>, app: &mut App| {
+        terminal.draw(|f| crate::ui::draw(f, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>()
+    };
+    let text = render(&mut terminal, &mut app);
+    assert!(text.contains("CPU 250m / limit 100m (250%)"), "{text}");
+    assert!(text.contains("(50%)"));
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    let text = render(&mut terminal, &mut app);
+    assert!(
+        text.contains("CPU 0 / request 50m (0%)") || text.contains("CPU 0m / request 50m (0%)"),
+        "{text}"
+    );
+    assert!(text.contains("no request or limit"));
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::new(),
+        containers: HashMap::new(),
+    });
+    assert!(render(&mut terminal, &mut app).contains("CPU unavailable"));
+    app.handle_msg(Msg::MetricsError {
+        generation: app.generation,
+        error: "offline".into(),
+    });
+    assert!(render(&mut terminal, &mut app).contains("[stale]"));
+    for (width, height) in [(1, 1), (20, 8), (80, 24)] {
+        terminal.backend_mut().resize(width, height);
+        crate::ui::resize(&mut terminal, &mut app).unwrap();
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,8 +6,8 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
-    Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
-    Paragraph, Row, Table,
+    Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, LineGauge, List, ListItem,
+    ListState, Paragraph, Row, Table,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -3378,7 +3378,7 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     // +2 borders, +1 so the last column doesn't touch the right border.
     let popup_w = (inner_w as u16 + 3).min(area.width);
     let rows = app.container_list.len() as u16;
-    let popup_h = (rows + 3).clamp(5, area.height); // header + rows + 2 borders
+    let popup_h = rows.saturating_add(5).max(7).min(area.height);
 
     let popup = centered_rect_exact(popup_w, popup_h, area);
     clear_region(frame, popup);
@@ -3392,8 +3392,17 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
-    let [header_area, list_area] =
-        Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(inner);
+    let gauge_height = if inner.height >= 4 && inner.width >= 44 {
+        2
+    } else {
+        0
+    };
+    let [header_area, list_area, gauge_area] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(gauge_height),
+    ])
+    .areas(inner);
     // Indent the header past the 2-column highlight gutter so it lines up with
     // the rows underneath it.
     frame.render_widget(
@@ -3409,6 +3418,80 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         .highlight_symbol("▌ ")
         .highlight_spacing(HighlightSpacing::Always);
     frame.render_stateful_widget(list, list_area, &mut app.container_state);
+    if gauge_height > 0 {
+        draw_container_gauges(frame, app, gauge_area);
+    }
+}
+
+fn draw_container_gauges(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(container) = app
+        .container_state
+        .selected()
+        .and_then(|i| app.container_list.get(i))
+    else {
+        return;
+    };
+    let usage = app.selected_pod_container_metrics(container);
+    let resources = app
+        .container_resources
+        .get(container)
+        .cloned()
+        .unwrap_or_default();
+    for (row, label, value, request, limit, format) in [
+        (
+            0,
+            "CPU",
+            usage.map(|u| u.0),
+            resources.cpu_request,
+            resources.cpu_limit,
+            crate::columns::fmt_cpu as fn(i64) -> String,
+        ),
+        (
+            1,
+            "MEM",
+            usage.map(|u| u.1),
+            resources.mem_request,
+            resources.mem_limit,
+            crate::columns::fmt_mem as fn(i64) -> String,
+        ),
+    ] {
+        let denominator = limit
+            .filter(|v| *v > 0)
+            .map(|v| ("limit", v))
+            .or_else(|| request.filter(|v| *v > 0).map(|v| ("request", v)));
+        let pct = value.and_then(|v| crate::columns::usage_pct(v, denominator.map(|d| d.1)));
+        let value_label = value
+            .map(|v| {
+                if v == 0 {
+                    if label == "CPU" {
+                        "0m".into()
+                    } else {
+                        "0B".into()
+                    }
+                } else {
+                    format(v)
+                }
+            })
+            .unwrap_or_else(|| "unavailable".into());
+        let base_label = denominator
+            .map(|(kind, v)| format!("{kind} {}", format(v)))
+            .unwrap_or_else(|| "no request or limit".into());
+        let percent = pct.map(|v| format!(" ({v}%)")).unwrap_or_default();
+        let stale = if app.metrics_error.is_some() {
+            " [stale]"
+        } else {
+            ""
+        };
+        let label = format!("{label} {value_label} / {base_label}{percent}{stale} ");
+        let gauge = LineGauge::default()
+            .label(label)
+            .ratio(pct.map_or(0.0, |p| (p as f64 / 100.0).clamp(0.0, 1.0)))
+            .filled_style(
+                Style::default().fg(util_color(pct, app.resolved_thresholds().utilization)),
+            )
+            .unfilled_style(theme::dim());
+        frame.render_widget(gauge, Rect::new(area.x, area.y + row, area.width, 1));
+    }
 }
 
 fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3546,7 +3546,7 @@ fn draw_container_gauges(frame: &mut Frame, app: &App, area: Rect) {
             .map(|(kind, v)| format!("{kind} {}", format(v)))
             .unwrap_or_else(|| "no request or limit".into());
         let percent = pct.map(|v| format!(" ({v}%)")).unwrap_or_default();
-        let stale = if app.metrics_error.is_some() {
+        let stale = if value.is_some() && app.metrics_error.is_some() {
             " [stale]"
         } else {
             ""


### PR DESCRIPTION
Add compact CPU and memory gauges for the selected container. Labels use a positive limit, or a positive request when there is no limit, and retain percentages above 100%. Measured zero, missing metrics, missing denominators, and retained values after a failed poll are shown separately.

The gauges hide on small screens. Numeric list columns remain available.

Validation: formatter, Clippy, and the full test suite passed in the commit hooks. Keyboard tests cover selection changes, excess usage, zero and missing values, failed polls, and narrow screens.

Closes #437
