### PR TITLE
feat: add age sort, namespace, and log marker shortcuts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ not reset the current compact mode. With `hide_header = true`, the compact
 header is hidden too. Command and filter input still appears when needed.
 
 `remember_sort` is enabled by default. Set it to `false` to stop saving and
-restoring sort choices from `S`, `I`, and column header clicks. Existing saved
+restoring sort choices from `S`, `A`, `I`, and column header clicks. Existing saved
 choices stay on disk and become available again when you enable the option.
 The option supports cluster and context overrides and `:reload`. A reload
 keeps the active sort; the option controls later sort changes and view starts.
@@ -93,6 +93,19 @@ To change or disable a shortcut, use the existing key configuration:
 favorite_namespace_1 = "f1"
 favorite_namespace_2 = []
 ```
+
+The age sort, selected namespace, and log marker actions can also be changed:
+
+```toml
+[keys.table]
+sort_age = "A"
+namespace_selected = "W"
+
+[keys.logs]
+log_marker = "m"
+```
+
+Use `[]` to disable an action. Custom keys use the normal conflict checks.
 
 ## Skins
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -179,6 +179,11 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   Unconfigured slots do nothing. `0` selects all namespaces. The
   last namespace picked in each context is remembered across restarts
   (`<state-dir>/namespaces.toml`); `-n`/`-A` override it for a session.
+- **Selected namespace** (`W`) switches to the cursor row's namespace and
+  keeps the resource kind. It uses normal namespace history and watch behavior.
+  Rows without a namespace show a status message.
+- **Sort by age** (`A`) selects `AGE` with the same direction as the sort picker.
+  Press it again to invert. If `AGE` is absent, the current sort stays active.
 - **Default sort** - `[views."*"].sort` sets a global initial sort, with
   resource-specific overrides. Sort choices are saved per kind by default.
   Set `remember_sort = false` to make user sort changes temporary.
@@ -352,6 +357,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   retries until its logs are available. sofka parses ANSI color from the source app
   and maps it onto the active skin instead of printing literal escapes. See
   [Log controls](debugging.md#log-controls).
+- **Log markers** (`m` in logs) add visual separators at the buffer tail.
+  Markers stay visible through filters, do not move a paused viewport, and are
+  excluded from sofka copy/save. Clearing or replacing the buffer removes them.
+  Their storage is bounded by the active log buffer cap.
 - **VictoriaLogs integration** (`L` / `:vlogs`) - log history from a
   VictoriaLogs backend for a pod, container, workload, service, or whole
   namespace, covering restarted and deleted pods. Zero config: sofka finds the

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -33,12 +33,14 @@ for the grammar and selector persistence rules.
 | `j`/`k`, `↓`/`↑`, `g`/`G`                     | navigate                                                                                                                                                            |
 | `ctrl-f` / `ctrl-b`, `PgDn` / `PgUp`          | page forward / back - one screenful at a time                                                                                                                       |
 | `S` / `I`                                     | sort-column picker (fuzzy; ⏎ on the active column inverts) / invert sort direction; saved per kind by default (`remember_sort = false` disables this)               |
+| `A`                                           | sort by `AGE`; press again to invert; uses the sort memory setting                                                                                                  |
 | `ctrl-e`                                      | compact mode: collapse the header + footer (for tiled/multiplexed panes)                                                                                            |
 | `space`                                       | mark/unmark row for bulk actions                                                                                                                                    |
 | `shift-up` / `shift-down`                     | extend or reduce the marked range from the starting row                                                                                                             |
 | `/`                                           | filter: fuzzy text · `"exact"` · `/regex/` · `!inverse` · `-l`/`-f` selectors (server-side on ⏎) · `status=X` `cpu>500m` `age<2h`                                   |
 | `Ctrl+Z`                                      | toggle faults filter in pod views; configured actions take precedence; combine with `/`; press again to turn off                                                    |
 | `n` / `0`                                     | namespace switcher / all namespaces                                                                                                                                 |
+| `W`                                           | switch to the selected resource's namespace and keep the resource kind                                                                                              |
 | `1` to `9`                                    | select a configured favourite namespace in fixed configuration order                                                                                                |
 | `shift-j`                                     | jump to owner/controller                                                                                                                                            |
 | `o`                                           | show the node the selected row names (pods built in; other kinds via `[views."…"].node`)                                                                            |
@@ -108,11 +110,19 @@ point instead. See [PVC explore](features.md#pvc-explore).
 ## Logs view
 
 `/` filter (substring · `/regex/` · `!invert`) · `s`/`f` autoscroll · `w` wrap ·
-`t` timestamps · `x` stop/resume stream · `z` clear buffer · `c` copy buffer ·
+`m` visual marker · `t` timestamps · `x` stop/resume stream · `z` clear buffer · `c` copy buffer ·
 `ctrl-s` save to file · `F` fullscreen (no chrome, clean text selection) ·
 `0`–`5` time anchors (tail · 1m · 5m · 15m · 30m · 1h) · `T` provider lookback
 (VictoriaLogs views) · `esc` back. The newest line anchors to the bottom of the
 viewport.
+
+`m` adds a separator after the latest received log line. Repeated presses add
+separate markers. Markers stay visible through filters and are excluded from
+sofka copy/save. While paused, a marker is added at the buffer tail without
+moving the viewport. Markers have no timestamp. They are removed when the
+buffer is cleared or replaced, or when their position is trimmed. Marker count
+is limited to the active log buffer cap. Manual terminal selection can include
+visible markers.
 
 ## Document views (YAML, describe, diff, events)
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -409,12 +409,14 @@ impl App {
             (Some(Action::Drain), _) => self.request_drain(),
             // Sorting: S opens the column picker, I inverts the direction.
             (Some(Action::Sort), _) => self.open_sort_picker(),
+            (Some(Action::SortAge), _) => self.sort_by_age(),
             (Some(Action::InvertSort), _) => self.toggle_sort_dir(),
             // Wide mode: show wide-only columns (kubectl `-o wide`).
             (Some(Action::Wide), _) => self.toggle_wide(),
             // `f`/Shift-F = port-forward.
             (Some(Action::PortForward), _) => self.request_port_forward(),
             (Some(Action::Namespaces), _) => self.open_namespaces(),
+            (Some(Action::NamespaceSelected), _) => self.select_resource_namespace(),
             // Browser-style view history: [ back, ] forward.
             (Some(Action::HistoryBack), _) => self.history_back(),
             (Some(Action::HistoryForward), _) => self.history_forward(),
@@ -1160,6 +1162,11 @@ impl App {
     }
 
     pub(super) fn key_logs(&mut self, key: KeyInput) {
+        if key.action == Some(Action::LogMarker) {
+            self.logs.add_marker(self.log_buffer_cap());
+            self.set_flash("log marker added");
+            return;
+        }
         if let Some(anchor) = key.action.and_then(Action::log_anchor) {
             self.apply_log_anchor(anchor);
             return;
@@ -1174,16 +1181,7 @@ impl App {
             (Some(Action::Follow), _) => {
                 self.logs.follow = !self.logs.follow;
                 if self.logs.follow {
-                    // Resumed tailing — trim the backlog accumulated while paused.
-                    let overflow = self
-                        .logs
-                        .view
-                        .lines
-                        .len()
-                        .saturating_sub(self.logs_cfg.buffer.max(1));
-                    if overflow > 0 {
-                        self.logs.view.drain_front(overflow);
-                    }
+                    self.trim_log_buffer();
                 }
                 self.flash = format!(
                     "autoscroll: {}",
@@ -1260,7 +1258,7 @@ impl App {
             }
             // Clear the on-screen buffer (the live stream keeps appending).
             (Some(Action::Clear), _) => {
-                self.logs.view.clear_lines();
+                self.logs.clear_lines();
                 self.logs.view.scroll = 0;
                 self.flash = "log buffer cleared".into();
                 self.flash_err = false;
@@ -1311,6 +1309,7 @@ impl App {
             (Some(Action::Last), _) => {
                 // Resume autoscroll; the next draw anchors to the bottom.
                 self.logs.follow = true;
+                self.trim_log_buffer();
             }
             _ => {}
         }

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -24,38 +24,22 @@ impl App {
                 .collect()
         }));
 
-        // While following, keep a tight tail buffer. While paused, avoid
-        // trimming so indices don't shift under the frozen view (only a huge
-        // backlog hits the larger paused cap).
-        let cap = if self.logs.follow {
+        self.trim_log_buffer();
+    }
+
+    pub(super) fn log_buffer_cap(&self) -> usize {
+        if self.logs.follow {
             self.logs_cfg.buffer.max(1)
         } else {
             MAX_LOG_LINES_PAUSED
-        };
-        let overflow = self.logs.view.lines.len().saturating_sub(cap);
-        if overflow == 0 {
-            return;
         }
+    }
 
-        // If we trim while paused, shift the anchored scroll by the display
-        // rows the dropped lines occupied on screen — filtered lines take none,
-        // wrapped lines take several — so the frozen view stays put.
-        if !self.logs.follow {
-            let rows: usize = self
-                .logs
-                .view
-                .lines
-                .iter()
-                .take(overflow)
-                .filter(|l| self.logs.matches(l))
-                .map(|l| match self.logs.last_wrap_width {
-                    0 => 1,
-                    w => crate::ui::wrapped_height(l, w),
-                })
-                .sum();
-            self.logs.view.scroll = self.logs.view.scroll.saturating_sub(rows);
-        }
-        self.logs.view.drain_front(overflow);
+    pub(super) fn trim_log_buffer(&mut self) {
+        let cap = self.log_buffer_cap();
+        self.logs.limit_markers(cap);
+        self.logs
+            .drain_front(self.logs.view.lines.len().saturating_sub(cap));
     }
 
     // ----- containers / logs --------------------------------------------
@@ -285,7 +269,7 @@ impl App {
         // A new Scrollable starts at revision 0, which can match the previous
         // buffer's revision. Do not let refresh_index mistake the replacement
         // for an append and retain stale line positions or wrapped heights.
-        self.logs.index = LogIndex::default();
+        self.logs.clear_lines();
         self.logs.follow = true;
         self.logs.set_filter(String::new());
         self.logs.stopped = false;
@@ -299,7 +283,7 @@ impl App {
         if self.logs.source.is_none() {
             return;
         }
-        self.logs.view.clear_lines();
+        self.logs.clear_lines();
         self.logs.view.scroll = 0;
         self.restart_log_stream();
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1043,8 +1043,9 @@ pub struct LogIndex {
     revision: u64,
     /// How many buffer lines have been folded in so far.
     consumed: usize,
-    /// Buffer indices that pass the filter, ascending.
-    shown: Vec<u32>,
+    /// Buffer indices in display order. None is a visual marker row.
+    shown: Vec<Option<u32>>,
+    consumed_markers: usize,
     /// Cumulative display rows *through* `shown[i]`, so the first row of
     /// `shown[i]` is `ends[i-1]` (0 for i == 0). Only maintained when
     /// wrapping; without wrap every line is exactly one row.
@@ -1061,9 +1062,13 @@ impl LogIndex {
         self.shown.len()
     }
 
-    /// Buffer index of the `i`th shown line.
+    pub fn matched_lines(&self) -> usize {
+        self.shown.len() - self.consumed_markers
+    }
+
+    /// Source index of a displayed entry. Markers return None.
     pub fn line_at(&self, i: usize) -> Option<usize> {
-        self.shown.get(i).map(|&x| x as usize)
+        self.shown.get(i).copied().flatten().map(|x| x as usize)
     }
 
     /// Display row where the `i`th shown line starts.
@@ -1101,6 +1106,7 @@ impl LogIndex {
         self.wrap_width = wrap_width;
         self.revision = revision;
         self.consumed = 0;
+        self.consumed_markers = 0;
         self.shown.clear();
         self.ends.clear();
         self.total_rows = 0;
@@ -1111,6 +1117,10 @@ impl LogIndex {
 /// the top-level `App` struct.
 pub struct LogsView {
     pub view: Scrollable,
+    /// Stable position of the first retained source line.
+    line_offset: usize,
+    /// Each marker precedes the source line at this stable position.
+    markers: VecDeque<usize>,
     pub follow: bool,
     pub filter: String,
     /// Compiled form of [`Self::filter`] (substring / regex / inverse). Rebuilt
@@ -1148,6 +1158,8 @@ impl Default for LogsView {
     fn default() -> Self {
         Self {
             view: Scrollable::empty(),
+            line_offset: 0,
+            markers: VecDeque::new(),
             follow: true,
             filter: String::new(),
             matcher: crate::logfilter::LogMatcher::default(),
@@ -1166,6 +1178,71 @@ impl Default for LogsView {
 }
 
 impl LogsView {
+    fn reset_index(&mut self) {
+        self.index
+            .reset(&self.filter, self.index.wrap_width, self.view.revision());
+    }
+
+    fn add_marker(&mut self, cap: usize) {
+        self.markers
+            .push_back(self.line_offset + self.view.lines.len());
+        self.limit_markers(cap);
+    }
+
+    fn limit_markers(&mut self, cap: usize) {
+        let overflow = self.markers.len().saturating_sub(cap.max(1));
+        if overflow == 0 {
+            return;
+        }
+        if !self.follow {
+            self.refresh_index(self.last_wrap_width);
+            let removed_before_scroll = self
+                .index
+                .shown
+                .iter()
+                .enumerate()
+                .filter(|(_, line)| line.is_none())
+                .take(overflow)
+                .filter(|(i, _)| self.index.start_row(*i) < self.view.scroll)
+                .count();
+            self.view.scroll = self.view.scroll.saturating_sub(removed_before_scroll);
+        }
+        self.markers.drain(..overflow);
+        self.reset_index();
+    }
+
+    fn clear_lines(&mut self) {
+        self.view.clear_lines();
+        self.markers.clear();
+        self.line_offset = 0;
+        self.reset_index();
+    }
+
+    fn drain_front(&mut self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        self.line_offset += count;
+        let removed_markers = self.markers.partition_point(|&pos| pos < self.line_offset);
+        if !self.follow {
+            let rows: usize = self
+                .view
+                .lines
+                .iter()
+                .take(count)
+                .filter(|line| self.matches(line))
+                .map(|line| match self.last_wrap_width {
+                    0 => 1,
+                    width => crate::ui::wrapped_height(line, width),
+                })
+                .sum();
+            self.view.scroll = self.view.scroll.saturating_sub(rows + removed_markers);
+        }
+        self.markers.drain(..removed_markers);
+        self.view.drain_front(count);
+        self.reset_index();
+    }
+
     /// Replace the filter text and recompile its matcher (substring / regex /
     /// inverse) in one place, so the cached matcher never drifts.
     pub fn set_filter(&mut self, filter: String) {
@@ -1198,6 +1275,8 @@ impl LogsView {
             filter,
             matcher,
             index,
+            markers,
+            line_offset,
             ..
         } = self;
 
@@ -1211,14 +1290,25 @@ impl LogsView {
             index.reset(filter, wrap_width, revision);
         }
 
-        for i in index.consumed..len {
+        for i in index.consumed..=len {
+            while markers
+                .get(index.consumed_markers)
+                .is_some_and(|&pos| pos == *line_offset + i)
+            {
+                index.shown.push(None);
+                index.total_rows += 1;
+                if wrap_width > 0 {
+                    index.ends.push(index.total_rows as u32);
+                }
+                index.consumed_markers += 1;
+            }
             let Some(line) = view.lines.get(i) else {
                 break;
             };
             if !matcher.matches(line) {
                 continue;
             }
-            index.shown.push(i as u32);
+            index.shown.push(Some(i as u32));
             if wrap_width > 0 {
                 index.total_rows += crate::ui::wrapped_height(line, wrap_width);
                 index.ends.push(index.total_rows as u32);

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -126,6 +126,22 @@ impl App {
         }
     }
 
+    pub(super) fn select_resource_namespace(&mut self) {
+        let Some(obj) = self.selected() else {
+            self.flash_warn("no resource selected");
+            return;
+        };
+        let Some(ns) = obj.metadata.namespace.filter(|ns| !ns.is_empty()) else {
+            self.flash_warn("resource has no namespace");
+            return;
+        };
+        if self.namespace == ns && self.owner.is_none() {
+            self.set_flash(format!("namespace: {ns}"));
+            return;
+        }
+        self.set_namespace(ns);
+    }
+
     pub(super) fn drill_into_cronjob_jobs(&mut self, obj: &DynamicObject) {
         let Some(jobs) = self.cluster.resolve("jobs") else {
             self.flash_warn("jobs kind unavailable");

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -302,6 +302,14 @@ impl App {
         self.sort_picker_state.select(Some(idx));
     }
 
+    pub(super) fn sort_by_age(&mut self) {
+        if !self.display_headers().iter().any(|h| h == "AGE") {
+            self.flash_warn("view has no AGE column");
+            return;
+        }
+        self.apply_sort_choice("AGE");
+    }
+
     /// Sort by a picked entry: the default entry clears the sort, a new column
     /// sorts ascending, and re-picking the active column toggles direction
     /// (the spreadsheet idiom).

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24080,3 +24080,355 @@ async fn scrollbars_hide_when_idle_and_return_on_keyboard_and_wheel_input() {
     app.handle_key(press(KeyCode::Esc)).unwrap();
     assert!(!app.scrollbars_visible());
 }
+
+#[tokio::test]
+async fn age_shortcut_sorts_toggles_and_obeys_sort_memory() {
+    for remember in [true, false] {
+        let (mut app, _rx) = test_app();
+        app.remember_sort = remember;
+        palette(&mut app, "pods");
+        app.handle_key(press(KeyCode::Char('A'))).unwrap();
+        assert_eq!(app.display_headers()[app.sort_column.unwrap()], "AGE");
+        assert!(!app.sort_desc);
+        assert_eq!(app.mode, Mode::Table);
+        for (name, created) in [
+            ("a-old", "2020-01-01T00:00:00Z"),
+            ("z-new", "2025-01-01T00:00:00Z"),
+        ] {
+            apply(
+                &mut app,
+                json!({"apiVersion":"v1", "kind":"Pod", "metadata": {
+                    "name":name, "namespace":"default", "creationTimestamp":created
+                }}),
+            );
+        }
+        let names = |app: &App| {
+            app.rows()
+                .iter()
+                .map(|o| o.metadata.name.clone().unwrap())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(names(&app), ["z-new", "a-old"]);
+        app.handle_key(press(KeyCode::Char('A'))).unwrap();
+        assert!(app.sort_desc);
+        assert_eq!(names(&app), ["a-old", "z-new"]);
+        assert_eq!(
+            app.sort_memory.get("pods"),
+            remember.then(|| ("AGE".into(), true))
+        );
+        palette(&mut app, "deployments");
+        palette(&mut app, "pods");
+        assert_eq!(app.sort_column.is_some(), remember);
+        if remember {
+            assert!(app.sort_desc);
+            app.handle_key(press(KeyCode::Char('A'))).unwrap();
+            assert!(!app.sort_desc);
+        }
+    }
+}
+
+#[tokio::test]
+async fn age_shortcut_keeps_sort_when_age_is_absent() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views.pods]
+        replace = true
+        columns = [{ name = "NAME", builtin = "NAME" }]
+    "#,
+    );
+    palette(&mut app, "pods");
+    select_sort_with_keys(&mut app, "NAME");
+    let sort = (app.sort_column, app.sort_desc);
+    app.handle_key(press(KeyCode::Char('A'))).unwrap();
+    assert_eq!((app.sort_column, app.sort_desc), sort);
+    assert_eq!(app.flash, "view has no AGE column");
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn namespace_shortcut_uses_cursor_and_records_history() {
+    let (mut app, _rx) = test_app();
+    palette(&mut app, "pods all /pod");
+    let pod = |ns: &str| {
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"pod", "namespace":ns}})
+    };
+    apply(&mut app, pod("alpha"));
+    apply(&mut app, pod("monitoring"));
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Char(' '))).unwrap();
+    app.handle_key(press(KeyCode::End)).unwrap();
+    assert_eq!(app.marked.len(), 1);
+    app.handle_key(press(KeyCode::Char('W'))).unwrap();
+    assert_eq!(app.namespace, "monitoring");
+    assert_eq!(app.kind_plural, "pods");
+    assert_eq!(app.filter, "pod");
+    app.handle_key(press(KeyCode::Char('['))).unwrap();
+    assert_eq!(app.namespace, "");
+    app.handle_key(press(KeyCode::Char(']'))).unwrap();
+    assert_eq!(app.namespace, "monitoring");
+    apply(&mut app, pod("monitoring"));
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    let generation = app.generation;
+    app.handle_key(press(KeyCode::Char('W'))).unwrap();
+    assert_eq!(app.generation, generation);
+    assert_eq!(app.flash, "namespace: monitoring");
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert!(app.wide);
+}
+
+#[tokio::test]
+async fn namespace_shortcut_rejects_missing_selection_and_namespace() {
+    let (mut app, _rx) = test_app();
+    palette(&mut app, "nodes");
+    app.handle_key(press(KeyCode::Char('W'))).unwrap();
+    assert_eq!(app.flash, "no resource selected");
+    for namespace in [None, Some("")] {
+        apply(
+            &mut app,
+            json!({"apiVersion":"v1", "kind":"Node",
+            "metadata":{"name":"node", "namespace":namespace}}),
+        );
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        let before = (app.namespace.clone(), app.generation);
+        app.handle_key(press(KeyCode::Char('W'))).unwrap();
+        assert_eq!(app.flash, "resource has no namespace");
+        assert_eq!((app.namespace.clone(), app.generation), before);
+    }
+}
+
+#[tokio::test]
+async fn namespace_shortcut_removes_owner_scope_in_current_namespace() {
+    let (mut app, _rx) = test_app();
+    palette(&mut app, "pods default");
+    app.owner = Some(OwnerScope {
+        kind: "Job".into(),
+        name: "backup".into(),
+        uid: None,
+    });
+    app.scope_label = Some("job/backup".into());
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"backup-0", "namespace":"default"}}),
+    );
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    let generation = app.generation;
+    app.handle_key(press(KeyCode::Char('W'))).unwrap();
+    assert!(app.owner.is_none());
+    assert!(app.scope_label.is_none());
+    assert!(app.generation > generation);
+    assert_eq!(app.namespace, "default");
+}
+
+fn shortcut_log_lines(app: &mut App, lines: Vec<String>) {
+    app.handle_msg(Msg::LogLines {
+        generation: app.log_gen,
+        lines,
+    });
+}
+
+#[tokio::test]
+async fn log_marker_shortcut_keeps_order_across_appends_and_filters() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.refresh_index(0).shown, [None, None]);
+    shortcut_log_lines(&mut app, vec!["before".into()]);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.refresh_index(0).shown, [None, None, Some(0), None]);
+    shortcut_log_lines(&mut app, vec!["after".into()]);
+    assert_eq!(
+        app.logs.refresh_index(0).shown,
+        [None, None, Some(0), None, Some(1)]
+    );
+    assert_eq!(app.logs.refresh_index(0).total_rows(), 5);
+    assert_eq!(app.logs.index().matched_lines(), 2);
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "after".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.logs.refresh_index(2).shown, [None, None, None, Some(1)]);
+    assert_eq!(app.logs.index().total_rows(), 6);
+    assert_eq!(app.logs.index().matched_lines(), 1);
+    assert_eq!(app.filtered_log_text(), "after");
+    app.handle_key(press(KeyCode::Char('z'))).unwrap();
+    assert!(app.logs.markers.is_empty());
+    assert_eq!(app.logs.refresh_index(0).total_rows(), 0);
+}
+
+#[tokio::test]
+async fn log_marker_shortcut_exports_only_source_lines() {
+    let (mut app, mut rx) = test_app();
+    app.mode = Mode::Logs;
+    app.logs.view.title = format!("marker-export-{}", std::process::id());
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert_eq!(app.flash, "no log lines to copy");
+    shortcut_log_lines(&mut app, vec!["before".into(), "--------".into()]);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    shortcut_log_lines(&mut app, vec!["after".into()]);
+    assert_eq!(app.filtered_log_text(), "before\n--------\nafter");
+    app.handle_key(ctrl(KeyCode::Char('s'))).unwrap();
+    let path = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Msg::LogsSaved { result, .. } = rx.recv().await.unwrap() {
+                break result.unwrap();
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "before\n--------\nafter"
+    );
+    std::fs::remove_file(path).unwrap();
+}
+
+#[tokio::test]
+async fn log_marker_shortcut_is_bounded_and_tracks_trimmed_positions() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.logs_cfg.buffer = 2;
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    shortcut_log_lines(&mut app, vec!["old".into()]);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    shortcut_log_lines(&mut app, vec!["keep".into(), "new".into()]);
+    assert_eq!(app.logs.refresh_index(0).shown, [None, Some(0), Some(1)]);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(
+        app.logs.refresh_index(0).shown,
+        [Some(0), Some(1), None, None]
+    );
+    for resume in ['s', 'G'] {
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        for _ in 0..4 {
+            app.handle_key(press(KeyCode::Char('m'))).unwrap();
+        }
+        assert!(!app.logs.follow);
+        assert_eq!(app.logs.markers.len(), 6);
+        app.handle_key(press(KeyCode::Char(resume))).unwrap();
+        assert!(app.logs.follow);
+        assert_eq!(app.logs.markers.len(), 2);
+    }
+    app.logs_cfg.buffer = 0;
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.markers.len(), 1);
+}
+
+#[tokio::test]
+async fn log_marker_shortcut_preserves_paused_scroll_during_trim() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.logs.last_wrap_width = 10;
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    shortcut_log_lines(&mut app, vec!["a".repeat(25)]);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    shortcut_log_lines(
+        &mut app,
+        (1..MAX_LOG_LINES_PAUSED).map(|i| format!("l{i}")).collect(),
+    );
+    app.logs.view.scroll = 500;
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.view.scroll, 500);
+    shortcut_log_lines(&mut app, vec!["new".into()]);
+    assert!(!app.logs.follow);
+    assert_eq!(app.logs.view.scroll, 496);
+    assert_eq!(app.logs.markers.len(), 2);
+    assert_eq!(app.logs.refresh_index(10).line_at(0), None);
+    assert_eq!(app.logs.index().line_at(1), Some(0));
+}
+
+#[tokio::test]
+async fn log_marker_shortcut_paused_marker_cap_preserves_scroll() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.logs.markers = std::iter::repeat_n(0, MAX_LOG_LINES_PAUSED).collect();
+    app.logs.view.scroll = 50;
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.markers.len(), MAX_LOG_LINES_PAUSED);
+    assert_eq!(app.logs.view.scroll, 49);
+}
+
+#[tokio::test]
+async fn log_marker_shortcut_renders_one_row_at_each_width() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.compact = true;
+    shortcut_log_lines(&mut app, vec!["before".into()]);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    shortcut_log_lines(&mut app, vec!["after".into()]);
+    app.logs.view.hscroll = 20;
+    let mut terminal = Terminal::new(TestBackend::new(40, 16)).unwrap();
+    for fullscreen in [false, true] {
+        if fullscreen {
+            app.handle_key(press(KeyCode::Char('F'))).unwrap();
+        }
+        for wrap in [true, false] {
+            app.handle_key(press(KeyCode::Char('w'))).unwrap();
+            assert_eq!(app.logs.wrap, wrap);
+            for width in [40, 28] {
+                terminal.backend_mut().resize(width, 16);
+                crate::ui::resize(&mut terminal, &mut app).unwrap();
+                terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+                let expected = if fullscreen { width } else { width - 2 } as usize;
+                let counts: Vec<_> = (0..16)
+                    .map(|y| {
+                        (0..width)
+                            .filter(|&x| terminal.backend().buffer()[(x, y)].symbol() == "-")
+                            .count()
+                    })
+                    .filter(|&count| count == expected)
+                    .collect();
+                assert_eq!(counts, [expected]);
+                assert_eq!(app.logs.viewport_rows, 3);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn log_marker_shortcut_handles_stopped_provider_and_replaced_buffers() {
+    let (mut app, _rx) = test_app();
+    palette(&mut app, "pods default");
+    apply(
+        &mut app,
+        json!({"apiVersion":"v1", "kind":"Pod",
+        "metadata":{"name":"web", "namespace":"default"},
+        "spec":{"containers":[{"name":"app"}]}}),
+    );
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Char('l'))).unwrap();
+    assert_eq!(app.mode, Mode::Logs);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert!(app.logs.markers.is_empty());
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    assert!(app.logs.stopped);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.markers.len(), 1);
+    app.logs.source = Some(LogSource::Provider {
+        request: crate::providers::LogRequest::Pod {
+            ns: "default".into(),
+            pod: "web".into(),
+            container: None,
+            multi_container: false,
+        },
+    });
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.markers.len(), 2);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Char('l'))).unwrap();
+    assert_eq!(app.mode, Mode::Logs);
+    assert!(app.logs.markers.is_empty());
+    assert_eq!(app.logs.refresh_index(0).total_rows(), 0);
+}

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -83,11 +83,13 @@ actions! {
     Last => ("last", "last row"),
     Left => ("left", "left"),
     Logs => ("logs", "logs"),
+    LogMarker => ("log_marker", "add visual log marker"),
     Lookback => ("lookback", "lookback"),
     Mark => ("mark", "mark"),
     RangeDown => ("range_down", "extend or reduce selection down"),
     RangeUp => ("range_up", "extend or reduce selection up"),
     Namespaces => ("namespaces", "namespaces"),
+    NamespaceSelected => ("namespace_selected", "selected resource namespace"),
     NextMatch => ("next_match", "next match"),
     NextView => ("next_view", "next view"),
     Node => ("node", "node"),
@@ -111,6 +113,7 @@ actions! {
     Shell => ("shell", "shell"),
     ShellOrScale => ("shell_or_scale", "shell or scale"),
     Sort => ("sort", "sort"),
+    SortAge => ("sort_age", "sort by age; repeat to invert"),
     Start => ("start", "start"),
     Stream => ("stream", "stream"),
     SwitchPane => ("switch_pane", "switch pane"),
@@ -378,6 +381,7 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("logs", Action::Fullscreen, &["F"]),
     ("logs", Action::Last, &["G", "end"]),
     ("logs", Action::Lookback, &["T"]),
+    ("logs", Action::LogMarker, &["m"]),
     ("logs", Action::PageDown, &["pagedown", "space"]),
     ("logs", Action::PageUp, &["pageup"]),
     ("logs", Action::Save, &["ctrl-s"]),
@@ -473,6 +477,7 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("table", Action::RangeDown, &["shift-down"]),
     ("table", Action::RangeUp, &["shift-up"]),
     ("table", Action::Namespaces, &["n"]),
+    ("table", Action::NamespaceSelected, &["W"]),
     ("table", Action::NextView, &["tab"]),
     ("table", Action::Node, &["o"]),
     ("table", Action::Open, &["enter"]),
@@ -489,6 +494,7 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("table", Action::SetImage, &["i"]),
     ("table", Action::ShellOrScale, &["s"]),
     ("table", Action::Sort, &["S"]),
+    ("table", Action::SortAge, &["A"]),
     ("table", Action::Timeline, &["T"]),
     ("table", Action::Uncordon, &["U"]),
     ("table", Action::Up, &["k", "up"]),
@@ -914,6 +920,45 @@ mod tests {
             ),
             Some(Action::ClearLine)
         );
+    }
+
+    #[test]
+    fn resource_and_log_shortcuts_support_overrides_and_conflicts() {
+        for (scope, action, default, custom) in [
+            ("table", Action::SortAge, 'A', "f8"),
+            ("table", Action::NamespaceSelected, 'W', "f9"),
+            ("logs", Action::LogMarker, 'm', "f10"),
+        ] {
+            let key = KeyEvent::new(KeyCode::Char(default), KeyModifiers::NONE);
+            assert_eq!(Keymap::default().action(scope, &key), Some(action));
+            let setting = format!("[keys.{scope}]\n{} = '{custom}'", action.name());
+            let map = compile(&setting).unwrap();
+            assert_eq!(map.label(scope, action), custom);
+            assert_eq!(map.action(scope, &key), None);
+            let disabled = compile(&format!("[keys.{scope}]\n{} = []", action.name())).unwrap();
+            assert_eq!(disabled.action(scope, &key), None);
+            let conflict = format!("[keys.{scope}]\n{} = 'w'", action.name());
+            assert!(
+                compile(&conflict)
+                    .unwrap_err()
+                    .iter()
+                    .any(|e| e.contains("conflicts"))
+            );
+        }
+        let map = Keymap::default();
+        for (scope, key, action) in [
+            ("table", 'a', Action::Attach),
+            ("table", 'w', Action::Wide),
+            ("logs", 'w', Action::Wrap),
+        ] {
+            assert_eq!(
+                map.action(
+                    scope,
+                    &KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)
+                ),
+                Some(action)
+            );
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1754,7 +1754,8 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
                 break;
             }
             let Some(buf_idx) = index.line_at(i) else {
-                break;
+                rows.push(Line::styled("-".repeat(inner_w), theme::dim()));
+                continue;
             };
             let Some(l) = app.logs.view.lines.get(buf_idx) else {
                 break;
@@ -1804,7 +1805,7 @@ fn draw_logs(frame: &mut Frame, app: &mut App, area: Rect) {
             " {} · /{} [{}]{} ",
             app.logs.view.title,
             filter,
-            app.logs.index().shown_len(),
+            app.logs.index().matched_lines(),
             flags
         )
     } else {
@@ -2557,6 +2558,8 @@ fn build_help(app: &App, width: usize) -> (Vec<Line<'static>>, String) {
         }
         let description = if scope == "table" && action == Action::Logs {
             "logs (marked pods, or current row)"
+        } else if action == Action::LogMarker {
+            "add visual marker at the log tail (excluded from copy/save)"
         } else if action == Action::AutoRefresh && scope == "detail" {
             "toggle refresh (YAML, decoded Secret, describe)"
         } else if action == Action::AutoRefresh && scope == "diff" {
@@ -4439,6 +4442,7 @@ fn navigation_hint(app: &App, width: u16) -> String {
             Action::Back,
             Action::Filter,
             Action::Follow,
+            Action::LogMarker,
             Action::Wrap,
             Action::Stream,
             Action::Copy,


### PR DESCRIPTION
Add configurable shortcuts for three repeated tasks: sort by age, switch to the selected resource's namespace, and mark a position in live logs.

- `A` selects `AGE` through the existing sort logic. Repeated presses reverse the direction, and sort memory settings still apply.
- `W` uses the normal namespace switch path, including history and watch restart. It reports missing selections or namespaces and avoids restarting an unchanged view.
- `m` adds a visual marker at the log buffer tail. Markers remain visible through filters, preserve paused scrolling, and are excluded from sofka copy/save. Storage is bounded, and positions remain stable when old lines are removed.

The change shares buffer-limit handling across incoming logs and follow controls. It also updates help, key configuration examples, and documentation.

Validation: `just check` passed with 1,233 tests passing. Tests cover key handling, sort memory, namespace history, marker order, trimming, export, and rendering at different widths. No live cluster test was run.

Closes #456.

Agreed feature discussion: https://github.com/nklmilojevic/sofka/discussions/450
