### PR TITLE
perf: cache the formatted help screen

### DIFF
--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -648,8 +648,37 @@ fn table_frames(c: &mut Criterion) {
     group.finish();
 }
 
+fn help_frames(c: &mut Criterion) {
+    let mut group = c.benchmark_group("help_frames");
+    for width in [80, 160] {
+        for filter in ["", "namespace"] {
+            let (mut app, _rx) = bs::pods_app(1);
+            app.handle_key(crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Char('?'),
+                crossterm::event::KeyModifiers::NONE,
+            ))
+            .unwrap();
+            app.help_filter = filter.into();
+            let mut terminal =
+                ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, 40)).unwrap();
+            terminal
+                .draw(|frame| sofka::ui::draw(frame, &mut app))
+                .unwrap();
+            group.bench_function(format!("{width}/{filter}"), |b| {
+                b.iter(|| {
+                    terminal
+                        .draw(|frame| sofka::ui::draw(frame, &mut app))
+                        .unwrap();
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
+    help_frames,
     table_frames,
     rows_cache,
     filter,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1729,6 +1729,7 @@ pub struct App {
     /// Search query for the help view (`?`), which has no backing
     /// [`Scrollable`] — its lines are built at render time.
     pub help_filter: String,
+    pub(crate) help_cache: Option<crate::ui::HelpCache>,
     /// Which view help was opened from, so closing it returns to that view.
     pub help_return: Mode,
     /// First visible line of the help view (`?`).
@@ -2149,6 +2150,7 @@ impl App {
             explain_refresh_source: None,
             explain_task: None,
             help_filter: String::new(),
+            help_cache: None,
             help_return: Mode::Table,
             help_scroll: 0,
             help_max_scroll: 0,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2457,7 +2457,7 @@ fn wrap_help_span(span: Span<'static>, width: usize, needle: &str) -> Vec<Line<'
     rows
 }
 
-fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
+fn build_help(app: &App, width: usize) -> (Vec<Line<'static>>, String) {
     let bind = |k: &str, d: &str| {
         Line::from(vec![
             Span::styled(k.to_string(), Style::default().fg(theme::yellow())),
@@ -2643,7 +2643,6 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
         app.keymap.label("help", Action::Close),
         "close help and return to the previous screen",
     ));
-    let width = usize::from(area.width.saturating_sub(2)).max(1);
     let key_width = lines
         .iter()
         .filter(|line| line.spans.len() == 2)
@@ -2717,13 +2716,61 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
                 .collect()
         })
         .collect();
+    (lines, title)
+}
+
+pub(crate) struct HelpCache {
+    key: u64,
+    lines: Vec<Line<'static>>,
+    title: String,
+}
+
+fn help_cache_key(app: &App, width: usize) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hash = std::collections::hash_map::DefaultHasher::new();
+    (
+        width,
+        &app.help_filter,
+        theme::yellow(),
+        theme::crust(),
+        theme::dim(),
+        theme::title(),
+    )
+        .hash(&mut hash);
+    for (scope, action, _) in app.keymap.entries() {
+        (scope, action.name(), app.keymap.label(scope, action)).hash(&mut hash);
+    }
+    app.plugins.len().hash(&mut hash);
+    for plugin in &app.plugins {
+        (&plugin.key, &plugin.palette, &plugin.scopes, &plugin.name).hash(&mut hash);
+    }
+    app.bookmarks.len().hash(&mut hash);
+    for bookmark in &app.bookmarks {
+        (&bookmark.key, &bookmark.name).hash(&mut hash);
+    }
+    app.workspaces.len().hash(&mut hash);
+    for workspace in &app.workspaces {
+        (&workspace.key, &workspace.name, workspace.views.len()).hash(&mut hash);
+    }
+    hash.finish()
+}
+
+fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
+    let width = usize::from(area.width.saturating_sub(2)).max(1);
+    let key = help_cache_key(app, width);
+    if app.help_cache.as_ref().is_none_or(|cache| cache.key != key) {
+        let (lines, title) = build_help(app, width);
+        app.help_cache = Some(HelpCache { key, lines, title });
+    }
+    let cache = app.help_cache.as_ref().expect("help content is ready");
     // Record the content height for paging and clamp the offset after layout changes.
     let inner_h = area.height.saturating_sub(2);
     app.help_viewport_h = inner_h;
-    let max_scroll = (lines.len() as u16).saturating_sub(inner_h);
+    let max_scroll = (cache.lines.len().min(usize::from(u16::MAX)) as u16).saturating_sub(inner_h);
     app.help_max_scroll = max_scroll;
     let scroll = app.help_scroll.min(max_scroll);
     app.help_scroll = scroll;
+    let title = &cache.title;
     let title = if max_scroll > 0 {
         format!(
             "{title} {} ",
@@ -2734,18 +2781,24 @@ fn draw_help(frame: &mut Frame, app: &mut App, area: Rect) {
             )
         )
     } else {
-        title
+        title.clone()
     };
-    frame.render_widget(
-        Paragraph::new(lines).scroll((scroll, 0)).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(theme::border_focused())
-                .title(Span::styled(title, theme::title())),
-        ),
-        area,
-    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(theme::border_focused())
+        .title(Span::styled(title, theme::title()));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    for (y, line) in cache
+        .lines
+        .iter()
+        .skip(usize::from(scroll))
+        .take(usize::from(inner.height))
+        .enumerate()
+    {
+        frame.render_widget(line, Rect::new(inner.x, inner.y + y as u16, inner.width, 1));
+    }
 }
 
 fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -4517,6 +4570,68 @@ mod tests {
         assert!(clipped.ends_with('…'));
         // No room even for the ellipsis.
         assert_eq!(clip_to_width("abc", 0), "");
+    }
+
+    #[tokio::test]
+    async fn help_cache_tracks_inputs_and_reuses_lines_when_scrolling() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use ratatui::{Terminal, backend::TestBackend};
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let mut app = App::new(crate::k8s::Cluster::fake(), tx);
+        let key = |c| KeyEvent::new(c, KeyModifiers::NONE);
+        app.handle_key(key(KeyCode::Char('?'))).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let initial = app.help_cache.as_ref().unwrap().lines.as_ptr();
+        app.handle_key(key(KeyCode::Down)).unwrap();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        assert_eq!(initial, app.help_cache.as_ref().unwrap().lines.as_ptr());
+        for step in 0..7 {
+            match step {
+                0 => app.plugins.push(crate::config::Plugin {
+                    name: "plugin sample".into(),
+                    key: "ctrl-p".into(),
+                    ..Default::default()
+                }),
+                1 => app.bookmarks.push(crate::config::Bookmark {
+                    name: "bookmark sample".into(),
+                    ..Default::default()
+                }),
+                2 => app.workspaces.push(crate::config::Workspace {
+                    name: "workspace sample".into(),
+                    ..Default::default()
+                }),
+                3 => app.workspaces[0]
+                    .views
+                    .push(crate::config::WorkspaceView::default()),
+                4 => {
+                    let cfg: crate::config::Config =
+                        toml::from_str("[keys.table]\nlogs = [\"ctrl-l\"]").unwrap();
+                    app.keymap = crate::keymap::Keymap::compile(&cfg.keys).unwrap();
+                }
+                5 => {
+                    app.handle_key(key(KeyCode::Char('/'))).unwrap();
+                    for c in "sample".chars() {
+                        app.handle_key(key(KeyCode::Char(c))).unwrap();
+                    }
+                    app.handle_key(key(KeyCode::Enter)).unwrap();
+                }
+                _ => terminal.backend_mut().resize(60, 30),
+            }
+            let previous_key = app.help_cache.as_ref().unwrap().key;
+            terminal.draw(|f| draw(f, &mut app)).unwrap();
+            let width = usize::from(terminal.backend().buffer().area.width.saturating_sub(2));
+            let cache = app.help_cache.as_ref().unwrap();
+            assert_ne!(previous_key, cache.key, "step {step}");
+            assert_eq!(
+                (cache.lines.clone(), cache.title.clone()),
+                build_help(&app, width)
+            );
+            let cached = terminal.backend().buffer().clone();
+            app.help_cache = None;
+            terminal.draw(|f| draw(f, &mut app)).unwrap();
+            assert_eq!(&cached, terminal.backend().buffer());
+        }
     }
 
     #[test]


### PR DESCRIPTION
The help screen previously rebuilt, filtered, and wrapped all entries on each frame. Cache one formatted layout for the current width, search text, colors, key bindings, plugins, bookmarks, and workspaces. Render only visible lines by reference.

Validation:
- The 21 help-related tests passed, including cache reuse while scrolling and refresh after input changes.
- Formatter, Clippy, and the full test suite passed in the commit hooks.
- TestBackend benchmarks showed lower repeated-frame times in all four cases:

| Width | Filter | Before | After |
| --- | --- | --- | --- |
| 80 | none | 506.96 µs | 109.08 µs |
| 80 | namespace | 214.78 µs | 162.76 µs |
| 160 | none | 544.79 µs | 232.17 µs |
| 160 | namespace | 258.34 µs | 211.32 µs |

These local measurements exclude a live terminal and cluster. The cache retains one layout and replaces it when its inputs change.

Closes #439
