### PR TITLE
fix: keep authentication errors inside the terminal interface

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11663,6 +11663,75 @@ async fn expired_sso_keeps_context_picker_usable() {
     assert_eq!(app.mode, Mode::Command);
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn expired_exec_credentials_show_login_instructions_in_metrics_diagnostics() {
+    for (provider_error, instruction) in [
+        ("SSO session expired", "aws sso login"),
+        (
+            "Provider session expired",
+            "Log in with your credential provider",
+        ),
+    ] {
+        let marker = std::env::temp_dir().join(format!(
+            "sofka-exec-refresh-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut config = kube::Config::new("https://127.0.0.1:1".parse().unwrap());
+        config.auth_info.exec = Some(
+            serde_json::from_value(json!({
+                "command": "sh",
+                "args": ["-c", r#"
+if test -f "$1"; then
+    cat "$1" >&2
+    exit 1
+fi
+printf '%s' '{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","status":{"token":"test-token","expirationTimestamp":"2000-01-01T00:00:00Z"}}'
+"#, "sofka-exec-refresh", marker.to_str().unwrap()]
+            }))
+            .unwrap(),
+        );
+        let client = crate::k8s::build_client(config, false).unwrap();
+        std::fs::write(
+            &marker,
+            format!("{provider_error}: private-provider-output"),
+        )
+        .unwrap();
+        let ar = kube::discovery::ApiResource::from_gvk(&kube::core::GroupVersionKind::gvk(
+            "metrics.k8s.io",
+            "v1beta1",
+            "PodMetrics",
+        ));
+        let api: kube::Api<kube::core::DynamicObject> = kube::Api::all_with(client, &ar);
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            api.list(&kube::api::ListParams::default()),
+        )
+        .await;
+        std::fs::remove_file(&marker).unwrap();
+        let error = result.unwrap().unwrap_err().to_string();
+        assert!(error.contains(instruction), "{error}");
+        assert!(!error.contains("private-provider-output"), "{error}");
+
+        let (mut app, _rx) = test_app();
+        app.handle_msg(Msg::MetricsError {
+            generation: app.generation,
+            error,
+        });
+        for ch in ":info".chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        let text = info_text(&app);
+        assert!(text.contains(instruction), "{text}");
+        assert!(!text.contains("private-provider-output"), "{text}");
+    }
+}
+
 #[tokio::test]
 async fn reselecting_never_connected_context_retries() {
     let (mut app, _rx) = test_app();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11639,6 +11639,30 @@ async fn disconnected_start_opens_context_picker() {
     assert!(app.flash.contains("Connection refused"), "{}", app.flash);
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn expired_sso_keeps_context_picker_usable() {
+    let mut config = kube::Config::new("https://127.0.0.1:1".parse().unwrap());
+    config.auth_info.exec = Some(
+        serde_json::from_value(json!({
+            "command": "sh",
+            "args": ["-c", "echo 'SSO session expired' >&2; exit 1"]
+        }))
+        .unwrap(),
+    );
+    let error = crate::k8s::build_client(config, false).err().unwrap();
+    let (mut app, _rx) = test_app();
+    app.cluster.connected = false;
+    app.start_disconnected(&error.to_string());
+    assert_eq!(app.mode, Mode::Contexts);
+    assert!(app.flash_err);
+    assert!(app.flash.contains("aws sso login"), "{}", app.flash);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert_eq!(app.mode, Mode::Command);
+}
+
 #[tokio::test]
 async fn reselecting_never_connected_context_retries() {
     let (mut app, _rx) = test_app();

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -53,7 +53,17 @@ pub(crate) fn build_client(mut config: Config, allow_v1_client_cert: bool) -> Re
             }
             request
         });
-    Ok(builder.with_layer(&layer).with_layer(&MeterLayer).build())
+    let auth_errors = tower::util::MapErrLayer::new(|error: tower::BoxError| -> tower::BoxError {
+        match exec_auth_message(error.as_ref()) {
+            Some(message) => std::io::Error::other(message).into(),
+            None => error,
+        }
+    });
+    Ok(builder
+        .with_layer(&layer)
+        .with_layer(&auth_errors)
+        .with_layer(&MeterLayer)
+        .build())
 }
 
 fn exec_auth_message(error: &(dyn std::error::Error + 'static)) -> Option<String> {
@@ -849,7 +859,7 @@ fn spawn_watch_task(
                     crate::log_warn!("watch.error", kind = kind, error = e);
                     Msg::Error {
                         generation,
-                        error: exec_auth_message(&e).unwrap_or_else(|| e.to_string()),
+                        error: e.to_string(),
                     }
                 }
             };

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -26,8 +26,18 @@ use crate::store::{Msg, row_key};
 mod discovery;
 mod proxy;
 
-pub(crate) fn build_client(config: Config, allow_v1_client_cert: bool) -> Result<Client> {
-    let builder = crate::legacy_tls::client_builder(config, allow_v1_client_cert)?;
+pub(crate) fn build_client(mut config: Config, allow_v1_client_cert: bool) -> Result<Client> {
+    if let Some(exec) = &mut config.auth_info.exec {
+        // Authentication commands must not read from or write to the TUI terminal.
+        exec.interactive_mode = Some(kube::config::ExecInteractiveMode::Never);
+    }
+    let builder =
+        crate::legacy_tls::client_builder(config, allow_v1_client_cert).map_err(|error| {
+            match exec_auth_message(error.as_ref()) {
+                Some(message) => anyhow::anyhow!(message),
+                None => error,
+            }
+        })?;
     let layer =
         tower::util::MapRequestLayer::new(|mut request: http::Request<kube::client::Body>| {
             let watch = request.uri().query().is_some_and(|query| {
@@ -44,6 +54,26 @@ pub(crate) fn build_client(config: Config, allow_v1_client_cert: bool) -> Result
             request
         });
     Ok(builder.with_layer(&layer).with_layer(&MeterLayer).build())
+}
+
+fn exec_auth_message(error: &(dyn std::error::Error + 'static)) -> Option<String> {
+    let mut source = Some(error);
+    while let Some(error) = source {
+        if let Some(kube::client::AuthError::AuthExecRun { out, .. }) =
+            error.downcast_ref::<kube::client::AuthError>()
+        {
+            let stderr = String::from_utf8_lossy(&out.stderr).to_ascii_lowercase();
+            return Some(if stderr.contains("sso") {
+                "Authentication failed. Run 'aws sso login' for the active AWS profile, then retry."
+                    .into()
+            } else {
+                "Authentication command failed. Log in with your credential provider, then retry."
+                    .into()
+            });
+        }
+        source = error.source();
+    }
+    None
 }
 
 /// Times every Kubernetes API request into [`crate::diagnostics`] and, at
@@ -819,7 +849,7 @@ fn spawn_watch_task(
                     crate::log_warn!("watch.error", kind = kind, error = e);
                     Msg::Error {
                         generation,
-                        error: e.to_string(),
+                        error: exec_auth_message(&e).unwrap_or_else(|| e.to_string()),
                     }
                 }
             };
@@ -1078,6 +1108,52 @@ impl Cluster {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_auth_failure_is_captured_for_all_interactive_modes() {
+        for mode in [None, Some("IfAvailable"), Some("Always"), Some("Never")] {
+            let mut config = kube::Config::new("https://127.0.0.1:1".parse().unwrap());
+            config.auth_info.exec = Some(
+                serde_json::from_value(serde_json::json!({
+                    "command": "sh",
+                    "args": ["-c", "case \"$KUBERNETES_EXEC_INFO\" in *'\"interactive\":false'*) echo 'SSO session expired' >&2 ;; *) echo 'unexpected interactive mode' >&2 ;; esac; exit 1"],
+                    "interactiveMode": mode
+                }))
+                .unwrap(),
+            );
+            let error = super::build_client(config, false).err().unwrap();
+            assert_eq!(
+                error.to_string(),
+                "Authentication failed. Run 'aws sso login' for the active AWS profile, then retry.",
+                "mode: {mode:?}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn watch_auth_failure_has_a_login_hint() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let error = kube::runtime::watcher::Error::WatchStartFailed(kube::Error::Auth(
+            kube::client::AuthError::AuthExecRun {
+                cmd: "aws".into(),
+                status: std::process::ExitStatus::from_raw(256),
+                out: std::process::Output {
+                    status: std::process::ExitStatus::from_raw(256),
+                    stdout: vec![],
+                    stderr: b"Error loading SSO Token: Token has expired".to_vec(),
+                },
+            },
+        ));
+        assert!(
+            super::exec_auth_message(&error)
+                .unwrap()
+                .contains("aws sso login")
+        );
+        assert!(super::exec_auth_message(&std::io::Error::other("connection refused")).is_none());
+    }
+
     use super::*;
 
     fn probe_cluster(streaming: bool, status: u16, delay: Duration) -> Cluster {


### PR DESCRIPTION
Expired authentication sessions could let Kubernetes credential commands write repeated errors directly to the terminal and damage the interface. Run these commands without terminal input or output, and show a login instruction in the interface when a command fails at startup or during any client request. The shared client handles credential refresh failures before they reach metrics diagnostics or other application handlers.

This applies to all Kubernetes exec authentication providers. Errors that mention SSO show an `aws sso login` instruction. Other failures show a general credential provider login instruction. Interactive login must take place outside sofka.

Validation: `just check` and the commit hooks passed. Four regression tests cover authentication settings, watch errors, keyboard use after an SSO failure, and metrics diagnostics after credential expiry for AWS SSO and a general provider error. Live AWS SSO validation was not run.

Closes #454
