### PR TITLE
feat: show recent trends for the selected container

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Container gauges** show CPU and memory for the selected container when space
+  is available. The bars use a positive limit, or a positive request when no
+  limit is set. Labels keep the numeric usage and percentages above 100%.
+  Missing metrics and missing denominators are shown explicitly. A failed
+  metrics poll marks the retained values as stale.
+
 - **Terminal title** shows `sofka: <context>/<namespace>` and follows navigation.
   The namespace is `all` when all namespaces are selected. Set
   `terminal_title = false` to disable title changes. Sofka clears the title on exit.

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,12 +11,7 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   History starts while the container is selected and keeps at most 60 samples.
   It clears on a selection or view change, context change, or pod replacement.
   It uses the existing metrics polls and is not saved between sessions.
-
-- **Container gauges** show CPU and memory for the selected container when space
-  is available. The bars use a positive limit, or a positive request when no
-  limit is set. Labels keep the numeric usage and percentages above 100%.
-  Missing metrics and missing denominators are shown explicitly. A failed
-  metrics poll marks the retained values as stale.
+  The table keeps the current values; the charts show their history.
 
 - **Scroll position** appears on the borders of long resource tables, document
   views, logs, and pickers. Tables and unwrapped documents also show horizontal

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,14 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Container trends** show CPU and memory for the selected container on wide
+  screens. Each chart covers the last five minutes in five-second bins, with
+  the newest sample on the right. The scale is zero to the largest visible
+  value. A dot marks a missing sample; measured zero has an empty bar.
+  History starts while the container is selected and keeps at most 60 samples.
+  It clears on a selection or view change, context change, or pod replacement.
+  It uses the existing metrics polls and is not saved between sessions.
+
 - **Container gauges** show CPU and memory for the selected container when space
   is available. The bars use a positive limit, or a positive request when no
   limit is set. Labels keep the numeric usage and percentages above 100%.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -25,6 +25,7 @@ impl App {
         let run = self.plugin_run;
         let result = self.handle_key_inner(key);
         self.check_resource_refresh();
+        self.sync_container_history();
         if self.should_quit || self.mode != Mode::Adjacent {
             self.cancel_children();
         }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -335,6 +335,7 @@ impl App {
         self.stop_plugins();
         self.cancel_adjacent_request();
         self.generation += 1;
+        self.container_history = metrics_history::ContainerHistory::default();
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
             t.abort();
@@ -859,6 +860,7 @@ impl App {
         self.stop_plugins();
         self.cancel_adjacent_request();
         self.generation += 1;
+        self.container_history = metrics_history::ContainerHistory::default();
         self.gen_flag.store(self.generation, Ordering::SeqCst);
         for t in self.tasks.drain(..) {
             t.abort();
@@ -1028,6 +1030,7 @@ impl App {
                 self.metrics_error = None;
                 self.metrics = data;
                 self.container_metrics = containers;
+                self.record_container_history(false);
                 if sort_uses_metrics
                     || self
                         .parsed_filter()
@@ -1054,6 +1057,7 @@ impl App {
             }
             Msg::MetricsError { generation, error } if generation == self.generation => {
                 self.metrics_error = Some(error);
+                self.record_container_history(true);
             }
             Msg::PrinterColumns {
                 generation,

--- a/src/app/metrics_history.rs
+++ b/src/app/metrics_history.rs
@@ -1,0 +1,137 @@
+use super::*;
+use std::time::Instant;
+
+const SAMPLES: usize = 60;
+const BIN_SECONDS: u64 = 5;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct TrendTarget {
+    generation: u64,
+    key: String,
+    uid: Option<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct ContainerHistory {
+    target: Option<TrendTarget>,
+    samples: VecDeque<(Instant, Option<(i64, i64)>)>,
+}
+
+impl ContainerHistory {
+    fn select(&mut self, target: Option<TrendTarget>) {
+        if self.target != target {
+            self.target = target;
+            self.samples.clear();
+        }
+    }
+
+    fn record(&mut self, value: Option<(i64, i64)>, now: Instant) {
+        if self.target.is_none() {
+            return;
+        }
+        while self.samples.front().is_some_and(|(time, _)| {
+            now.saturating_duration_since(*time).as_secs() >= SAMPLES as u64 * BIN_SECONDS
+        }) {
+            self.samples.pop_front();
+        }
+        if self.samples.len() == SAMPLES {
+            self.samples.pop_front();
+        }
+        self.samples.push_back((now, value));
+    }
+
+    fn bars(&self, now: Instant, cpu: bool) -> [Option<u64>; SAMPLES] {
+        let mut bars = [None; SAMPLES];
+        for (time, value) in &self.samples {
+            let age = now.saturating_duration_since(*time).as_secs() / BIN_SECONDS;
+            if age < SAMPLES as u64 {
+                bars[SAMPLES - 1 - age as usize] = value
+                    .map(|(c, m)| if cpu { c } else { m })
+                    .and_then(|v| u64::try_from(v).ok());
+            }
+        }
+        bars
+    }
+}
+
+impl App {
+    fn container_trend_target(&self) -> Option<TrendTarget> {
+        if self.mode != Mode::Containers
+            && !(self.mode == Mode::Command && self.palette_return == Mode::Containers)
+        {
+            return None;
+        }
+        let (ns, pod) = self.container_pod.as_ref()?;
+        let container = self.container_list.get(self.container_state.selected()?)?;
+        let pod_key = format!("{ns}/{pod}");
+        let obj = self.store.get(&pod_key)?;
+        Some(TrendTarget {
+            generation: self.generation,
+            key: format!("{pod_key}/{container}"),
+            uid: obj.metadata.uid.clone(),
+        })
+    }
+
+    pub(super) fn sync_container_history(&mut self) {
+        self.container_history.select(self.container_trend_target());
+    }
+
+    pub(super) fn record_container_history(&mut self, failed: bool) {
+        self.sync_container_history();
+        let value = self.container_history.target.as_ref().and_then(|target| {
+            if failed {
+                None
+            } else {
+                self.container_metrics.get(&target.key).copied()
+            }
+        });
+        self.container_history.record(value, Instant::now());
+    }
+
+    pub(crate) fn container_trend_bars(&self, cpu: bool) -> [Option<u64>; SAMPLES] {
+        if self.container_history.target != self.container_trend_target() {
+            return [None; SAMPLES];
+        }
+        self.container_history.bars(Instant::now(), cpu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn samples_are_bounded_and_missing_values_are_not_zero() {
+        let mut history = ContainerHistory::default();
+        history.select(Some(TrendTarget {
+            generation: 1,
+            key: "ns/pod/app".into(),
+            uid: Some("a".into()),
+        }));
+        let start = Instant::now();
+        for i in 0..100 {
+            history.record(Some((i, i * 2)), start + Duration::from_secs(i as u64 * 5));
+        }
+        assert_eq!(history.samples.len(), 60);
+        let now = start + Duration::from_secs(500);
+        history.record(None, now);
+        let bars = history.bars(now, true);
+        assert_eq!(bars[59], None);
+        assert_eq!(bars[58], Some(99));
+        history.record(Some((0, 0)), now + Duration::from_secs(5));
+        assert_eq!(
+            history.bars(now + Duration::from_secs(5), true)[59],
+            Some(0)
+        );
+        assert_eq!(
+            history.bars(now + Duration::from_secs(400), true),
+            [None; 60]
+        );
+        history.select(Some(TrendTarget {
+            generation: 1,
+            key: "ns/pod/app".into(),
+            uid: Some("b".into()),
+        }));
+        assert!(history.samples.is_empty());
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1954,6 +1954,7 @@ pub struct App {
     pub metrics: HashMap<String, (i64, i64)>,
     /// Latest pod-container metrics: "ns/pod/container" -> (cpu_m, mem_bytes).
     pub container_metrics: HashMap<String, (i64, i64)>,
+    pub(crate) container_history: metrics_history::ContainerHistory,
     /// Latest pod count per node (nodes view PODS column). `None` until the
     /// first successful pods list, so "no data yet" renders as "-" instead of
     /// a misleading 0.
@@ -2247,6 +2248,7 @@ impl App {
             image_target: None,
             metrics: HashMap::new(),
             container_metrics: HashMap::new(),
+            container_history: metrics_history::ContainerHistory::default(),
             node_pods: None,
             pulse: Pulse::default(),
             xray_items: Vec::new(),
@@ -2389,6 +2391,7 @@ mod input;
 mod journal;
 mod lifecycle;
 mod logs;
+mod metrics_history;
 mod mouse;
 mod navigation;
 mod notify;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23637,69 +23637,6 @@ async fn explain_refresh_clears_a_removed_selection_and_blocks_implicit_root_act
 }
 
 #[tokio::test]
-async fn container_gauges_follow_selection_and_missing_metrics() {
-    use ratatui::{Terminal, backend::TestBackend};
-    let (mut app, _rx) = test_app();
-    app.switch_kind("pods");
-    apply(
-        &mut app,
-        json!({"apiVersion":"v1", "kind":"Pod",
-        "metadata":{"name":"api", "namespace":"default"},
-        "spec":{"containers":[
-            {"name":"app", "resources":{"limits":{"cpu":"100m", "memory":"64Mi"}}},
-            {"name":"sidecar", "resources":{"requests":{"cpu":"50m"}, "limits":{"cpu":"0"}}}
-        ]}}),
-    );
-    app.handle_msg(Msg::Metrics {
-        generation: app.generation,
-        data: HashMap::new(),
-        containers: HashMap::from([
-            ("default/api/app".into(), (250, 32 * 1024 * 1024)),
-            ("default/api/sidecar".into(), (0, 0)),
-        ]),
-    });
-    app.handle_key(press(KeyCode::Home)).unwrap();
-    app.handle_key(press(KeyCode::Enter)).unwrap();
-    assert_eq!(app.mode, Mode::Containers);
-    let mut terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
-    let render = |terminal: &mut Terminal<TestBackend>, app: &mut App| {
-        terminal.draw(|f| crate::ui::draw(f, app)).unwrap();
-        terminal
-            .backend()
-            .buffer()
-            .content
-            .iter()
-            .map(|c| c.symbol())
-            .collect::<String>()
-    };
-    let text = render(&mut terminal, &mut app);
-    assert!(text.contains("CPU 250m / limit 100m (250%)"), "{text}");
-    assert!(text.contains("(50%)"));
-    app.handle_key(press(KeyCode::Down)).unwrap();
-    let text = render(&mut terminal, &mut app);
-    assert!(
-        text.contains("CPU 0 / request 50m (0%)") || text.contains("CPU 0m / request 50m (0%)"),
-        "{text}"
-    );
-    assert!(text.contains("no request or limit"));
-    app.handle_msg(Msg::Metrics {
-        generation: app.generation,
-        data: HashMap::new(),
-        containers: HashMap::new(),
-    });
-    assert!(render(&mut terminal, &mut app).contains("CPU unavailable"));
-    app.handle_msg(Msg::MetricsError {
-        generation: app.generation,
-        error: "offline".into(),
-    });
-    assert!(render(&mut terminal, &mut app).contains("[stale]"));
-    for (width, height) in [(1, 1), (20, 8), (80, 24)] {
-        terminal.backend_mut().resize(width, height);
-        crate::ui::resize(&mut terminal, &mut app).unwrap();
-    }
-}
-
-#[tokio::test]
 async fn container_trends_follow_keys_and_reject_stale_samples() {
     use ratatui::{Terminal, backend::TestBackend};
     let (mut app, _rx) = test_app();
@@ -23736,6 +23673,25 @@ async fn container_trends_follow_keys_and_reject_stale_samples() {
         .collect();
     assert!(text.contains("last 5 min, 5 s bins"));
     assert!(text.contains("CPU 0..100m"));
+    assert!(!text.contains(" / limit "));
+    assert!(!text.contains(" / request "));
+    let buffer = terminal.backend().buffer();
+    let heading_y = (0..40)
+        .find(|&y| {
+            (0..160)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+                .contains("last 5 min")
+        })
+        .unwrap();
+    let rows_above: String = (0..160)
+        .map(|x| buffer[(x, heading_y - 1)].symbol())
+        .collect();
+    assert!(
+        rows_above.contains("sidecar"),
+        "the charts must follow the table without gauges or empty rows"
+    );
+
     app.handle_key(press(KeyCode::Down)).unwrap();
     assert_eq!(app.container_trend_bars(true), [None; 60]);
     app.handle_msg(metrics(app.generation));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23698,3 +23698,66 @@ async fn container_gauges_follow_selection_and_missing_metrics() {
         crate::ui::resize(&mut terminal, &mut app).unwrap();
     }
 }
+
+#[tokio::test]
+async fn container_trends_follow_keys_and_reject_stale_samples() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let pod = |uid: &str| {
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"api", "namespace":"default", "uid":uid},
+        "spec":{"containers":[{"name":"app"}, {"name":"sidecar"}]}})
+    };
+    apply(&mut app, pod("first"));
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Containers);
+    let metrics = |generation| Msg::Metrics {
+        generation,
+        data: HashMap::new(),
+        containers: HashMap::from([
+            ("default/api/app".into(), (100, 2000)),
+            ("default/api/sidecar".into(), (0, 0)),
+        ]),
+    };
+    app.handle_msg(metrics(app.generation.wrapping_sub(1)));
+    assert_eq!(app.container_trend_bars(true), [None; 60]);
+    app.handle_msg(metrics(app.generation));
+    assert_eq!(app.container_trend_bars(true)[59], Some(100));
+    let mut terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    let text: String = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|c| c.symbol())
+        .collect();
+    assert!(text.contains("last 5 min, 5 s bins"));
+    assert!(text.contains("CPU 0..100m"));
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    assert_eq!(app.container_trend_bars(true), [None; 60]);
+    app.handle_msg(metrics(app.generation));
+    assert_eq!(app.container_trend_bars(true)[59], Some(0));
+    app.handle_msg(Msg::MetricsError {
+        generation: app.generation,
+        error: "offline".into(),
+    });
+    assert_eq!(app.container_trend_bars(true)[59], None);
+    app.handle_msg(metrics(app.generation));
+    apply(&mut app, pod("replacement"));
+    assert_eq!(app.container_trend_bars(true), [None; 60]);
+    app.handle_msg(metrics(app.generation));
+    app.handle_msg(Msg::Deleted {
+        generation: app.generation,
+        key: "default/api".into(),
+    });
+    assert_eq!(app.container_trend_bars(true), [None; 60]);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.container_trend_bars(true), [None; 60]);
+    for (width, height) in [(3, 3), (60, 12), (160, 40)] {
+        terminal.backend_mut().resize(width, height);
+        crate::ui::resize(&mut terminal, &mut app).unwrap();
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23635,3 +23635,66 @@ async fn explain_refresh_clears_a_removed_selection_and_blocks_implicit_root_act
     assert!(app.detail.title.starts_with("web"));
     app.handle_key(ctrl(KeyCode::Char('c'))).unwrap();
 }
+
+#[tokio::test]
+async fn container_gauges_follow_selection_and_missing_metrics() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"api", "namespace":"default"},
+        "spec":{"containers":[
+            {"name":"app", "resources":{"limits":{"cpu":"100m", "memory":"64Mi"}}},
+            {"name":"sidecar", "resources":{"requests":{"cpu":"50m"}, "limits":{"cpu":"0"}}}
+        ]}}),
+    );
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::new(),
+        containers: HashMap::from([
+            ("default/api/app".into(), (250, 32 * 1024 * 1024)),
+            ("default/api/sidecar".into(), (0, 0)),
+        ]),
+    });
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Containers);
+    let mut terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
+    let render = |terminal: &mut Terminal<TestBackend>, app: &mut App| {
+        terminal.draw(|f| crate::ui::draw(f, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<String>()
+    };
+    let text = render(&mut terminal, &mut app);
+    assert!(text.contains("CPU 250m / limit 100m (250%)"), "{text}");
+    assert!(text.contains("(50%)"));
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    let text = render(&mut terminal, &mut app);
+    assert!(
+        text.contains("CPU 0 / request 50m (0%)") || text.contains("CPU 0m / request 50m (0%)"),
+        "{text}"
+    );
+    assert!(text.contains("no request or limit"));
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::new(),
+        containers: HashMap::new(),
+    });
+    assert!(render(&mut terminal, &mut app).contains("CPU unavailable"));
+    app.handle_msg(Msg::MetricsError {
+        generation: app.generation,
+        error: "offline".into(),
+    });
+    assert!(render(&mut terminal, &mut app).contains("[stale]"));
+    for (width, height) in [(1, 1), (20, 8), (80, 24)] {
+        terminal.backend_mut().resize(width, height);
+        crate::ui::resize(&mut terminal, &mut app).unwrap();
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,8 +6,8 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
-    Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
-    Paragraph, Row, Table,
+    Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, LineGauge, List, ListItem,
+    ListState, Paragraph, Row, Table,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -3378,7 +3378,7 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     // +2 borders, +1 so the last column doesn't touch the right border.
     let popup_w = (inner_w as u16 + 3).min(area.width);
     let rows = app.container_list.len() as u16;
-    let popup_h = (rows + 3).clamp(5, area.height); // header + rows + 2 borders
+    let popup_h = rows.saturating_add(5).max(7).min(area.height);
 
     let popup = centered_rect_exact(popup_w, popup_h, area);
     clear_region(frame, popup);
@@ -3392,8 +3392,17 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
-    let [header_area, list_area] =
-        Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(inner);
+    let gauge_height = if inner.height >= 4 && inner.width >= 44 {
+        2
+    } else {
+        0
+    };
+    let [header_area, list_area, gauge_area] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(gauge_height),
+    ])
+    .areas(inner);
     // Indent the header past the 2-column highlight gutter so it lines up with
     // the rows underneath it.
     frame.render_widget(
@@ -3409,6 +3418,80 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         .highlight_symbol("▌ ")
         .highlight_spacing(HighlightSpacing::Always);
     frame.render_stateful_widget(list, list_area, &mut app.container_state);
+    if gauge_height > 0 {
+        draw_container_gauges(frame, app, gauge_area);
+    }
+}
+
+fn draw_container_gauges(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(container) = app
+        .container_state
+        .selected()
+        .and_then(|i| app.container_list.get(i))
+    else {
+        return;
+    };
+    let usage = app.selected_pod_container_metrics(container);
+    let resources = app
+        .container_resources
+        .get(container)
+        .cloned()
+        .unwrap_or_default();
+    for (row, label, value, request, limit, format) in [
+        (
+            0,
+            "CPU",
+            usage.map(|u| u.0),
+            resources.cpu_request,
+            resources.cpu_limit,
+            crate::columns::fmt_cpu as fn(i64) -> String,
+        ),
+        (
+            1,
+            "MEM",
+            usage.map(|u| u.1),
+            resources.mem_request,
+            resources.mem_limit,
+            crate::columns::fmt_mem as fn(i64) -> String,
+        ),
+    ] {
+        let denominator = limit
+            .filter(|v| *v > 0)
+            .map(|v| ("limit", v))
+            .or_else(|| request.filter(|v| *v > 0).map(|v| ("request", v)));
+        let pct = value.and_then(|v| crate::columns::usage_pct(v, denominator.map(|d| d.1)));
+        let value_label = value
+            .map(|v| {
+                if v == 0 {
+                    if label == "CPU" {
+                        "0m".into()
+                    } else {
+                        "0B".into()
+                    }
+                } else {
+                    format(v)
+                }
+            })
+            .unwrap_or_else(|| "unavailable".into());
+        let base_label = denominator
+            .map(|(kind, v)| format!("{kind} {}", format(v)))
+            .unwrap_or_else(|| "no request or limit".into());
+        let percent = pct.map(|v| format!(" ({v}%)")).unwrap_or_default();
+        let stale = if app.metrics_error.is_some() {
+            " [stale]"
+        } else {
+            ""
+        };
+        let label = format!("{label} {value_label} / {base_label}{percent}{stale} ");
+        let gauge = LineGauge::default()
+            .label(label)
+            .ratio(pct.map_or(0.0, |p| (p as f64 / 100.0).clamp(0.0, 1.0)))
+            .filled_style(
+                Style::default().fg(util_color(pct, app.resolved_thresholds().utilization)),
+            )
+            .unfilled_style(theme::dim());
+        frame.render_widget(gauge, Rect::new(area.x, area.y + row, area.width, 1));
+    }
 }
 
 fn draw_prompt_popup(frame: &mut Frame, app: &App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,8 +6,8 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
-    Block, BorderType, Borders, Clear, Gauge, HighlightSpacing, LineGauge, List, ListItem,
-    ListState, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Sparkline,
+    Block, BorderType, Borders, Clear, Gauge, HighlightSpacing, List, ListItem, ListState,
+    Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Sparkline,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -3434,7 +3434,12 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     // +2 borders, +1 so the last column doesn't touch the right border.
     let popup_w = (inner_w as u16 + 3).min(area.width);
     let rows = app.container_list.len() as u16;
-    let popup_h = rows.saturating_add(8).max(10).min(area.height);
+    let trend_height = if popup_w >= 80 && area.height >= 7 && rows > 0 {
+        3
+    } else {
+        0
+    };
+    let popup_h = rows.saturating_add(3 + trend_height).min(area.height);
 
     let popup = centered_rect_exact(popup_w, popup_h, area);
     clear_region(frame, popup);
@@ -3448,20 +3453,9 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
-    let gauge_height = if inner.height >= 4 && inner.width >= 44 {
-        2
-    } else {
-        0
-    };
-    let trend_height = if inner.height >= 7 && inner.width >= 78 {
-        3
-    } else {
-        0
-    };
-    let [header_area, list_area, gauge_area, trend_area] = Layout::vertical([
+    let [header_area, list_area, trend_area] = Layout::vertical([
         Constraint::Length(1),
         Constraint::Min(1),
-        Constraint::Length(gauge_height),
         Constraint::Length(trend_height),
     ])
     .areas(inner);
@@ -3494,9 +3488,6 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         usize::from(list_area.height),
         false,
     );
-    if gauge_height > 0 {
-        draw_container_gauges(frame, app, gauge_area);
-    }
     if trend_height > 0 {
         draw_container_trends(frame, app, trend_area);
     }
@@ -3534,77 +3525,6 @@ fn draw_container_trends(frame: &mut Frame, app: &App, area: Rect) {
             .absent_value_symbol("·")
             .absent_value_style(theme::dim());
         frame.render_widget(sparkline, Rect::new(area.x + 18, area.y + row, 60, 1));
-    }
-}
-
-fn draw_container_gauges(frame: &mut Frame, app: &App, area: Rect) {
-    let Some(container) = app
-        .container_state
-        .selected()
-        .and_then(|i| app.container_list.get(i))
-    else {
-        return;
-    };
-    let usage = app.selected_pod_container_metrics(container);
-    let resources = app
-        .container_resources
-        .get(container)
-        .cloned()
-        .unwrap_or_default();
-    for (row, label, value, request, limit, format) in [
-        (
-            0,
-            "CPU",
-            usage.map(|u| u.0),
-            resources.cpu_request,
-            resources.cpu_limit,
-            crate::columns::fmt_cpu as fn(i64) -> String,
-        ),
-        (
-            1,
-            "MEM",
-            usage.map(|u| u.1),
-            resources.mem_request,
-            resources.mem_limit,
-            crate::columns::fmt_mem as fn(i64) -> String,
-        ),
-    ] {
-        let denominator = limit
-            .filter(|v| *v > 0)
-            .map(|v| ("limit", v))
-            .or_else(|| request.filter(|v| *v > 0).map(|v| ("request", v)));
-        let pct = value.and_then(|v| crate::columns::usage_pct(v, denominator.map(|d| d.1)));
-        let value_label = value
-            .map(|v| {
-                if v == 0 {
-                    if label == "CPU" {
-                        "0m".into()
-                    } else {
-                        "0B".into()
-                    }
-                } else {
-                    format(v)
-                }
-            })
-            .unwrap_or_else(|| "unavailable".into());
-        let base_label = denominator
-            .map(|(kind, v)| format!("{kind} {}", format(v)))
-            .unwrap_or_else(|| "no request or limit".into());
-        let percent = pct.map(|v| format!(" ({v}%)")).unwrap_or_default();
-        let stale = if app.metrics_error.is_some() {
-            " [stale]"
-        } else {
-            ""
-        };
-        let label = format!("{label} {value_label} / {base_label}{percent}{stale} ");
-        let gauge = LineGauge::default()
-            .label(label)
-            .ratio(pct.map_or(0.0, |p| (p as f64 / 100.0).clamp(0.0, 1.0)))
-            .filled_style(
-                Style::default().fg(util_color(pct, app.resolved_thresholds().utilization)),
-            )
-            .unfilled_style(theme::dim());
-        frame.render_widget(gauge, Rect::new(area.x, area.y + row, area.width, 1));
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,7 +7,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
     Block, BorderType, Borders, Cell, Clear, Gauge, HighlightSpacing, LineGauge, List, ListItem,
-    ListState, Paragraph, Row, Table,
+    ListState, Paragraph, Row, Sparkline, Table,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -3374,11 +3374,12 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         + C_GAP + C_MEM_PCT;
     let inner_w = content_w
         .max(title.chars().count())
-        .max(footer.chars().count());
+        .max(footer.chars().count())
+        .max(78);
     // +2 borders, +1 so the last column doesn't touch the right border.
     let popup_w = (inner_w as u16 + 3).min(area.width);
     let rows = app.container_list.len() as u16;
-    let popup_h = rows.saturating_add(5).max(7).min(area.height);
+    let popup_h = rows.saturating_add(8).max(10).min(area.height);
 
     let popup = centered_rect_exact(popup_w, popup_h, area);
     clear_region(frame, popup);
@@ -3397,10 +3398,16 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         0
     };
-    let [header_area, list_area, gauge_area] = Layout::vertical([
+    let trend_height = if inner.height >= 7 && inner.width >= 78 {
+        3
+    } else {
+        0
+    };
+    let [header_area, list_area, gauge_area, trend_area] = Layout::vertical([
         Constraint::Length(1),
         Constraint::Min(1),
         Constraint::Length(gauge_height),
+        Constraint::Length(trend_height),
     ])
     .areas(inner);
     // Indent the header past the 2-column highlight gutter so it lines up with
@@ -3420,6 +3427,44 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_stateful_widget(list, list_area, &mut app.container_state);
     if gauge_height > 0 {
         draw_container_gauges(frame, app, gauge_area);
+    }
+    if trend_height > 0 {
+        draw_container_trends(frame, app, trend_area);
+    }
+}
+
+fn draw_container_trends(frame: &mut Frame, app: &App, area: Rect) {
+    frame.render_widget(
+        Line::styled(
+            "Selected container: last 5 min, 5 s bins; · = no sample",
+            theme::dim(),
+        ),
+        Rect::new(area.x, area.y, area.width, 1),
+    );
+    for (row, cpu, name, color) in [
+        (1, true, "CPU", theme::yellow()),
+        (2, false, "MEM", theme::teal()),
+    ] {
+        let bars = app.container_trend_bars(cpu);
+        let maximum = bars.iter().flatten().copied().max().unwrap_or(0);
+        let scale = if cpu {
+            format!("{maximum}m")
+        } else if maximum == 0 {
+            "0B".into()
+        } else {
+            crate::columns::fmt_mem(maximum as i64)
+        };
+        frame.render_widget(
+            Line::styled(format!("{name} 0..{scale}"), theme::dim()),
+            Rect::new(area.x, area.y + row, 18, 1),
+        );
+        let sparkline = Sparkline::default()
+            .data(bars)
+            .max(maximum.max(1))
+            .style(Style::default().fg(color))
+            .absent_value_symbol("·")
+            .absent_value_style(theme::dim());
+        frame.render_widget(sparkline, Rect::new(area.x + 18, area.y + row, 60, 1));
     }
 }
 


### PR DESCRIPTION
Add CPU and memory trend charts below the container table. The table shows current values and percentages; the charts show recent history. Remove the separate gauges so the popup does not repeat the same values or reserve extra rows.

Keep at most 60 samples from the existing metrics polls. Each chart covers five minutes in five-second bins, with the newest sample on the right. Dots mark missing samples, and each chart shows its scale. History clears when the selected container, watch generation, or pod UID changes. The charts hide when the terminal is too small.

Validation: formatter, Clippy, and the full test suite passed. Tests cover bounded history, gaps, zero values, stale generations, selection changes, pod replacement and deletion, resize, and charts placed directly below the table.

Closes #438
