### PR TITLE
fix: keep log order when toggling timestamps

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -82,7 +82,10 @@ table are included. With no marks, `l` opens logs for the current row.
 
 The pod set is fixed when the view opens, including when timestamps or time
 anchors change, or streaming resumes. New pods are not added automatically.
-Lines appear in arrival order, without a guarantee of timestamp order. A source
+Lines with timestamps are sorted by time, even when timestamp text is hidden.
+Press `t` to show or hide timestamps without clearing the buffer or restarting
+the streams. Lines with equal timestamps keep their arrival order. Lines without
+a valid timestamp stay after the newest timestamp received so far. A source
 error includes its prefix, and other streams continue. The existing filter and
 buffer controls apply to the combined view. `p` and `L` still use the current row.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -84,8 +84,10 @@ The pod set is fixed when the view opens, including when timestamps or time
 anchors change, or streaming resumes. New pods are not added automatically.
 Lines with timestamps are sorted by time, even when timestamp text is hidden.
 Press `t` to show or hide timestamps without clearing the buffer or restarting
-the streams. Lines with equal timestamps keep their arrival order. Lines without
-a valid timestamp stay after the newest timestamp received so far. A source
+the streams. A paused view keeps the same log line or marker in view, within
+the scroll limits. Lines with equal timestamps keep their arrival order. Lines
+without a valid timestamp use the newest known time for sorting. If no time is
+known, sofka uses the arrival time. A source
 error includes its prefix, and other streams continue. The existing filter and
 buffer controls apply to the combined view. `p` and `L` still use the current row.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -353,7 +353,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   [Debug containers and pods](debugging.md#debug-containers-and-pods).
 - **Logs** (`l`) - combined logs for marked pods, per-container on a pod, or aggregated across all matching
   pods on a workload/service, with filtering, previous-container logs, and
-  configurable tail/buffer/lookback. If a container is waiting to start, sofka
+  configurable tail/buffer/lookback. Lines with timestamps are sorted by time.
+  Press `t` to show or hide timestamps without changing log order or restarting
+  streams. If a container is waiting to start, sofka
   retries until its logs are available. sofka parses ANSI color from the source app
   and maps it onto the active skin instead of printing literal escapes. See
   [Log controls](debugging.md#log-controls).

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -116,6 +116,9 @@ point instead. See [PVC explore](features.md#pvc-explore).
 (VictoriaLogs views) · `esc` back. The newest line anchors to the bottom of the
 viewport.
 
+`t` shows or hides timestamps in the current buffer without restarting the
+streams. Log lines keep their timestamp order in both display settings.
+
 `m` adds a separator after the latest received log line. Repeated presses add
 separate markers. Markers stay visible through filters and are excluded from
 sofka copy/save. While paused, a marker is added at the buffer tail without

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1223,17 +1223,14 @@ impl App {
                 }
                 return;
             }
-            // k9s: `t` toggles timestamps (re-streams).
+            // Show or hide timestamps in the current buffer.
             (Some(Action::Timestamps), _) => {
-                self.logs.timestamps = !self.logs.timestamps;
+                self.logs.toggle_timestamps();
                 self.flash = format!(
                     "timestamps: {}",
                     if self.logs.timestamps { "on" } else { "off" }
                 );
                 self.flash_err = false;
-                if !self.logs.stopped {
-                    self.retail_logs();
-                }
                 return;
             }
             // Stop / resume the live stream.

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -1,5 +1,103 @@
 use super::*;
 
+#[derive(Default)]
+pub(super) struct LogLineMeta {
+    sort_time: Option<i128>,
+    timestamp: Option<(usize, String)>,
+}
+
+impl LogLineMeta {
+    fn parse(line: &str, fallback: Option<i128>) -> Self {
+        let start = if line.starts_with('[') {
+            line.find("] ").map_or(0, |end| end + 2)
+        } else {
+            0
+        };
+        let end = line[start..]
+            .find(' ')
+            .map_or(line.len(), |end| start + end);
+        let Ok(time) = line[start..end].parse::<k8s_openapi::jiff::Timestamp>() else {
+            return Self {
+                sort_time: fallback,
+                timestamp: None,
+            };
+        };
+        let end = (end + 1).min(line.len());
+        Self {
+            sort_time: Some(time.as_nanosecond()),
+            timestamp: Some((start, line[start..end].to_owned())),
+        }
+    }
+}
+
+impl LogsView {
+    fn push_line(&mut self, mut line: String) {
+        self.line_meta
+            .resize_with(self.view.lines.len(), LogLineMeta::default);
+        let meta = LogLineMeta::parse(&line, self.line_meta.back().and_then(|m| m.sort_time));
+        if !self.timestamps
+            && let Some((start, timestamp)) = &meta.timestamp
+        {
+            line.replace_range(*start..start + timestamp.len(), "");
+        }
+        // Equal timestamps keep their arrival order. Lines without a timestamp
+        // stay after the newest timestamp received so far.
+        let index = if self
+            .line_meta
+            .back()
+            .is_none_or(|m| m.sort_time <= meta.sort_time)
+        {
+            self.view.lines.len()
+        } else {
+            self.line_meta
+                .partition_point(|m| m.sort_time <= meta.sort_time)
+        };
+        if index < self.view.lines.len() {
+            if !self.follow && self.matches(&line) {
+                self.refresh_index(self.last_wrap_width);
+                let mut marker_index = 0;
+                if let Some(shown) = self.index.shown.iter().position(|entry| match entry {
+                    Some(i) => *i as usize >= index,
+                    None => {
+                        let after = self.markers[marker_index] > self.line_offset + index;
+                        marker_index += 1;
+                        after
+                    }
+                }) && self.index.start_row(shown) <= self.view.scroll
+                {
+                    self.view.scroll += match self.last_wrap_width {
+                        0 => 1,
+                        width => crate::ui::wrapped_height(&line, width),
+                    };
+                }
+            }
+            for marker in &mut self.markers {
+                if *marker > self.line_offset + index {
+                    *marker += 1;
+                }
+            }
+            self.view.revision = self.view.revision.wrapping_add(1);
+        }
+        self.line_meta.insert(index, meta);
+        self.view.lines.insert(index, line);
+    }
+
+    pub(super) fn toggle_timestamps(&mut self) {
+        self.timestamps = !self.timestamps;
+        for (line, meta) in self.view.lines.iter_mut().zip(&self.line_meta) {
+            if let Some((start, timestamp)) = &meta.timestamp {
+                if self.timestamps {
+                    line.insert_str(*start, timestamp);
+                } else {
+                    line.replace_range(*start..start + timestamp.len(), "");
+                }
+            }
+        }
+        self.view.revision = self.view.revision.wrapping_add(1);
+        self.reset_index();
+    }
+}
+
 impl App {
     // ----- selection -----------------------------------------------------
 
@@ -7,22 +105,21 @@ impl App {
     where
         I: IntoIterator<Item = String>,
     {
-        // Strip carriage returns so progress output doesn't overwrite a row,
-        // and expand tabs to spaces — many loggers separate timestamp/level/body
-        // with tabs, which some terminals render awkwardly in a TUI cell.
-        // Clean lines (the vast majority) pass through without reallocating.
-        self.logs.view.lines.extend(lines.into_iter().map(|line| {
-            if !line.contains('\r') && !line.contains('\t') {
-                return line;
-            }
-            line.chars()
-                .filter_map(|c| match c {
-                    '\r' => None,
-                    '\t' => Some(' '),
-                    c => Some(c),
-                })
-                .collect()
-        }));
+        // Remove carriage returns and replace tabs with spaces for display.
+        for line in lines {
+            let line = if line.contains('\r') || line.contains('\t') {
+                line.chars()
+                    .filter_map(|c| match c {
+                        '\r' => None,
+                        '\t' => Some(' '),
+                        c => Some(c),
+                    })
+                    .collect()
+            } else {
+                line
+            };
+            self.logs.push_line(line);
+        }
 
         self.trim_log_buffer();
     }
@@ -277,8 +374,7 @@ impl App {
         self.restart_log_stream();
     }
 
-    /// Re-stream the current source (e.g. after toggling timestamps), keeping
-    /// the title, filter, and follow state.
+    /// Restart the current source and keep the title, filter, and follow state.
     pub(super) fn retail_logs(&mut self) {
         if self.logs.source.is_none() {
             return;
@@ -307,7 +403,6 @@ impl App {
 
     /// Spawn the streaming task(s) for the current `log_source`.
     pub(super) fn start_logs(&mut self) {
-        let ts = self.logs.timestamps;
         match self.logs.source.clone() {
             Some(LogSource::Pods(pods)) => {
                 for PodLogTarget {
@@ -318,18 +413,11 @@ impl App {
                 {
                     if containers.is_empty() {
                         let prefix = format!("[{ns}/{name}] ");
-                        self.spawn_one_log(ns, name, None, prefix, false, ts);
+                        self.spawn_one_log(ns, name, None, prefix, false);
                     } else {
                         for c in containers {
                             let prefix = format!("[{ns}/{name}:{c}] ");
-                            self.spawn_one_log(
-                                ns.clone(),
-                                name.clone(),
-                                Some(c),
-                                prefix,
-                                false,
-                                ts,
-                            );
+                            self.spawn_one_log(ns.clone(), name.clone(), Some(c), prefix, false);
                         }
                     }
                 }
@@ -341,7 +429,7 @@ impl App {
             }) => {
                 if containers.is_empty() {
                     // Unknown container set (e.g. from xray) — stream the default.
-                    self.spawn_one_log(ns, name, None, String::new(), false, ts);
+                    self.spawn_one_log(ns, name, None, String::new(), false);
                 } else {
                     let multi = containers.len() > 1;
                     for c in containers {
@@ -350,32 +438,26 @@ impl App {
                         } else {
                             String::new()
                         };
-                        self.spawn_one_log(ns.clone(), name.clone(), Some(c), prefix, false, ts);
+                        self.spawn_one_log(ns.clone(), name.clone(), Some(c), prefix, false);
                     }
                 }
             }
-            Some(LogSource::Selector { ns, labels }) => self.spawn_selector_logs(ns, labels, ts),
+            Some(LogSource::Selector { ns, labels }) => self.spawn_selector_logs(ns, labels),
             Some(LogSource::Single {
                 ns,
                 pod,
                 container,
                 previous,
-            }) => self.spawn_one_log(ns, pod, container, String::new(), previous, ts),
-            Some(LogSource::Provider { request }) => self.spawn_provider_logs(request, ts),
+            }) => self.spawn_one_log(ns, pod, container, String::new(), previous),
+            Some(LogSource::Provider { request }) => self.spawn_provider_logs(request),
             None => {}
         }
     }
 
-    /// Spawn the provider backfill + live tail task for `request`. Shares the
-    /// log-stream lifecycle (`log_gen`/`log_flag`), so stop/resume, timestamp
-    /// re-streams, and view exits all work unchanged. With nothing configured,
-    /// the task first autodiscovers a VictoriaLogs service in the cluster and
-    /// reports it back for caching.
-    pub(super) fn spawn_provider_logs(
-        &mut self,
-        request: crate::providers::LogRequest,
-        timestamps: bool,
-    ) {
+    /// Start the provider history query and live stream for `request`.
+    /// Use the log generation for stream restarts and view exits. If no
+    /// provider is configured, discover and cache a VictoriaLogs service.
+    pub(super) fn spawn_provider_logs(&mut self, request: crate::providers::LogRequest) {
         let provider = self.log_provider.clone().unwrap_or_default();
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
@@ -440,7 +522,7 @@ impl App {
             if !info.is_empty() && !send_log_batch(&tx, genr, &mut info).await {
                 return;
             }
-            provider_log_task(provider, request, client, tx, genr, flag, timestamps).await;
+            provider_log_task(provider, request, client, tx, genr, flag).await;
         });
         self.log_tasks.push(handle);
     }
@@ -452,7 +534,6 @@ impl App {
         container: Option<String>,
         prefix: String,
         previous: bool,
-        timestamps: bool,
     ) {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
@@ -472,7 +553,8 @@ impl App {
                 follow: !previous,
                 previous,
                 container,
-                timestamps,
+                // Keep timestamps for sorting, even when their text is hidden.
+                timestamps: true,
                 tail_lines,
                 since_seconds,
                 ..Default::default()
@@ -533,7 +615,7 @@ impl App {
         }
     }
 
-    pub(super) fn spawn_selector_logs(&mut self, ns: String, labels: String, timestamps: bool) {
+    pub(super) fn spawn_selector_logs(&mut self, ns: String, labels: String) {
         let client = self.cluster.client.clone();
         let tx = self.tx.clone();
         let genr = self.log_gen;
@@ -591,7 +673,7 @@ impl App {
                         let lp = LogParams {
                             follow: true,
                             container: Some(c),
-                            timestamps,
+                            timestamps: true,
                             tail_lines: Some(per_pod_tail),
                             since_seconds: since,
                             ..Default::default()
@@ -621,7 +703,6 @@ async fn provider_log_task(
     tx: Sender<Msg>,
     generation: u64,
     flag: Arc<AtomicU64>,
-    timestamps: bool,
 ) {
     use crate::providers::{LogRequest, LogScope, Prefix};
 
@@ -682,7 +763,7 @@ async fn provider_log_task(
                 if let Some(n) = e.nanos {
                     backfill_max = backfill_max.max(n);
                 }
-                lines.extend(e.lines(prefix, timestamps));
+                lines.extend(e.lines(prefix, true));
             }
             if lines.is_empty() {
                 lines.push(format!("(no logs in the last {})", provider.lookback_label));
@@ -727,7 +808,7 @@ async fn provider_log_task(
                     // Skip anything the backfill already showed (the tail may
                     // replay a little history at the seam).
                     if e.nanos.is_none_or(|n| n > backfill_max) {
-                        batch.extend(e.lines(prefix, timestamps));
+                        batch.extend(e.lines(prefix, true));
                     }
                     if batch.len() >= LOG_BATCH_LINES
                         && !send_log_batch(&tx, generation, &mut batch).await

--- a/src/app/logs.rs
+++ b/src/app/logs.rs
@@ -18,7 +18,9 @@ impl LogLineMeta {
             .map_or(line.len(), |end| start + end);
         let Ok(time) = line[start..end].parse::<k8s_openapi::jiff::Timestamp>() else {
             return Self {
-                sort_time: fallback,
+                sort_time: Some(
+                    fallback.unwrap_or_else(|| k8s_openapi::jiff::Timestamp::now().as_nanosecond()),
+                ),
                 timestamp: None,
             };
         };
@@ -40,8 +42,8 @@ impl LogsView {
         {
             line.replace_range(*start..start + timestamp.len(), "");
         }
-        // Equal timestamps keep their arrival order. Lines without a timestamp
-        // stay after the newest timestamp received so far.
+        // Equal timestamps keep their arrival order. Missing timestamps use
+        // the newest known time, or the arrival time if no time is known.
         let index = if self
             .line_meta
             .back()
@@ -83,6 +85,18 @@ impl LogsView {
     }
 
     pub(super) fn toggle_timestamps(&mut self) {
+        let anchor = if self.follow {
+            None
+        } else {
+            let (scroll, height) = (self.view.scroll, self.viewport_h);
+            let index = self.refresh_index(self.last_wrap_width);
+            let row = scroll.min(index.total_rows().saturating_sub(height));
+            let shown = index.first_at_row(row);
+            index.shown.get(shown).map(|line| {
+                let marker = index.shown[..shown].iter().filter(|l| l.is_none()).count();
+                (*line, marker, row - index.start_row(shown))
+            })
+        };
         self.timestamps = !self.timestamps;
         for (line, meta) in self.view.lines.iter_mut().zip(&self.line_meta) {
             if let Some((start, timestamp)) = &meta.timestamp {
@@ -94,7 +108,35 @@ impl LogsView {
             }
         }
         self.view.revision = self.view.revision.wrapping_add(1);
-        self.reset_index();
+        self.viewport_rows = self.refresh_index(self.last_wrap_width).total_rows();
+        if !self.follow {
+            let row = anchor.map_or(0, |(line, marker, offset)| {
+                let index = &self.index;
+                let shown = match line {
+                    Some(line) => index
+                        .shown
+                        .iter()
+                        .position(|entry| entry.is_some_and(|i| i >= line))
+                        .or_else(|| index.shown.len().checked_sub(1)),
+                    None => index
+                        .shown
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, line)| line.is_none())
+                        .nth(marker)
+                        .map(|(i, _)| i),
+                };
+                shown.map_or(0, |shown| {
+                    let offset = if index.shown[shown] == line {
+                        offset.min(index.height_at(shown).saturating_sub(1))
+                    } else {
+                        0
+                    };
+                    index.start_row(shown) + offset
+                })
+            });
+            self.view.scroll = row.min(self.viewport_rows.saturating_sub(self.viewport_h));
+        }
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -410,8 +410,7 @@ struct PodLogTarget {
     containers: Vec<String>,
 }
 
-/// What the logs view is currently streaming, so it can be re-streamed when
-/// toggling timestamps (k9s `t`).
+/// The current log source, retained for stream restarts.
 #[derive(Clone, Debug)]
 enum LogSource {
     /// The marked pods captured when the log view opens.
@@ -1117,6 +1116,8 @@ impl LogIndex {
 /// the top-level `App` struct.
 pub struct LogsView {
     pub view: Scrollable,
+    /// Timestamp text and sort keys for the corresponding display lines.
+    line_meta: VecDeque<logs::LogLineMeta>,
     /// Stable position of the first retained source line.
     line_offset: usize,
     /// Each marker precedes the source line at this stable position.
@@ -1147,8 +1148,7 @@ pub struct LogsView {
     /// handler convert trimmed *lines* into the display *rows* they occupied
     /// when shifting a paused scroll anchor.
     pub last_wrap_width: usize,
-    /// What is being streamed, so it can be re-streamed (e.g. toggling
-    /// timestamps) without re-deriving the source.
+    /// The current source, retained for stream restarts.
     source: Option<LogSource>,
     /// Filter/wrap index over [`Self::view`], maintained incrementally.
     index: LogIndex,
@@ -1158,6 +1158,7 @@ impl Default for LogsView {
     fn default() -> Self {
         Self {
             view: Scrollable::empty(),
+            line_meta: VecDeque::new(),
             line_offset: 0,
             markers: VecDeque::new(),
             follow: true,
@@ -1213,6 +1214,7 @@ impl LogsView {
 
     fn clear_lines(&mut self) {
         self.view.clear_lines();
+        self.line_meta.clear();
         self.markers.clear();
         self.line_offset = 0;
         self.reset_index();
@@ -1239,6 +1241,7 @@ impl LogsView {
             self.view.scroll = self.view.scroll.saturating_sub(rows + removed_markers);
         }
         self.markers.drain(..removed_markers);
+        self.line_meta.drain(..count.min(self.line_meta.len()));
         self.view.drain_front(count);
         self.reset_index();
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -9002,6 +9002,101 @@ async fn log_timestamp_order_keeps_ties_errors_and_newest_lines_within_the_cap()
 }
 
 #[tokio::test]
+async fn log_timestamp_initial_status_lines_follow_older_history() {
+    use k8s_openapi::jiff::Timestamp;
+
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.logs_cfg.buffer = 3;
+    let now = Timestamp::now().as_second();
+    shortcut_log_lines(
+        &mut app,
+        vec![
+            "[provider] connected".into(),
+            "[a] [error] unavailable".into(),
+        ],
+    );
+    shortcut_log_lines(
+        &mut app,
+        (1..=3)
+            .map(|i| {
+                format!(
+                    "{} history {i}",
+                    Timestamp::from_second(now - 60 + i).unwrap()
+                )
+            })
+            .collect(),
+    );
+    assert_eq!(
+        app.filtered_log_text(),
+        "history 3\n[provider] connected\n[a] [error] unavailable"
+    );
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert!(
+        app.filtered_log_text()
+            .ends_with("history 3\n[provider] connected\n[a] [error] unavailable")
+    );
+    shortcut_log_lines(
+        &mut app,
+        (1..=3)
+            .map(|i| format!("{} live {i}", Timestamp::from_second(now + 60 + i).unwrap()))
+            .collect(),
+    );
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(app.filtered_log_text(), "live 1\nlive 2\nlive 3");
+}
+
+#[tokio::test]
+async fn log_timestamp_toggle_preserves_paused_wrapped_line_and_marker() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    for marker in [false, true] {
+        let (mut app, _rx) = test_app();
+        app.mode = Mode::Logs;
+        app.handle_key(press(KeyCode::Char('F'))).unwrap();
+        app.handle_key(press(KeyCode::Char('w'))).unwrap();
+        for i in 0..40 {
+            if i == 10 {
+                app.handle_key(press(KeyCode::Char('m'))).unwrap();
+                app.handle_key(press(KeyCode::Char('m'))).unwrap();
+            }
+            shortcut_log_lines(
+                &mut app,
+                vec![format!(
+                    "2026-09-10T10:00:{i:02}Z keep line {i:02} with enough text to wrap across rows"
+                )],
+            );
+        }
+        app.handle_key(press(KeyCode::Char('/'))).unwrap();
+        for c in "keep".chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(28, 10)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        app.handle_key(press(KeyCode::Home)).unwrap();
+        let shown = if marker { 11 } else { 15 };
+        let offset = usize::from(!marker);
+        let target = app.logs.index().start_row(shown) + offset;
+        for _ in 0..target {
+            app.handle_key(press(KeyCode::Char('j'))).unwrap();
+        }
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        assert_eq!(app.logs.view.scroll, target);
+        let anchor = app.logs.index().line_at(shown);
+        for _ in 0..4 {
+            app.handle_key(press(KeyCode::Char('t'))).unwrap();
+            terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+            assert!(!app.logs.follow);
+            let index = app.logs.index();
+            assert_eq!(index.first_at_row(app.logs.view.scroll), shown);
+            assert_eq!(index.line_at(shown), anchor);
+            assert_eq!(app.logs.view.scroll - index.start_row(shown), offset);
+        }
+    }
+}
+
+#[tokio::test]
 async fn log_timestamp_order_keeps_paused_scroll_filters_and_markers() {
     let (mut app, _rx) = test_app();
     app.mode = Mode::Logs;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8780,7 +8780,7 @@ async fn marked_pod_logs_stream_all_containers_and_identify_errors() {
                     .to_string(),
                 )
             } else {
-                (200, "ready\n".to_owned())
+                (200, "2026-09-10T10:00:00Z ready\n".to_owned())
             };
             async move {
                 Ok::<_, std::convert::Infallible>(
@@ -8820,11 +8820,238 @@ async fn marked_pod_logs_stream_all_containers_and_identify_errors() {
         assert!(!uri.path().contains("gamma"));
         let query = uri.query().unwrap();
         assert!(query.contains("follow=true"));
+        assert!(query.contains("timestamps=true"));
         assert!(query.contains(&format!("tailLines={}", app.logs_cfg.tail)));
     }
     app.handle_key(press(KeyCode::Esc)).unwrap();
     assert!(app.log_tasks.is_empty());
     assert_eq!(app.marked.len(), 2);
+}
+
+#[tokio::test]
+async fn log_timestamp_requests_cover_pods_selectors_and_previous_containers() {
+    for source in ["pod", "selector", "previous"] {
+        let (mut app, mut rx) = test_app();
+        let pod = json!({"apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web", "namespace": "default"},
+            "spec": {"containers": [{"name": "app"}, {"name": "sidecar"}]}});
+        if source == "selector" {
+            app.switch_kind("deployments");
+            apply(
+                &mut app,
+                json!({"apiVersion": "apps/v1", "kind": "Deployment",
+                "metadata": {"name": "web", "namespace": "default"},
+                "spec": {"selector": {"matchLabels": {"app": "web"}}}}),
+            );
+        } else {
+            app.switch_kind("pods");
+            apply(&mut app, pod.clone());
+        }
+        app.table_state.select(Some(0));
+        let requests = Arc::new(AtomicU64::new(0));
+        let seen = requests.clone();
+        app.cluster.client = kube::Client::new(
+            tower::service_fn(move |request: http::Request<kube::client::Body>| {
+                let body = if request.uri().path().ends_with("/log") {
+                    let query = request.uri().query().unwrap();
+                    assert!(query.contains("timestamps=true"));
+                    seen.fetch_add(1, Ordering::SeqCst);
+                    if query.contains("container=sidecar") {
+                        "2026-09-10T10:00:00Z first\n".to_owned()
+                    } else {
+                        "2026-09-10T10:00:01Z second\n".to_owned()
+                    }
+                } else {
+                    json!({"apiVersion": "v1", "kind": "PodList",
+                        "metadata": {}, "items": [pod]})
+                    .to_string()
+                };
+                async move {
+                    Ok::<_, std::convert::Infallible>(http::Response::new(
+                        http_body_util::Full::new(hyper::body::Bytes::from(body)),
+                    ))
+                }
+            }),
+            "default",
+        );
+        let key = if source == "previous" { 'p' } else { 'l' };
+        app.handle_key(press(KeyCode::Char(key))).unwrap();
+        let count = if source == "previous" { 1 } else { 2 };
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while app.logs.view.lines.len() < count {
+                app.handle_msg(rx.recv().await.unwrap());
+            }
+        })
+        .await
+        .unwrap();
+        let hidden = app.filtered_log_text();
+        assert!(!hidden.contains("2026-09-10"));
+        if source != "previous" {
+            assert!(hidden.find("first").unwrap() < hidden.find("second").unwrap());
+        }
+        let generation = app.log_gen;
+        for _ in 0..2 {
+            app.handle_key(press(KeyCode::Char('t'))).unwrap();
+            assert!(app.filtered_log_text().contains("2026-09-10"));
+            app.handle_key(press(KeyCode::Char('t'))).unwrap();
+            assert_eq!(app.filtered_log_text(), hidden);
+        }
+        assert_eq!(app.log_gen, generation);
+        assert_eq!(requests.load(Ordering::SeqCst), count as u64);
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn log_timestamp_toggle_keeps_chronological_order_without_restarting() {
+    let (mut app, _rx) = marked_logs_app();
+    app.handle_key(press(KeyCode::Char('l'))).unwrap();
+    let generation = app.log_gen;
+    shortcut_log_lines(
+        &mut app,
+        vec![
+            "[alpha/web:app] 2026-09-10T10:00:00.100000001Z third".into(),
+            "[alpha/web:app] 2026-09-10T10:00:00.2Z fourth".into(),
+        ],
+    );
+    app.logs.refresh_index(20);
+    shortcut_log_lines(
+        &mut app,
+        vec![
+            "[beta/web:app] 2026-09-10T12:00:00+02:00 first".into(),
+            "[beta/web:app] 2026-09-10T10:00:00.1Z second".into(),
+        ],
+    );
+    let hidden = "[beta/web:app] first\n[beta/web:app] second\n[alpha/web:app] third\n[alpha/web:app] fourth";
+    assert_eq!(app.filtered_log_text(), hidden);
+    assert_index_matches_naive(&mut app.logs, 20, "sorted batches");
+    for stopped in [false, true] {
+        if stopped {
+            app.handle_key(press(KeyCode::Char('x'))).unwrap();
+        }
+        let generation = app.log_gen;
+        let tasks = app.log_tasks.len();
+        app.handle_key(press(KeyCode::Char('t'))).unwrap();
+        assert!(app.logs.timestamps);
+        assert_eq!(app.log_gen, generation);
+        assert_eq!(app.log_tasks.len(), tasks);
+        assert_eq!(
+            app.filtered_log_text(),
+            "[beta/web:app] 2026-09-10T12:00:00+02:00 first\n[beta/web:app] 2026-09-10T10:00:00.1Z second\n[alpha/web:app] 2026-09-10T10:00:00.100000001Z third\n[alpha/web:app] 2026-09-10T10:00:00.2Z fourth"
+        );
+        assert_index_matches_naive(&mut app.logs, 20, "visible timestamps");
+        app.handle_key(press(KeyCode::Char('t'))).unwrap();
+        assert_eq!(app.filtered_log_text(), hidden);
+        assert_index_matches_naive(&mut app.logs, 20, "hidden timestamps");
+    }
+    assert_eq!(app.log_gen, generation + 1);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+}
+
+#[tokio::test]
+async fn log_timestamp_order_keeps_ties_errors_and_newest_lines_within_the_cap() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    app.logs_cfg.buffer = 3;
+    shortcut_log_lines(
+        &mut app,
+        vec![
+            "[a] 2026-09-10T10:00:03Z latest".into(),
+            "[b] [error] unavailable".into(),
+            "[b] 2026-09-10T10:00:01Z oldest".into(),
+            "[b] 2026-09-10T10:00:02Z middle".into(),
+        ],
+    );
+    assert_eq!(
+        app.filtered_log_text(),
+        "[b] middle\n[a] latest\n[b] [error] unavailable"
+    );
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    shortcut_log_lines(
+        &mut app,
+        vec!["[c] 2026-09-10T10:00:03.000Z same time".into()],
+    );
+    assert_eq!(
+        app.filtered_log_text(),
+        "[a] 2026-09-10T10:00:03Z latest\n[b] [error] unavailable\n[c] 2026-09-10T10:00:03.000Z same time"
+    );
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(
+        app.filtered_log_text(),
+        "[a] latest\n[b] [error] unavailable\n[c] same time"
+    );
+    app.handle_key(press(KeyCode::Char('z'))).unwrap();
+    shortcut_log_lines(
+        &mut app,
+        vec![
+            "2026-09-10T10:00:00Z 2026-09-10T09:59:59Z body timestamp".into(),
+            "[a] invalid-time plain text".into(),
+            "2026-09-10T10:00:01Z ".into(),
+        ],
+    );
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(
+        app.filtered_log_text(),
+        "2026-09-10T10:00:00Z 2026-09-10T09:59:59Z body timestamp\n[a] invalid-time plain text\n2026-09-10T10:00:01Z "
+    );
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    assert_eq!(
+        app.filtered_log_text(),
+        "2026-09-10T09:59:59Z body timestamp\n[a] invalid-time plain text\n"
+    );
+}
+
+#[tokio::test]
+async fn log_timestamp_order_keeps_paused_scroll_filters_and_markers() {
+    let (mut app, _rx) = test_app();
+    app.mode = Mode::Logs;
+    shortcut_log_lines(
+        &mut app,
+        vec![
+            "[a] 2026-09-10T10:00:02Z keep second".into(),
+            "[a] 2026-09-10T10:00:03Z keep third".into(),
+        ],
+    );
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    for c in "keep".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_key(press(KeyCode::Home)).unwrap();
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    app.logs.last_wrap_width = 10;
+    app.logs.refresh_index(10);
+    app.logs.view.scroll = app.logs.index().start_row(1);
+    shortcut_log_lines(
+        &mut app,
+        vec![
+            "[b] 2026-09-10T10:00:00Z excluded".into(),
+            "[b] 2026-09-10T10:00:01Z keep first".into(),
+        ],
+    );
+    let index = app.logs.refresh_index(10);
+    assert_eq!(index.shown, [Some(1), Some(2), Some(3), None]);
+    assert_eq!(app.logs.view.scroll, app.logs.index().start_row(2));
+    for _ in 0..2 {
+        app.handle_key(press(KeyCode::Char('t'))).unwrap();
+        assert!(!app.logs.follow);
+        assert_eq!(app.logs.filter, "keep");
+        assert_eq!(
+            app.logs.refresh_index(10).shown,
+            [Some(1), Some(2), Some(3), None]
+        );
+    }
+    assert_eq!(
+        app.filtered_log_text(),
+        "[b] keep first\n[a] keep second\n[a] keep third"
+    );
+    app.handle_key(press(KeyCode::Char('z'))).unwrap();
+    shortcut_log_lines(&mut app, vec!["2026-09-10T10:00:03Z excluded".into()]);
+    app.handle_key(press(KeyCode::Char('m'))).unwrap();
+    assert_eq!(app.logs.refresh_index(10).shown, [None]);
+    shortcut_log_lines(&mut app, vec!["2026-09-10T10:00:02Z keep earlier".into()]);
+    assert_eq!(app.logs.refresh_index(10).shown, [Some(0), None]);
+    assert_eq!(app.logs.view.scroll, app.logs.index().start_row(1));
 }
 
 #[tokio::test]
@@ -8852,7 +9079,7 @@ async fn marked_pod_logs_keep_the_snapshot_and_existing_controls() {
     for key in ['t', '2'] {
         let generation = app.log_gen;
         app.handle_key(press(KeyCode::Char(key))).unwrap();
-        assert!(app.log_gen > generation);
+        assert_eq!(app.log_gen > generation, key == '2');
         assert_eq!(format!("{:?}", app.logs.source), snapshot);
         assert_eq!(app.log_tasks.len(), 5);
         assert_eq!(app.logs.filter, "ready");
@@ -24411,11 +24638,11 @@ async fn log_marker_shortcut_handles_stopped_provider_and_replaced_buffers() {
     assert_eq!(app.mode, Mode::Logs);
     app.handle_key(press(KeyCode::Char('m'))).unwrap();
     app.handle_key(press(KeyCode::Char('t'))).unwrap();
-    assert!(app.logs.markers.is_empty());
+    assert_eq!(app.logs.markers.len(), 1);
     app.handle_key(press(KeyCode::Char('x'))).unwrap();
     assert!(app.logs.stopped);
     app.handle_key(press(KeyCode::Char('m'))).unwrap();
-    assert_eq!(app.logs.markers.len(), 1);
+    assert_eq!(app.logs.markers.len(), 2);
     app.logs.source = Some(LogSource::Provider {
         request: crate::providers::LogRequest::Pod {
             ns: "default".into(),
@@ -24425,7 +24652,7 @@ async fn log_marker_shortcut_handles_stopped_provider_and_replaced_buffers() {
         },
     });
     app.handle_key(press(KeyCode::Char('m'))).unwrap();
-    assert_eq!(app.logs.markers.len(), 2);
+    assert_eq!(app.logs.markers.len(), 3);
     app.handle_key(press(KeyCode::Esc)).unwrap();
     app.handle_key(press(KeyCode::Char('l'))).unwrap();
     assert_eq!(app.mode, Mode::Logs);


### PR DESCRIPTION
Combined log streams could show the same entries in a different order after `t` was pressed. Keep timestamps for sorting, and let `t` show or hide timestamp text in the current buffer without restarting streams.

Preserve arrival order for equal timestamps, buffer limits, filters, and log markers. Use arrival time to order initial lines without timestamps. Keep the paused view on its current line or marker when timestamp visibility changes line wrapping. Update the log documentation.

Validation: `just check` and the commit hooks passed. Regression tests cover timestamp precision and visibility, pod and selector streams, previous-container logs, initial status lines, paused wrapped views, and buffer controls. No live cluster test was run.

Closes #458
