### PR TITLE
feat: add CPU and memory display formats for quantity columns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,11 @@ Custom text path columns accept `format = "image-tag"` to show only the image
 tag. See the [image tag example](views.md#image-tags) for configuration and
 validation rules.
 
+Quantity path columns accept `format = "cpu"` or `format = "memory"` with
+`type = "quantity"`. These formats use millicores or Mi/Gi for display and
+the original values for sorting and numeric filters. See
+[quantity formats](views.md#quantity-formats).
+
 ## Other sections
 
 Each of these is documented where the feature itself is:

--- a/docs/features.md
+++ b/docs/features.md
@@ -108,7 +108,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   totals, and utilization percentages. Metric columns support numeric sorting,
   structured filters, and threshold colors. Custom text path columns support
   `format = "image-tag"` to show image tags, with registry ports and digests
-  handled separately. An
+  handled separately. Quantity path columns support `format = "cpu"` and
+  `format = "memory"` for millicore and Mi/Gi display. Sorting and numeric
+  filters use values before display rounding. An
   unknown custom resource picks up its CRD `additionalPrinterColumns`
   automatically. If no usable CRD columns are available, server Table columns
   can supply the view. Explicit views and built-in columns keep their priority.

--- a/docs/views.md
+++ b/docs/views.md
@@ -72,9 +72,49 @@ Empty strings and values that are not strings keep their usual display.
 Sorting and text filters use the displayed tag. If `format` is omitted, the
 column keeps its usual behavior. The default Pod columns do not change.
 
-The formatter accepts an omitted `type` or `type = "text"`. Other types,
+The image tag formatter accepts an omitted `type` or `type = "text"`. Other types,
 `metric` sources, and `builtin` sources are incompatible with `format`.
 Unsupported formats and incompatible columns are skipped with a config warning.
+
+### Quantity formats
+
+Use `format = "cpu"` or `format = "memory"` with `type = "quantity"`
+to display a path value in the same units as the metric columns:
+
+```toml
+[[views."v1/nodes".columns]]
+name = "CPU/A"
+path = "/status/allocatable/cpu"
+type = "quantity"
+format = "cpu"
+
+[[views."v1/nodes".columns]]
+name = "MEM/A"
+path = "/status/allocatable/memory"
+type = "quantity"
+format = "memory"
+```
+
+CPU values display as whole millicores: `4` becomes `4000m`.
+Memory values display as whole Mi below 1 Gi, or Gi with one decimal place:
+`16374956Ki` becomes `15.6Gi`. These formats also accept JSON numbers.
+Values without a suffix mean CPU cores or memory bytes. The format is explicit;
+sofka does not infer it from the name, path, or suffix.
+
+Without `format`, quantity columns keep their original display. Missing and null
+values show `<none>`. Invalid, negative, non-finite, and out-of-range values keep
+their original display. Zero shows `0m` or `0Mi`. Small positive values can also
+round to zero in the display.
+
+Sorting and numeric filters use the original numeric value before display
+rounding. For example, `cpu/a>=4`, `cpu/a>=4000m`, and `mem/a>1Gi` compare source
+values. Text searches match the displayed value, such as `"15.6Gi"`.
+Invalid and missing values do not match numeric comparisons and sort last in
+ascending order.
+
+Both formats require a path source and `type = "quantity"`. Other types,
+an omitted type, and `metric` or `builtin` sources are incompatible. Unsupported
+formats and incompatible columns are skipped with a config warning.
 
 ### Built-in and metric columns
 

--- a/src/app/rows.rs
+++ b/src/app/rows.rs
@@ -272,10 +272,23 @@ impl App {
         now: i64,
     ) -> Option<bool> {
         use crate::filter::CmpValue;
+        if let Some(column) = self.spec.formatted_quantity_column(&cmp.key) {
+            let wanted = match &cmp.value {
+                CmpValue::Num(value) | CmpValue::Quantity { value, .. } => Some(*value),
+                CmpValue::Cpu { quantity, .. } | CmpValue::Mem { quantity, .. } => Some(*quantity),
+                _ => None,
+            };
+            if let Some(wanted) = wanted {
+                let actual = crate::views::formatted_quantity_value(o, column)?;
+                return wanted
+                    .is_finite()
+                    .then_some(cmp.op.eval(actual.partial_cmp(&wanted)?));
+            }
+        }
         if let Some(metric) = self.spec.metric(&cmp.key) {
             let actual = self.metric_value(o, metric)? as f64;
             let wanted = match &cmp.value {
-                CmpValue::Cpu(v) | CmpValue::Mem(v) => *v as f64,
+                CmpValue::Cpu { milli: v, .. } | CmpValue::Mem { bytes: v, .. } => *v as f64,
                 CmpValue::Num(v) | CmpValue::Quantity { value: v, .. } => {
                     if metric.cpu() && !metric.percentage() {
                         v * 1000.0
@@ -305,8 +318,8 @@ impl App {
             return Some(cmp.op.eval(ordering));
         }
         let ordering = match &cmp.value {
-            CmpValue::Cpu(want) => self.row_metrics(o, key)?.0.cmp(want),
-            CmpValue::Mem(want) => self.row_metrics(o, key)?.1.cmp(want),
+            CmpValue::Cpu { milli: want, .. } => self.row_metrics(o, key)?.0.cmp(want),
+            CmpValue::Mem { bytes: want, .. } => self.row_metrics(o, key)?.1.cmp(want),
             CmpValue::Duration(want) => crate::columns::age_secs(o, now)?.cmp(want),
             CmpValue::Quantity { text, .. } => {
                 let cell = self.column_cell(o, key, &cmp.key, cells, now)?;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -22685,6 +22685,254 @@ async fn terminal_title_removes_control_characters() {
 }
 
 #[tokio::test]
+async fn quantity_formats_render_values_and_keep_unformatted_columns() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/nodes"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "CPU/A", path = "/status/allocatable/cpu", type = "quantity", format = "cpu" },
+            { name = "CPU/RAW", path = "/status/allocatable/cpu", type = "quantity" },
+            { name = "MEM/A", path = "/status/allocatable/memory", type = "quantity", format = "memory", wide = true },
+            { name = "MEM/RAW", path = "/status/allocatable/memory", type = "quantity", wide = true },
+        ]
+        "#,
+    );
+    palette(&mut app, "nodes");
+    assert_eq!(app.display_headers().to_vec(), ["NAME", "CPU/A", "CPU/RAW"]);
+    app.handle_key(press(KeyCode::Char('w'))).unwrap();
+    let cases = [
+        (json!("4"), json!("16374956Ki"), "4000m", "15.6Gi"),
+        (json!("250m"), json!("512Mi"), "250m", "512Mi"),
+        (json!("1000000n"), json!("1Gi"), "1m", "1.0Gi"),
+        (json!("1500u"), json!("129M"), "2m", "123Mi"),
+        (json!("1e-3"), json!("1e6"), "1m", "1Mi"),
+        (json!(4), json!(1048576), "4000m", "1Mi"),
+        (json!(0), json!(0), "0m", "0Mi"),
+        (json!("0"), json!("0Ki"), "0m", "0Mi"),
+        (json!("-0"), json!("-0"), "0m", "0Mi"),
+        (json!("0.1m"), json!("0.1"), "0m", "0Mi"),
+        (json!("bad"), json!("bad"), "bad", "bad"),
+        (json!(""), json!(""), "", ""),
+        (json!("-1m"), json!("-1Mi"), "-1m", "-1Mi"),
+        (json!("NaN"), json!("NaN"), "NaN", "NaN"),
+        (json!("inf"), json!("inf"), "inf", "inf"),
+        (json!("1e30"), json!("1e30"), "1e30", "1e30"),
+        (
+            json!("9223372036854776"),
+            json!("8Ei"),
+            "9223372036854776",
+            "8Ei",
+        ),
+        (json!(true), json!(false), "true", "false"),
+        (
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+            "<none>",
+            "<none>",
+        ),
+    ];
+    for (index, (cpu, memory, _, _)) in cases.iter().enumerate() {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": format!("node-{index:02}")},
+                "status": {"allocatable": {"cpu": cpu, "memory": memory}}}),
+        );
+    }
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "missing"}}),
+    );
+    let (headers, rows) = app.snapshot_table();
+    assert_eq!(headers, ["NAME", "CPU/A", "CPU/RAW", "MEM/A", "MEM/RAW"]);
+    assert_eq!(rows.len(), cases.len() + 1);
+    assert_eq!(rows[0], ["missing", "<none>", "<none>", "<none>", "<none>"]);
+    for (row, (cpu, memory, expected_cpu, expected_memory)) in rows[1..].iter().zip(&cases) {
+        assert_eq!(row[1], *expected_cpu, "{cpu}");
+        assert_eq!(row[3], *expected_memory, "{memory}");
+        for (index, value) in [(2, cpu), (4, memory)] {
+            let raw = if value.is_null() {
+                "<none>".into()
+            } else if let Some(text) = value.as_str() {
+                text.to_string()
+            } else {
+                value.to_string()
+            };
+            assert_eq!(row[index], raw);
+        }
+    }
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    type_filter(&mut app, "cpu/a=0 mem/a=0");
+    assert_eq!(row_names(&app), ["node-06", "node-07", "node-08"]);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    type_filter(&mut app, "cpu/a=bad");
+    assert_eq!(row_names(&app), ["node-10"]);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    type_filter(&mut app, "\"15.6Gi\"");
+    assert_eq!(row_names(&app), ["node-00"]);
+}
+
+#[tokio::test]
+async fn quantity_formats_sort_and_filter_before_display_rounding() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/nodes"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "CPU/A", path = "/status/allocatable/cpu", type = "quantity", format = "cpu" },
+            { name = "MEM/A", path = "/status/allocatable/memory", type = "quantity", format = "memory" },
+        ]
+        "#,
+    );
+    palette(&mut app, "nodes");
+    for (name, cpu, memory) in [
+        ("a-high", "1000200000n", 1073741826_u64),
+        ("z-low", "1000100000n", 1073741825),
+    ] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": name},
+            "status": {"allocatable": {"cpu": cpu, "memory": memory}}}),
+        );
+    }
+    let (_, rows) = app.snapshot_table();
+    assert!(rows.iter().all(|row| row[1..] == ["1000m", "1.0Gi"]));
+    for header in ["CPU/A", "MEM/A"] {
+        app.handle_key(press(KeyCode::Char('S'))).unwrap();
+        for key in header.chars() {
+            app.handle_key(press(KeyCode::Char(key))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(row_names(&app), ["z-low", "a-high"]);
+        app.handle_key(press(KeyCode::Char('I'))).unwrap();
+        assert_eq!(row_names(&app), ["a-high", "z-low"]);
+    }
+    for filter in [
+        "cpu/a>1.00015",
+        "CPU/A>1000150000n",
+        "mem/a>1073741825",
+        "mem/a=1073741826",
+        "(cpu/a>1000150u || mem/a<1Gi)",
+    ] {
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        type_filter(&mut app, filter);
+        assert_eq!(row_names(&app), ["a-high"], "{filter}");
+    }
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    type_filter(&mut app, "cpu/a=1000100000n mem/a>1Gi");
+    assert_eq!(row_names(&app), ["z-low"]);
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    type_filter(&mut app, "mem/a>1073741825");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "a-high", "resourceVersion": "2"},
+        "status": {"allocatable": {"cpu": "1000200000n", "memory": "1Gi"}}}),
+    );
+    assert!(row_names(&app).is_empty());
+}
+
+#[tokio::test]
+async fn quantity_formats_with_metric_headers_filter_the_source_without_rounding() {
+    let (mut app, _rx) = test_app();
+    install_views(
+        &mut app,
+        r#"
+        [views."v1/nodes"]
+        replace = true
+        columns = [
+            { name = "NAME", builtin = "NAME" },
+            { name = "CPU", path = "/status/allocatable/cpu", type = "quantity", format = "cpu" },
+            { name = "MEM", path = "/status/allocatable/memory", type = "quantity", format = "memory" },
+        ]
+        "#,
+    );
+    palette(&mut app, "nodes");
+    for (name, cpu, memory) in [
+        ("a-high", "1000200000n", "0.2"),
+        ("z-low", "1000100000n", "0.1"),
+    ] {
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": name},
+            "status": {"allocatable": {"cpu": cpu, "memory": memory}}}),
+        );
+    }
+    app.handle_msg(Msg::Metrics {
+        generation: app.generation,
+        data: HashMap::from([
+            ("a-high".into(), (100, 100)),
+            ("z-low".into(), (10000, 10000)),
+        ]),
+        containers: HashMap::new(),
+    });
+    for filter in ["cpu>1000150000n", "cpu>1.00015", "mem>0.15", "mem=200m"] {
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        type_filter(&mut app, filter);
+        assert_eq!(row_names(&app), ["a-high"], "{filter}");
+    }
+}
+
+#[tokio::test]
+async fn quantity_formats_reject_incompatible_columns_and_keep_valid_columns() {
+    for format in ["cpu", "memory"] {
+        let (mut app, _rx) = test_app();
+        let text = format!(
+            r#"
+            [views."v1/nodes"]
+            replace = true
+            columns = [
+                {{ name = "NAME", builtin = "NAME" }},
+                {{ name = "VALID", path = "/status/allocatable/cpu", type = "quantity", format = "{format}" }},
+                {{ name = "RAW", path = "/status/allocatable/cpu", type = "quantity" }},
+                {{ name = "TAG", path = "/spec/image", format = "image-tag" }},
+                {{ name = "NO-TYPE", path = "/spec/value", format = "{format}" }},
+                {{ name = "TEXT", path = "/spec/value", type = "text", format = "{format}" }},
+                {{ name = "NUMBER", path = "/spec/value", type = "number", format = "{format}" }},
+                {{ name = "TIME", path = "/spec/value", type = "time", format = "{format}" }},
+                {{ name = "STATUS", path = "/spec/value", type = "status", format = "{format}" }},
+                {{ name = "CONDITION", path = "Ready", type = "condition", format = "{format}" }},
+                {{ name = "METRIC", metric = "cpu", format = "{format}" }},
+                {{ name = "BUILTIN", builtin = "NAME", format = "{format}" }},
+                {{ name = "BAD-PATH", path = "value", type = "quantity", format = "{format}" }},
+                {{ name = "UNKNOWN", path = "/spec/value", type = "quantity", format = "bytes" }},
+            ]
+        "#
+        );
+        let cfg: crate::config::Config = toml::from_str(&text).unwrap();
+        let (views, warnings) = crate::views::compile(&cfg.views);
+        assert_eq!(warnings.len(), 10, "{warnings:?}");
+        assert!(
+            warnings[..8]
+                .iter()
+                .all(|warning| warning.contains("format applies only to quantity path columns"))
+        );
+        assert!(warnings[8].contains("JSON Pointer"));
+        assert!(warnings[9].contains("unknown format 'bytes'"));
+        app.user_views = views;
+        app.config_warnings = warnings;
+        palette(&mut app, "nodes");
+        assert_eq!(
+            app.display_headers().to_vec(),
+            ["NAME", "VALID", "RAW", "TAG"]
+        );
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node", "metadata": {"name": "node"},
+            "spec": {"image": "registry:5000/app:1.2.3"}, "status": {"allocatable": {"cpu": "4"}}}),
+        );
+        let (_, rows) = app.snapshot_table();
+        assert_eq!(rows[0][1], if format == "cpu" { "4000m" } else { "0Mi" });
+        assert_eq!(rows[0][2..], ["4", "1.2.3"]);
+    }
+}
+
+#[tokio::test]
 async fn image_tag_columns_render_selected_paths_and_filter_by_tag() {
     let (mut app, _rx) = test_app();
     install_views(

--- a/src/columns.rs
+++ b/src/columns.rs
@@ -642,6 +642,17 @@ impl ViewSpec {
         self.metric_at(self.header_index(header)?)
     }
 
+    pub fn formatted_quantity_column(&self, header: &str) -> Option<&crate::views::UserColumn> {
+        match &self.columns.get(self.header_index(header)?)?.source {
+            SpecSource::User(column)
+                if matches!(column.kind, crate::views::ColumnKind::QuantityFormat(_)) =>
+            {
+                Some(column)
+            }
+            _ => None,
+        }
+    }
+
     pub fn canonical_header(&self, idx: usize) -> Option<&str> {
         if self.metric_at(idx).is_some() {
             return None;

--- a/src/config.rs
+++ b/src/config.rs
@@ -782,7 +782,7 @@ pub struct ViewColumnConfig {
     /// Value type: `text` (default), `status`, `number`, `quantity`, `time`.
     #[serde(rename = "type")]
     pub kind: Option<String>,
-    /// Optional text path formatter: `image-tag`.
+    /// Path display format: `image-tag` for text, `cpu` or `memory` for quantities.
     pub format: Option<String>,
     /// Only shown in wide mode.
     pub wide: bool,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -76,7 +76,7 @@ impl Term {
     pub fn metrics_sensitive(&self, is_metric: &impl Fn(&str) -> bool) -> bool {
         match self {
             Self::Cmp(Cmp {
-                value: CmpValue::Cpu(_) | CmpValue::Mem(_),
+                value: CmpValue::Cpu { .. } | CmpValue::Mem { .. },
                 ..
             }) => true,
             Self::Cmp(cmp) => is_metric(&cmp.key),
@@ -254,10 +254,10 @@ pub enum CmpValue {
     Num(f64),
     /// A quantity for metric columns, with text retained for other columns.
     Quantity { value: f64, text: String },
-    /// CPU quantity in millicores (`cpu>500m`).
-    Cpu(i64),
-    /// Memory quantity in bytes (`memory>1Gi`).
-    Mem(i64),
+    /// CPU quantity in cores, with rounded millicores for metric comparisons.
+    Cpu { quantity: f64, milli: i64 },
+    /// Memory quantity in bytes, with rounded bytes for metric comparisons.
+    Mem { quantity: f64, bytes: i64 },
     /// Duration in seconds (`age<2h`).
     Duration(i64),
     /// Anything else: case-insensitive text comparison. Stored pre-folded to
@@ -781,10 +781,12 @@ pub fn cmp_folded_lower(cell: &str, want: &str) -> std::cmp::Ordering {
 fn typed_value(key: &str, raw: &str) -> Result<CmpValue, String> {
     match key.to_ascii_lowercase().as_str() {
         "cpu" => parse_cpu(raw)
-            .map(CmpValue::Cpu)
+            .zip(crate::views::parse_quantity(raw))
+            .map(|(milli, quantity)| CmpValue::Cpu { quantity, milli })
             .ok_or_else(|| format!("bad cpu quantity '{raw}'")),
         "mem" | "memory" => parse_mem(raw)
-            .map(CmpValue::Mem)
+            .zip(crate::views::parse_quantity(raw))
+            .map(|(bytes, quantity)| CmpValue::Mem { quantity, bytes })
             .ok_or_else(|| format!("bad memory quantity '{raw}'")),
         "age" => parse_duration(raw)
             .map(CmpValue::Duration)
@@ -1406,7 +1408,10 @@ mod tests {
             vec![Term::Cmp(Cmp {
                 key: "cpu".into(),
                 op: Op::Gt,
-                value: CmpValue::Cpu(500),
+                value: CmpValue::Cpu {
+                    quantity: 0.5,
+                    milli: 500
+                },
             })]
         );
 
@@ -1416,7 +1421,10 @@ mod tests {
             vec![Term::Cmp(Cmp {
                 key: "cpu".into(),
                 op: Op::Ge,
-                value: CmpValue::Cpu(1000),
+                value: CmpValue::Cpu {
+                    quantity: 1.0,
+                    milli: 1000
+                },
             })]
         );
 
@@ -1426,7 +1434,10 @@ mod tests {
             vec![Term::Cmp(Cmp {
                 key: "memory".into(),
                 op: Op::Gt,
-                value: CmpValue::Mem(1024 * 1024 * 1024),
+                value: CmpValue::Mem {
+                    quantity: 1073741824.0,
+                    bytes: 1024 * 1024 * 1024
+                },
             })]
         );
 
@@ -1436,7 +1447,10 @@ mod tests {
             vec![Term::Cmp(Cmp {
                 key: "mem".into(),
                 op: Op::Le,
-                value: CmpValue::Mem(512 * 1024 * 1024),
+                value: CmpValue::Mem {
+                    quantity: 536870912.0,
+                    bytes: 512 * 1024 * 1024
+                },
             })]
         );
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -32,6 +32,7 @@ pub enum ColumnKind {
     Number,
     /// Kubernetes quantity (`500m`, `1Gi`, `2k`) — sorted by value.
     Quantity,
+    QuantityFormat(QuantityFormat),
     /// RFC 3339 timestamp — rendered as compact elapsed time (`3d4h`, or
     /// `in 30d` for the future), sorted by the timestamp.
     Time,
@@ -39,6 +40,38 @@ pub enum ColumnKind {
     /// [`UserColumn::pointer`]. Shows `status` (`True`/`False`/`Unknown`)
     /// and controls row colors like `Status`.
     Condition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantityFormat {
+    Cpu,
+    Memory,
+}
+
+impl QuantityFormat {
+    fn display_value(self, value: f64) -> f64 {
+        match self {
+            Self::Cpu => (value * 1000.0).round(),
+            Self::Memory => value.ceil(),
+        }
+    }
+
+    fn value(self, value: &Extracted<'_>) -> Option<f64> {
+        value.quantity().filter(|value| {
+            value.is_finite() && *value >= 0.0 && self.display_value(*value) < i64::MAX as f64
+        })
+    }
+
+    fn render(self, value: &Extracted<'_>) -> String {
+        let Some(number) = self.value(value) else {
+            return value.render();
+        };
+        let sample = Some(self.display_value(number) as i64);
+        match self {
+            Self::Cpu => crate::columns::fmt_cpu_sample(sample),
+            Self::Memory => crate::columns::fmt_mem_sample(sample),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -321,15 +354,23 @@ pub fn compile(
                 continue;
             }
             if let Some(format) = &c.format {
-                if format != "image-tag" {
-                    warnings.push(format!("views.\"{key}\": column {header}: unknown format '{format}' (expected image-tag); column skipped"));
+                let (formatted_kind, required_type) = match format.as_str() {
+                    "image-tag" => (ColumnKind::ImageTag, "text"),
+                    "cpu" => (ColumnKind::QuantityFormat(QuantityFormat::Cpu), "quantity"),
+                    "memory" => (
+                        ColumnKind::QuantityFormat(QuantityFormat::Memory),
+                        "quantity",
+                    ),
+                    _ => {
+                        warnings.push(format!("views.\"{key}\": column {header}: unknown format '{format}' (expected image-tag/cpu/memory); column skipped"));
+                        continue;
+                    }
+                };
+                if c.path.is_empty() || c.kind.as_deref().unwrap_or("text") != required_type {
+                    warnings.push(format!("views.\"{key}\": column {header}: format applies only to {required_type} path columns; column skipped"));
                     continue;
                 }
-                if c.path.is_empty() || c.kind.as_deref().is_some_and(|kind| kind != "text") {
-                    warnings.push(format!("views.\"{key}\": column {header}: format applies only to text path columns; column skipped"));
-                    continue;
-                }
-                kind = ColumnKind::ImageTag;
+                kind = formatted_kind;
             }
             let mut pointer = c.path.trim().to_string();
             if let Some(metric) = &c.metric {
@@ -764,8 +805,16 @@ pub fn render_cell(obj: &DynamicObject, col: &UserColumn, now: i64) -> String {
     match col.kind {
         ColumnKind::Time => render_time(&v, now),
         ColumnKind::ImageTag => render_image_tag(&v),
+        ColumnKind::QuantityFormat(format) => format.render(&v),
         _ => v.render(),
     }
+}
+
+pub fn formatted_quantity_value(obj: &DynamicObject, col: &UserColumn) -> Option<f64> {
+    let ColumnKind::QuantityFormat(format) = col.kind else {
+        return None;
+    };
+    format.value(&cell_value(obj, col)?)
 }
 
 fn render_image_tag(v: &Extracted<'_>) -> String {
@@ -874,6 +923,11 @@ pub fn sort_value(obj: &DynamicObject, col: &UserColumn, now: i64) -> SortValue 
         ColumnKind::Quantity => {
             SortValue::Num(v.as_ref().and_then(Extracted::quantity).unwrap_or(f64::MAX))
         }
+        ColumnKind::QuantityFormat(format) => SortValue::Num(
+            v.as_ref()
+                .and_then(|value| format.value(value))
+                .unwrap_or(f64::MAX),
+        ),
         // Elapsed seconds, like AGE: ascending = most recent (or furthest in
         // the future) first, unknowns last.
         ColumnKind::Time => SortValue::Num(


### PR DESCRIPTION
Custom quantity columns currently show API values such as `16374956Ki` and CPU `4`, which are hard to compare with metric columns. Add `format = "memory"` and `format = "cpu"` to `type = "quantity"` path columns. These examples display as `15.6Gi` and `4000m`.

Sorting and numeric filters use source values before display rounding, including columns named CPU or MEM. Existing columns without a format keep their display. Zero, missing values, and invalid values have distinct displays. The change includes configuration validation, documentation, and application tests through `handle_key`.

Validation: `just check` passed, including formatting, Clippy with warnings denied, and 1,277 tests. Two tests were ignored. The commit hooks also passed.

Closes #471

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/462#discussioncomment-18387106
