### PR TITLE
feat: show container state and configuration details

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,18 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 ## Core navigation
 
+- **Container details** show readiness, state or failure reason, and restart
+  count beside the existing resource columns. The selected container's details
+  show its type, full image reference, declared ports, and configured startup,
+  readiness, and liveness probes. Images and ports wrap to fit the popup.
+  Probe labels show configuration, not the current probe result.
+  Regular, init, native sidecar, and ephemeral containers are included. Pod watch
+  updates refresh the details and keep the selected container by name. Missing
+  status values show `-` or `Unknown`. If the selected container disappears,
+  its selection clears. Name, state, and restarts have priority on narrow
+  terminals. Resource percentages hide first, then usage and readiness columns.
+  The popup uses fixed columns.
+
 - **Container trends** show CPU and memory for the selected container on wide
   screens. Each chart covers the last five minutes in five-second bins, with
   the newest sample on the right. The scale is zero to the largest visible

--- a/src/app/containers.rs
+++ b/src/app/containers.rs
@@ -1,0 +1,193 @@
+use super::*;
+
+pub(crate) struct ContainerDetails {
+    pub kind: &'static str,
+    pub ready: Option<bool>,
+    pub state: String,
+    pub restarts: Option<u64>,
+    pub image: String,
+    pub ports: String,
+    pub probes: [bool; 3],
+}
+
+fn container_details_of(obj: &DynamicObject) -> HashMap<String, ContainerDetails> {
+    let mut details = HashMap::new();
+    for (spec, status, kind) in [
+        ("containers", "containerStatuses", "regular"),
+        ("initContainers", "initContainerStatuses", "init"),
+        (
+            "ephemeralContainers",
+            "ephemeralContainerStatuses",
+            "ephemeral",
+        ),
+    ] {
+        let statuses = obj.data.pointer(&format!("/status/{status}"));
+        for container in obj
+            .data
+            .pointer(&format!("/spec/{spec}"))
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let Some(name) = container.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let status = statuses
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .find(|s| s.get("name").and_then(Value::as_str) == Some(name));
+            let state = status
+                .and_then(|s| s.get("state"))
+                .map(container_state)
+                .unwrap_or_else(|| "Unknown".into());
+            let ports: Vec<_> = container
+                .get("ports")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|port| {
+                    let number = port.get("containerPort")?.as_u64()?;
+                    let protocol = port
+                        .get("protocol")
+                        .and_then(Value::as_str)
+                        .unwrap_or("TCP");
+                    let name = port.get("name").and_then(Value::as_str).unwrap_or("");
+                    Some(if name.is_empty() {
+                        format!("{number}/{protocol}")
+                    } else {
+                        format!("{name}:{number}/{protocol}")
+                    })
+                })
+                .collect();
+            details.insert(
+                name.into(),
+                ContainerDetails {
+                    kind: if kind == "init"
+                        && container.get("restartPolicy").and_then(Value::as_str) == Some("Always")
+                    {
+                        "sidecar"
+                    } else {
+                        kind
+                    },
+                    ready: status.and_then(|s| s.get("ready")).and_then(Value::as_bool),
+                    state,
+                    restarts: status
+                        .and_then(|s| s.get("restartCount"))
+                        .and_then(Value::as_u64),
+                    image: container
+                        .get("image")
+                        .and_then(Value::as_str)
+                        .unwrap_or("-")
+                        .into(),
+                    ports: if ports.is_empty() {
+                        "none declared".into()
+                    } else {
+                        ports.join(", ")
+                    },
+                    probes: ["startupProbe", "readinessProbe", "livenessProbe"]
+                        .map(|probe| container.get(probe).is_some_and(Value::is_object)),
+                },
+            );
+        }
+    }
+    details
+}
+
+fn container_state(state: &Value) -> String {
+    for (key, fallback) in [
+        ("waiting", "Waiting"),
+        ("terminated", "Terminated"),
+        ("running", "Running"),
+    ] {
+        let Some(value) = state.get(key).filter(|v| v.is_object()) else {
+            continue;
+        };
+        if let Some(reason) = value
+            .get("reason")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+        {
+            return reason.into();
+        }
+        if key == "terminated" {
+            if let Some(signal) = value
+                .get("signal")
+                .and_then(Value::as_i64)
+                .filter(|&s| s != 0)
+            {
+                return format!("Signal:{signal}");
+            }
+            if let Some(code) = value.get("exitCode").and_then(Value::as_i64) {
+                return if code == 0 {
+                    "Completed".into()
+                } else {
+                    format!("ExitCode:{code}")
+                };
+            }
+        }
+        return fallback.into();
+    }
+    "Unknown".into()
+}
+
+impl App {
+    pub(super) fn open_containers(&mut self, obj: &DynamicObject) {
+        if container_names(obj).is_empty() {
+            self.flash_warn("no containers found");
+            return;
+        }
+        self.container_pod = Some((
+            obj.metadata.namespace.clone().unwrap_or_default(),
+            obj.metadata.name.clone().unwrap_or_default(),
+        ));
+        self.update_containers(obj);
+        self.container_state.select(Some(0));
+        self.mode = Mode::Containers;
+    }
+
+    fn update_containers(&mut self, obj: &DynamicObject) {
+        let selected = self
+            .container_state
+            .selected()
+            .and_then(|i| self.container_list.get(i))
+            .cloned();
+        self.container_details = container_details_of(obj);
+        self.container_list = self.container_details.keys().cloned().collect();
+        self.container_list.sort();
+        self.container_resources = container_resources_of(obj).into_iter().collect();
+        self.container_qos = qos_class(obj);
+        self.container_state
+            .select(selected.and_then(|name| self.container_list.iter().position(|n| n == &name)));
+    }
+
+    pub(super) fn sync_container_picker(&mut self) {
+        if self.mode != Mode::Containers
+            && !(self.mode == Mode::Command && self.palette_return == Mode::Containers)
+        {
+            return;
+        }
+        let Some((ns, pod)) = &self.container_pod else {
+            return;
+        };
+        if let Some(obj) = self.store.shared(&format!("{ns}/{pod}")) {
+            self.update_containers(&obj);
+        } else {
+            self.container_list.clear();
+            self.container_details.clear();
+            self.container_resources.clear();
+            self.container_qos.clear();
+            self.container_state.select(None);
+        }
+        self.sync_container_history();
+    }
+
+    /// Get the latest metrics for a container in the open popup.
+    /// `None` means that Metrics Server data is not available.
+    pub fn selected_pod_container_metrics(&self, container: &str) -> Option<(i64, i64)> {
+        let (namespace, pod) = self.container_pod.as_ref()?;
+        self.container_metrics
+            .get(&format!("{namespace}/{pod}/{container}"))
+            .copied()
+    }
+}

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -873,7 +873,26 @@ impl App {
     /// report, a bundle) can displace the PVC browser without a keystroke
     /// being involved at all.
     pub fn handle_msg(&mut self, msg: Msg) {
+        let refresh_containers = match &msg {
+            Msg::Applied {
+                generation, key, ..
+            }
+            | Msg::Deleted { generation, key } => {
+                *generation == self.generation
+                    && self
+                        .container_pod
+                        .as_ref()
+                        .is_some_and(|(ns, pod)| key == &format!("{ns}/{pod}"))
+            }
+            Msg::Reset { generation } | Msg::Synced { generation } => {
+                *generation == self.generation
+            }
+            _ => false,
+        };
         self.handle_msg_inner(msg);
+        if refresh_containers {
+            self.sync_container_picker();
+        }
         self.check_resource_refresh();
         if self.mode != Mode::Adjacent {
             self.cancel_children();

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -42,35 +42,6 @@ impl App {
             .drain_front(self.logs.view.lines.len().saturating_sub(cap));
     }
 
-    // ----- containers / logs --------------------------------------------
-
-    pub(super) fn open_containers(&mut self, obj: &DynamicObject) {
-        let mut names = container_names(obj);
-        if names.is_empty() {
-            self.flash_warn("no containers found");
-            return;
-        }
-        names.sort();
-        let ns = obj.metadata.namespace.clone().unwrap_or_default();
-        let name = obj.metadata.name.clone().unwrap_or_default();
-        self.container_pod = Some((ns, name));
-        self.container_list = names;
-        self.container_resources = container_resources_of(obj).into_iter().collect();
-        self.container_qos = qos_class(obj);
-        self.container_state.select(Some(0));
-        self.mode = Mode::Containers;
-    }
-
-    /// Latest metrics for a container in the pod currently shown by the
-    /// container picker. `None` distinguishes unavailable Metrics Server data
-    /// from a measured zero value.
-    pub fn selected_pod_container_metrics(&self, container: &str) -> Option<(i64, i64)> {
-        let (namespace, pod) = self.container_pod.as_ref()?;
-        self.container_metrics
-            .get(&format!("{namespace}/{pod}/{container}"))
-            .copied()
-    }
-
     /// Logs for marked pods or the current selection. Stream every container. For
     /// workloads/services: list matching pods and aggregate all their logs.
     pub(super) fn open_logs(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1978,6 +1978,7 @@ pub struct App {
     /// Declared requests/limits for the pod shown by the container picker,
     /// keyed by container name. Drives the request/limit percentage columns.
     pub container_resources: HashMap<String, crate::columns::ContainerResources>,
+    pub(crate) container_details: HashMap<String, containers::ContainerDetails>,
     /// QoS class of the pod shown by the container picker (empty if unknown).
     pub container_qos: String,
 
@@ -2319,6 +2320,7 @@ impl App {
             container_state: ListState::default(),
             container_pod: None,
             container_resources: HashMap::new(),
+            container_details: HashMap::new(),
             container_qos: String::new(),
             flux_menu_state: ListState::default(),
             transfer_menu_state: ListState::default(),
@@ -2483,6 +2485,7 @@ mod adjacent;
 mod authz;
 mod bookmarks;
 mod bundle;
+mod containers;
 mod dashboards;
 mod details;
 mod diagnostics;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8606,8 +8606,8 @@ async fn container_picker_populates_resources_and_qos() {
         }),
     );
 
-    let pod = app.selected().unwrap();
-    app.open_containers(&pod);
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.container_qos, "Burstable");
     assert_eq!(app.container_resources["app"].cpu_request, Some(250));
     assert_eq!(
@@ -8652,8 +8652,8 @@ async fn container_picker_renders_qos_and_utilization() {
         ]),
     });
 
-    let pod = app.selected().unwrap();
-    app.open_containers(&pod);
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
 
     let mut term = Terminal::new(TestBackend::new(120, 32)).unwrap();
     term.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
@@ -8684,6 +8684,383 @@ async fn container_picker_renders_qos_and_utilization() {
         screen.contains("13%/-"),
         "missing missing-limit indicator in:\n{screen}"
     );
+}
+
+fn container_details_pod() -> Value {
+    json!({
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": "api", "namespace": "default", "uid": "original"},
+        "spec": {
+            "containers": [
+                {"name": "app", "image": "registry:5000/team/app:1.2.3@sha256:abcdef",
+                 "ports": [{"name": "http", "containerPort": 8080}, {"containerPort": 5353, "protocol": "UDP"}],
+                 "startupProbe": {"tcpSocket": {"port": 8080}},
+                 "readinessProbe": {"httpGet": {"path": "/ready", "port": "http"}},
+                 "livenessProbe": null,
+                 "resources": {"requests": {"cpu": "100m"}, "limits": {"cpu": "200m"}}},
+                {"name": "worker", "image": "worker:v2"}
+            ],
+            "initContainers": [
+                {"name": "setup", "image": "setup:v1"},
+                {"name": "sidecar", "image": "proxy:v1", "restartPolicy": "Always",
+                 "livenessProbe": {"tcpSocket": {"port": 15000}}}
+            ],
+            "ephemeralContainers": [{"name": "debug", "image": "debug:v1"}]
+        },
+        "status": {
+            "containerStatuses": [
+                {"name": "worker", "ready": true, "restartCount": 0, "state": {"running": {}}},
+                {"name": "app", "ready": false, "restartCount": 7,
+                 "state": {"waiting": {"reason": "CrashLoopBackOff"}},
+                 "lastState": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}
+            ],
+            "initContainerStatuses": [
+                {"name": "sidecar", "ready": true, "restartCount": 1, "state": {"running": {}}},
+                {"name": "setup", "ready": false, "restartCount": 3, "state": {"terminated": {"reason": "Completed", "exitCode": 0}}}
+            ],
+            "ephemeralContainerStatuses": [
+                {"name": "debug", "ready": false, "restartCount": 2, "state": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}
+            ]
+        }
+    })
+}
+
+fn render_container_popup(app: &mut App, width: u16, height: u16) -> Vec<String> {
+    use ratatui::{Terminal, backend::TestBackend};
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+    terminal.draw(|f| crate::ui::draw(f, app)).unwrap();
+    let buffer = terminal.backend().buffer();
+    let top = (0..height)
+        .find(|&y| {
+            (0..width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+                .contains(" Containers")
+        })
+        .expect("container popup title");
+    let left = (0..width)
+        .find(|&x| buffer[(x, top)].symbol() == "╭")
+        .unwrap();
+    let right = (left..width)
+        .find(|&x| buffer[(x, top)].symbol() == "╮")
+        .unwrap();
+    (top + 1..height)
+        .take_while(|&y| buffer[(left, y)].symbol() != "╰")
+        .map(|y| (left + 1..right).map(|x| buffer[(x, y)].symbol()).collect())
+        .collect()
+}
+
+#[tokio::test]
+async fn container_details_follow_selection_and_match_status_by_name() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(&mut app, container_details_pod());
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Containers);
+    assert_eq!(
+        app.container_list,
+        ["app", "debug", "setup", "sidecar", "worker"]
+    );
+
+    for (index, name, kind, ready, state, restarts, image) in [
+        (
+            0,
+            "app",
+            "regular",
+            false,
+            "CrashLoopBackOff",
+            7,
+            "registry:5000/team/app:1.2.3@sha256:abcdef",
+        ),
+        (1, "debug", "ephemeral", false, "OOMKilled", 2, "debug:v1"),
+        (2, "setup", "init", false, "Completed", 3, "setup:v1"),
+        (3, "sidecar", "sidecar", true, "Running", 1, "proxy:v1"),
+        (4, "worker", "regular", true, "Running", 0, "worker:v2"),
+    ] {
+        if index > 0 {
+            app.handle_key(press(KeyCode::Down)).unwrap();
+        }
+        assert_eq!(app.container_state.selected(), Some(index));
+        let details = &app.container_details[name];
+        assert_eq!(details.kind, kind);
+        assert_eq!(details.ready, Some(ready));
+        assert_eq!(details.state, state);
+        assert_eq!(details.restarts, Some(restarts));
+        let lines = render_container_popup(&mut app, 160, 40);
+        let screen = lines.join("\n");
+        assert!(
+            screen.contains(&format!("Container: {name} ({kind})")),
+            "{screen}"
+        );
+        assert!(screen.contains(&format!("Image: {image}")), "{screen}");
+        let row = lines
+            .iter()
+            .find(|line| line.trim_start().starts_with("▌ "))
+            .unwrap();
+        let cells: Vec<_> = row.split_whitespace().collect();
+        assert_eq!(
+            &cells[1..5],
+            &[
+                name,
+                if ready { "true" } else { "false" },
+                state,
+                &restarts.to_string()
+            ]
+        );
+        if name == "app" {
+            assert!(
+                screen.contains("Ports: http:8080/TCP, 5353/UDP"),
+                "{screen}"
+            );
+            assert!(
+                screen.contains("startup=configured, readiness=configured, liveness=absent"),
+                "{screen}"
+            );
+        } else if name == "sidecar" {
+            assert!(screen.contains("Ports: none declared"), "{screen}");
+            assert!(
+                screen.contains("startup=absent, readiness=absent, liveness=configured"),
+                "{screen}"
+            );
+        } else {
+            assert!(screen.contains("Ports: none declared"), "{screen}");
+            assert!(
+                screen.contains("startup=absent, readiness=absent, liveness=absent"),
+                "{screen}"
+            );
+        }
+    }
+    app.handle_key(press(KeyCode::Up)).unwrap();
+    assert!(
+        render_container_popup(&mut app, 160, 40)
+            .join("\n")
+            .contains("Container: sidecar (sidecar)")
+    );
+}
+
+#[tokio::test]
+async fn container_details_refresh_without_changing_the_selected_name() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let mut pod = container_details_pod();
+    apply(&mut app, pod.clone());
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    assert_eq!(
+        app.container_list[app.container_state.selected().unwrap()],
+        "debug"
+    );
+
+    pod["spec"]["ephemeralContainers"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({"name": "aaa", "image": "debug:v2"}));
+    pod["spec"]["ephemeralContainers"][0]["image"] = json!("debug:v3");
+    pod["status"]["ephemeralContainerStatuses"][0]["state"] = json!({"running": {}});
+    pod["status"]["ephemeralContainerStatuses"][0]["restartCount"] = json!(4);
+    pod["spec"]["containers"][0]["resources"]["limits"]["cpu"] = json!("500m");
+    app.handle_msg(Msg::Applied {
+        generation: app.generation.wrapping_sub(1),
+        key: "default/api".into(),
+        obj: Box::new(obj(pod.clone())),
+    });
+    assert_eq!(app.container_details["debug"].state, "OOMKilled");
+    apply(&mut app, pod.clone());
+    assert_eq!(app.container_state.selected(), Some(2));
+    assert_eq!(app.container_list[2], "debug");
+    assert_eq!(app.container_details["debug"].state, "Running");
+    assert_eq!(app.container_details["debug"].restarts, Some(4));
+    assert_eq!(app.container_resources["app"].cpu_limit, Some(500));
+    let screen = render_container_popup(&mut app, 160, 40).join("\n");
+    assert!(
+        screen.contains("Container: debug (ephemeral)") && screen.contains("Image: debug:v3"),
+        "{screen}"
+    );
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    let Some(Suspend::Shell(argv)) = app.pending.take() else {
+        panic!("expected a shell command for the selected container");
+    };
+    let container_arg = argv.iter().position(|arg| arg == "-c").unwrap();
+    assert_eq!(argv[container_arg + 1], "debug");
+
+    let mut other = pod.clone();
+    other["metadata"]["namespace"] = json!("other");
+    other["status"]["ephemeralContainerStatuses"][0]["restartCount"] = json!(99);
+    apply(&mut app, other);
+    assert_eq!(app.container_details["debug"].restarts, Some(4));
+
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert_eq!(app.mode, Mode::Command);
+    pod["status"]["ephemeralContainerStatuses"][0]["restartCount"] = json!(5);
+    apply(&mut app, pod.clone());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Containers);
+    assert_eq!(app.container_details["debug"].restarts, Some(5));
+    assert_eq!(
+        app.container_list[app.container_state.selected().unwrap()],
+        "debug"
+    );
+
+    app.handle_msg(Msg::Reset {
+        generation: app.generation,
+    });
+    pod["status"]["ephemeralContainerStatuses"][0]["restartCount"] = json!(6);
+    apply(&mut app, pod);
+    assert_eq!(app.container_details["debug"].restarts, Some(5));
+    app.handle_msg(Msg::Synced {
+        generation: app.generation,
+    });
+    assert_eq!(app.container_details["debug"].restarts, Some(6));
+    assert_eq!(
+        app.container_list[app.container_state.selected().unwrap()],
+        "debug"
+    );
+
+    app.handle_msg(Msg::Deleted {
+        generation: app.generation,
+        key: "default/api".into(),
+    });
+    assert!(app.container_list.is_empty());
+    assert!(app.container_details.is_empty());
+    assert!(app.container_state.selected().is_none());
+    assert!(
+        render_container_popup(&mut app, 160, 40)
+            .join("\n")
+            .contains("No containers available.")
+    );
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    assert!(app.pending.is_none());
+}
+
+#[tokio::test]
+async fn container_details_clear_selection_when_a_container_disappears() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let mut pod = container_details_pod();
+    apply(&mut app, pod.clone());
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    pod["spec"]["ephemeralContainers"] = json!([]);
+    apply(&mut app, pod);
+    assert!(app.container_state.selected().is_none());
+    assert!(
+        render_container_popup(&mut app, 160, 40)
+            .join("\n")
+            .contains("Select a container to see its details.")
+    );
+    app.handle_key(press(KeyCode::Char('s'))).unwrap();
+    assert!(app.pending.is_none());
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    assert!(app.container_state.selected().is_some());
+}
+
+#[tokio::test]
+async fn container_details_distinguish_missing_status_and_state_fallbacks() {
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let mut pod = container_details_pod();
+    pod["status"]["containerStatuses"] = json!([]);
+    apply(&mut app, pod.clone());
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.container_details["app"].ready, None);
+    assert_eq!(app.container_details["app"].restarts, None);
+    let lines = render_container_popup(&mut app, 160, 40);
+    let cells: Vec<_> = lines
+        .iter()
+        .find(|line| line.trim_start().starts_with("▌ "))
+        .unwrap()
+        .split_whitespace()
+        .collect();
+    assert_eq!(&cells[1..5], &["app", "-", "Unknown", "-"]);
+    for (state, expected) in [
+        (json!({"waiting": {}}), "Waiting"),
+        (json!({"terminated": {"exitCode": 42}}), "ExitCode:42"),
+        (
+            json!({"terminated": {"reason": "", "signal": 9, "exitCode": 137}}),
+            "Signal:9",
+        ),
+        (json!({"terminated": {"exitCode": 0}}), "Completed"),
+        (json!({"terminated": {}}), "Terminated"),
+        (json!({}), "Unknown"),
+    ] {
+        pod["status"]["containerStatuses"] =
+            json!([{"name": "app", "ready": false, "restartCount": 0, "state": state}]);
+        apply(&mut app, pod.clone());
+        assert_eq!(app.container_details["app"].state, expected);
+        assert_eq!(app.container_details["app"].restarts, Some(0));
+        assert!(
+            render_container_popup(&mut app, 160, 40)
+                .join("\n")
+                .contains(expected)
+        );
+    }
+}
+
+#[tokio::test]
+async fn container_details_keep_health_columns_and_wrap_long_images() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    let mut pod = container_details_pod();
+    let image = format!(
+        "registry.example.com/{}/app:1.2.3@sha256:{}",
+        "long-path/".repeat(8),
+        "a".repeat(64)
+    );
+    pod["spec"]["containers"][0]["image"] = json!(image);
+    apply(&mut app, pod);
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::new(),
+        containers: HashMap::from([("default/api/app".into(), (50, 1024 * 1024))]),
+    });
+    for (width, percentages, usage, readiness) in [
+        (160, true, true, true),
+        (80, false, true, true),
+        (50, false, false, true),
+        (40, false, false, false),
+    ] {
+        let lines = render_container_popup(&mut app, width, 40);
+        let header = &lines[0];
+        assert!(
+            header.contains("NAME") && header.contains("STATE") && header.contains("RESTARTS"),
+            "{header}"
+        );
+        assert_eq!(header.contains("%R/L"), percentages, "{header}");
+        assert_eq!(
+            header.contains("CPU") && header.contains("MEM"),
+            usage,
+            "{header}"
+        );
+        assert_eq!(header.contains("READY"), readiness, "{header}");
+        let app_row = lines
+            .iter()
+            .find(|line| line.trim_start().starts_with("▌ "))
+            .unwrap();
+        assert!(
+            app_row.contains("app") && app_row.contains("CrashLoopBackOff"),
+            "{app_row}"
+        );
+        assert!(app_row.split_whitespace().any(|v| v == "7"), "{app_row}");
+        let image_rows: String = lines
+            .iter()
+            .skip_while(|line| !line.contains("Image:"))
+            .take_while(|line| !line.contains("Ports:"))
+            .map(|line| line.trim())
+            .collect();
+        assert_eq!(image_rows, format!("Image: {image}"));
+        assert!(lines.join("\n").contains("http:8080/TCP, 5353/UDP"));
+    }
+    for (width, height) in [(3, 3), (10, 6), (30, 12), (80, 12), (160, 40)] {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+    }
 }
 
 #[tokio::test]
