### PR TITLE
feat: show server Table columns for generic resources

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -110,7 +110,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   `format = "image-tag"` to show image tags, with registry ports and digests
   handled separately. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
-  automatically. `w` toggles wide-only columns (kubectl `-o wide`), including
+  automatically. If no usable CRD columns are available, server Table columns
+  can supply the view. Explicit views and built-in columns keep their priority.
+  Table cells use watch updates, periodic refresh, and a polling fallback.
+  `w` toggles wide-only columns (kubectl `-o wide`), including
   node labels. Add `@<namespace>` to a view key to select columns for one
   namespace. See
   [Views and thresholds](views.md).

--- a/docs/views.md
+++ b/docs/views.md
@@ -386,6 +386,44 @@ Other JSONPath filter
 or wildcard expressions aren't representable and those columns are skipped. So
 most custom resources get useful columns with zero configuration.
 
+### Server Table columns
+
+If a resource has no built-in columns, no explicit view columns, and no usable
+CRD printer columns, sofka requests columns from the Kubernetes Table API.
+This supports aggregated APIs such as Calico's `projectcalico.org/v3`
+`CalicoNodeStatus` resources. It also works when you can read a resource but
+cannot read its CRD. An API that does not support Tables keeps the NAME/AGE
+view. Explicit views, built-in columns, and usable CRD printer columns keep
+their current priority.
+
+Server columns keep their order. Headers are shown in uppercase. Columns with
+`priority > 0` appear in wide mode (`w`). NAME and any AGE column use resource
+metadata, so AGE continues to advance between server updates. NAME is added
+if the server does not define it.
+
+Integer and number columns support numeric sorting and structured filters,
+such as `sessions>5`. Date columns sort by their timestamps. Other columns
+use their displayed text. A string such as `2/3` stays text; a numeric filter
+does not read its leading number. Missing cells show `<none>` and do not
+match structured comparisons.
+
+sofka keeps the full resource watch for details and resource actions. Server
+cells are stored separately and shown only when their object UID and resource
+version match the watched object. A cell can show `<none>` after an object
+changes, until a matching Table update arrives.
+
+Table watches provide cell updates when the API supports them. Each Table
+watch runs for up to 30 seconds, then sofka reads a fresh Table to update
+relative time text and recover from missed changes. If Table watches are
+unsupported, sofka polls instead. A new Table list cycle starts at most once
+every five seconds, including retries. A cycle can contain multiple pages
+of up to 500 rows. Slow requests can delay updates.
+
+Table requests follow the active namespace and label and field selectors.
+They stop when the resource watch stops. A view or context change discards
+the previous Table cells. Failed Table requests show an error and clear the
+server cells while the full resource view remains available.
+
 ## Thresholds
 
 The warning and critical values behind RESTARTS/CPU/MEM cell color (and the

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -340,6 +340,8 @@ impl App {
         for t in self.tasks.drain(..) {
             t.abort();
         }
+        self.server_table = crate::server_table::State::default();
+        self.server_table_started = false;
         // Stash the outgoing view's rows, then show the incoming view's
         // cached snapshot (if it was visited recently) so navigation renders
         // instantly — the fresh watch relists behind it and swaps in on sync.
@@ -448,10 +450,7 @@ impl App {
         self.view_cache_order.clear();
     }
 
-    /// For a custom resource with neither curated columns nor a user view,
-    /// fetch its CRD off-thread and read `additionalPrinterColumns` for the
-    /// watched version — a better automatic fallback than NAME/AGE. Results
-    /// (including "nothing usable") are cached per API resource for the session.
+    /// Read CRD columns first, then try server Tables if no columns are available.
     fn maybe_fetch_printer_columns(&mut self, kind: &Kind) {
         let user_has_columns = self
             .active_user_view()
@@ -459,12 +458,17 @@ impl App {
         if crate::columns::has_curated(&kind.ar.group, &self.kind_plural)
             || kind.ar.group.is_empty()
             || kind.ar.plural.to_lowercase() != self.kind_plural
-            || self.crd_views.contains_key(&kind.resource_key())
             || user_has_columns
         {
             return;
         }
+        if self.crd_views.contains_key(&kind.resource_key()) {
+            self.maybe_start_server_table();
+            return;
+        }
         let Some(crd_kind) = self.cluster.resolve("customresourcedefinitions") else {
+            self.crd_views.insert(kind.resource_key(), None);
+            self.maybe_start_server_table();
             return;
         };
         let client = self.cluster.client.clone();
@@ -475,11 +479,11 @@ impl App {
         let genr = self.generation;
         let handle = tokio::spawn(async move {
             let api: Api<DynamicObject> = Api::all_with(client, &crd_kind.ar);
-            // No CRD (aggregated API) or no permission → stay on NAME/AGE.
-            let Ok(crd) = api.get(&name).await else {
-                return;
-            };
-            let view = crate::views::printer_columns_view(&crd.data, &version);
+            let view = tokio::time::timeout(Duration::from_secs(10), api.get(&name))
+                .await
+                .ok()
+                .and_then(Result::ok)
+                .and_then(|crd| crate::views::printer_columns_view(&crd.data, &version));
             let _ = tx
                 .send(Msg::PrinterColumns {
                     generation: genr,
@@ -489,6 +493,34 @@ impl App {
                 .await;
         });
         self.tasks.push(handle);
+    }
+
+    pub(super) fn server_table_eligible(&self) -> bool {
+        let Some(kind) = &self.kind else { return false };
+        !kind.ar.group.is_empty()
+            && kind.ar.plural.to_lowercase() == self.kind_plural
+            && !crate::columns::has_curated(&kind.ar.group, &self.kind_plural)
+            && self.active_user_view().is_none_or(|v| v.columns.is_empty())
+            && self
+                .crd_views
+                .get(&kind.resource_key())
+                .is_some_and(Option::is_none)
+    }
+
+    fn maybe_start_server_table(&mut self) {
+        if self.server_table_started || !self.server_table_eligible() {
+            return;
+        }
+        let Some(kind) = &self.kind else { return };
+        self.server_table_started = true;
+        self.tasks.push(self.cluster.spawn_server_table(
+            kind,
+            &self.namespace,
+            join_selectors(&self.labels, &self.applied_filter_labels),
+            join_selectors(&self.fields, &self.applied_filter_fields),
+            self.generation,
+            self.tx.clone(),
+        ));
     }
 
     /// Restart the watch when the filter's `-l`/`-f` selectors no longer
@@ -865,6 +897,8 @@ impl App {
         for t in self.tasks.drain(..) {
             t.abort();
         }
+        self.server_table = crate::server_table::State::default();
+        self.server_table_started = false;
     }
 
     /// Fold one background message into the app, then tidy up after any view
@@ -971,6 +1005,9 @@ impl App {
             }
             Msg::Deleted { generation, key } if generation == self.generation => {
                 self.timeline.observe_delete(&self.kind_plural, &key);
+                if let Some(obj) = self.store.latest(&key) {
+                    self.server_table.remove(&key, obj.metadata.uid.as_deref());
+                }
                 if self.store.remove(&key) == StoreMutation::Removed {
                     self.invalidate_row(&key);
                 }
@@ -1095,7 +1132,41 @@ impl App {
                     // resolvable now that the CRD's columns are known.
                     self.apply_remembered_sort();
                     self.apply_view_sort();
+                    self.maybe_start_server_table();
                 }
+            }
+            Msg::ServerTable {
+                generation,
+                resource,
+                update,
+            } if generation == self.generation
+                && self.server_table_started
+                && self.server_table_eligible()
+                && self
+                    .kind
+                    .as_ref()
+                    .is_some_and(|k| k.resource_key() == resource) =>
+            {
+                let (layout_changed, changed) = self.server_table.apply(update);
+                if layout_changed {
+                    self.refresh_view_spec();
+                    self.apply_remembered_sort();
+                    self.apply_view_sort();
+                } else {
+                    for key in changed {
+                        self.invalidate_row_contents(&key);
+                    }
+                }
+            }
+            Msg::ServerTableError { generation, error }
+                if generation == self.generation && self.server_table_eligible() =>
+            {
+                for key in self.server_table.clear_cells() {
+                    self.invalidate_row_contents(&key);
+                }
+                crate::log_warn!("table.error", kind = self.kind_plural, error = error);
+                self.last_error = Some(error.clone());
+                self.borrow_status(error, true);
             }
             Msg::FindResults {
                 generation,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2174,6 +2174,8 @@ pub struct App {
     /// CRD printer-column fallbacks fetched per API resource for this cluster
     /// (`None` = fetched, nothing usable). Cleared on context switch.
     crd_views: HashMap<GroupVersionResource, Option<crate::views::View>>,
+    server_table: crate::server_table::State,
+    server_table_started: bool,
     /// Wide mode (`w`): show wide-only columns.
     pub wide: bool,
     /// Compact mode (`ctrl-e`): collapse the header to one line and hide the
@@ -2427,6 +2429,8 @@ impl App {
             user_views: HashMap::new(),
             thresholds: crate::thresholds::Compiled::default(),
             crd_views: HashMap::new(),
+            server_table: crate::server_table::State::default(),
+            server_table_started: false,
             wide: false,
             compact: false,
             hide_header: false,

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -212,7 +212,9 @@ impl App {
             Entry::Occupied(e) if fresh(e.get()) => return e.into_mut(),
             slot => slot,
         };
-        let (rendered, status_idx, helm_updated) = self.spec.cells_with_helm_time(o, now);
+        let (rendered, status_idx, helm_updated) =
+            self.spec
+                .cells_with_helm_time(o, now, self.server_table.cells(o));
         let cell_masks: Vec<u64> = rendered.iter().map(|c| subseq_mask(c)).collect();
         let row_mask = cell_masks.iter().fold(0u64, |a, m| a | m);
         let built = CellCacheEntry {
@@ -279,6 +281,20 @@ impl App {
             return wanted
                 .is_finite()
                 .then(|| cmp.op.eval(actual.total_cmp(&wanted)));
+        }
+        if let Some((index, column)) = self.spec.server_column(&cmp.key) {
+            let value = self.server_table.cells(o)?.get(index)?;
+            if value.is_null() {
+                return None;
+            }
+            let ordering = match &cmp.value {
+                CmpValue::Num(want) if column.numeric() => value.as_f64()?.total_cmp(want),
+                CmpValue::Str(want) | CmpValue::Quantity { text: want, .. } => {
+                    crate::filter::cmp_folded_lower(&crate::server_table::render(Some(value)), want)
+                }
+                _ => return None,
+            };
+            return Some(cmp.op.eval(ordering));
         }
         let ordering = match &cmp.value {
             CmpValue::Cpu(want) => self.row_metrics(o, key)?.0.cmp(want),
@@ -856,7 +872,16 @@ impl App {
                 .and_then(Option::as_ref),
             self.wide,
         );
-        self.spec = spec;
+        self.spec = if self.server_table_eligible() && !self.server_table.columns.is_empty() {
+            crate::columns::build_table_spec(
+                self.kind.as_ref().map_or("", |kind| kind.ar.group.as_str()),
+                &self.kind_plural,
+                &self.server_table.columns,
+                self.wide,
+            )
+        } else {
+            spec
+        };
         self.spec_rev = self.spec_rev.wrapping_add(1);
         if let Some((h, desc)) = sort {
             self.sort_column = self.display_headers().iter().position(|x| *x == h);
@@ -1014,7 +1039,9 @@ impl App {
         // time…), and win over the curated special cases so an overlay that
         // redefines a header sorts by its own values.
         if self.spec.is_user_column(header)
-            && let Some(v) = self.spec.sort_value(o, header, now)
+            && let Some(v) =
+                self.spec
+                    .sort_value_with_table(o, header, now, self.server_table.cells(o))
         {
             return SortKey::from(v);
         }
@@ -1175,7 +1202,9 @@ impl App {
             values.push(obj.metadata.namespace.clone().unwrap_or_default());
         }
         let now = crate::columns::now_secs();
-        let (cells, _, helm_updated) = self.spec.cells_with_helm_time(obj, now);
+        let (cells, _, helm_updated) =
+            self.spec
+                .cells_with_helm_time(obj, now, self.server_table.cells(obj));
         for (i, cell) in cells.into_iter().enumerate() {
             values.push(
                 self.live_cell(obj, i)

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver};
 
 mod proxy;
+mod server_table;
 
 fn obj(v: serde_json::Value) -> DynamicObject {
     serde_json::from_value(v).unwrap()
@@ -20863,7 +20864,7 @@ fn helm_updated_custom_columns_keep_their_own_type_and_clock() {
     );
     let spec = crate::columns::build_spec("", "helm", Some(view), None, false);
     let before = crate::helm::release_decode_count();
-    let (_, _, cached) = spec.cells_with_helm_time(&secret, base + 59);
+    let (_, _, cached) = spec.cells_with_helm_time(&secret, base + 59, None);
     assert_eq!(
         spec.volatile_cached(&secret, "helm", 0, base + 60, cached)
             .as_deref(),

--- a/src/app/tests/server_table.rs
+++ b/src/app/tests/server_table.rs
@@ -1,0 +1,527 @@
+use super::*;
+use crate::server_table::{Table, Update};
+use futures_util::{StreamExt, stream};
+use hyper::body::{Bytes, Frame};
+use std::convert::Infallible;
+use std::sync::Mutex;
+
+fn resource(name: &str, version: &str, uid: &str) -> serde_json::Value {
+    json!({
+        "apiVersion": "example.com/v1", "kind": "Widget",
+        "metadata": {"name": name, "namespace": "default", "uid": uid, "resourceVersion": version},
+        "spec": {"detail": "full object data"}
+    })
+}
+
+fn table(objects: &[serde_json::Value], counts: &[serde_json::Value]) -> serde_json::Value {
+    json!({
+        "kind": "Table", "apiVersion": "meta.k8s.io/v1",
+        "metadata": {"resourceVersion": "10"},
+        "columnDefinitions": [
+            {"name": "Name", "type": "string", "format": "name"},
+            {"name": "Count", "type": "integer"},
+            {"name": "Ratio", "type": "string"},
+            {"name": "Detail", "type": "string", "priority": 1}
+        ],
+        "rows": objects.iter().zip(counts).map(|(obj, count)| json!({
+            "cells": [obj["metadata"]["name"], count, "2/3", "server detail"],
+            "object": {"metadata": obj["metadata"]}
+        })).collect::<Vec<_>>()
+    })
+}
+
+fn deliver(app: &mut App, value: serde_json::Value, replace: bool) {
+    let table = Table::decode(value, &app.server_table.columns).unwrap();
+    app.handle_msg(Msg::ServerTable {
+        generation: app.generation,
+        resource: app.kind.as_ref().unwrap().resource_key(),
+        update: if replace {
+            Update::Replace(table)
+        } else {
+            Update::Apply(table)
+        },
+    });
+}
+
+fn open_widgets(app: &mut App) {
+    app.cluster
+        .register_kind("example.com", "Widget", "widgets", true);
+    palette(app, "widgets.example.com");
+}
+
+fn set_filter(app: &mut App, text: &str) {
+    app.handle_key(press(KeyCode::Char('/'))).unwrap();
+    app.handle_key(ctrl(KeyCode::Char('u'))).unwrap();
+    for ch in text.chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+}
+
+fn sort_by(app: &mut App, header: &str) {
+    app.handle_key(press(KeyCode::Char('S'))).unwrap();
+    for ch in header.chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+}
+
+#[tokio::test]
+async fn server_columns_sort_filter_and_keep_full_objects() {
+    let (mut app, _rx) = test_app();
+    open_widgets(&mut app);
+    let objects = [
+        resource("large", "1", "a"),
+        resource("small", "1", "b"),
+        resource("missing", "1", "c"),
+    ];
+    for object in &objects {
+        apply(&mut app, object.clone());
+    }
+    deliver(
+        &mut app,
+        table(&objects, &[json!(10), json!(2), json!(null)]),
+        true,
+    );
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "COUNT", "RATIO"]);
+    sort_by(&mut app, "COUNT");
+    assert_eq!(row_names(&app), ["small", "large", "missing"]);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(
+        app.display_headers().to_vec(),
+        ["NAME", "COUNT", "RATIO", "DETAIL"]
+    );
+    assert_eq!(app.snapshot_table().1[0][3], "server detail");
+    assert_eq!(app.snapshot_table().1[2][1], "<none>");
+
+    set_filter(&mut app, "count>5");
+    assert_eq!(row_names(&app), ["large"]);
+    set_filter(&mut app, "ratio>1");
+    assert!(
+        app.rows().is_empty(),
+        "string columns must not use leading-number comparisons"
+    );
+    set_filter(&mut app, "server detail");
+    assert_eq!(app.rows().len(), 3);
+    set_filter(&mut app, "count=2");
+    let fields = app.selected_row_fields();
+    assert!(fields.contains(&("COUNT".into(), "2".into())));
+    assert!(fields.contains(&("DETAIL".into(), "server detail".into())));
+    app.handle_key(press(KeyCode::Char('y'))).unwrap();
+    assert_eq!(app.mode, Mode::Detail);
+    let yaml = app
+        .detail
+        .lines
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(yaml.contains("full object data"));
+    assert!(!yaml.contains("server detail"));
+    assert!(!yaml.contains("columnDefinitions"));
+}
+
+#[tokio::test]
+async fn cells_follow_object_versions_and_clear_after_deletion() {
+    let (mut app, _rx) = test_app();
+    open_widgets(&mut app);
+    let old = resource("one", "1", "uid-1");
+    apply(&mut app, old.clone());
+    deliver(
+        &mut app,
+        table(std::slice::from_ref(&old), &[json!(10)]),
+        true,
+    );
+    set_filter(&mut app, "count>5");
+    assert_eq!(row_names(&app), ["one"]);
+
+    let updated = resource("one", "2", "uid-1");
+    apply(&mut app, updated.clone());
+    assert!(app.rows().is_empty());
+    deliver(
+        &mut app,
+        table(std::slice::from_ref(&old), &[json!(100)]),
+        true,
+    );
+    assert!(
+        app.rows().is_empty(),
+        "a late Table snapshot must not restore old cells"
+    );
+    deliver(
+        &mut app,
+        table(std::slice::from_ref(&updated), &[json!(20)]),
+        false,
+    );
+    assert_eq!(row_names(&app), ["one"]);
+
+    let replacement = resource("one", "3", "uid-2");
+    deliver(
+        &mut app,
+        table(std::slice::from_ref(&replacement), &[json!(30)]),
+        false,
+    );
+    assert!(app.rows().is_empty());
+    app.handle_msg(Msg::Deleted {
+        generation: app.generation,
+        key: "default/one".into(),
+    });
+    apply(&mut app, replacement.clone());
+    assert_eq!(
+        app.snapshot_table().1[0][1],
+        "30",
+        "an old delete must keep the new object's cells"
+    );
+
+    let deleted = Table::decode(table(std::slice::from_ref(&updated), &[json!(20)]), &[]).unwrap();
+    app.handle_msg(Msg::ServerTable {
+        generation: app.generation,
+        resource: app.kind.as_ref().unwrap().resource_key(),
+        update: Update::Delete(deleted),
+    });
+    assert_eq!(app.snapshot_table().1[0][1], "30");
+    app.handle_msg(Msg::Deleted {
+        generation: app.generation,
+        key: "default/one".into(),
+    });
+    assert!(app.rows().is_empty());
+    assert!(app.server_table.cells(&obj(replacement)).is_none());
+}
+
+#[tokio::test]
+async fn periodic_cells_and_watch_resets_invalidate_cached_values() {
+    let (mut app, _rx) = test_app();
+    open_widgets(&mut app);
+    let first = resource("one", "1", "a");
+    let second = resource("two", "1", "b");
+    apply(&mut app, first.clone());
+    apply(&mut app, second.clone());
+    app.handle_msg(Msg::Synced {
+        generation: app.generation,
+    });
+    deliver(
+        &mut app,
+        table(&[first.clone(), second.clone()], &[json!(2), json!(10)]),
+        true,
+    );
+    sort_by(&mut app, "COUNT");
+    assert_eq!(row_names(&app), ["one", "two"]);
+    deliver(
+        &mut app,
+        table(&[first.clone(), second.clone()], &[json!(20), json!(10)]),
+        true,
+    );
+    assert_eq!(
+        row_names(&app),
+        ["two", "one"],
+        "cells can change without a resource version change"
+    );
+    app.handle_msg(Msg::Reset {
+        generation: app.generation,
+    });
+    apply(&mut app, first.clone());
+    app.handle_msg(Msg::Synced {
+        generation: app.generation,
+    });
+    deliver(&mut app, table(&[first], &[json!(4)]), true);
+    assert_eq!(row_names(&app), ["one"]);
+    assert_eq!(app.snapshot_table().1[0][1], "4");
+    assert!(app.server_table.cells(&obj(second)).is_none());
+
+    app.handle_msg(Msg::ServerTableError {
+        generation: app.generation,
+        error: "Table request failed".into(),
+    });
+    assert_eq!(app.snapshot_table().1[0][1], "<none>");
+    app.handle_msg(Msg::ServerTable {
+        generation: app.generation,
+        resource: app.kind.as_ref().unwrap().resource_key(),
+        update: Update::Unavailable,
+    });
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "AGE"]);
+}
+
+#[tokio::test]
+async fn namespace_and_resource_changes_discard_old_table_results() {
+    let (mut app, _rx) = test_app();
+    open_widgets(&mut app);
+    let object = resource("one", "1", "a");
+    apply(&mut app, object.clone());
+    deliver(
+        &mut app,
+        table(std::slice::from_ref(&object), &[json!(2)]),
+        true,
+    );
+    let old_generation = app.generation;
+    let old_resource = app.kind.as_ref().unwrap().resource_key();
+    app.handle_key(press(KeyCode::Char('0'))).unwrap();
+    assert!(app.namespace.is_empty());
+    assert_eq!(app.display_headers().to_vec(), ["NAMESPACE", "NAME", "AGE"]);
+    app.handle_msg(Msg::ServerTable {
+        generation: old_generation,
+        resource: old_resource.clone(),
+        update: Update::Replace(
+            Table::decode(table(std::slice::from_ref(&object), &[json!(2)]), &[]).unwrap(),
+        ),
+    });
+    assert!(app.server_table.columns.is_empty());
+    for resource in [
+        GroupVersionResource::gvr("other.example.com", "v1", "widgets"),
+        GroupVersionResource::gvr("example.com", "v2", "widgets"),
+    ] {
+        app.handle_msg(Msg::ServerTable {
+            generation: app.generation,
+            resource,
+            update: Update::Replace(
+                Table::decode(table(std::slice::from_ref(&object), &[json!(2)]), &[]).unwrap(),
+            ),
+        });
+        assert!(app.server_table.columns.is_empty());
+    }
+    palette(&mut app, "pods");
+    app.handle_msg(Msg::ServerTable {
+        generation: app.generation,
+        resource: old_resource,
+        update: Update::Replace(Table::decode(table(&[object], &[json!(2)]), &[]).unwrap()),
+    });
+    assert!(app.display_headers().contains(&"RESTARTS".into()));
+    assert!(!app.display_headers().contains(&"COUNT".into()));
+}
+
+#[tokio::test]
+async fn explicit_and_crd_views_keep_priority_over_server_tables() {
+    for explicit in [false, true] {
+        let (mut app, _rx) = test_app();
+        app.cluster
+            .register_kind("example.com", "Widget", "widgets", true);
+        let config = "[[views.widgets.columns]]\nname = 'LOCAL'\npath = '/spec/detail'\n";
+        if explicit {
+            install_views(&mut app, config);
+        } else {
+            let cfg: crate::config::Config = toml::from_str(config).unwrap();
+            let (views, _) = crate::views::compile(&cfg.views);
+            app.crd_views.insert(
+                app.cluster.resolve("widgets").unwrap().resource_key(),
+                views.get("widgets").cloned(),
+            );
+        }
+        palette(&mut app, "widgets");
+        assert!(!app.server_table_started);
+        let object = resource("one", "1", "a");
+        apply(&mut app, object.clone());
+        deliver(&mut app, table(&[object], &[json!(2)]), true);
+        assert_eq!(app.display_headers().to_vec(), ["NAME", "LOCAL", "AGE"]);
+        assert_eq!(app.snapshot_table().1[0][1], "full object data");
+    }
+}
+
+#[tokio::test]
+async fn context_changes_stop_the_old_feed_and_discard_its_cells() {
+    let (mut app, _rx) = test_app();
+    open_widgets(&mut app);
+    let object = resource("one", "1", "a");
+    apply(&mut app, object.clone());
+    deliver(
+        &mut app,
+        table(std::slice::from_ref(&object), &[json!(2)]),
+        true,
+    );
+    let old_generation = app.generation;
+    let old_resource = app.kind.as_ref().unwrap().resource_key();
+    let old_tasks: Vec<_> = app.tasks.iter().map(|t| t.abort_handle()).collect();
+    pick_context(&mut app, "west");
+    let mut cluster = Cluster::fake();
+    cluster.context = "west".into();
+    cluster.register_kind("example.com", "Widget", "widgets", true);
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: "west".into(),
+        result: Ok(Box::new(cluster)),
+    });
+    tokio::task::yield_now().await;
+    assert!(old_tasks.iter().all(|t| t.is_finished()));
+    assert_eq!(app.cluster.context, "west");
+    assert!(app.server_table.columns.is_empty());
+    palette(&mut app, "widgets.example.com");
+    apply(&mut app, object.clone());
+    app.handle_msg(Msg::ServerTable {
+        generation: old_generation,
+        resource: old_resource,
+        update: Update::Replace(
+            Table::decode(table(std::slice::from_ref(&object), &[json!(2)]), &[]).unwrap(),
+        ),
+    });
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "AGE"]);
+    deliver(&mut app, table(&[object], &[json!(9)]), true);
+    assert_eq!(app.snapshot_table().1[0][1], "9");
+}
+
+#[tokio::test]
+async fn sort_only_config_applies_when_server_columns_arrive() {
+    let (mut app, _rx) = test_app();
+    install_views(&mut app, "[views.widgets]\nsort = 'COUNT:desc'\n");
+    open_widgets(&mut app);
+    let objects = [resource("large", "1", "a"), resource("small", "1", "b")];
+    for object in &objects {
+        apply(&mut app, object.clone());
+    }
+    assert!(app.server_table_started);
+    deliver(&mut app, table(&objects, &[json!(10), json!(2)]), true);
+    assert!(app.sort_desc);
+    assert_eq!(row_names(&app), ["large", "small"]);
+    sort_by(&mut app, "COUNT");
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert!(!app.sort_desc);
+    assert_eq!(row_names(&app), ["small", "large"]);
+}
+
+#[tokio::test]
+async fn denied_crd_read_uses_calico_server_columns() {
+    let (mut app, mut rx) = test_app();
+    app.cluster.register_kind(
+        "projectcalico.org",
+        "CalicoNodeStatus",
+        "caliconodestatuses",
+        false,
+    );
+    app.cluster.register_kind(
+        "apiextensions.k8s.io",
+        "CustomResourceDefinition",
+        "customresourcedefinitions",
+        false,
+    );
+    let mut kind = app.cluster.resolve("caliconodestatuses").unwrap();
+    kind.ar.version = "v3".into();
+    kind.ar.api_version = "projectcalico.org/v3".into();
+    app.kind = Some(kind);
+    app.kind_plural = "caliconodestatuses".into();
+    let object = json!({"apiVersion": "projectcalico.org/v3", "kind": "CalicoNodeStatus",
+        "metadata": {"name": "mystatus", "uid": "node-status", "resourceVersion": "10", "creationTimestamp": "2026-01-01T00:00:00Z"},
+        "spec": {"node": "node0", "classes": ["Agent", "BGP", "Routes"], "updatePeriodSeconds": 10},
+        "status": {"lastUpdated": "2026-01-01T00:00:00Z"}});
+    let table = json!({"kind": "Table", "apiVersion": "meta.k8s.io/v1", "metadata": {"resourceVersion": "10"},
+        "columnDefinitions": [
+            {"name": "Name", "type": "string", "format": "name"},
+            {"name": "Node", "type": "string"}, {"name": "Classes", "type": "string"},
+            {"name": "Update Interval", "type": "string"}, {"name": "Age", "type": "string"},
+            {"name": "last Updated", "type": "string"},
+            {"name": "Agent State", "type": "string", "priority": 1},
+            {"name": "ESTABLISHED-V4", "type": "string", "priority": 1},
+            {"name": "ESTABLISHED-V6", "type": "string", "priority": 1},
+            {"name": "NUM-V4-ROUTES", "type": "string", "priority": 1},
+            {"name": "NUM-V6-ROUTES", "type": "string", "priority": 1}
+        ], "rows": [{"object": {"metadata": object["metadata"]},
+            "cells": ["mystatus", "node0", "Agent,BGP,Routes", "10s", "3m", "3m ago", "v4(Ready) v6(Ready)", "2/3", "1/1", "2", "1"]}]});
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let requests = seen.clone();
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            let uri = request.uri().clone();
+            let accept = request
+                .headers()
+                .get(http::header::ACCEPT)
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            requests.lock().unwrap().push((uri.clone(), accept.clone()));
+            let object = object.clone();
+            let table = table.clone();
+            async move {
+                let query: HashMap<_, _> =
+                    form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes())
+                        .into_owned()
+                        .collect();
+                let watch = query.get("watch").is_some_and(|v| v == "true");
+                let (code, body) = if uri.path() == "/apis/projectcalico.org/v3/caliconodestatuses"
+                {
+                    if accept.contains("as=Table") {
+                        (
+                            200,
+                            if watch {
+                                String::new()
+                            } else {
+                                table.to_string()
+                            },
+                        )
+                    } else if query.contains_key("sendInitialEvents") {
+                        (
+                            200,
+                            format!(
+                                "{}\n{}\n",
+                                json!({"type": "ADDED", "object": object}),
+                                json!({"type": "BOOKMARK", "object": {"apiVersion": "projectcalico.org/v3", "kind": "CalicoNodeStatus",
+                            "metadata": {"resourceVersion": "10", "annotations": {"k8s.io/initial-events-end": "true"}}}})
+                            ),
+                        )
+                    } else {
+                        (200, String::new())
+                    }
+                } else {
+                    (403, json!({"apiVersion": "v1", "kind": "Status", "status": "Failure", "reason": "Forbidden", "message": "read denied", "code": 403}).to_string())
+                };
+                let frames = stream::iter([Ok::<_, Infallible>(Frame::data(Bytes::from(body)))]);
+                let frames = if watch && code == 200 {
+                    frames.chain(stream::pending()).boxed()
+                } else {
+                    frames.boxed()
+                };
+                Ok::<_, Infallible>(
+                    http::Response::builder()
+                        .status(code)
+                        .body(http_body_util::StreamBody::new(frames))
+                        .unwrap(),
+                )
+            }
+        }),
+        "default",
+    );
+    app.handle_key(ctrl(KeyCode::Char('r'))).unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !app.store.synced || !app.display_headers().contains(&"NODE".into()) {
+            app.handle_msg(rx.recv().await.unwrap());
+        }
+    })
+    .await
+    .unwrap();
+    let base = "2026-01-01T00:00:00Z"
+        .parse::<Timestamp>()
+        .unwrap()
+        .as_second();
+    assert_eq!(
+        app.snapshot_table_at(base + 180).1[0],
+        [
+            "mystatus",
+            "node0",
+            "Agent,BGP,Routes",
+            "10s",
+            "3m",
+            "3m ago"
+        ]
+    );
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    assert_eq!(
+        &app.snapshot_table_at(base + 240).1[0][4..],
+        [
+            "4m",
+            "3m ago",
+            "v4(Ready) v6(Ready)",
+            "2/3",
+            "1/1",
+            "2",
+            "1"
+        ]
+    );
+    assert_eq!(
+        app.crd_views[&app.kind.as_ref().unwrap().resource_key()]
+            .as_ref()
+            .map(|v| v.columns.len()),
+        None
+    );
+    let seen = seen.lock().unwrap();
+    assert!(seen.iter().any(|(uri, _)| {
+        uri.path()
+            .ends_with("customresourcedefinitions/caliconodestatuses.projectcalico.org")
+    }));
+    assert!(seen.iter().any(|(uri, accept)| uri.path()
+        == "/apis/projectcalico.org/v3/caliconodestatuses"
+        && accept.contains("as=Table")));
+}

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -415,6 +415,10 @@ struct SpecColumn {
 enum SpecSource {
     Curated(CellFn),
     User(crate::views::UserColumn),
+    Server {
+        index: usize,
+        column: crate::server_table::Column,
+    },
 }
 
 fn spec_curated(c: &Column) -> SpecColumn {
@@ -580,6 +584,49 @@ pub fn build_spec(
     }
 }
 
+/// Use server columns for an otherwise generic resource view.
+pub fn build_table_spec(
+    group: &str,
+    plural: &str,
+    columns: &[crate::server_table::Column],
+    wide: bool,
+) -> ViewSpec {
+    let fallback = columns_for("", "");
+    let mut resolved: Vec<SpecColumn> = columns
+        .iter()
+        .enumerate()
+        .filter(|(_, col)| wide || col.priority <= 0)
+        .map(|(index, column)| {
+            let header = column.name.to_uppercase();
+            let local = fallback.iter().find(|c| c.header == header);
+            if let Some(local) = local {
+                return spec_curated(local);
+            }
+            SpecColumn {
+                header: header.clone(),
+                original_header: header,
+                source: SpecSource::Server {
+                    index,
+                    column: column.clone(),
+                },
+                width: None,
+                align: column.numeric().then_some(crate::views::Align::Right),
+                is_status: false,
+                wide: column.priority > 0,
+            }
+        })
+        .collect();
+    if !resolved.iter().any(|col| col.header == "NAME") {
+        resolved.insert(0, spec_curated(&fallback[0]));
+    }
+    ViewSpec {
+        group: group.into(),
+        plural: plural.into(),
+        columns: resolved,
+        status_idx: None,
+    }
+}
+
 impl ViewSpec {
     pub fn metric_at(&self, idx: usize) -> Option<MetricColumn> {
         match &self.columns.get(idx)?.source {
@@ -613,6 +660,9 @@ impl ViewSpec {
         if let SpecSource::User(uc) = &self.columns[idx].source {
             return uc.kind == crate::views::ColumnKind::Time;
         }
+        if matches!(self.columns[idx].source, SpecSource::Server { .. }) {
+            return false;
+        }
         match self.canonical_header(idx) {
             Some("AGE") => true,
             Some("DURATION") if plural == "jobs" => true,
@@ -627,7 +677,7 @@ impl ViewSpec {
     /// Cells for one object, aligned with [`Self::headers`], plus the index
     /// of the status column (if any).
     pub fn cells(&self, obj: &DynamicObject, now: i64) -> (Vec<String>, Option<usize>) {
-        let (cells, status_idx, _) = self.cells_with_helm_time(obj, now);
+        let (cells, status_idx, _) = self.cells_with_helm_time(obj, now, None);
         (cells, status_idx)
     }
 
@@ -636,6 +686,7 @@ impl ViewSpec {
         &self,
         obj: &DynamicObject,
         now: i64,
+        server: Option<&[serde_json::Value]>,
     ) -> (Vec<String>, Option<usize>, Option<i64>) {
         let ctx = CellContext::new(obj, now);
         let values = self
@@ -644,6 +695,9 @@ impl ViewSpec {
             .map(|c| match &c.source {
                 SpecSource::Curated(extract) => extract(&ctx).into_owned(),
                 SpecSource::User(uc) => crate::views::render_cell(obj, uc, now),
+                SpecSource::Server { index, .. } => {
+                    crate::server_table::render(server.and_then(|cells| cells.get(*index)))
+                }
             })
             .collect();
         let helm_time = ctx
@@ -668,7 +722,7 @@ impl ViewSpec {
             SpecSource::User(uc) if uc.kind == crate::views::ColumnKind::Time => {
                 Some(crate::views::render_cell(obj, uc, now))
             }
-            SpecSource::User(_) => None,
+            SpecSource::User(_) | SpecSource::Server { .. } => None,
             SpecSource::Curated(_) => volatile_cell(obj, plural, &col.original_header, now),
         }
     }
@@ -713,6 +767,7 @@ impl ViewSpec {
         let col = self.columns.get(idx)?;
         Some(match &col.source {
             SpecSource::User(uc) => Cow::Owned(crate::views::render_cell(obj, uc, now)),
+            SpecSource::Server { .. } => Cow::Borrowed("<none>"),
             SpecSource::Curated(extract) => {
                 let ctx = CellContext::new(obj, now);
                 extract(&ctx)
@@ -723,9 +778,10 @@ impl ViewSpec {
     /// Whether `header` is a user/printer column (typed sorting applies) as
     /// opposed to a curated one.
     pub fn is_user_column(&self, header: &str) -> bool {
-        self.columns
-            .iter()
-            .any(|c| c.header == header && matches!(c.source, SpecSource::User(_)))
+        self.columns.iter().any(|c| {
+            c.header == header
+                && matches!(c.source, SpecSource::User(_) | SpecSource::Server { .. })
+        })
     }
 
     /// Comparable value of `header`'s cell for `obj`, or `None` when the
@@ -736,9 +792,22 @@ impl ViewSpec {
         header: &str,
         now: i64,
     ) -> Option<crate::views::SortValue> {
+        self.sort_value_with_table(obj, header, now, None)
+    }
+
+    pub fn sort_value_with_table(
+        &self,
+        obj: &DynamicObject,
+        header: &str,
+        now: i64,
+        server: Option<&[serde_json::Value]>,
+    ) -> Option<crate::views::SortValue> {
         let col = self.columns.iter().find(|c| c.header == header)?;
         Some(match &col.source {
             SpecSource::User(uc) => crate::views::sort_value(obj, uc, now),
+            SpecSource::Server { index, column } => {
+                column.sort_value(server.and_then(|cells| cells.get(*index)))
+            }
             SpecSource::Curated(extract) => {
                 let ctx = CellContext::new(obj, now);
                 let v = extract(&ctx);
@@ -749,6 +818,13 @@ impl ViewSpec {
                 }
             }
         })
+    }
+
+    pub fn server_column(&self, header: &str) -> Option<(usize, &crate::server_table::Column)> {
+        match &self.columns.get(self.header_index(header)?)?.source {
+            SpecSource::Server { index, column } => Some((*index, column)),
+            _ => None,
+        }
     }
 
     /// Configured fixed width for the column at `idx`, when it's a user

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -25,6 +25,7 @@ use crate::store::{Msg, row_key};
 
 mod discovery;
 mod proxy;
+mod table;
 
 pub(crate) fn build_client(mut config: Config, allow_v1_client_cert: bool) -> Result<Client> {
     if let Some(exec) = &mut config.auth_info.exec {
@@ -608,6 +609,30 @@ impl Cluster {
             namespace.to_string(),
             cfg,
             Arc::clone(&self.streaming_lists),
+            generation,
+            tx,
+        )
+    }
+
+    pub fn spawn_server_table(
+        &self,
+        kind: &Kind,
+        namespace: &str,
+        labels: Option<String>,
+        fields: Option<String>,
+        generation: u64,
+        tx: Sender<Msg>,
+    ) -> JoinHandle<()> {
+        let api = watch_api(self.client.clone(), kind, namespace);
+        table::spawn(
+            self.client.clone(),
+            api.resource_url().to_string(),
+            ListParams {
+                label_selector: labels,
+                field_selector: fields,
+                ..Default::default()
+            },
+            kind.resource_key(),
             generation,
             tx,
         )

--- a/src/k8s/table.rs
+++ b/src/k8s/table.rs
@@ -1,0 +1,252 @@
+//! Table list and watch requests for the active generic resource view.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use anyhow::{Context, Result, ensure};
+use futures_util::StreamExt;
+use kube::Client;
+use kube::api::{ListParams, WatchParams};
+use kube::core::{GroupVersionResource, Request, WatchEvent};
+use serde_json::Value;
+use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, sleep_until, timeout};
+
+use crate::server_table::{Column, Table, Update};
+use crate::store::Msg;
+
+const ACCEPT: &str = "application/json;as=Table;g=meta.k8s.io;v=v1,application/json";
+const RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+struct Feed {
+    client: Client,
+    request: Request,
+    params: ListParams,
+    resource: GroupVersionResource,
+    generation: u64,
+    tx: Sender<Msg>,
+}
+
+pub(super) fn spawn(
+    client: Client,
+    path: String,
+    params: ListParams,
+    resource: GroupVersionResource,
+    generation: u64,
+    tx: Sender<Msg>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        Feed {
+            client,
+            request: Request::new(path),
+            params,
+            resource,
+            generation,
+            tx,
+        }
+        .run(RETRY_INTERVAL, REFRESH_INTERVAL)
+        .await;
+    })
+}
+
+fn table_request(mut request: http::Request<Vec<u8>>) -> Result<http::Request<Vec<u8>>> {
+    // Full objects continue to arrive through the resource watch.
+    let uri = format!("{}&includeObject=Metadata", request.uri());
+    *request.uri_mut() = uri.parse()?;
+    request
+        .headers_mut()
+        .insert(http::header::ACCEPT, http::HeaderValue::from_static(ACCEPT));
+    Ok(request)
+}
+
+fn api_code(error: &anyhow::Error) -> Option<u16> {
+    match error.downcast_ref::<kube::Error>()? {
+        kube::Error::Api(status) => Some(status.code),
+        _ => None,
+    }
+}
+
+impl Feed {
+    async fn send(&self, update: Update) -> Result<()> {
+        self.tx
+            .send(Msg::ServerTable {
+                generation: self.generation,
+                resource: self.resource.clone(),
+                update,
+            })
+            .await
+            .context("resource view closed")
+    }
+
+    async fn report(&self, error: &anyhow::Error, last: &mut Option<String>) {
+        let message = format!("Table columns: {error:#}");
+        if last.as_ref() != Some(&message) {
+            let _ = self
+                .tx
+                .send(Msg::ServerTableError {
+                    generation: self.generation,
+                    error: message.clone(),
+                })
+                .await;
+            *last = Some(message);
+        }
+    }
+
+    async fn list_page(&self, params: &ListParams) -> Result<Value> {
+        let request = table_request(self.request.list(params)?)?;
+        let result = timeout(REQUEST_TIMEOUT, self.client.request(request))
+            .await
+            .context("Table request timed out")?;
+        match result {
+            Err(kube::Error::Api(status)) if status.code == 406 => {
+                let mut request = self.request.list(params)?;
+                request.headers_mut().insert(
+                    http::header::ACCEPT,
+                    http::HeaderValue::from_static("application/json"),
+                );
+                Ok(timeout(REQUEST_TIMEOUT, self.client.request(request))
+                    .await
+                    .context("JSON fallback timed out")??)
+            }
+            other => Ok(other?),
+        }
+    }
+
+    async fn list(&self) -> Result<Option<Table>> {
+        let mut params = self.params.clone();
+        params.limit = Some(500);
+        let mut result: Option<Table> = None;
+        let mut tokens = HashSet::new();
+        let mut keys = HashSet::new();
+        loop {
+            let value = self.list_page(&params).await?;
+            if value["kind"] != "Table" {
+                ensure!(
+                    value["items"].is_array(),
+                    "invalid JSON fallback from Table request"
+                );
+                ensure!(result.is_none(), "Table response changed during pagination");
+                return Ok(None);
+            }
+            let previous = result.as_ref().map_or(&[][..], |t| t.columns.as_slice());
+            let page = Table::decode(value, previous)?;
+            for row in &page.rows {
+                ensure!(
+                    keys.insert(row.key.clone()),
+                    "Table contains duplicate resource rows"
+                );
+            }
+            let next = page.continue_token.clone();
+            if let Some(table) = &mut result {
+                ensure!(
+                    table.columns == page.columns,
+                    "Table columns changed during pagination"
+                );
+                ensure!(
+                    table.resource_version == page.resource_version,
+                    "Table version changed during pagination"
+                );
+                table.rows.extend(page.rows);
+                table.continue_token = next.clone();
+            } else {
+                result = Some(page);
+            }
+            let Some(token) = next else { return Ok(result) };
+            ensure!(
+                tokens.insert(token.clone()),
+                "Table pagination did not advance"
+            );
+            params.continue_token = Some(token);
+        }
+    }
+
+    /// Return false when this endpoint sends ordinary objects instead of Tables.
+    async fn watch(&self, version: &str, mut columns: Vec<Column>) -> Result<bool> {
+        let params = WatchParams {
+            label_selector: self.params.label_selector.clone(),
+            field_selector: self.params.field_selector.clone(),
+            ..WatchParams::default().timeout(30).disable_bookmarks()
+        };
+        let request = table_request(self.request.watch(&params, version)?)?;
+        let stream = self.client.request_events::<Value>(request).await?;
+        futures_util::pin_mut!(stream);
+        while let Some(event) = stream.next().await {
+            let (value, delete) = match event? {
+                WatchEvent::Added(value) | WatchEvent::Modified(value) => (value, false),
+                WatchEvent::Deleted(value) => (value, true),
+                WatchEvent::Bookmark(_) => continue,
+                WatchEvent::Error(status) => return Err(kube::Error::Api(status).into()),
+            };
+            if value["kind"] != "Table" {
+                ensure!(
+                    value["metadata"].is_object(),
+                    "invalid JSON fallback from Table watch"
+                );
+                return Ok(false);
+            }
+            let table = Table::decode(value, &columns)?;
+            columns.clone_from(&table.columns);
+            self.send(if delete {
+                Update::Delete(table)
+            } else {
+                Update::Apply(table)
+            })
+            .await?;
+        }
+        Ok(true)
+    }
+
+    async fn run(self, retry_interval: Duration, refresh_interval: Duration) {
+        let mut watch_supported = true;
+        let mut last_error = None;
+        while !self.tx.is_closed() {
+            let started = Instant::now();
+            match self.list().await {
+                Ok(None) => {
+                    let _ = self.send(Update::Unavailable).await;
+                    return;
+                }
+                Ok(Some(table)) => {
+                    let version = table.resource_version.clone();
+                    let columns = table.columns.clone();
+                    if self.send(Update::Replace(table)).await.is_err() {
+                        return;
+                    }
+                    if watch_supported && !version.is_empty() {
+                        match timeout(refresh_interval, self.watch(&version, columns)).await {
+                            Ok(Ok(supported)) => {
+                                watch_supported = supported;
+                                last_error = None;
+                            }
+                            Ok(Err(error))
+                                if matches!(
+                                    api_code(&error),
+                                    Some(400 | 404 | 405 | 406 | 422)
+                                ) =>
+                            {
+                                watch_supported = false;
+                            }
+                            Ok(Err(error)) if api_code(&error) == Some(410) => {}
+                            Ok(Err(error)) => self.report(&error, &mut last_error).await,
+                            Err(_) => {
+                                last_error = None;
+                            }
+                        }
+                    } else {
+                        last_error = None;
+                    }
+                }
+                Err(error) => self.report(&error, &mut last_error).await,
+            }
+            // One list cycle per five seconds at most, independent of row count
+            // or UI ticks. A healthy watch also refreshes relative time cells.
+            sleep_until(started + retry_interval).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/k8s/table/tests.rs
+++ b/src/k8s/table/tests.rs
@@ -1,0 +1,366 @@
+use super::*;
+use std::collections::VecDeque;
+use std::convert::Infallible;
+use std::sync::{Arc, Mutex};
+
+use http_body_util::{BodyExt, Full, StreamBody, combinators::BoxBody};
+use hyper::body::{Bytes, Frame};
+use serde_json::json;
+use tokio::sync::mpsc::{self, Receiver};
+
+enum Reply {
+    Json(u16, Value),
+    Events(String),
+    Pending,
+}
+
+struct Seen {
+    uri: http::Uri,
+    accept: String,
+    time: Instant,
+}
+
+fn table(name: &str, version: &str, value: Value) -> Value {
+    json!({
+        "kind": "Table", "apiVersion": "meta.k8s.io/v1",
+        "metadata": {"resourceVersion": "10"},
+        "columnDefinitions": [
+            {"name": "Name", "type": "string", "format": "name"},
+            {"name": "Count", "type": "integer"}
+        ],
+        "rows": [{"cells": [name, value], "object": {
+            "apiVersion": "meta.k8s.io/v1", "kind": "PartialObjectMetadata",
+            "metadata": {"name": name, "namespace": "team", "uid": name, "resourceVersion": version}
+        }}]
+    })
+}
+
+fn status(code: u16) -> Value {
+    json!({"apiVersion": "v1", "kind": "Status", "status": "Failure",
+        "reason": "TestError", "message": "test API error", "code": code})
+}
+
+fn mock(replies: Vec<Reply>) -> (Feed, Receiver<Msg>, Arc<Mutex<Vec<Seen>>>) {
+    let replies = Arc::new(Mutex::new(VecDeque::from(replies)));
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let requests = seen.clone();
+    let client = Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            requests.lock().unwrap().push(Seen {
+                uri: request.uri().clone(),
+                accept: request
+                    .headers()
+                    .get(http::header::ACCEPT)
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .into(),
+                time: Instant::now(),
+            });
+            let reply = replies
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("unexpected API request");
+            async move {
+                let (code, body): (u16, BoxBody<Bytes, Infallible>) = match reply {
+                    Reply::Json(code, value) => {
+                        (code, Full::new(Bytes::from(value.to_string())).boxed())
+                    }
+                    Reply::Events(events) => (200, Full::new(Bytes::from(events)).boxed()),
+                    Reply::Pending => (
+                        200,
+                        BodyExt::boxed(StreamBody::new(futures_util::stream::pending::<
+                            std::result::Result<Frame<Bytes>, Infallible>,
+                        >())),
+                    ),
+                };
+                Ok::<_, Infallible>(http::Response::builder().status(code).body(body).unwrap())
+            }
+        }),
+        "default",
+    );
+    let (tx, rx) = mpsc::channel(32);
+    (
+        Feed {
+            client,
+            request: Request::new("/apis/example.com/v1/namespaces/team/widgets"),
+            params: ListParams::default()
+                .labels("app=web")
+                .fields("metadata.name=one"),
+            resource: GroupVersionResource::gvr("example.com", "v1", "widgets"),
+            generation: 7,
+            tx,
+        },
+        rx,
+        seen,
+    )
+}
+
+fn query(uri: &http::Uri) -> std::collections::HashMap<String, String> {
+    form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes())
+        .into_owned()
+        .collect()
+}
+
+#[tokio::test]
+async fn negotiates_tables_and_preserves_scope_across_pages() {
+    let mut first = table("one", "8", json!(2));
+    first["metadata"]["continue"] = json!("next/page+");
+    let mut second = table("two", "9", json!(10));
+    second["columnDefinitions"] = Value::Null;
+    let (feed, _rx, seen) = mock(vec![Reply::Json(200, first), Reply::Json(200, second)]);
+    let result = feed.list().await.unwrap().unwrap();
+    assert_eq!(result.rows.len(), 2);
+    assert_eq!(result.rows[1].cells[1], 10);
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 2);
+    for request in seen.iter() {
+        assert_eq!(request.accept, ACCEPT);
+        assert_eq!(
+            request.uri.path(),
+            "/apis/example.com/v1/namespaces/team/widgets"
+        );
+        let params = query(&request.uri);
+        assert_eq!(params["includeObject"], "Metadata");
+        assert_eq!(params["labelSelector"], "app=web");
+        assert_eq!(params["fieldSelector"], "metadata.name=one");
+        assert_eq!(params["limit"], "500");
+    }
+    assert_eq!(query(&seen[1].uri)["continue"], "next/page+");
+}
+
+#[tokio::test]
+async fn ordinary_json_and_406_keep_the_resource_fallback() {
+    let list = json!({"apiVersion": "example.com/v1", "kind": "WidgetList", "items": []});
+    for rejected in [false, true] {
+        let mut replies = Vec::new();
+        if rejected {
+            replies.push(Reply::Json(406, status(406)));
+        }
+        replies.push(Reply::Json(200, list.clone()));
+        let (feed, mut rx, seen) = mock(replies);
+        feed.run(RETRY_INTERVAL, REFRESH_INTERVAL).await;
+        assert!(matches!(
+            rx.recv().await,
+            Some(Msg::ServerTable {
+                update: Update::Unavailable,
+                ..
+            })
+        ));
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), if rejected { 2 } else { 1 });
+        if rejected {
+            assert_eq!(seen[1].accept, "application/json");
+            assert!(!query(&seen[1].uri).contains_key("includeObject"));
+        }
+    }
+}
+
+#[tokio::test]
+async fn permission_and_server_errors_do_not_mean_tables_are_unsupported() {
+    for code in [401, 403, 429, 500, 503] {
+        let (feed, _rx, seen) = mock(vec![Reply::Json(code, status(code))]);
+        let error = feed.list().await.unwrap_err();
+        assert_eq!(api_code(&error), Some(code));
+        assert_eq!(seen.lock().unwrap().len(), 1);
+    }
+    let (feed, _rx, _) = mock(vec![
+        Reply::Json(406, status(406)),
+        Reply::Json(403, status(403)),
+    ]);
+    assert_eq!(api_code(&feed.list().await.unwrap_err()), Some(403));
+}
+
+#[tokio::test]
+async fn empty_and_null_rows_keep_the_column_definitions() {
+    for empty in [Value::Null, json!([])] {
+        let mut value = table("one", "8", Value::Null);
+        value["rows"] = empty;
+        let (feed, _rx, _) = mock(vec![Reply::Json(200, value)]);
+        let table = feed.list().await.unwrap().unwrap();
+        assert!(table.rows.is_empty());
+        assert_eq!(table.columns.len(), 2);
+    }
+}
+
+#[tokio::test]
+async fn invalid_rows_and_schemas_return_errors() {
+    let mut invalid = Vec::new();
+    let mut value = table("one", "8", json!(1));
+    value["rows"][0]["cells"] = json!(["one"]);
+    invalid.push(value);
+    let mut value = table("one", "8", json!(1));
+    value["rows"][0]["object"] = Value::Null;
+    invalid.push(value);
+    let mut value = table("one", "8", json!(1));
+    value["columnDefinitions"][1]["name"] = json!("NAME");
+    invalid.push(value);
+    let mut value = table("one", "8", json!(1));
+    value["rows"] = json!([value["rows"][0], value["rows"][0]]);
+    invalid.push(value);
+    for value in invalid {
+        let (feed, _rx, _) = mock(vec![Reply::Json(200, value)]);
+        assert!(feed.list().await.is_err());
+    }
+}
+
+#[tokio::test]
+async fn inconsistent_pages_do_not_publish_partial_tables() {
+    let mut first = table("one", "8", json!(1));
+    first["metadata"]["continue"] = json!("next");
+    let mut second = table("two", "9", json!(2));
+    second["metadata"]["resourceVersion"] = json!("11");
+    let (feed, _rx, _) = mock(vec![Reply::Json(200, first), Reply::Json(200, second)]);
+    assert!(
+        feed.list()
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("version changed")
+    );
+}
+
+#[tokio::test]
+async fn watches_cells_when_later_events_omit_headers() {
+    let initial = table("one", "8", json!(1));
+    let columns = Table::decode(initial.clone(), &[]).unwrap().columns;
+    let mut updated = table("one", "9", json!(20));
+    updated.as_object_mut().unwrap().remove("columnDefinitions");
+    let mut deleted = table("one", "10", Value::Null);
+    deleted["columnDefinitions"] = Value::Null;
+    let events = [
+        json!({"type": "ADDED", "object": initial}),
+        json!({"type": "MODIFIED", "object": updated}),
+        json!({"type": "DELETED", "object": deleted}),
+        json!({"type": "ERROR", "object": status(410)}),
+    ]
+    .into_iter()
+    .map(|v| format!("{v}\n"))
+    .collect();
+    let (feed, mut rx, seen) = mock(vec![Reply::Events(events)]);
+    assert_eq!(
+        api_code(&feed.watch("8", columns).await.unwrap_err()),
+        Some(410)
+    );
+    assert!(matches!(
+        rx.recv().await,
+        Some(Msg::ServerTable {
+            generation: 7,
+            update: Update::Apply(_),
+            ..
+        })
+    ));
+    let Some(Msg::ServerTable {
+        update: Update::Apply(updated),
+        ..
+    }) = rx.recv().await
+    else {
+        panic!("missing update")
+    };
+    assert_eq!(updated.rows[0].cells[1], 20);
+    assert!(matches!(
+        rx.recv().await,
+        Some(Msg::ServerTable {
+            update: Update::Delete(_),
+            ..
+        })
+    ));
+    let seen = seen.lock().unwrap();
+    let params = query(&seen[0].uri);
+    assert_eq!(params["watch"], "true");
+    assert_eq!(params["resourceVersion"], "8");
+    assert_eq!(params["labelSelector"], "app=web");
+    assert_eq!(params["fieldSelector"], "metadata.name=one");
+    assert_eq!(params["includeObject"], "Metadata");
+}
+
+#[tokio::test]
+async fn ordinary_watch_events_select_polling() {
+    let events = format!(
+        "{}\n",
+        json!({"type": "ADDED", "object": {
+            "kind": "Widget", "apiVersion": "example.com/v1", "metadata": {"name": "one"}
+        }})
+    );
+    let (feed, _rx, _) = mock(vec![Reply::Events(events)]);
+    assert!(!feed.watch("8", Vec::new()).await.unwrap());
+}
+
+#[tokio::test]
+async fn refreshes_after_watch_rejection_silence_and_expiry() {
+    let retry = Duration::from_millis(30);
+    let refresh = Duration::from_millis(70);
+    for (reply, min_wait) in [
+        (Reply::Json(406, status(406)), retry),
+        (Reply::Pending, refresh),
+        (
+            Reply::Events(format!(
+                "{}\n",
+                json!({"type": "ERROR", "object": status(410)})
+            )),
+            retry,
+        ),
+    ] {
+        let (feed, mut rx, seen) = mock(vec![
+            Reply::Json(200, table("one", "8", json!(1))),
+            reply,
+            Reply::Json(200, table("one", "8", json!(2))),
+            Reply::Pending,
+        ]);
+        let began = Instant::now();
+        let task = tokio::spawn(feed.run(retry, refresh));
+        timeout(Duration::from_secs(2), async {
+            let mut snapshots = 0;
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::ServerTable {
+                        update: Update::Replace(table),
+                        ..
+                    } => {
+                        snapshots += 1;
+                        assert_eq!(table.rows[0].cells[1], snapshots);
+                        if snapshots == 2 {
+                            break;
+                        }
+                    }
+                    Msg::ServerTableError { error, .. } => panic!("{error}"),
+                    _ => panic!("unexpected Table message"),
+                }
+            }
+            assert_eq!(snapshots, 2);
+        })
+        .await
+        .unwrap();
+        task.abort();
+        let seen = seen.lock().unwrap();
+        assert!(seen[2].time.duration_since(began) >= min_wait);
+    }
+}
+
+#[tokio::test]
+async fn retries_transient_list_failure() {
+    let (feed, mut rx, seen) = mock(vec![
+        Reply::Json(503, status(503)),
+        Reply::Json(200, table("one", "8", json!(2))),
+        Reply::Pending,
+    ]);
+    let task = tokio::spawn(feed.run(Duration::from_millis(30), REFRESH_INTERVAL));
+    timeout(Duration::from_secs(2), async {
+        assert!(matches!(
+            rx.recv().await,
+            Some(Msg::ServerTableError { .. })
+        ));
+        assert!(matches!(
+            rx.recv().await,
+            Some(Msg::ServerTable {
+                update: Update::Replace(_),
+                ..
+            })
+        ));
+    })
+    .await
+    .unwrap();
+    task.abort();
+    assert_eq!(seen.lock().unwrap()[1].accept, ACCEPT);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod pvcexplore;
 pub mod redact;
 pub mod rightsize;
 pub mod sanitize;
+pub mod server_table;
 mod server_tls;
 pub mod snapshot;
 pub mod sortmem;

--- a/src/server_table.rs
+++ b/src/server_table.rs
@@ -1,0 +1,237 @@
+//! Server column definitions and cells, kept separate from resource objects.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, ensure};
+use k8s_openapi::jiff::Timestamp;
+use kube::core::{DynamicObject, ObjectMeta};
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct Column {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub format: String,
+    #[serde(default)]
+    pub priority: i32,
+}
+
+impl Column {
+    pub fn numeric(&self) -> bool {
+        matches!(self.kind.as_str(), "number" | "integer")
+    }
+
+    pub fn sort_value(&self, value: Option<&Value>) -> crate::views::SortValue {
+        use crate::views::SortValue;
+        if self.numeric() {
+            SortValue::Num(value.and_then(Value::as_f64).unwrap_or(f64::MAX))
+        } else if self.kind == "date" || (self.kind == "string" && self.format == "date-time") {
+            SortValue::Num(
+                value
+                    .and_then(Value::as_str)
+                    .and_then(|s| s.parse::<Timestamp>().ok())
+                    .map(|t| t.as_second() as f64)
+                    .unwrap_or(f64::MAX),
+            )
+        } else {
+            SortValue::Text(render(value).to_lowercase())
+        }
+    }
+}
+
+pub fn render(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => "<none>".into(),
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Row {
+    pub key: String,
+    uid: Option<String>,
+    resource_version: Option<String>,
+    pub cells: Vec<Value>,
+}
+
+impl Row {
+    fn matches(&self, obj: &DynamicObject) -> bool {
+        self.uid == obj.metadata.uid && self.resource_version == obj.metadata.resource_version
+    }
+}
+
+#[derive(Debug)]
+pub struct Table {
+    pub columns: Vec<Column>,
+    pub rows: Vec<Row>,
+    pub resource_version: String,
+    pub continue_token: Option<String>,
+}
+
+impl Table {
+    /// Later watch events can omit definitions. Their cells use the last schema.
+    pub fn decode(value: Value, previous: &[Column]) -> Result<Self> {
+        ensure!(
+            value["kind"] == "Table" && value["apiVersion"] == "meta.k8s.io/v1",
+            "expected a meta.k8s.io/v1 Table"
+        );
+        let columns: Vec<Column> = match value.get("columnDefinitions") {
+            None | Some(Value::Null) => previous.to_vec(),
+            Some(Value::Array(columns)) if columns.is_empty() => previous.to_vec(),
+            Some(columns) => serde_json::from_value(columns.clone())
+                .context("invalid Table column definitions")?,
+        };
+        let mut names = std::collections::HashSet::new();
+        for col in &columns {
+            ensure!(
+                !col.name.trim().is_empty() && names.insert(col.name.to_uppercase()),
+                "Table column names must be nonempty and unique"
+            );
+        }
+        let raw_rows = match value.get("rows") {
+            None | Some(Value::Null) => &[][..],
+            Some(Value::Array(rows)) => rows.as_slice(),
+            _ => anyhow::bail!("invalid Table rows"),
+        };
+        let mut rows = Vec::with_capacity(raw_rows.len());
+        let mut keys = std::collections::HashSet::new();
+        for row in raw_rows {
+            let cells = row["cells"].as_array().context("invalid Table cells")?;
+            ensure!(
+                cells.len() == columns.len(),
+                "Table cell count does not match its columns"
+            );
+            let metadata: ObjectMeta = serde_json::from_value(row["object"]["metadata"].clone())
+                .context("Table row has no valid object metadata")?;
+            let name = metadata
+                .name
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .context("Table row has no object name")?;
+            let key = match metadata.namespace.as_deref() {
+                Some(ns) => format!("{ns}/{name}"),
+                None => name.to_string(),
+            };
+            ensure!(
+                keys.insert(key.clone()),
+                "Table contains duplicate resource rows"
+            );
+            rows.push(Row {
+                key,
+                uid: metadata.uid,
+                resource_version: metadata.resource_version,
+                cells: cells.clone(),
+            });
+        }
+        Ok(Self {
+            columns,
+            rows,
+            resource_version: value["metadata"]["resourceVersion"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            continue_token: value["metadata"]["continue"]
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum Update {
+    Replace(Table),
+    Apply(Table),
+    Delete(Table),
+    Unavailable,
+}
+
+#[derive(Default)]
+pub struct State {
+    pub columns: Vec<Column>,
+    rows: HashMap<String, Row>,
+}
+
+impl State {
+    pub fn cells(&self, obj: &DynamicObject) -> Option<&[Value]> {
+        if self.rows.is_empty() {
+            return None;
+        }
+        self.rows
+            .get(&crate::store::row_key(obj))
+            .filter(|row| row.matches(obj))
+            .map(|row| row.cells.as_slice())
+    }
+
+    /// Return whether the layout changed and which rows need a new render.
+    pub fn apply(&mut self, update: Update) -> (bool, Vec<String>) {
+        let (table, replace, delete) = match update {
+            Update::Replace(table) => (table, true, false),
+            Update::Apply(table) => (table, false, false),
+            Update::Delete(table) => (table, false, true),
+            Update::Unavailable => {
+                let changed = !self.columns.is_empty();
+                self.columns.clear();
+                return (changed, self.clear_cells());
+            }
+        };
+        let layout_changed = self.columns != table.columns;
+        let mut changed = Vec::new();
+        if layout_changed {
+            changed.extend(self.rows.keys().cloned());
+            self.rows.clear();
+            self.columns = table.columns;
+        }
+        if replace {
+            let fresh: HashMap<_, _> = table.rows.into_iter().map(|r| (r.key.clone(), r)).collect();
+            changed.extend(
+                self.rows
+                    .keys()
+                    .filter(|k| !fresh.contains_key(*k))
+                    .cloned(),
+            );
+            changed.extend(
+                fresh
+                    .iter()
+                    .filter(|(k, r)| self.rows.get(*k) != Some(*r))
+                    .map(|(k, _)| k.clone()),
+            );
+            self.rows = fresh;
+        } else {
+            for row in table.rows {
+                if delete {
+                    if self
+                        .rows
+                        .get(&row.key)
+                        .is_some_and(|old| old.uid == row.uid)
+                    {
+                        self.rows.remove(&row.key);
+                        changed.push(row.key);
+                    }
+                } else if self.rows.get(&row.key) != Some(&row) {
+                    changed.push(row.key.clone());
+                    self.rows.insert(row.key.clone(), row);
+                }
+            }
+        }
+        (layout_changed, changed)
+    }
+
+    pub fn clear_cells(&mut self) -> Vec<String> {
+        self.rows.drain().map(|(key, _)| key).collect()
+    }
+
+    pub fn remove(&mut self, key: &str, uid: Option<&str>) {
+        if self
+            .rows
+            .get(key)
+            .is_some_and(|row| row.uid.as_deref() == uid)
+        {
+            self.rows.remove(key);
+        }
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -71,6 +71,15 @@ pub enum Msg {
         resource: GroupVersionResource,
         view: Box<Option<crate::views::View>>,
     },
+    ServerTable {
+        generation: u64,
+        resource: GroupVersionResource,
+        update: crate::server_table::Update,
+    },
+    ServerTableError {
+        generation: u64,
+        error: String,
+    },
     PulseData {
         generation: u64,
         claim: StatusClaim,


### PR DESCRIPTION
Aggregated APIs can define useful columns without a matching CRD. sofka previously showed NAME/AGE for these resources. This change uses Kubernetes Table responses when explicit views, built-in columns, and usable CRD printer columns are absent.

- Add Table negotiation with JSON fallback, pagination, watches, and polling when Table watches are unavailable.
- Keep full resource objects for actions and details. Match display cells by UID and resource version, and discard old view results.
- Support wide columns, numeric sorting and filters, and periodic refresh of server time text. Table watches run for up to 30 seconds. List cycles start at least five seconds apart.
- Document column priority and refresh behavior.

Validation: `just check` passed, including formatting, Clippy with warnings denied, and 1,262 tests. Mock API and keyboard tests cover Calico's `CalicoNodeStatus` columns with a denied CRD read, fallback, watch recovery, refresh timing, sorting, filtering, and view changes. No live cluster test was run.

Closes #465.

Agreed discussion: [#463](https://github.com/nklmilojevic/sofka/discussions/463). The maintainer approved implementation and requested this pull request.