@@ -23823,8 +24200,8 @@ async fn container_trends_follow_keys_and_reject_stale_samples() {
         .map(|x| buffer[(x, heading_y - 1)].symbol())
         .collect();
     assert!(
-        rows_above.contains("sidecar"),
-        "the charts must follow the table without gauges or empty rows"
+        rows_above.contains("Probes:"),
+        "the charts must follow the selected container details"
     );
 
     app.handle_key(press(KeyCode::Down)).unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3448,87 +3448,128 @@ const C_GAP: usize = 2;
 
 use crate::text::ellipsize as truncate_cols;
 
-fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
-    let show_scrollbars = app.scrollbars_visible();
-    let gap = " ".repeat(C_GAP);
-    // Keep the name column readable but bounded so long names can't push the
-    // numeric columns off the right edge; anything longer is ellipsized.
-    let name_cap = (area.width as usize).saturating_sub(40).max(8);
-    let util_band = app.resolved_thresholds().utilization;
+fn container_columns_width(widths: &[usize; 8]) -> usize {
+    widths.iter().sum::<usize>()
+        + widths.iter().filter(|&&w| w > 0).count().saturating_sub(1) * C_GAP
+}
+
+fn container_column_widths(app: &App, available: usize) -> [usize; 8] {
     let name_width = app
         .container_list
         .iter()
-        .map(|name| name.chars().count())
+        .map(|s| s.width())
         .max()
         .unwrap_or(4)
-        .clamp(4, name_cap);
+        .clamp(8, 40);
+    let state_width = app
+        .container_details
+        .values()
+        .map(|c| c.state.width())
+        .max()
+        .unwrap_or(7)
+        .clamp(7, 32);
+    let restart_width = app
+        .container_details
+        .values()
+        .filter_map(|c| c.restarts)
+        .map(|n| n.to_string().len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+    let mut widths = [
+        8,
+        5,
+        state_width,
+        restart_width,
+        C_CPU,
+        C_CPU_PCT,
+        C_MEM,
+        C_MEM_PCT,
+    ];
+    for indices in [&[5, 7][..], &[4, 6][..], &[1][..]] {
+        if container_columns_width(&widths) <= available {
+            break;
+        }
+        for &i in indices {
+            widths[i] = 0;
+        }
+    }
+    if container_columns_width(&widths) > available {
+        widths[2] = available
+            .saturating_sub(8 + restart_width + 2 * C_GAP)
+            .min(state_width);
+    }
+    widths[0] = 0;
+    let other_width = container_columns_width(&widths);
+    let gap = if other_width > 0 { C_GAP } else { 0 };
+    widths[0] = available.saturating_sub(other_width + gap).min(name_width);
+    widths
+}
 
-    let header = Line::from(format!(
-        "{name:<name_width$}{gap}{cpu:>C_CPU$}{gap}{cpu_pct:>C_CPU_PCT$}{gap}{mem:>C_MEM$}{gap}{mem_pct:>C_MEM_PCT$}",
-        name = "NAME",
-        cpu = "CPU",
-        cpu_pct = "%R/L",
-        mem = "MEM",
-        mem_pct = "%R/L",
-    ))
-    .style(theme::dim());
+fn container_table_line(
+    values: [&str; 8],
+    colors: [Color; 8],
+    widths: &[usize; 8],
+) -> Line<'static> {
+    let mut spans = Vec::new();
+    for (i, &width) in widths.iter().enumerate().filter(|(_, w)| **w > 0) {
+        if !spans.is_empty() {
+            spans.push(Span::raw(" ".repeat(C_GAP)));
+        }
+        let value = truncate_cols(values[i], width);
+        let padding = " ".repeat(width.saturating_sub(value.width()));
+        let text = if i >= 3 {
+            format!("{padding}{value}")
+        } else {
+            format!("{value}{padding}")
+        };
+        spans.push(Span::styled(text, Style::default().fg(colors[i])));
+    }
+    Line::from(spans)
+}
 
-    let items: Vec<ListItem> = app
-        .container_list
-        .iter()
-        .map(|container| {
-            let usage = app.selected_pod_container_metrics(container);
-            let (cpu, memory) = usage
-                .map(|(cpu, memory)| {
-                    (
-                        crate::columns::fmt_cpu(cpu),
-                        crate::columns::fmt_mem(memory),
-                    )
-                })
-                .unwrap_or_else(|| ("-".into(), "-".into()));
-            let res = app
-                .container_resources
-                .get(container)
-                .cloned()
-                .unwrap_or_default();
-            let (cpu_pct, cpu_pct_color) = util_cell(
-                usage.map(|(c, _)| c),
-                res.cpu_request,
-                res.cpu_limit,
-                util_band,
-            );
-            let (mem_pct, mem_pct_color) = util_cell(
-                usage.map(|(_, m)| m),
-                res.mem_request,
-                res.mem_limit,
-                util_band,
-            );
-            let name = truncate_cols(container, name_width);
-            ListItem::new(Line::from(vec![
-                Span::styled(
-                    format!("{name:<name_width$}"),
-                    Style::default().fg(theme::text()),
-                ),
-                Span::styled(
-                    format!("{gap}{cpu:>C_CPU$}"),
-                    Style::default().fg(theme::yellow()),
-                ),
-                Span::styled(
-                    format!("{gap}{cpu_pct:>C_CPU_PCT$}"),
-                    Style::default().fg(cpu_pct_color),
-                ),
-                Span::styled(
-                    format!("{gap}{memory:>C_MEM$}"),
-                    Style::default().fg(theme::teal()),
-                ),
-                Span::styled(
-                    format!("{gap}{mem_pct:>C_MEM_PCT$}"),
-                    Style::default().fg(mem_pct_color),
-                ),
-            ]))
-        })
-        .collect();
+fn container_detail_lines(app: &App, width: usize) -> Vec<Line<'static>> {
+    let selected = app
+        .container_state
+        .selected()
+        .and_then(|i| app.container_list.get(i));
+    let Some((name, details)) =
+        selected.and_then(|name| app.container_details.get(name).map(|d| (name, d)))
+    else {
+        return vec![Line::styled(
+            if app.container_list.is_empty() {
+                "No containers available."
+            } else {
+                "Select a container to see its details."
+            },
+            theme::dim(),
+        )];
+    };
+    let [startup, readiness, liveness] = details
+        .probes
+        .map(|present| if present { "configured" } else { "absent" });
+    [
+        Line::styled(
+            format!("Container: {name} ({})", details.kind),
+            theme::title(),
+        ),
+        Line::from(format!("Image: {}", details.image)),
+        Line::from(format!("Ports: {}", details.ports)),
+        Line::from(format!(
+            "Probes: startup={startup}, readiness={readiness}, liveness={liveness}"
+        )),
+    ]
+    .into_iter()
+    .flat_map(|line| wrap_line(line, width))
+    .collect()
+}
 
+fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
+    if area.width < 4 || area.height < 4 {
+        return;
+    }
+    let show_scrollbars = app.scrollbars_visible();
+    let thresholds = app.resolved_thresholds();
     let qos = if app.container_qos.is_empty() {
         String::new()
     } else {
@@ -3547,32 +3588,31 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
             (Action::ProviderLogs, "provider"),
         ],
     );
-
-    // Size the box to its contents: header + rows + borders, and wide enough
-    // for the columns, the title, or the footer — whichever needs the most.
-    let content_w = 2 // list highlight symbol ("▌ ")
-        + name_width
-        + C_GAP + C_CPU
-        + C_GAP + C_CPU_PCT
-        + C_GAP + C_MEM
-        + C_GAP + C_MEM_PCT;
-    let inner_w = content_w
-        .max(title.chars().count())
-        .max(footer.chars().count())
-        .max(78);
-    // +2 borders, +1 so the last column doesn't touch the right border.
-    let popup_w = (inner_w as u16 + 3).min(area.width);
-    let rows = app.container_list.len() as u16;
-    let trend_height = if popup_w >= 80 && area.height >= 7 && rows > 0 {
+    let desired_width = container_columns_width(&container_column_widths(app, usize::MAX)) + 4;
+    let popup_w = desired_width
+        .max(82)
+        .max(footer.width() + 2)
+        .min(usize::from(area.width)) as u16;
+    let widths = container_column_widths(app, usize::from(popup_w.saturating_sub(4)));
+    let details = container_detail_lines(app, usize::from(popup_w.saturating_sub(4)));
+    let rows = app.container_list.len().max(1).min(usize::from(u16::MAX)) as u16;
+    let content_height = area.height.saturating_sub(3);
+    let min_rows = rows.min(3).min(content_height);
+    let detail_height = details
+        .len()
+        .min(usize::from(content_height.saturating_sub(min_rows))) as u16;
+    let trend_height = if popup_w >= 80
+        && !app.container_list.is_empty()
+        && content_height >= min_rows + detail_height + 3
+    {
         3
     } else {
         0
     };
-    let popup_h = rows.saturating_add(3 + trend_height).min(area.height);
-
+    let list_height = rows.min(content_height.saturating_sub(detail_height + trend_height));
+    let popup_h = 3 + list_height + detail_height + trend_height;
     let popup = centered_rect_exact(popup_w, popup_h, area);
     clear_region(frame, popup);
-
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -3581,15 +3621,20 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
         .title_bottom(Line::from(Span::styled(footer, theme::dim())).right_aligned());
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
-
-    let [header_area, list_area, trend_area] = Layout::vertical([
+    let [header_area, list_area, detail_area, trend_area] = Layout::vertical([
         Constraint::Length(1),
-        Constraint::Min(1),
+        Constraint::Length(list_height),
+        Constraint::Length(detail_height),
         Constraint::Length(trend_height),
     ])
     .areas(inner);
-    // Indent the header past the 2-column highlight gutter so it lines up with
-    // the rows underneath it.
+    let header = container_table_line(
+        [
+            "NAME", "READY", "STATE", "RESTARTS", "CPU", "%R/L", "MEM", "%R/L",
+        ],
+        [theme::overlay1(); 8],
+        &widths,
+    );
     frame.render_widget(
         Paragraph::new(header),
         Rect {
@@ -3598,6 +3643,81 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
             ..header_area
         },
     );
+    let items: Vec<ListItem> = app
+        .container_list
+        .iter()
+        .map(|container| {
+            let details = app.container_details.get(container);
+            let ready = match details.and_then(|d| d.ready) {
+                Some(true) => "true",
+                Some(false) => "false",
+                None => "-",
+            };
+            let state = details.map(|d| d.state.as_str()).unwrap_or("Unknown");
+            let restarts = details.and_then(|d| d.restarts);
+            let restart_text = restarts
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "-".into());
+            let restart_color = restarts
+                .and_then(|n| i64::try_from(n).ok())
+                .and_then(|n| thresholds.restarts.severity(n))
+                .map(theme::severity_fg)
+                .unwrap_or_else(theme::text);
+            let usage = app.selected_pod_container_metrics(container);
+            let (cpu, memory) = usage
+                .map(|(cpu, memory)| {
+                    (
+                        crate::columns::fmt_cpu(cpu),
+                        crate::columns::fmt_mem(memory),
+                    )
+                })
+                .unwrap_or_else(|| ("-".into(), "-".into()));
+            let res = app
+                .container_resources
+                .get(container)
+                .cloned()
+                .unwrap_or_default();
+            let (cpu_pct, cpu_pct_color) = util_cell(
+                usage.map(|(c, _)| c),
+                res.cpu_request,
+                res.cpu_limit,
+                thresholds.utilization,
+            );
+            let (mem_pct, mem_pct_color) = util_cell(
+                usage.map(|(_, m)| m),
+                res.mem_request,
+                res.mem_limit,
+                thresholds.utilization,
+            );
+            ListItem::new(container_table_line(
+                [
+                    container,
+                    ready,
+                    state,
+                    &restart_text,
+                    &cpu,
+                    &cpu_pct,
+                    &memory,
+                    &mem_pct,
+                ],
+                [
+                    theme::text(),
+                    match ready {
+                        "true" => theme::green(),
+                        "false" => theme::yellow(),
+                        _ => theme::overlay1(),
+                    },
+                    theme::status_color(state),
+                    restart_color,
+                    theme::yellow(),
+                    cpu_pct_color,
+                    theme::teal(),
+                    mem_pct_color,
+                ],
+                &widths,
+            ))
+        })
+        .collect();
     let list = List::new(items)
         .highlight_style(theme::selected_row())
         .highlight_symbol("▌ ")
@@ -3617,6 +3737,14 @@ fn draw_containers(frame: &mut Frame, app: &mut App, area: Rect) {
             .saturating_sub(usize::from(list_area.height)),
         usize::from(list_area.height),
         false,
+    );
+    frame.render_widget(
+        Paragraph::new(details).style(Style::default().fg(theme::text())),
+        Rect {
+            x: detail_area.x + 2,
+            width: detail_area.width.saturating_sub(2),
+            ..detail_area
+        },
     );
     if trend_height > 0 {
         draw_container_trends(frame, app, trend_area);


### PR DESCRIPTION
The container popup shows resource use but omits state and configuration details. This change adds readiness, state or failure reason, and restart counts to the table. Details below the table show the selected container's type, full image reference, declared ports, and configured probes.

Pod watch updates refresh the popup and preserve selection by name. The view includes regular, init, native sidecar, and ephemeral containers. Long image references wrap, and health columns have priority on narrow terminals. Column configuration is deferred as agreed.

Validation: `just check` covers formatting, Clippy with warnings treated as errors, and the full test suite. New tests use keyboard input and fake Pod updates to cover selection, all container types, missing status, live updates, and narrow and wide layouts.

Closes #459.

Agreed discussion: [#449](https://github.com/nklmilojevic/sofka/discussions/449), with [maintainer scope agreement](https://github.com/nklmilojevic/sofka/discussions/449#discussioncomment-18382633).
