### PR TITLE
feat: show how far a PVC copy has got

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,10 @@ adjacent.rs  Which objects connect to which: built-in and configured reference
 timeline.rs  Session-local per-object state-change history diffed from the
              watch stream (pure transition logic, unit-tested).
 pvcexplore.rs PVC browsing: which pod already mounts a claim, the helper pod
-             for one nothing mounts, and the `ls` parser, all pure and
-             unit-tested. `app/pvcexplore.rs` drives it.
+             for one nothing mounts, the `ls` parser, and the size probes and
+             progress-bar arithmetic behind a running copy, all pure and
+             unit-tested. `app/pvcexplore.rs` drives it, `app/transfer.rs`
+             samples a `kubectl cp` in flight.
 ui.rs        All ratatui rendering: header, table, scrollable views, popups,
              status bar.
 theme.rs     Palette + semantic styles, skin resolution.

--- a/docs/features.md
+++ b/docs/features.md
@@ -461,6 +461,43 @@ right - so a download or an upload is one keystroke rather than a hand-written
   splits its arguments on the first `:`, so a name containing one is refused
   with an explanation rather than a `filespec must match the canonical format`
   from kubectl.
+- **A copy in flight fills a bar** where the row's size was, so a 5 GB file or
+  a directory of thousands of them shows how far it has got rather than one
+  unchanging "copying" line for minutes. `kubectl cp` reports nothing while it
+  runs, so what is measured is the destination: a download's bar comes from the
+  local file (or tree) it is writing, an upload's from one `kubectl exec` that
+  prints the destination's size once a second - one exec for the whole copy,
+  not one per second. A folder is measured whole, so its bar is the recursive
+  total and not one file at a time. The status bar carries the percentage as
+  well, which is also where a copy started by `t` on a pod - with typed paths
+  and no row to draw on - reports itself.
+
+  Quitting sofka while an upload is running leaves that `du` loop in the pod
+  until it times itself out - fifteen minutes where the container has a clock,
+  and 300 passes, at least five minutes, where it has not - because the signal that stops it is the
+  connection closing, and a killed process does not send one; the copy itself
+  is left to finish either way.
+
+  Measuring the volume side is an exec of its own - `du`, alongside the `tar`
+  that `kubectl cp` already runs there - and it is gated no further than the
+  copy it belongs to; see [safety](safety.md#guardrails) for why. A copy also
+  starts a moment later than it used to, since the destination is measured
+  before it is touched.
+
+  The source's total comes from the listing for a single file and from `du`
+  for a directory, so the pod needs `du` as well as the `ls` a listing needs
+  and the `tar` a copy needs; without it the copy runs with no bar. The total
+  is an estimate either way, and a bar can finish short of the end or reach it
+  early and wait: a `du` that can only report whole disk blocks reads high, a
+  subdirectory the serving pod cannot read is missing from the total, and both
+  ends count directory entries at whatever their own filesystem charges for
+  one - 4 KiB on ext4 against a couple of hundred bytes on APFS, which on a
+  tree of many small directories is a visible fraction rather than a rounding
+  error. What is already at the destination is not counted - an overwrite
+  opens at zero rather than at yesterday's copy - but a whole folder copied
+  over a copy of itself is the case this cannot measure: almost nothing new
+  lands, so its bar ends well short even though the copy is complete.
+
 - **`s` opens a shell** at the directory the remote pane is showing (or at the
   mount point, from the PVC row directly). The exec lands in a real pod, so it
   passes the same `shell` guardrail as `s` on that pod's row - a rule that

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -33,6 +33,22 @@ pod they reach the volume through, exactly like `s` and `t` on that pod's row -
 a rule that already blocks shells or uploads in prod is not defeated by
 reaching the same pod through a claim it mounts.
 
+Measuring a copy's progress runs `du` in the pod, and the two directions cost
+very different things. A download of a single file from the browser adds no
+exec at all - its size is already on screen, from the listing, though a `t`
+download of a typed path has no listing and so runs the probe - and a download of a directory
+adds one `du`, which carries its own `timeout` inside the container. An
+upload adds more: one long-lived exec that measures the destination once a
+second for as long as the copy runs, because nothing else can see a volume
+being written to from outside. That exec ends when sofka closes it, but a
+sofka that is killed cannot close anything, and the loop then runs on in the
+pod until its own bound expires - see [PVC explore](features.md#pvc-explore).
+
+All of it is gated no further than the copy it belongs to, and recorded as
+that one action in `:journal`, on the reasoning that a `du` reaches nothing a
+permitted copy could not already reach: `kubectl cp` has always run `tar`
+there.
+
 sofka combines the restrictions from all matching rules:
 
 - Any matching rule with `deny = true` blocks the action.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1752,6 +1752,32 @@ impl App {
         );
     }
 
+    /// `kubectl exec` up to and including `--`, pinned to the active context.
+    /// What a script's argv is appended to.
+    ///
+    /// `stdin` asks for `-i`, which is not a convenience: a script that has to
+    /// notice sofka went away can only do it by reading end-of-input, and
+    /// without a stdin stream it gets that immediately.
+    pub(super) fn exec_prefix(
+        &self,
+        ns: &str,
+        pod: &str,
+        container: Option<&str>,
+        stdin: bool,
+    ) -> Vec<String> {
+        let mut argv = self.kubectl_base();
+        argv.push("exec".into());
+        if stdin {
+            argv.push("-i".into());
+        }
+        argv.extend(["-n".into(), ns.to_string(), pod.to_string()]);
+        if let Some(c) = container {
+            argv.extend(["-c".into(), c.to_string()]);
+        }
+        argv.push("--".into());
+        argv
+    }
+
     /// The `kubectl cp` argv for a transfer, pinned to the active context.
     pub(super) fn cp_argv(
         &self,
@@ -1777,9 +1803,15 @@ impl App {
         argv
     }
 
-    /// Run `kubectl cp` off-thread and flash the outcome. Not a foreground
-    /// `Suspend::Shell` — cp is non-interactive (and silent on success), and
-    /// a large copy would otherwise freeze the UI for its whole duration.
+    /// Run `kubectl cp` off-thread, reporting progress and flashing the
+    /// outcome. Not a foreground `Suspend::Shell` — cp is non-interactive
+    /// (and silent on success), and a large copy would otherwise freeze the
+    /// UI for its whole duration.
+    ///
+    /// Silent for its whole duration is also why it is measured: `cp` reports
+    /// nothing between "started" and "finished", so `super::transfer` samples
+    /// the destination instead and the size column of the row it came from
+    /// fills as the bytes land.
     pub(super) fn start_transfer(
         &mut self,
         ns: String,
@@ -1789,60 +1821,51 @@ impl App {
         src: String,
         dest: String,
     ) {
+        let job = self.begin_transfer(ns, pod, container, upload, src, dest);
+        // Never under test: `kubectl cp` here would reach the developer's own
+        // current context. Everything the tests need is either in the job
+        // (which they build the same way) or in the messages the task would
+        // have sent, which they feed by hand.
+        if !cfg!(test) {
+            tokio::spawn(super::transfer::run_transfer(job));
+        }
+    }
+
+    /// Claim the status bar, register the row the bar goes on, and gather
+    /// everything the background copy needs. Separate from the spawn so a
+    /// test can check the wiring — which end is which, which exec asks for
+    /// stdin — without a cluster to run it against.
+    pub(super) fn begin_transfer(
+        &mut self,
+        ns: String,
+        pod: String,
+        container: Option<String>,
+        upload: bool,
+        src: String,
+        dest: String,
+    ) -> super::transfer::TransferJob {
         let argv = self.cp_argv(&ns, &pod, container.as_deref(), upload, &src, &dest);
-        let from = argv[argv.len() - 2].clone();
-        let to = argv[argv.len() - 1].clone();
+        let (from, to) = (&argv[argv.len() - 2], &argv[argv.len() - 1]);
+        let label = format!("copying {from} → {to}");
         self.note_action(
             if upload { "cp upload" } else { "cp download" },
             format!("{pod} in {ns}"),
         );
-        let claim = self.claim_status(format!("copying {from} → {to}…"));
-        let tx = self.tx.clone();
-        let genr = self.generation;
-        tokio::spawn(async move {
-            let out = tokio::process::Command::new(&argv[0])
-                .args(&argv[1..])
-                .output()
-                .await;
-            let result = match out {
-                Ok(o) if o.status.success() => Ok(format!("copied {from} → {to}")),
-                Ok(o) => {
-                    let stderr = String::from_utf8_lossy(&o.stderr);
-                    // The actual cause (a tar/exec error) comes before
-                    // kubectl's generic "command terminated with exit code"
-                    // trailer — flash the last line that says something.
-                    let line = |skip_trailer: bool| {
-                        stderr
-                            .lines()
-                            .rev()
-                            .map(str::trim)
-                            .find(|l| {
-                                !l.is_empty()
-                                    && !(skip_trailer && l.starts_with("command terminated"))
-                            })
-                            .unwrap_or_default()
-                            .to_string()
-                    };
-                    let err = match line(true) {
-                        e if e.is_empty() => line(false),
-                        e => e,
-                    };
-                    Err(if err.is_empty() {
-                        format!("kubectl cp exited with {}", o.status)
-                    } else {
-                        err
-                    })
-                }
-                Err(e) => Err(format!("kubectl cp failed to start: {e}")),
-            };
-            let _ = tx
-                .send(Msg::TransferDone {
-                    generation: genr,
-                    claim,
-                    result,
-                })
-                .await;
-        });
+        let claim = self.claim_status(format!("{label}…"));
+        let known = self.register_transfer(claim, label, upload, &src);
+        super::transfer::TransferJob {
+            cp: argv,
+            // `-i` for an upload only: its watcher stops when stdin closes,
+            // and a download's one-shot `du` has nothing to wait for.
+            exec: self.exec_prefix(&ns, &pod, container.as_deref(), upload),
+            upload,
+            src,
+            dest,
+            known,
+            claim,
+            generation: self.generation,
+            tx: self.tx.clone(),
+        }
     }
 
     /// Open the `t` action menu (Flux suspend/resume, CronJob
@@ -2352,6 +2375,40 @@ impl App {
                 owner
             });
         }
+    }
+
+    /// Refresh a still-running operation's progress without giving up the
+    /// claim its result has to present. Unlike [`Self::set_claimed_status`]
+    /// the claim stays pending, so the operation still reports when it lands.
+    ///
+    /// `shown` is the text this operation last wrote, and it is what makes
+    /// the refresh polite. [`Self::borrow_status`] leaves the claim in place
+    /// while putting its own message on the bar — a watch error, a failed
+    /// state write, a notification — so a caller that refreshed unconditionally
+    /// would wipe that message within a sample or two of its arriving. A
+    /// borrowed *error* is never cleared by [`Self::expire_flash`], so it
+    /// holds the text for the rest of the operation — which is the intended
+    /// order of importance: the bar keeps moving, only its number stops.
+    /// Returns the text now on the bar, for the next refresh to check.
+    pub(super) fn set_claimed_progress(
+        &mut self,
+        claim: StatusClaim,
+        shown: &str,
+        msg: impl Into<String>,
+    ) -> String {
+        // An empty bar is nobody's: a borrowed message that has expired
+        // leaves one behind, and progress is welcome there again.
+        if !self.owns_status(claim) || !(self.flash.is_empty() || self.flash == shown) {
+            return shown.to_string();
+        }
+        let message = msg.into();
+        self.set_flash(message.clone());
+        self.status_claim = Some(ActiveStatusClaim {
+            claim,
+            text: message.clone(),
+            pending: true,
+        });
+        message
     }
 
     /// Temporarily show a process/watch-level message without stealing an

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1432,19 +1432,33 @@ impl App {
                 // search-match cache behind.
                 self.detail.replace_lines(lines.into());
             }
+            Msg::TransferProgress {
+                generation,
+                claim,
+                done,
+                total,
+            } if generation == self.generation => self.update_transfer(claim, done, total),
             Msg::TransferDone {
                 generation,
                 claim,
                 result,
-            } if generation == self.generation => match result {
-                Ok(summary) => {
-                    self.set_claimed_status(claim, summary, false);
-                    // A copy made in the PVC browser changed one of the two
-                    // panes; show the file where it landed.
-                    self.refresh_pvc_panes();
+            } => {
+                // The bar is dropped whatever the generation: a copy that
+                // started before a context switch still has a row registered
+                // against it, and this is the only message that ends one.
+                self.end_transfer(claim);
+                if generation == self.generation {
+                    match result {
+                        Ok(summary) => {
+                            self.set_claimed_status(claim, summary, false);
+                            // A copy made in the PVC browser changed one of
+                            // the two panes; show the file where it landed.
+                            self.refresh_pvc_panes();
+                        }
+                        Err(e) => self.set_claimed_status(claim, format!("cp failed: {e}"), true),
+                    }
                 }
-                Err(e) => self.set_claimed_status(claim, format!("cp failed: {e}"), true),
-            },
+            }
             // Deliberately not generation-guarded: a helper pod may already
             // exist by the time this lands, and the stale branch is the only
             // thing that can clean it up.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35,6 +35,11 @@ use crate::store::{Msg, Pulse, RowKey, StatusClaim, Store, StoreMutation, XrayIt
 
 pub(crate) use guardrails::ConfirmLevel;
 pub use pvcexplore::{Pane, PvcExplore, PvcIntent};
+pub(crate) use transfer::TransferProgress;
+// Only the renderer's own test names an anchor; the app builds them inside
+// `transfer` and hands out `pane_transfers`.
+#[cfg(test)]
+pub(crate) use transfer::TransferAnchor;
 
 impl App {
     pub fn terminal_title(&self) -> Option<String> {
@@ -1900,6 +1905,12 @@ pub struct App {
     pub transfer_menu_state: ListState,
     pub transfer_target: Option<(String, String, Option<String>)>,
 
+    /// Copies running in the background (`c` in the PVC browser, `t` on a
+    /// pod), and how far each has got. One entry per copy, so copies of two
+    /// different rows draw two bars; two copies of the *same* row draw the
+    /// older one's, there being one size column to draw in.
+    pub(crate) transfers: Vec<TransferProgress>,
+
     /// Split-pane PVC browser state (`x` on a PVC row, `:pvc-explore`).
     pub pvc: PvcExplore,
     /// `[pvc_explore]` helper-pod defaults.
@@ -2233,6 +2244,7 @@ impl App {
             flux_menu_state: ListState::default(),
             transfer_menu_state: ListState::default(),
             transfer_target: None,
+            transfers: Vec::new(),
             pvc: PvcExplore::default(),
             pvc_cfg: crate::config::PvcExploreConfig::default(),
             confirm_return: Mode::Table,
@@ -2419,6 +2431,7 @@ mod rightsize;
 mod rows;
 mod snapshot;
 mod timeline;
+mod transfer;
 mod workspaces;
 
 use helpers::*;

--- a/src/app/pvcexplore.rs
+++ b/src/app/pvcexplore.rs
@@ -565,15 +565,13 @@ impl App {
     fn pvc_list_argv(&self, path: &str) -> Option<(Vec<String>, String)> {
         let mount = self.pvc.mount.as_ref()?;
         let probe = pvc::list_probe(&mount.path);
-        let mut argv = self.kubectl_base();
+        let mut argv = self.exec_prefix(
+            &self.pvc.namespace,
+            &mount.pod,
+            Some(mount.container.as_str()),
+            false,
+        );
         argv.extend([
-            "exec".into(),
-            "-n".into(),
-            self.pvc.namespace.clone(),
-            mount.pod.clone(),
-            "-c".into(),
-            mount.container.clone(),
-            "--".into(),
             "sh".into(),
             "-c".into(),
             probe.script,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -16720,7 +16720,9 @@ fn pvc_entry(
     crate::pvcexplore::Entry {
         name: name.into(),
         kind,
-        size: Some(size),
+        // Like both listings: a directory's own inode size is not its tree's,
+        // so neither parser reports one.
+        size: (kind != crate::pvcexplore::EntryKind::Dir).then_some(size),
         link_target: String::new(),
     }
 }
@@ -16884,6 +16886,622 @@ async fn uploading_into_a_read_only_mount_is_refused() {
     app.handle_key(press(KeyCode::Tab)).unwrap();
     app.handle_key(press(KeyCode::Char('c'))).unwrap();
     assert!(app.flash.contains("read-only"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_copy_fills_a_bar_where_the_size_was_and_takes_it_away_after() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+    // Nothing is drawn before a total lands: a bar against a total nobody
+    // knows would be an animation, not a report.
+    assert!(app.pane_transfers(Pane::Remote, "/srv").is_empty());
+
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    assert_eq!(
+        app.pane_transfers(Pane::Remote, "/srv"),
+        vec![("big.tar", 2_500, 5_000)]
+    );
+    assert!(app.flash.contains("(50%)…"), "{}", app.flash);
+    // The row it came from, not the pane it is going into.
+    assert!(app.pane_transfers(Pane::Local, "/srv").is_empty());
+    // And not a same-named row in a directory the browser has moved to.
+    assert!(app.pane_transfers(Pane::Remote, "/srv/logs").is_empty());
+
+    app.handle_msg(Msg::TransferDone {
+        generation: app.generation,
+        claim,
+        result: Ok("copied big.tar".into()),
+    });
+    assert!(app.transfers.is_empty(), "the bar outlived the copy");
+    assert_eq!(app.flash, "copied big.tar");
+}
+
+#[tokio::test]
+async fn a_copy_of_a_folder_measures_the_whole_tree() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    // A directory has no size in a listing — `ls -l` reports the directory
+    // entry, not what is under it — so the total is `du`'s, and the bar is
+    // the sum rather than one file at a time.
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("cache", EntryKind::Dir, 0)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+
+    // A directory's total can only come from `du`, so it arrives with the
+    // first sample rather than from the listing — and it is the whole tree,
+    // not the 4 KiB the directory entry itself measures.
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 3 * 1024 * 1024 * 1024,
+        total: Some(4 * 1024 * 1024 * 1024),
+    });
+    assert_eq!(
+        app.pane_transfers(Pane::Remote, "/srv"),
+        vec![("cache", 3 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024)]
+    );
+    assert!(app.flash.contains("(75%)…"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn an_upload_puts_its_bar_on_the_local_row_it_came_from() {
+    use crate::pvcexplore::EntryKind;
+    let dir = std::env::temp_dir().join(format!("sofka-pvc-up-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    app.pvc.local_path = dir.clone();
+    app.pvc.local = vec![pvc_entry("notes.txt", EntryKind::File, 12)];
+    app.pvc.local_state.select(Some(0));
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+
+    let claim = app.transfers[0].claim;
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 3,
+        total: Some(12),
+    });
+    let shown = dir.to_string_lossy().into_owned();
+    assert_eq!(
+        app.pane_transfers(Pane::Local, &shown),
+        vec![("notes.txt", 3, 12)]
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn a_transfer_with_no_row_still_reports_that_it_is_moving() {
+    // `t` on a pod takes typed paths, so there is no row to draw on — and a
+    // copy with no measurable total has no share of it to report either. The
+    // bytes that have landed are still the difference between a slow copy
+    // and a stalled one.
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({"apiVersion": "v1", "kind": "Pod",
+               "metadata": {"name": "p", "namespace": "default"}}),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.prompt_input = "/var/log/app.log".into();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+
+    let claim = app.transfers[0].claim;
+    assert_eq!(app.transfers[0].anchor, None);
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 5 * 1024 * 1024,
+        total: None,
+    });
+    assert!(app.flash.contains("(5.0M)…"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn a_copy_that_outlived_its_generation_still_frees_its_row() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+
+    // A context switch, a dashboard, a restarted watch: the result is
+    // discarded, but the row it registered is not somebody else's to keep.
+    app.handle_msg(Msg::TransferDone {
+        generation: app.generation - 1,
+        claim,
+        result: Ok("copied big.tar".into()),
+    });
+    assert!(app.transfers.is_empty());
+    assert_ne!(app.flash, "copied big.tar");
+}
+
+#[tokio::test]
+async fn the_watcher_exec_asks_for_stdin_and_the_listing_does_not() {
+    // Load-bearing, not cosmetic: the watcher's loop in the container ends
+    // when its stdin closes, and with no stdin stream it would be killed
+    // before its first sample. The listing has nothing to wait for.
+    let (app, _rx) = test_app();
+    let watch = app.exec_prefix("default", "p", Some("c"), true);
+    assert_eq!(&watch[..5], ["kubectl", "--context", "test", "exec", "-i"]);
+    let once = app.exec_prefix("default", "p", Some("c"), false);
+    assert!(!once.contains(&"-i".to_string()), "{once:?}");
+    // Both still address the same container and end ready for a script.
+    for argv in [&watch, &once] {
+        let c = argv.iter().position(|a| a == "-c").unwrap();
+        assert_eq!(argv[c + 1], "c");
+        assert_eq!(argv.last().unwrap(), "--");
+    }
+}
+
+#[tokio::test]
+async fn a_bar_belongs_to_the_cluster_its_copy_started_in() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    assert_eq!(app.pane_transfers(Pane::Remote, "/srv").len(), 1);
+
+    // A context switch bumps the generation. The copy keeps running — nothing
+    // can stop it — but another cluster's claim that happens to mount at
+    // /srv and hold a big.tar is not the row it was drawn on.
+    app.generation += 1;
+    assert!(
+        app.pane_transfers(Pane::Remote, "/srv").is_empty(),
+        "a stale bar followed the browser into another cluster"
+    );
+}
+
+#[tokio::test]
+async fn a_borrowed_status_is_not_wiped_by_the_next_progress_sample() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+
+    // Something else borrows the bar mid-copy — a watch note, a failed state
+    // write, a notification. It keeps this copy's claim, so the copy still
+    // reports when it lands, but four samples a second must not wipe a
+    // message the user has had a quarter of a second to read.
+    // A sample first, so the claim is mid-flight when the borrow lands —
+    // the order a real copy sees.
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 1_000,
+        total: Some(5_000),
+    });
+    assert!(app.flash.contains("(20%)…"), "{}", app.flash);
+    app.borrow_status("session state was not saved", false);
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    assert_eq!(app.flash, "session state was not saved");
+    // The bar still moved; only the text was left alone.
+    assert_eq!(
+        app.pane_transfers(Pane::Remote, "/srv"),
+        vec![("big.tar", 2_500, 5_000)]
+    );
+
+    // Once the borrowed message has had its time, the copy has the bar back.
+    app.flash_since = std::time::Instant::now() - std::time::Duration::from_secs(9);
+    app.expire_flash();
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 4_000,
+        total: Some(5_000),
+    });
+    assert!(app.flash.contains("(80%)…"), "{}", app.flash);
+}
+
+#[tokio::test]
+async fn the_percentage_keeps_up_with_the_copy() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 4_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+
+    // Sample after sample, not just the first: the refresh only writes the
+    // bar while the text on it is still this copy's own, so a copy that
+    // forgot what it had written would freeze at its first percentage.
+    for (done, want) in [(1_000, "(25%)…"), (3_200, "(80%)…"), (4_000, "(100%)…")] {
+        app.handle_msg(Msg::TransferProgress {
+            generation: app.generation,
+            claim,
+            done,
+            total: Some(4_000),
+        });
+        assert!(app.flash.contains(want), "{}", app.flash);
+    }
+}
+
+#[tokio::test]
+async fn a_transfer_job_carries_the_direction_into_every_part_of_itself() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![
+            pvc_entry("big.tar", EntryKind::File, 5_000),
+            pvc_entry("cache", EntryKind::Dir, 0),
+        ],
+    );
+
+    let down = app.begin_transfer(
+        "ns".into(),
+        "api-0".into(),
+        Some("app".into()),
+        false,
+        "/srv/big.tar".into(),
+        "/tmp/big.tar".into(),
+    );
+    // Downloads read the volume once; nothing waits on their stdin.
+    assert!(!down.exec.contains(&"-i".to_string()), "{:?}", down.exec);
+    assert_eq!(down.cp[down.cp.len() - 2], "api-0:/srv/big.tar");
+    assert_eq!(down.cp[down.cp.len() - 1], "/tmp/big.tar");
+    // The listing already knew this file's size, so no `du` need run.
+    assert_eq!(down.known, Some(5_000));
+    assert_eq!(down.generation, app.generation);
+
+    // A directory has no size in a listing, so its total can only come from
+    // `du` — the job says so by carrying none.
+    let dir = app.begin_transfer(
+        "ns".into(),
+        "api-0".into(),
+        Some("app".into()),
+        false,
+        "/srv/cache".into(),
+        "/tmp/cache".into(),
+    );
+    assert_eq!(dir.known, None);
+
+    // An upload from somewhere other than the local pane gets no row, the
+    // same way: `t` takes typed paths too.
+    let stray = app.begin_transfer(
+        "ns".into(),
+        "api-0".into(),
+        Some("app".into()),
+        true,
+        "/somewhere/else/notes.txt".into(),
+        "/srv/notes.txt".into(),
+    );
+    assert_eq!(stray.known, None);
+    assert_eq!(app.transfers.last().and_then(|t| t.anchor.clone()), None);
+
+    // A path the browser is not showing gets no row: `t` transfers any path
+    // the user types, and a bar on the row that happens to share its name
+    // would point at the wrong file.
+    let elsewhere = app.begin_transfer(
+        "ns".into(),
+        "api-0".into(),
+        Some("app".into()),
+        false,
+        "/elsewhere/big.tar".into(),
+        "/tmp/big.tar".into(),
+    );
+    assert_eq!(elsewhere.known, None);
+    assert_eq!(
+        app.transfers
+            .last()
+            .and_then(|t| t.anchor.as_ref())
+            .map(|a| a.name.clone()),
+        None
+    );
+    assert!(app.pane_transfers(Pane::Remote, "/srv").is_empty());
+
+    let up = app.begin_transfer(
+        "ns".into(),
+        "api-0".into(),
+        Some("app".into()),
+        true,
+        "/tmp/notes.txt".into(),
+        "/srv/notes.txt".into(),
+    );
+    // The upload's watcher lives until its stdin closes, so it must have one.
+    assert!(up.exec.contains(&"-i".to_string()), "{:?}", up.exec);
+    // And its size comes from a `stat` in the task, not from the local
+    // listing: that listing is a snapshot, and the file is on this disk.
+    assert_eq!(up.known, None);
+    assert_eq!(up.cp[up.cp.len() - 2], "/tmp/notes.txt");
+    assert_eq!(up.cp[up.cp.len() - 1], "api-0:/srv/notes.txt");
+}
+
+#[tokio::test]
+async fn two_copies_at_once_draw_two_bars_and_leave_together() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![
+            pvc_entry("one.tar", EntryKind::File, 1_000),
+            pvc_entry("two.tar", EntryKind::File, 2_000),
+        ],
+    );
+
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let (first, second) = (app.transfers[0].claim, app.transfers[1].claim);
+    assert_ne!(first, second);
+
+    for (claim, done, total) in [(first, 500, 1_000), (second, 1_500, 2_000)] {
+        app.handle_msg(Msg::TransferProgress {
+            generation: app.generation,
+            claim,
+            done,
+            total: Some(total),
+        });
+    }
+    let bars = app.pane_transfers(Pane::Remote, "/srv");
+    assert_eq!(bars.len(), 2, "{bars:?}");
+    assert!(bars.contains(&("one.tar", 500, 1_000)), "{bars:?}");
+    assert!(bars.contains(&("two.tar", 1_500, 2_000)), "{bars:?}");
+
+    // Each leaves on its own result, and the other stays.
+    app.handle_msg(Msg::TransferDone {
+        generation: app.generation,
+        claim: first,
+        result: Ok("copied one.tar".into()),
+    });
+    assert_eq!(
+        app.pane_transfers(Pane::Remote, "/srv"),
+        vec![("two.tar", 1_500, 2_000)]
+    );
+    app.handle_msg(Msg::TransferDone {
+        generation: app.generation,
+        claim: second,
+        result: Ok("copied two.tar".into()),
+    });
+    assert!(app.transfers.is_empty());
+}
+
+#[tokio::test]
+async fn a_copy_whose_task_never_reported_does_not_keep_its_row_forever() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert_eq!(app.transfers.len(), 1);
+
+    // Its task died without a result — a panic, a runtime shutdown — so
+    // nothing will ever end it. The next copy in a new generation clears it:
+    // nothing that old can be drawn any more.
+    app.generation += 1;
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    assert_eq!(app.transfers.len(), 1, "the abandoned row was kept");
+    // And the one that remains is the live one: a progress message for the
+    // current generation finds it.
+    let claim = app.transfers[0].claim;
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    assert_eq!(
+        app.pane_transfers(Pane::Remote, "/srv"),
+        vec![("big.tar", 2_500, 5_000)]
+    );
+}
+
+#[tokio::test]
+async fn a_failed_copy_takes_its_bar_with_it_and_says_why() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    assert_eq!(app.pane_transfers(Pane::Remote, "/srv").len(), 1);
+
+    app.handle_msg(Msg::TransferDone {
+        generation: app.generation,
+        claim,
+        result: Err("tar: /srv/big.tar: Permission denied".into()),
+    });
+    assert!(app.transfers.is_empty(), "a failed copy kept its bar");
+    assert!(app.flash.contains("Permission denied"), "{}", app.flash);
+    assert!(app.flash_err);
+}
+
+#[tokio::test]
+async fn progress_from_a_cluster_the_browser_has_left_is_ignored() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+
+    // A copy still running in the cluster the user switched away from. Its
+    // samples must not write the status bar the new context owns.
+    let stale = app.generation;
+    app.generation += 1;
+    app.handle_msg(Msg::TransferProgress {
+        generation: stale,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    // Not merely invisible: the copy's own record is untouched, so nothing
+    // it reports can reach the bar the new context owns.
+    assert_eq!(app.transfers[0].done, 0);
+    assert_eq!(app.transfers[0].total, None);
+}
+
+#[tokio::test]
+async fn a_mount_path_written_with_a_slash_still_gets_its_bar() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    // A pod spec is free to write `mountPath: /srv/`, and the browser shows
+    // it as it found it. The row's bar is looked up by that same string, so
+    // anything deriving a second spelling of it silently never matches.
+    let mount = crate::pvcexplore::Mount {
+        path: "/srv/".into(),
+        ..pvc_mount()
+    };
+    resolve_pvc(&mut app, Ok(Some(mount)));
+    list_pvc(
+        &mut app,
+        "/srv/",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    assert_eq!(
+        app.pane_transfers(Pane::Remote, app.pvc.current_dir()),
+        vec![("big.tar", 2_500, 5_000)]
+    );
+
+    // And it survives ordinary navigation: `parent_path` hands back `/srv`
+    // where the mount was shown as `/srv/`, so an anchor holding either
+    // spelling would lose its row on the way back up.
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    list_pvc(&mut app, "/srv/logs", vec![]);
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    assert_eq!(
+        app.pane_transfers(Pane::Remote, app.pvc.current_dir()),
+        vec![("big.tar", 2_500, 5_000)],
+        "the bar was lost by walking into a directory and back out"
+    );
+}
+
+#[tokio::test]
+async fn a_bar_belongs_to_the_volume_its_copy_came_from() {
+    use crate::pvcexplore::EntryKind;
+    let (mut app, _rx) = app_with_pvc("Bound");
+    app.handle_key(press(KeyCode::Char('x'))).unwrap();
+    resolve_pvc(&mut app, Ok(Some(pvc_mount())));
+    list_pvc(
+        &mut app,
+        "/srv",
+        vec![pvc_entry("big.tar", EntryKind::File, 5_000)],
+    );
+    app.handle_key(press(KeyCode::Char('c'))).unwrap();
+    let claim = app.transfers[0].claim;
+    app.handle_msg(Msg::TransferProgress {
+        generation: app.generation,
+        claim,
+        done: 2_500,
+        total: Some(5_000),
+    });
+    assert_eq!(app.pane_transfers(Pane::Remote, "/srv").len(), 1);
+
+    // The user leaves and opens another claim, served by another pod, that
+    // mounts at the same path and happens to hold a file of the same name.
+    // `/data` and `/srv` are common enough that this is not exotic, and the
+    // copy still running has nothing to do with what is on screen now.
+    app.pvc.claim = "other".into();
+    app.pvc.remote = vec![pvc_entry("big.tar", EntryKind::File, 77)];
+    assert!(
+        app.pane_transfers(Pane::Remote, "/srv").is_empty(),
+        "a copy out of one volume drew its bar on another's row"
+    );
 }
 
 #[tokio::test]

--- a/src/app/transfer.rs
+++ b/src/app/transfer.rs
@@ -1,0 +1,1360 @@
+//! Progress for a background `kubectl cp`, measured at the destination:
+//! locally for a download, through one long-lived exec for an upload.
+//!
+//! The copy itself is still `kubectl cp`. Nothing here changes what is
+//! transferred, in which direction, or which guardrail had to allow it.
+//!
+//! Measuring the volume side is an exec of its own, gated no further than
+//! the copy it belongs to; `docs/safety.md` carries that argument. How the
+//! pod-side sampler is stopped, and why nothing simpler works, is
+//! [`pvc::size_watch`]'s to explain — this module holds the other end.
+
+use super::*;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::io::{AsyncBufReadExt, BufReader, Lines};
+use tokio::process::{ChildStdin, ChildStdout, Command};
+
+use crate::pvcexplore as pvc;
+
+/// Ceiling on measuring a copy's source, whichever end it is on: a `du` in
+/// the container for a download, a walk of this disk for an upload. A copy
+/// whose source cannot be measured in that time still runs; it has no bar.
+const SIZE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long to wait for a closed watcher to exit before letting
+/// `kill_on_drop` take the local process. Generous, because killing it
+/// before the API server has passed the stdin close through is the leak
+/// this design exists to prevent, and nothing waits on the result.
+const WATCH_STOP: Duration = Duration::from_secs(120);
+
+/// How long to wait for an opening measurement before the copy starts
+/// without one. Long enough for an exec handshake against a busy API
+/// server, because the fallback — the first sample that arrives, taken
+/// after the copy began — quietly writes off everything copied until then.
+/// It costs nothing when there is nothing to wait for: a watcher that
+/// cannot start ends its stream, and that is not waited on.
+const BASELINE_WAIT: Duration = Duration::from_secs(3);
+
+/// The rest a walk of `cost` earns before the next one. Three times over,
+/// because a walk is a recursive `stat` of everything copied so far against
+/// the disk `tar` is writing to, and a quarter duty cycle is plenty for a
+/// bar. Bounded by [`WALK_LIMIT`] bounding the walk.
+fn rest_after(cost: Duration) -> Duration {
+    cost * 3
+}
+
+/// Ceiling on one walk of a download's destination. A destination that
+/// cannot be measured inside it will not be measurable at this cadence at
+/// all, so the sampler retires rather than starting another walk.
+const WALK_LIMIT: Duration = Duration::from_secs(20);
+
+/// How often a download's destination is re-measured: smooth enough to read
+/// as motion, and one `stat` for the single large file this is mostly for.
+const LOCAL_SAMPLE: Duration = Duration::from_millis(250);
+
+/// Which row a copy's bar belongs on: a volume, a pane and a directory, not
+/// just a name. By the time a sample lands the browser can be showing
+/// another directory, or another claim entirely, and a same-named entry
+/// there is a different file — `/data` and `/srv` are common enough mount
+/// paths for that to be an ordinary Tuesday.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferAnchor {
+    pub pane: Pane,
+    /// The volume this row belongs to, as `namespace/claim`.
+    pub claim: String,
+    pub dir: String,
+    pub name: String,
+}
+
+/// A copy in flight, and how far along it is.
+pub struct TransferProgress {
+    /// The claim the copy's result will present, and what a sample names to
+    /// find its way back here.
+    pub(crate) claim: StatusClaim,
+    /// The status text this copy owns, without its progress suffix.
+    label: String,
+    /// The last status text this copy wrote, so a refresh can tell its own
+    /// text from one something else borrowed the bar for. See
+    /// [`App::set_claimed_progress`].
+    shown: String,
+    /// The watch generation the copy started under: a context switch cannot
+    /// stop a copy, but the row it was drawn on is no longer on screen.
+    generation: u64,
+    /// Where the bar goes, when the copy started from a row at all. A
+    /// transfer prompted by `t` with a typed path has no row to draw on.
+    pub anchor: Option<TransferAnchor>,
+    /// Bytes at the destination.
+    pub done: u64,
+    /// The source's total, when it could be measured. Without one there is
+    /// no bar — only the byte count on the status bar.
+    pub total: Option<u64>,
+}
+
+impl TransferProgress {
+    /// One copy's progress, for a renderer test.
+    #[cfg(test)]
+    pub(crate) fn fake(generation: u64, anchor: TransferAnchor, done: u64, total: u64) -> Self {
+        Self {
+            claim: StatusClaim(0),
+            label: String::new(),
+            shown: String::new(),
+            generation,
+            anchor: Some(anchor),
+            done,
+            total: Some(total),
+        }
+    }
+}
+
+/// Everything one background copy needs, gathered on the UI thread because
+/// the task that runs it cannot touch [`App`].
+pub(super) struct TransferJob {
+    /// The `kubectl cp` argv.
+    pub cp: Vec<String>,
+    /// `kubectl exec` up to and including `--`: a download sizes its source
+    /// through it, an upload watches its destination (and so asks for `-i`).
+    pub exec: Vec<String>,
+    pub upload: bool,
+    pub src: String,
+    pub dest: String,
+    /// The source's size, already known from the listing that showed it — so
+    /// copying a single file costs no `du` at all.
+    pub known: Option<u64>,
+    pub claim: StatusClaim,
+    pub generation: u64,
+    pub tx: Sender<Msg>,
+}
+
+impl App {
+    /// Register a copy so its samples have somewhere to land, and work out
+    /// which row wears its bar.
+    pub(super) fn register_transfer(
+        &mut self,
+        claim: StatusClaim,
+        label: String,
+        upload: bool,
+        src: &str,
+    ) -> Option<u64> {
+        // A copy whose task died without reporting — a panic, a runtime
+        // shutdown — would otherwise keep its row for the session. Nothing
+        // older than the current watch can still be drawn, so nothing older
+        // needs keeping.
+        self.transfers.retain(|t| t.generation == self.generation);
+        let anchor = self.transfer_anchor(upload, src);
+        // Only the volume side is worth trusting a listing for. A local
+        // source is a `stat` away in the task, which cannot be stale.
+        let known = anchor
+            .as_ref()
+            .filter(|a| a.pane == Pane::Remote)
+            .and_then(|a| self.anchored_size(a));
+        self.transfers.push(TransferProgress {
+            // What `claim_status` just put on the bar, so the first refresh
+            // recognises the text as this copy's own.
+            shown: format!("{label}…"),
+            claim,
+            label,
+            generation: self.generation,
+            anchor,
+            done: 0,
+            total: None,
+        });
+        known
+    }
+
+    /// A sample landed: move the bar, and put the percentage on the status
+    /// bar so a copy with no row to draw on still reports itself.
+    pub(super) fn update_transfer(&mut self, claim: StatusClaim, done: u64, total: Option<u64>) {
+        let Some(transfer) = self.transfers.iter_mut().find(|t| t.claim == claim) else {
+            return;
+        };
+        transfer.done = done;
+        transfer.total = total;
+        let progress = match total {
+            Some(total) => format!("{}%", pvc::progress_pct(done, total)),
+            // No total, so no share of it — but the byte count still tells a
+            // copy that is moving from one that has stalled.
+            None => pvc::human_size(done),
+        };
+        // Still ending in `…`: an unfinished operation's status is what lets
+        // a stale failure borrow the bar (see `set_claimed_status`), and a
+        // copy that is 62% done is unfinished.
+        let text = format!("{} ({progress})…", transfer.label);
+        let shown = transfer.shown.clone();
+        let shown = self.set_claimed_progress(claim, &shown, text);
+        if let Some(transfer) = self.transfers.iter_mut().find(|t| t.claim == claim) {
+            transfer.shown = shown;
+        }
+    }
+
+    /// The copy is over, whichever way it went.
+    pub(super) fn end_transfer(&mut self, claim: StatusClaim) {
+        self.transfers.retain(|t| t.claim != claim);
+    }
+
+    /// The rows in `pane` being copied while it shows `dir`, as `(name,
+    /// done, total)` — for this volume, this watch, and only for copies
+    /// with a measured total: a bar against a total nobody knows would be
+    /// an animation, not a report.
+    pub fn pane_transfers(&self, pane: Pane, dir: &str) -> Vec<(&str, u64, u64)> {
+        self.transfers
+            .iter()
+            .filter_map(|t| {
+                let anchor = t.anchor.as_ref()?;
+                let total = t.total?;
+                (t.generation == self.generation
+                    && anchor.claim == self.pvc_key()
+                    && anchor.pane == pane
+                    && anchor.dir == dir.trim_end_matches('/'))
+                .then_some((anchor.name.as_str(), t.done, total))
+            })
+            .collect()
+    }
+
+    /// The row a copy started from, or `None` when it did not start from one.
+    ///
+    /// The path is checked against the pane it should have come from rather
+    /// than trusted: `t` can transfer any path the user types, and a bar on
+    /// the row that happens to share its name would be pointing at the wrong
+    /// file.
+    fn transfer_anchor(&self, upload: bool, src: &str) -> Option<TransferAnchor> {
+        if !self.pvc.active {
+            return None;
+        }
+        if upload {
+            let path = Path::new(src);
+            let name = path.file_name()?.to_string_lossy().into_owned();
+            // Compared as paths, stored as the pane's own rendering of it:
+            // that rendering is what the renderer looks the bar up by, so
+            // deriving a second one here would be a second chance to differ.
+            if path.parent() != Some(self.pvc.local_path.as_path()) {
+                return None;
+            }
+            return Some(TransferAnchor {
+                pane: Pane::Local,
+                claim: self.pvc_key(),
+                dir: self.pvc.local_path.to_string_lossy().into_owned(),
+                name,
+            });
+        }
+        let (dir, name) = src.rsplit_once('/')?;
+        // Trimmed on both sides and stored trimmed, so a directory has
+        // exactly one spelling. A `mountPath` written as `/srv/` is shown
+        // verbatim at the mount root but comes back from `parent_path` as
+        // `/srv`, so an anchor holding either spelling stops matching the
+        // moment the browser walks down and back up.
+        let shown = self.pvc.current_dir().trim_end_matches('/');
+        (dir.trim_end_matches('/') == shown).then(|| TransferAnchor {
+            pane: Pane::Remote,
+            claim: self.pvc_key(),
+            dir: shown.to_string(),
+            name: name.to_string(),
+        })
+    }
+
+    /// The volume the browser is showing, as `namespace/claim`.
+    fn pvc_key(&self) -> String {
+        format!("{}/{}", self.pvc.namespace, self.pvc.claim)
+    }
+
+    /// The size the pane's own listing already reported for an anchored entry.
+    /// `None` for a directory, which is exactly when `du` has to run.
+    fn anchored_size(&self, anchor: &TransferAnchor) -> Option<u64> {
+        let entries = match anchor.pane {
+            Pane::Local => &self.pvc.local,
+            Pane::Remote => &self.pvc.remote,
+        };
+        // A directory has no size in either listing — `ls` reports its
+        // inode's, not its tree's — so this is a file's size or nothing.
+        entries.iter().find(|e| e.name == anchor.name)?.size
+    }
+}
+
+/// Run one `kubectl cp`, reporting how far it has got until it lands.
+pub(super) async fn run_transfer(job: TransferJob) {
+    let TransferJob {
+        cp,
+        exec,
+        upload,
+        src,
+        dest,
+        known,
+        claim,
+        generation,
+        tx,
+    } = job;
+
+    // The two ends as `cp` addresses them: its own last two arguments,
+    // rather than a second copy of them carried alongside.
+    let from = cp[cp.len() - 2].clone();
+    let to = cp[cp.len() - 1].clone();
+
+    let mut sampler = Sampler::start(upload, &exec, &dest).await;
+    // What the destination holds before the copy can touch it — see
+    // `Sampler::baseline` for why it is not just the first sample.
+    let mut baseline = sampler.baseline().await;
+
+    let mut command = Command::new(&cp[0]);
+    // No `kill_on_drop`: a copy is the user's data moving, and quitting
+    // sofka has always let an in-flight one finish rather than leaving a
+    // truncated file. Null stdin, like every child here — sofka's own is a
+    // terminal in raw mode and `output()` does not close it for the child.
+    command.args(&cp[1..]).stdin(std::process::Stdio::null());
+    let copy = command.output();
+    tokio::pin!(copy);
+
+    // Behind the copy, not ahead of it: sizing first would leave the child
+    // spawned but unpolled for as long as a `du` over a whole tree takes,
+    // its result unobserved and its stderr pipe filling unread.
+    let sizing = resolve_total(&exec, upload, &src, known);
+    tokio::pin!(sizing);
+    let mut sized = false;
+
+    let mut total: Option<u64> = None;
+    let mut done = 0;
+    // Nothing will measure this destination, and no later total can undo
+    // that. Decided before the loop for the sampler that never started; a
+    // watcher that starts and then ends its stream is caught inside it
+    // instead, one sample later, which the run loop folds into the same
+    // frame — so a bar is withdrawn before it can be drawn either way.
+    let mut blind = matches!(sampler, Sampler::Idle);
+    let report = |done: u64, total: Option<u64>| {
+        let tx = tx.clone();
+        async move {
+            let _ = tx
+                .send(Msg::TransferProgress {
+                    generation,
+                    claim,
+                    done,
+                    total,
+                })
+                .await;
+        }
+    };
+    let out = loop {
+        tokio::select! {
+            finished = &mut copy => break finished,
+            measured = &mut sizing, if !sized => {
+                // Polled to the end even when the destination has already
+                // proven unmeasurable: the result costs nothing to throw
+                // away, and a future dropped mid-poll leaves its `du` to
+                // the container-side `timeout` rather than to anything
+                // here.
+                sized = true;
+                if !blind {
+                    // The bar can only appear once something knows what it
+                    // is a share of; until then the status bar counts bytes.
+                    total = measured;
+                    report(done, total).await;
+                }
+            }
+            sampled = sampler.sample() => {
+                if let Some(sampled) = sampled {
+                    let moved = moved(sampled, &mut baseline);
+                    // Never backwards: a destination is walked while it is
+                    // being written, and a walk that raced a rename would
+                    // make the bar retreat for no reason.
+                    if moved > done {
+                        done = moved;
+                        report(done, total).await;
+                    }
+                } else if matches!(sampler, Sampler::Idle) && !blind {
+                    // The sampler has retired, so nothing will move again.
+                    // A bar left at the fraction it reached says the copy
+                    // stopped there, which is a claim; dropping the total
+                    // leaves the byte count, which is only a number that
+                    // stopped. No total still on its way re-draws it.
+                    blind = true;
+                    report(done, None).await;
+                }
+            }
+        }
+    };
+    // No closing measurement, and no waiting for a total still in flight.
+    // The run loop drains its channel before drawing, so a report sent here
+    // usually shares a frame with the row's removal and is never seen — and
+    // what it would buy, at the cost of another exec, is one sample period
+    // of accuracy on a bar that is about to disappear.
+    // Closing its stdin is what the container can see; nothing waits on the
+    // unwinding, which `reap` does after the result has gone out.
+    sampler.close();
+
+    let result = match out {
+        Ok(o) if o.status.success() => Ok(format!("copied {from} → {to}")),
+        Ok(o) => Err(cp_error(&String::from_utf8_lossy(&o.stderr), &o.status)),
+        Err(e) => Err(format!("kubectl cp failed to start: {e}")),
+    };
+    let _ = tx
+        .send(Msg::TransferDone {
+            generation,
+            claim,
+            result,
+        })
+        .await;
+    sampler.reap().await;
+}
+
+/// What a raw destination measurement says has *moved*, against what was at
+/// the destination when the copy started.
+///
+/// The baseline is what [`Sampler::baseline`] measured before the copy
+/// started, or the first sample when nothing could: whatever was already
+/// there is not progress, or an overwrite would open the bar at 100%.
+///
+/// It ratchets down to the lowest sample seen and never below, so a file
+/// `cp` truncates is measured from zero while a directory, which only dips
+/// by the file being replaced at that moment, is measured from what
+/// survived. A folder copied over a copy of itself therefore ends short —
+/// under-reporting being the direction to err in.
+fn moved(sampled: u64, baseline: &mut Option<u64>) -> u64 {
+    let base = baseline.get_or_insert(sampled);
+    *base = (*base).min(sampled);
+    sampled - *base
+}
+
+/// The line of `kubectl cp`'s stderr worth flashing. The actual cause (a
+/// tar/exec error) comes before kubectl's generic "command terminated with
+/// exit code" trailer, so the trailer is only used when it is all there is.
+fn cp_error(stderr: &str, status: &std::process::ExitStatus) -> String {
+    let line = |skip_trailer: bool| {
+        stderr
+            .lines()
+            .rev()
+            .map(str::trim)
+            .find(|l| !(l.is_empty() || skip_trailer && l.starts_with("command terminated")))
+            .unwrap_or_default()
+            .to_string()
+    };
+    match line(true) {
+        e if e.is_empty() => match line(false) {
+            e if e.is_empty() => format!("kubectl cp exited with {status}"),
+            e => e,
+        },
+        e => e,
+    }
+}
+
+/// The source's byte total, or `None` when nothing could measure it — an
+/// unreadable tree, a `du` the container does not have, a walk past
+/// [`pvc::MAX_SIZE_ENTRIES`], or a source that measures zero, which is what a
+/// tree nothing could read comes back as.
+async fn resolve_total(
+    exec: &[String],
+    upload: bool,
+    src: &str,
+    known: Option<u64>,
+) -> Option<u64> {
+    if known.is_some() {
+        return known.filter(|&bytes| bytes > 0);
+    }
+    let measured = if upload {
+        // Timed out like the remote probe: `read_dir` on a hung network mount
+        // never returns, and the copy is already running behind this.
+        let walk = local_size(PathBuf::from(src), pvc::MAX_SIZE_ENTRIES);
+        match tokio::time::timeout(SIZE_TIMEOUT, walk).await.ok()? {
+            pvc::Measure::Bytes(bytes) => Some(bytes),
+            pvc::Measure::Absent | pvc::Measure::TooBig => None,
+        }
+    } else {
+        let argv = size_argv(exec, &pvc::size_probe(), src);
+        let run = Command::new(&argv[0])
+            .args(&argv[1..])
+            .stdin(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .output();
+        let out = tokio::time::timeout(SIZE_TIMEOUT, run).await.ok()?.ok()?;
+        if !out.status.success()
+            && let Some(line) = String::from_utf8_lossy(&out.stderr)
+                .lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+        {
+            // A denial, or a container without a shell, is otherwise a bar
+            // that quietly never appears.
+            crate::log_warn!("pvc.size", error = line);
+        }
+        pvc::parse_size(&String::from_utf8_lossy(&out.stdout))
+    };
+    // A zero-byte file has a size; a bar against a total of zero renders as
+    // instantly complete, so neither kind of zero is a total.
+    measured.filter(|&bytes| bytes > 0)
+}
+
+/// `sh -c <script> sh <path>` appended to an exec prefix. The path is a
+/// positional parameter, never spliced into the script — the same shape the
+/// listing uses, and for the same reason.
+fn size_argv(exec: &[String], script: &str, path: &str) -> Vec<String> {
+    let mut argv = exec.to_vec();
+    argv.extend([
+        "sh".to_string(),
+        "-c".to_string(),
+        script.to_string(),
+        "sh".to_string(),
+        path.to_string(),
+    ]);
+    argv
+}
+
+/// Blocking work, so it runs off the runtime — and blocking work the
+/// runtime waits for at shutdown, so giving up on the future is not enough.
+/// The flag is how the thread is told, and it is raised whether this returns
+/// or is dropped mid-flight.
+async fn local_size(path: PathBuf, cap: usize) -> pvc::Measure {
+    let stop = Arc::new(AtomicBool::new(false));
+    let _raised = Stop(stop.clone());
+    tokio::task::spawn_blocking(move || pvc::local_size_capped(&path, cap, &stop))
+        .await
+        // The blocking pool is gone (shutdown); nothing will measure again.
+        .unwrap_or(pvc::Measure::TooBig)
+}
+
+/// Raises its flag when it goes, however it goes — the walk behind it then
+/// stops at the next directory instead of running on unwatched.
+struct Stop(Arc<AtomicBool>);
+
+impl Drop for Stop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+/// The exec an upload's samples arrive on.
+struct Watcher {
+    /// The write end of the exec's stdin, held open for as long as the
+    /// watcher is wanted and dropped to stop it — see [`Sampler::close`].
+    stdin: Option<ChildStdin>,
+    child: tokio::process::Child,
+    lines: Lines<BufReader<ChildStdout>>,
+}
+
+/// Where a copy's samples come from.
+enum Sampler {
+    /// A download lands on the user's own disk, so sampling is a walk of the
+    /// destination and costs the cluster nothing.
+    Local {
+        path: PathBuf,
+        tick: tokio::time::Interval,
+        /// Rest owed to the destination before the next walk, when the last
+        /// one cost more than the interval.
+        owed: Duration,
+        /// Entry cap for one walk, so a test can reach the retirement branch
+        /// without a tree of [`pvc::MAX_SIZE_ENTRIES`] files.
+        cap: usize,
+        /// Ceiling on one walk, an argument for the same reason.
+        limit: Duration,
+    },
+    /// An upload lands in the pod, so the samples come from one exec that
+    /// prints the destination's size once a second — not one exec per sample
+    /// against somebody's production pod.
+    Remote(Box<Watcher>),
+
+    /// Nothing to sample from: the watcher would not start, or its stream
+    /// has ended. A copy in this state has no bar rather than one pinned
+    /// wherever it had got to.
+    Idle,
+}
+
+impl Sampler {
+    async fn start(upload: bool, exec: &[String], dest: &str) -> Self {
+        if !upload {
+            let mut tick = tokio::time::interval(LOCAL_SAMPLE);
+            // Skip, not the default Burst: a walk of a large destination can
+            // take longer than the interval, and burst ticking would then run
+            // walks back to back with no pause for the rest of the copy.
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            return Sampler::Local {
+                path: PathBuf::from(dest),
+                tick,
+                owed: Duration::ZERO,
+                cap: pvc::MAX_SIZE_ENTRIES,
+                limit: WALK_LIMIT,
+            };
+        }
+        let argv = size_argv(exec, &pvc::size_watch(), dest);
+        let child = Command::new(&argv[0])
+            .args(&argv[1..])
+            // Piped and then left alone: the write end stays open for as long
+            // as the child does, and closes with it. `null()` here would end
+            // the loop before its first sample.
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            // Kept, not discarded: an RBAC denial, a container without a
+            // shell and a quiet copy all look the same from out here, and
+            // the only symptom is a bar that never moves.
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn();
+        match child {
+            Ok(mut child) => {
+                if let Some(stderr) = child.stderr.take() {
+                    tokio::spawn(async move {
+                        // The first line says why a watcher is not working —
+                        // an RBAC denial, a container with no shell — and
+                        // the rest is drained rather than read. Dropping the
+                        // reader would close the pipe, and kubectl's next
+                        // write to a closed stderr takes it down with
+                        // SIGPIPE: a kubectl killed rather than closed
+                        // abandons the exec instead of ending it, and the
+                        // loop keeps running in the pod. `copy` keeps the
+                        // pipe open to EOF whatever the bytes are, which
+                        // `lines()` would not for invalid UTF-8.
+                        let mut lines = BufReader::new(stderr).lines();
+                        if let Ok(Some(line)) = lines.next_line().await
+                            && !line.trim().is_empty()
+                        {
+                            crate::log_warn!("pvc.watch", error = line.trim());
+                        }
+                        let mut reader = lines.into_inner();
+                        let mut sink = tokio::io::sink();
+                        let _ = tokio::io::copy(&mut reader, &mut sink).await;
+                    });
+                }
+                match child.stdout.take() {
+                    Some(stdout) => Sampler::Remote(Box::new(Watcher {
+                        stdin: child.stdin.take(),
+                        child,
+                        lines: BufReader::new(stdout).lines(),
+                    })),
+                    None => Sampler::Idle,
+                }
+            }
+            // No watcher means no bar, not a failed copy.
+            Err(e) => {
+                crate::log_warn!("pvc.watch", error = e.to_string());
+                Sampler::Idle
+            }
+        }
+    }
+
+    /// What the destination measures before the copy touches it.
+    ///
+    /// A download's destination is on this disk, so this is one walk and
+    /// costs nothing. An upload's is in the pod, so its watcher's first
+    /// sample is the measurement, waited for briefly — one exec's setup,
+    /// spent before the copy starts, for a baseline that is exactly right
+    /// rather than one that quietly subtracts the first second of it.
+    ///
+    /// `None` when nothing could measure it, and [`moved`] then falls back to
+    /// the first sample. A destination that does not exist is not that case:
+    /// it is a baseline of zero, and the most common one.
+    async fn baseline(&mut self) -> Option<u64> {
+        match self {
+            Sampler::Local { path, cap, .. } => {
+                // Bounded like everything else that runs before the copy can
+                // report: a walk of an enormous existing destination must not
+                // hold up the thing being measured.
+                let walk = local_size(path.clone(), *cap);
+                match tokio::time::timeout(BASELINE_WAIT, walk).await {
+                    Ok(pvc::Measure::Bytes(bytes)) => Some(bytes),
+                    Ok(pvc::Measure::Absent) => Some(0),
+                    Ok(pvc::Measure::TooBig) | Err(_) => None,
+                }
+            }
+            Sampler::Remote(watcher) => {
+                // Read directly rather than through `sample`, which parks
+                // for good at end-of-input: a container with no `du` exits
+                // the script at once, and waiting out `BASELINE_WAIT` for a
+                // sample that cannot come would delay every such copy.
+                let lines = &mut watcher.lines;
+                let first = async {
+                    while let Ok(Some(line)) = lines.next_line().await {
+                        if let Some(bytes) = pvc::parse_size_sample(&line) {
+                            return Some(bytes);
+                        }
+                    }
+                    None
+                };
+                tokio::time::timeout(BASELINE_WAIT, first)
+                    .await
+                    .unwrap_or_default()
+            }
+            Sampler::Idle => None,
+        }
+    }
+
+    /// End the watcher the only way the container can see: by closing its
+    /// stdin, which is the end-of-input [`pvc::size_watch`] explains. On the
+    /// paths that never get here — a cancelled task, a killed session —
+    /// nothing carries the close and the loop runs to its own bound.
+    fn close(&mut self) {
+        if let Sampler::Remote(watcher) = self {
+            drop(watcher.stdin.take());
+        }
+    }
+
+    /// Wait for a closed watcher to actually exit, so its `kubectl` is reaped
+    /// rather than left to the runtime. Separate from [`Self::close`] and
+    /// called after the copy's result has been sent: the close is what the
+    /// container needs, and nothing should wait on the unwinding.
+    async fn reap(&mut self) {
+        if let Sampler::Remote(watcher) = self {
+            let _ = tokio::time::timeout(WATCH_STOP, watcher.child.wait()).await;
+        }
+    }
+
+    /// The destination's size, whenever it can next be read, and `None` when
+    /// this attempt could not read it. `None` rather than zero, because zero
+    /// is a measurement: fed to [`moved`] it would look like a destination
+    /// that had just been truncated and take the baseline with it.
+    ///
+    /// Cancel-safe: `Lines::next_line` keeps its state in `self`, and an
+    /// abandoned walk is a number nobody needs.
+    async fn sample(&mut self) -> Option<u64> {
+        match self {
+            Sampler::Local {
+                path,
+                tick,
+                owed,
+                cap,
+                limit,
+            } => {
+                // Paid at the top, not after measuring: sleeping the debt
+                // off before the *next* walk keeps the number just measured
+                // from ageing on the way out.
+                if *owed > Duration::ZERO {
+                    tokio::time::sleep(*owed).await;
+                    // Cleared after the sleep, not before: a sample dropped
+                    // mid-sleep would otherwise forget it owed anything.
+                    *owed = Duration::ZERO;
+                }
+                tick.tick().await;
+                let started = std::time::Instant::now();
+                let walk = local_size(path.clone(), *cap);
+                let measured = match tokio::time::timeout(*limit, walk).await {
+                    Ok(measured) => measured,
+                    // Too much destination to measure at this cadence,
+                    // which is what the cap means as well.
+                    Err(_) => pvc::Measure::TooBig,
+                };
+                *owed = rest_after(started.elapsed());
+                match measured {
+                    pvc::Measure::Bytes(bytes) => Some(bytes),
+                    // Not there yet, or not readable this time round: one
+                    // `lstat`, and asking again is the whole point.
+                    pvc::Measure::Absent => None,
+                    // Over the entry cap, which it will not come back under.
+                    pvc::Measure::TooBig => {
+                        *self = Sampler::Idle;
+                        None
+                    }
+                }
+            }
+            Sampler::Remote(watcher) => loop {
+                let lines = &mut watcher.lines;
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        if let Some(bytes) = pvc::parse_size_sample(&line) {
+                            return Some(bytes);
+                        }
+                    }
+                    // The watcher is over — it ran out of samples, the
+                    // container took it with it, or it never had a `du` to
+                    // run. The copy is not, and the bar must not sit at
+                    // whatever fraction it had reached.
+                    _ => {
+                        // Closed, not just dropped: `Idle` lets go of the
+                        // `Watcher`, and `kill_on_drop` on a `kubectl` that
+                        // has not been closed abandons the exec rather than
+                        // ending it. Once, so the caller can take the bar
+                        // away; after that there is nothing to wait for.
+                        drop(watcher.stdin.take());
+                        *self = Sampler::Idle;
+                        return None;
+                    }
+                }
+            },
+            Sampler::Idle => std::future::pending().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scratch directory of this test's own.
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("sofka-xfer-{}-{name}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// A job whose "cluster" is this machine: an empty exec prefix leaves
+    /// [`size_argv`] producing `sh -c <script> sh <path>`, so the real probe
+    /// and watcher scripts run here against a real directory, and `cp` being
+    /// an argv like any other, a script that writes slowly stands in for the
+    /// copy.
+    fn local_job(cp: &str, upload: bool, src: &Path, dest: &Path, tx: Sender<Msg>) -> TransferJob {
+        TransferJob {
+            cp: vec!["sh".into(), "-c".into(), cp.into()],
+            exec: Vec::new(),
+            upload,
+            src: src.display().to_string(),
+            dest: dest.display().to_string(),
+            known: None,
+            claim: StatusClaim(1),
+            generation: 0,
+            tx,
+        }
+    }
+
+    /// Every progress report a run produced, and its result.
+    async fn drain(mut rx: tokio::sync::mpsc::Receiver<Msg>) -> (Vec<(u64, Option<u64>)>, String) {
+        let mut seen = Vec::new();
+        let mut outcome = String::new();
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                Msg::TransferProgress { done, total, .. } => seen.push((done, total)),
+                Msg::TransferDone { result, .. } => {
+                    outcome = match result {
+                        Ok(summary) => summary,
+                        Err(e) => format!("FAILED: {e}"),
+                    };
+                }
+                _ => {}
+            }
+        }
+        (seen, outcome)
+    }
+
+    #[tokio::test]
+    async fn a_run_sizes_its_source_and_follows_its_destination() {
+        let dir = scratch("run");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 8192]).unwrap();
+        let dest = dir.join("dest.bin");
+        // Eight visible steps, so the samples have something to follow.
+        let cp = format!(
+            "i=0; while [ $i -lt 8 ]; do printf '%1024s' '' >> '{}'; i=$((i+1)); sleep 0.1; done",
+            dest.display()
+        );
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        run_transfer(local_job(&cp, false, &src, &dest, tx)).await;
+        let (seen, outcome) = drain(rx).await;
+
+        assert!(outcome.starts_with("copied"), "{outcome}");
+        // Nothing is reported until something is known: the status bar
+        // already says "copying …", and rewriting it to "(0B)…" says less.
+        assert_eq!(seen[0].0, 0, "the first report claimed progress: {seen:?}");
+        // The source was measured by the probe script, running here.
+        let total = seen
+            .iter()
+            .find_map(|(_, total)| *total)
+            .expect("no total: the size probe produced nothing");
+        assert!(total >= 8192, "{total} is less than the source");
+        // Progress only rises.
+        assert!(
+            seen.windows(2).all(|w| w[1].0 >= w[0].0),
+            "progress went backwards: {seen:?}"
+        );
+        assert!(
+            seen.iter().any(|(done, _)| *done >= 4096),
+            "nothing was ever reported as moved: {seen:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn what_was_already_at_the_destination_is_not_progress() {
+        let dir = scratch("baseline");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 4096]).unwrap();
+        // Yesterday's copy, sixteen times the size of what is about to be
+        // added to it — an upload merging into a directory behaves this way,
+        // and absolute samples would call it 1600% done.
+        let dest = dir.join("dest.bin");
+        std::fs::write(&dest, vec![1u8; 65536]).unwrap();
+        // The trailing rest is not padding: there is no closing measurement,
+        // so the last sample is whatever the timer caught, and a copy that
+        // ends the instant it writes leaves the last write unmeasured.
+        let cp = format!(
+            "sleep 0.3; i=0; while [ $i -lt 4 ]; do printf '%1024s' '' >> '{}'; i=$((i+1)); sleep 0.1; done; sleep 0.4",
+            dest.display()
+        );
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        run_transfer(local_job(&cp, false, &src, &dest, tx)).await;
+        let (seen, outcome) = drain(rx).await;
+
+        assert!(outcome.starts_with("copied"), "{outcome}");
+        let moved: Vec<u64> = seen.iter().map(|(done, _)| *done).collect();
+        assert_eq!(moved[0], 0, "the copy opened part-done: {moved:?}");
+        assert!(
+            moved.iter().all(|done| *done <= 4096),
+            "the file that was already there was counted as progress: {moved:?}"
+        );
+        assert_eq!(
+            moved.last(),
+            Some(&4096),
+            "the bytes that were added were not all counted: {moved:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_copy_that_cannot_be_watched_draws_no_bar_at_all() {
+        // The watcher could not start — denied, no shell, a pod that went
+        // away. Without a word from the sampler the row would render an
+        // empty bar and "(0%)…" for the whole copy, which is worse than the
+        // line it replaced; and with nothing to measure against, the source
+        // is not sized either.
+        let dir = scratch("unwatched");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 4096]).unwrap();
+        let dest = dir.join("dest.bin");
+        let cp = format!("sleep 0.2; printf '%2048s' '' > '{}'", dest.display());
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let mut job = local_job(&cp, true, &src, &dest, tx);
+        // An upload, so the sampler is the watcher — pointed at a binary
+        // that does not exist.
+        job.exec = vec!["sofka-no-such-binary".to_string()];
+        run_transfer(job).await;
+        let (seen, outcome) = drain(rx).await;
+
+        assert!(outcome.starts_with("copied"), "{outcome}");
+        assert!(
+            seen.iter().all(|(_, total)| total.is_none()),
+            "a bar was drawn against a destination nothing can measure: {seen:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_bar_that_was_drawn_and_then_cannot_be_kept_is_taken_away() {
+        // The sampler stops mid-copy — the watcher's exec dies, the pod
+        // restarts. The bar has a total by then, so leaving it alone would
+        // freeze it at the fraction it had reached, which reads as a copy
+        // that stopped there. The last word is that there is no bar.
+        let dir = scratch("collapse-run");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 8192]).unwrap();
+        let dest = dir.join("dest.bin");
+        let cp = format!("sleep 1.2; printf '%2048s' '' > '{}'", dest.display());
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let mut job = local_job(&cp, true, &src, &dest, tx);
+        // A watcher that answers twice and then goes away: the first is the
+        // baseline, the second moves the bar, and the end of its output is
+        // what the sampler has to notice.
+        job.exec = vec![
+            "sh".into(),
+            "-c".into(),
+            "printf 'sofka-size:1:0\n'; sleep 0.4; printf 'sofka-size:1:2048\n'; sleep 0.2".into(),
+        ];
+        run_transfer(job).await;
+        let (seen, outcome) = drain(rx).await;
+
+        assert!(outcome.starts_with("copied"), "{outcome}");
+        assert!(
+            seen.iter().any(|(_, total)| total.is_some()),
+            "the bar was never drawn, so this proves nothing: {seen:?}"
+        );
+        assert_eq!(
+            seen.last().map(|(_, total)| *total),
+            Some(None),
+            "the bar was left frozen instead of taken away: {seen:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_run_does_not_end_before_it_has_closed_its_watcher() {
+        // `reap` waits on a watcher that has not been told to stop, and the
+        // real script only stops when its stdin closes. A run that reaped
+        // before closing would sit here for `WATCH_STOP`.
+        let dir = scratch("closed");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 4096]).unwrap();
+        let dest = dir.join("dest.bin");
+        let cp = format!("sleep 0.2; printf '%2048s' '' > '{}'", dest.display());
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        // An upload with an empty exec prefix: the real watcher script runs
+        // here, and runs until something closes its stdin.
+        let job = local_job(&cp, true, &src, &dest, tx);
+        tokio::time::timeout(Duration::from_secs(15), run_transfer(job))
+            .await
+            .expect("the run never returned: its watcher was not closed");
+        let (_, outcome) = drain(rx).await;
+        assert!(outcome.starts_with("copied"), "{outcome}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn an_upload_measures_its_destination_before_the_copy_touches_it() {
+        // Through the real watcher script, against a destination that
+        // already holds something: without this the copy would be measured
+        // from whatever was there and open near its own total.
+        let dir = scratch("remote-baseline");
+        let dest = dir.join("dest.bin");
+        std::fs::write(&dest, vec![1u8; 65536]).unwrap();
+        let mut sampler = Sampler::start(true, &[], &dest.display().to_string()).await;
+        let baseline = tokio::time::timeout(Duration::from_secs(10), sampler.baseline())
+            .await
+            .expect("the baseline never arrived");
+        assert!(
+            baseline.is_some_and(|held| held >= 65536),
+            "{baseline:?} does not measure what was already there"
+        );
+        sampler.close();
+        sampler.reap().await;
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_destination_too_big_to_measure_collapses_the_bar() {
+        // The other way to stop having a number: the destination outgrows
+        // the entry cap mid-copy. Same answer — no bar rather than one
+        // frozen at whatever fraction it had reached.
+        let dir = scratch("collapse");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 4096]).unwrap();
+        let dest = dir.join("dest");
+        std::fs::create_dir_all(&dest).unwrap();
+        for i in 0..8 {
+            std::fs::write(dest.join(format!("f{i}")), b"x").unwrap();
+        }
+        let cp = format!("sleep 0.5; printf '%2048s' '' > '{}/new'", dest.display());
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let mut job = local_job(&cp, false, &src, &dest, tx);
+        job.dest = dest.display().to_string();
+        // Run it with a cap the destination is already over.
+        let mut sampler = Sampler::Local {
+            path: dest.clone(),
+            tick: tokio::time::interval(Duration::from_millis(10)),
+            owed: Duration::ZERO,
+            cap: 3,
+            limit: WALK_LIMIT,
+        };
+        assert_eq!(sampler.sample().await, None, "an over-cap walk gave a size");
+        assert!(matches!(sampler, Sampler::Idle), "the sampler kept walking");
+        drop(job);
+        let _ = drain(rx).await;
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_destination_too_slow_to_walk_loses_its_bar_too() {
+        // The other way a destination stops being measurable. Left alone,
+        // a walk that cannot finish would be started again every ceiling,
+        // and the bar would sit at the fraction it reached.
+        let dir = scratch("slow");
+        // Enough entries that the walk is still running when its ceiling is
+        // checked; a handful of files can finish before the first poll.
+        for i in 0..3_000 {
+            std::fs::write(dir.join(format!("f{i}")), b"x").unwrap();
+        }
+        let mut sampler = Sampler::Local {
+            path: dir.clone(),
+            tick: tokio::time::interval(Duration::from_millis(1)),
+            owed: Duration::ZERO,
+            cap: pvc::MAX_SIZE_ENTRIES,
+            // No walk of three thousand entries finishes in a nanosecond.
+            limit: Duration::from_nanos(1),
+        };
+        assert_eq!(sampler.sample().await, None);
+        assert!(
+            matches!(sampler, Sampler::Idle),
+            "a walk that cannot finish was left to be started again"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_walk_that_cost_more_than_the_interval_is_slept_off_first() {
+        // The only thing keeping a large destination from being walked
+        // back to back against the disk `tar` is writing to.
+        let dir = scratch("owed");
+        let mut sampler = Sampler::Local {
+            path: dir.clone(),
+            tick: tokio::time::interval(Duration::from_millis(1)),
+            owed: Duration::from_millis(300),
+            cap: pvc::MAX_SIZE_ENTRIES,
+            limit: WALK_LIMIT,
+        };
+        let started = std::time::Instant::now();
+        assert!(sampler.sample().await.is_some());
+        assert!(
+            started.elapsed() >= Duration::from_millis(300),
+            "the rest owed was skipped: {:?}",
+            started.elapsed()
+        );
+        let Sampler::Local { owed, .. } = &sampler else {
+            unreachable!()
+        };
+        // What is owed now is what this walk earned, not what it was
+        // handed: a debt that outlived its payment would compound.
+        assert!(
+            *owed > Duration::ZERO && *owed < Duration::from_millis(300),
+            "the rest owed is not this walk's own: {owed:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_destination_that_shrinks_does_not_walk_the_bar_backwards() {
+        // A destination is walked while it is being written, so a sample can
+        // land mid-rename or mid-truncate and read short. The bar is a
+        // report on a copy, not on the filesystem: it does not retreat.
+        let dir = scratch("shrink");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 8192]).unwrap();
+        let dest = dir.join("dest.bin");
+        // Each state is held for several sample periods: the sampler runs
+        // on a timer, and a window it can miss makes the test a coin toss
+        // rather than a check.
+        let cp = format!(
+            "printf '%4096s' '' > '{0}'; sleep 1.2; printf '%1s' '' > '{0}'; sleep 1.2",
+            dest.display()
+        );
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        run_transfer(local_job(&cp, false, &src, &dest, tx)).await;
+        let (seen, outcome) = drain(rx).await;
+        assert!(outcome.starts_with("copied"), "{outcome}");
+        let moved: Vec<u64> = seen.iter().map(|(done, _)| *done).collect();
+        assert!(
+            moved.iter().any(|done| *done >= 4096),
+            "the first write was never measured: {moved:?}"
+        );
+        assert!(
+            moved.windows(2).all(|w| w[1] >= w[0]),
+            "the bar went backwards when the file shrank: {moved:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn the_watcher_script_samples_a_growing_destination_and_stops_on_close() {
+        let dir = scratch("watch");
+        let dest = dir.join("grows.bin");
+        std::fs::write(&dest, vec![0u8; 4096]).unwrap();
+        // The real `size_watch` script, run by a real `sh` — the exec prefix
+        // is empty, so this is everything the pod side does but the pod.
+        let mut sampler = Sampler::start(true, &[], &dest.display().to_string()).await;
+        assert!(matches!(sampler, Sampler::Remote(_)), "no watcher started");
+
+        let first = tokio::time::timeout(Duration::from_secs(10), sampler.sample())
+            .await
+            .expect("no sample arrived")
+            .expect("the sample carried no size");
+        assert!(first >= 4096, "{first} does not measure the destination");
+        std::fs::write(&dest, vec![0u8; 4096 * 8]).unwrap();
+        let grown = tokio::time::timeout(Duration::from_secs(10), sampler.sample())
+            .await
+            .expect("the watcher stopped sampling")
+            .expect("the sample carried no size");
+        assert!(
+            grown > first,
+            "{grown} did not follow the file: was {first}"
+        );
+
+        // Closing stdin is what ends the loop; nothing else can reach it.
+        sampler.close();
+        tokio::time::timeout(Duration::from_secs(10), sampler.reap())
+            .await
+            .expect("the watcher outlived its close");
+        let Sampler::Remote(watcher) = &mut sampler else {
+            unreachable!()
+        };
+        assert!(
+            watcher.child.try_wait().unwrap().is_some(),
+            "the watcher is still running after its stdin closed"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_size_already_known_skips_the_probe_but_not_the_zero_check() {
+        // A listing gave the size, so nothing runs. An unreachable exec
+        // prefix proves it: a probe would fail against it.
+        let nowhere = vec!["definitely-not-a-binary".to_string()];
+        assert_eq!(
+            resolve_total(&nowhere, false, "/srv/x", Some(4096)).await,
+            Some(4096)
+        );
+        // Except zero, which is not a total any bar can be drawn against —
+        // whether a listing said so or a walk of an empty file did.
+        assert_eq!(
+            resolve_total(&nowhere, false, "/srv/x", Some(0)).await,
+            None
+        );
+        let dir = scratch("empty");
+        let empty = dir.join("nothing");
+        std::fs::write(&empty, b"").unwrap();
+        assert_eq!(
+            resolve_total(&[], true, &empty.display().to_string(), None).await,
+            None
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn progress_is_measured_from_what_was_already_there() {
+        let step = |baseline: &mut Option<u64>, sampled| moved(sampled, baseline);
+
+        // A destination that did not exist: everything that lands is progress.
+        let mut fresh = None;
+        assert_eq!(step(&mut fresh, 0), 0);
+        assert_eq!(step(&mut fresh, 4096), 4096);
+
+        // One file being overwritten: `cp` truncates it, the baseline goes
+        // with it, and the new copy is measured from zero — including past
+        // the size of the file it replaced.
+        let mut overwrite = None;
+        assert_eq!(step(&mut overwrite, 5_000), 0);
+        assert_eq!(step(&mut overwrite, 0), 0);
+        assert_eq!(step(&mut overwrite, 2_000), 2_000);
+        assert_eq!(step(&mut overwrite, 9_000), 9_000);
+
+        // A directory being re-copied only ever dips by the file `tar` is
+        // replacing at that moment. The baseline follows the dip and no
+        // further: handing over the whole existing tree at the first
+        // truncation would read as ~100% for the rest of the copy.
+        let mut retree = None;
+        assert_eq!(step(&mut retree, 10_000), 0);
+        assert_eq!(step(&mut retree, 9_900), 0);
+        assert_eq!(step(&mut retree, 10_400), 500);
+        assert_eq!(step(&mut retree, 9_800), 0);
+        assert_eq!(step(&mut retree, 10_600), 800);
+    }
+
+    #[tokio::test]
+    async fn a_destination_too_big_to_measure_stops_being_measured() {
+        // Past the entry cap a walk can only ever fail, and it is the most
+        // expensive failure in the module — so the sampler retires. Driven
+        // through a cap of 3 rather than a tree of 200,000 files.
+        let dir = scratch("cap");
+        for i in 0..8 {
+            std::fs::write(dir.join(format!("f{i}")), b"x").unwrap();
+        }
+        let go = AtomicBool::new(false);
+        assert_eq!(pvc::local_size_capped(&dir, 3, &go), pvc::Measure::TooBig);
+
+        let mut sampler = Sampler::Local {
+            path: dir.clone(),
+            tick: tokio::time::interval(Duration::from_millis(1)),
+            owed: Duration::ZERO,
+            cap: 3,
+            limit: WALK_LIMIT,
+        };
+        assert_eq!(sampler.sample().await, None);
+        assert!(
+            matches!(sampler, Sampler::Idle),
+            "a tree that will never fit kept being walked"
+        );
+
+        // A path that is not there is the other empty answer, and it must
+        // not retire anything: `cp` has simply not created it yet.
+        let mut waiting = Sampler::Local {
+            path: dir.join("not-yet"),
+            tick: tokio::time::interval(Duration::from_millis(1)),
+            owed: Duration::ZERO,
+            cap: pvc::MAX_SIZE_ENTRIES,
+            limit: WALK_LIMIT,
+        };
+        assert_eq!(waiting.sample().await, None);
+        assert!(
+            matches!(waiting, Sampler::Local { .. }),
+            "the sampler gave up on a destination that was merely late"
+        );
+        // And it is a baseline of zero, not an unknown one: this copy is
+        // about to create it, so everything that lands is progress.
+        assert_eq!(waiting.baseline().await, Some(0));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn nothing_is_reported_after_the_result() {
+        // `store.rs` promises a copy's progress never follows its result,
+        // which is what lets `end_transfer` drop the row on `TransferDone`
+        // without racing a sample that is still on its way.
+        let dir = scratch("order");
+        let src = dir.join("src.bin");
+        std::fs::write(&src, vec![7u8; 4096]).unwrap();
+        let dest = dir.join("dest.bin");
+        let cp = format!(
+            "i=0; while [ $i -lt 3 ]; do printf '%1024s' '' >> '{}'; i=$((i+1)); sleep 0.1; done",
+            dest.display()
+        );
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        run_transfer(local_job(&cp, false, &src, &dest, tx)).await;
+
+        let mut ended = false;
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                Msg::TransferDone { .. } => ended = true,
+                Msg::TransferProgress { .. } => {
+                    assert!(!ended, "progress arrived after the result");
+                }
+                _ => {}
+            }
+        }
+        assert!(ended, "no result was ever sent");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_slow_walk_earns_a_rest_three_times_its_own_length() {
+        // The accrual, not the payment: without it a large destination is
+        // walked back to back against the disk `tar` is writing to.
+        assert_eq!(
+            rest_after(Duration::from_millis(200)),
+            Duration::from_millis(600)
+        );
+        assert_eq!(rest_after(Duration::ZERO), Duration::ZERO);
+        // And it cannot outrun the ceiling on a walk by more than that.
+        assert_eq!(rest_after(WALK_LIMIT), WALK_LIMIT * 3);
+    }
+
+    #[test]
+    fn a_walk_that_nobody_is_waiting_for_is_told_to_stop() {
+        // The producer's half: a `spawn_blocking` walk cannot be cancelled,
+        // so the flag is the only thing that reaches it — and it has to be
+        // raised however the future ends, not only when it returns.
+        let flag = Arc::new(AtomicBool::new(false));
+        {
+            let _raised = Stop(flag.clone());
+            assert!(!flag.load(Ordering::Relaxed));
+        }
+        assert!(
+            flag.load(Ordering::Relaxed),
+            "an abandoned walk was never told to stop"
+        );
+    }
+
+    #[test]
+    fn a_script_argv_keeps_the_path_out_of_the_script() {
+        let exec = ["kubectl", "exec", "-i", "--"].map(String::from).to_vec();
+        let argv = size_argv(&exec, "echo hi", "/pvc/a b'c\n");
+        assert_eq!(&argv[..4], exec.as_slice());
+        // `sh -c <script> sh <path>`: the path is $1, never text in $0's
+        // script, so no name on a volume can close a quote in it.
+        assert_eq!(&argv[4..7], ["sh", "-c", "echo hi"]);
+        assert_eq!(argv[7], "sh");
+        assert_eq!(argv[8], "/pvc/a b'c\n");
+    }
+
+    fn status() -> std::process::ExitStatus {
+        std::os::unix::process::ExitStatusExt::from_raw(1 << 8)
+    }
+
+    #[test]
+    fn a_copy_failure_reports_the_cause_not_kubectls_trailer() {
+        // What kubectl actually prints when tar cannot write: the reason
+        // first, then its own generic trailer.
+        let stderr = "tar: can't open '/pvc/x': Read-only file system\n\
+                      command terminated with exit code 2\n";
+        assert_eq!(
+            cp_error(stderr, &status()),
+            "tar: can't open '/pvc/x': Read-only file system"
+        );
+        // The trailer alone is all there is: better than nothing.
+        assert_eq!(
+            cp_error("command terminated with exit code 2\n", &status()),
+            "command terminated with exit code 2"
+        );
+        // Nothing at all — the exit status is the only fact available.
+        assert!(cp_error("  \n\n", &status()).contains("exited with"));
+    }
+}

--- a/src/app/transfer.rs
+++ b/src/app/transfer.rs
@@ -837,16 +837,17 @@ mod tests {
         let (seen, outcome) = drain(rx).await;
 
         assert!(outcome.starts_with("copied"), "{outcome}");
-        // Nothing is reported until something is known: the status bar
-        // already says "copying …", and rewriting it to "(0B)…" says less.
-        assert_eq!(seen[0].0, 0, "the first report claimed progress: {seen:?}");
         // The source was measured by the probe script, running here.
         let total = seen
             .iter()
             .find_map(|(_, total)| *total)
             .expect("no total: the size probe produced nothing");
         assert!(total >= 8192, "{total} is less than the source");
-        // Progress only rises.
+        // Progress only rises, and reaches what landed. Which sample lands
+        // first is a race with the copy's own first write and is not a
+        // property to assert — that a copy opens at zero is
+        // `what_was_already_at_the_destination_is_not_progress`'s to say,
+        // where the destination is pre-filled and the fixture waits.
         assert!(
             seen.windows(2).all(|w| w[1].0 >= w[0].0),
             "progress went backwards: {seen:?}"
@@ -854,6 +855,10 @@ mod tests {
         assert!(
             seen.iter().any(|(done, _)| *done >= 4096),
             "nothing was ever reported as moved: {seen:?}"
+        );
+        assert!(
+            seen.last().is_some_and(|(done, _)| *done <= total),
+            "more was reported than the source holds: {seen:?}"
         );
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -871,8 +876,11 @@ mod tests {
         // The trailing rest is not padding: there is no closing measurement,
         // so the last sample is whatever the timer caught, and a copy that
         // ends the instant it writes leaves the last write unmeasured.
+        // The quiet at the front is what makes the first assertion below a
+        // property rather than a race: the destination is pre-filled, so a
+        // sample taken before anything is appended must read zero moved.
         let cp = format!(
-            "sleep 0.3; i=0; while [ $i -lt 4 ]; do printf '%1024s' '' >> '{}'; i=$((i+1)); sleep 0.1; done; sleep 0.4",
+            "sleep 0.6; i=0; while [ $i -lt 4 ]; do printf '%1024s' '' >> '{}'; i=$((i+1)); sleep 0.1; done; sleep 0.4",
             dest.display()
         );
         let (tx, rx) = tokio::sync::mpsc::channel(64);

--- a/src/pvcexplore.rs
+++ b/src/pvcexplore.rs
@@ -9,6 +9,7 @@
 //! lives in `app/pvcexplore.rs`.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use kube::core::DynamicObject;
 use serde_json::{Value, json};
@@ -789,6 +790,356 @@ pub fn human_size(bytes: u64) -> String {
     }
 }
 
+/// Marker every size sample is reported on, carrying the multiplier that
+/// turns `du`'s number into bytes.
+///
+/// Unlike the listing's status line this needs no nonce, because a name on the
+/// volume cannot put a line through that looks like one: `du` prints the size
+/// *and the path*, and the scripts below echo only the leading number, so the
+/// path never reaches stdout at all.
+const SIZE_MARKER: &str = "sofka-size:";
+
+/// Cap on entries walked to size a local path: past it, a cache directory of
+/// a million files is being walked in full for a number only a bar reads.
+pub const MAX_SIZE_ENTRIES: usize = 200_000;
+
+/// How many samples [`size_watch`] takes, and how many seconds it may spend
+/// taking them, before it gives up and the script exits. An upload longer
+/// than that keeps copying; only its bar stops moving. The bound is the
+/// backstop for a stdin that never closes — the ordinary end is the reader
+/// seeing end-of-input.
+///
+/// Both, because neither alone is a duration: a `du` over a large tree can
+/// take tens of seconds, so a sample count is a lower bound on the time it
+/// buys. Fifteen minutes is already a long time to leave a `du` loop in
+/// somebody's pod for a bar nobody is watching any more.
+pub const SIZE_SAMPLES: u32 = 900;
+
+/// Passes a destination may stay missing before the watcher gives up on it
+/// too. `cp` creates its destination almost at once, so a path still absent
+/// after this is one the container cannot see — a parent it may not search
+/// answers "not there" exactly like a path that is not there — and
+/// reporting zero at a bar for the length of a copy is what that would
+/// otherwise look like.
+pub const ABSENT_PASSES: u32 = 60;
+
+/// Consecutive passes whose `du` answers nothing before the watcher gives
+/// up and exits. A path that is merely not there yet answers zero and does
+/// not count; this is the container where `du` exists but cannot run — an
+/// applet that rejects the `timeout` in front of it, a permission it lacks
+/// — and streaming zeros at a bar for the length of a copy says the copy
+/// has stalled when it has not. Ending the stream instead is what tells the
+/// sampler to drop the bar.
+pub const GIVE_UP: u32 = 3;
+
+/// Passes a watcher gets when the container has no `date` to bound itself
+/// by. Much smaller, because a pass is then bounded only by its own `du`
+/// and the second it sleeps. An upload that outlasts it keeps copying;
+/// only its bar stops.
+pub const BLIND_SAMPLES: u32 = 300;
+
+/// The `du` invocation both size scripts are built from, reporting `$p`'s
+/// recursive total on one [`SIZE_MARKER`] line.
+///
+/// `du` is the only recursive sizer GNU coreutils and busybox both have, and
+/// `-b` is the one spelling of "apparent size in bytes" they agree on: GNU's
+/// shorthand for `--apparent-size --block-size=1`, and a plain option on
+/// busybox, which rejects both long forms — including in the image this
+/// browser builds its own helper pods from, so the long pair would have left
+/// the common case on the fallback. That fallback, `-k` in KiB of disk usage,
+/// is why the marker carries the multiplier that was used rather than leaving
+/// the reader to guess which `du` answered.
+///
+/// The branch is on whether a *number* came back, not on `du`'s exit status:
+/// a directory the serving pod cannot read is ordinary on a volume, and `du`
+/// prints the total it did reach and *then* exits non-zero. Keying off the
+/// status would throw that away and fall through to a fallback about to fail
+/// the same way, leaving no bar at all.
+///
+/// `set -- $(…)` is what keeps the path off stdout: it word-splits `du`'s
+/// `size<TAB>path` and takes `$1`, the number. A name containing a newline
+/// therefore cannot forge a sample, only make one unparseable. `set -f`
+/// first, because that same split would otherwise glob a destination path
+/// containing `*` against the working directory, once a second.
+fn size_sample_body() -> String {
+    format!(
+        r#"u=1
+set -- $($dl du -s -b -- "$p" 2>/dev/null)
+case "${{1:-}}" in
+''|*[!0-9]*)
+u=1024
+set -- $($dl du -s -k -- "$p" 2>/dev/null)
+;;
+esac
+case "${{1:-}}" in
+''|*[!0-9]*)
+if [ -e "$p" ]; then
+bad=$((bad+1))
+set -- ""
+else
+gone=$((gone+1))
+[ "$gone" -lt {ABSENT_PASSES} ] || bad={GIVE_UP}
+set -- 0
+fi
+;;
+*) bad=0; gone=0 ;;
+esac
+[ -z "$1" ] || printf '{SIZE_MARKER}%s:%s\n' "$u" "$1""#
+    )
+}
+
+/// One recursive byte total for `$1`, for sizing a copy's source while the
+/// copy is already running. Run as `sh -c <script> sh <path>`, like the listing: the
+/// path arrives as a positional parameter and is never spliced into the
+/// script.
+pub fn size_probe() -> String {
+    format!(
+        "p=$1\n{PASS_SETUP}\nbad=0\ngone=0\n{}\n{}",
+        du_deadline(),
+        size_sample_body()
+    )
+}
+
+/// What every sample needs and nothing changes between them, so the watcher
+/// runs it once rather than eighteen hundred times. `set -f` is for the
+/// word-splitting below: only `du`'s leading number is ever read, but
+/// without it a destination path containing a `*` would be globbed against
+/// the working directory once a second for nothing.
+const PASS_SETUP: &str = "set -f";
+
+/// A `timeout` in front of `du`, when the container has one.
+///
+/// The container's half of every bound here: killing the local `kubectl`
+/// does not reach a `du` already running in the pod, so a tree on a wedged
+/// mount would sit there long after sofka gave up on it. Empty when the
+/// container has no `timeout`, which is the one case where only the local
+/// half is bounded.
+fn du_deadline() -> String {
+    format!(
+        "dl=\"\"\ncommand -v timeout >/dev/null 2>&1 && dl=\"timeout {}\"",
+        DU_TIMEOUT
+    )
+}
+
+/// Seconds a single `du` may run inside the container.
+pub const DU_TIMEOUT: u32 = 20;
+
+/// The same total, once a second, for as long as an upload can reasonably run.
+/// One exec for the whole copy rather than one per sample — the alternative is
+/// an exec per second against somebody's production pod.
+///
+/// A destination that does not exist yet — every upload, until `cp` creates
+/// it — reports the zero that is the truth about it. A `du` that answers
+/// nothing about a path that *is* there is a different thing, counted
+/// towards [`GIVE_UP`]: nothing is printed, and after a few such passes the
+/// watcher exits, so the bar is dropped rather than pinned at zero. That zero is what gives such
+/// a copy a baseline of nothing rather than no baseline at all. A container
+/// with no `du` is the other case and a different answer: nothing can be
+/// measured there, so the script exits and the copy runs without a bar.
+///
+/// The `cat` is what ends the loop, and the arrangement is load-bearing in
+/// three ways. A `printf` into an exec stream nobody reads keeps succeeding,
+/// so the loop cannot notice its reader on its own — stdin closing is the
+/// only signal that reaches the container, which is why the watcher's exec
+/// needs `-i`. The reader must take an explicit dup of stdin, because a
+/// shell gives a background command `/dev/null` otherwise and it would read
+/// end-of-input at once. And the loop runs in the foreground with the reader
+/// behind it, each ending the other, so that neither the sample bound nor a
+/// closed stdin can leave the other half sitting in somebody's pod.
+pub fn size_watch() -> String {
+    format!(
+        r#"p=$1
+command -v du >/dev/null 2>&1 || exit 0
+{PASS_SETUP}
+bad=0
+gone=0
+{}
+n=0
+end=$(($(date +%s 2>/dev/null || echo 0)+{SIZE_SAMPLES}))
+lim={SIZE_SAMPLES}
+[ "$end" -gt {SIZE_SAMPLES} ] || lim={BLIND_SAMPLES}
+exec 3<&0
+cat <&3 > /dev/null &
+reader=$!
+while [ "$n" -lt "$lim" ]; do
+kill -0 "$reader" 2>/dev/null || break
+if [ "$end" -gt {SIZE_SAMPLES} ] && [ "$(date +%s 2>/dev/null || echo 0)" -ge "$end" ]; then
+break
+fi
+t0=$(date +%s 2>/dev/null || echo 0)
+{}
+[ "$bad" -lt {GIVE_UP} ] || break
+n=$((n+1))
+rest=$(($(date +%s 2>/dev/null || echo 0)-t0))
+[ "$rest" -gt 1 ] || rest=1
+[ "$rest" -lt 30 ] || rest=30
+sleep "$rest"
+done
+kill "$reader" 2>/dev/null
+exit 0"#,
+        du_deadline(),
+        size_sample_body()
+    )
+}
+
+/// Bytes from one [`size_probe`]/[`size_watch`] sample line, or `None` for a
+/// line that is not one — including the sample a `du` that could not read the
+/// path prints.
+///
+/// Zero is a reading like any other: it is what a destination measures
+/// before its copy has created it, and knowing that is what lets the copy be
+/// measured from zero rather than from whatever had landed by the time
+/// something first looked. Zero as a *total* is filtered where totals are
+/// decided, not here.
+pub fn parse_size_sample(line: &str) -> Option<u64> {
+    let (mult, count) = line.trim().strip_prefix(SIZE_MARKER)?.split_once(':')?;
+    mult.parse::<u64>()
+        .ok()?
+        .checked_mul(count.trim().parse::<u64>().ok()?)
+}
+
+/// The last sample in a one-shot probe's output — the last, not the first,
+/// since a run that printed a partial line has nothing to lose by it.
+pub fn parse_size(out: &str) -> Option<u64> {
+    out.lines().filter_map(parse_size_sample).next_back()
+}
+
+/// What one attempt to size a local path produced. Three answers rather
+/// than an `Option`, because the two empty ones want opposite treatment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Measure {
+    Bytes(u64),
+    /// Not there, or not readable — for a copy's destination, not yet.
+    Absent,
+    /// Past [`MAX_SIZE_ENTRIES`], and it will not come back under.
+    TooBig,
+}
+
+/// The recursive apparent size of a local path: the byte total a copy of it
+/// has to move, giving up past `cap` entries.
+///
+/// The cap is an argument rather than [`MAX_SIZE_ENTRIES`] itself so a test
+/// can reach [`Measure::TooBig`] without building a tree of 200,000 files.
+///
+/// `stop` is how a caller that has given up says so: this runs on a blocking
+/// thread that no timeout can cancel, and a thread still walking is one the
+/// runtime waits for at shutdown. Checking it bounds every case except a
+/// `read_dir` the kernel has not returned from, which nothing in userspace
+/// can bound. A stopped walk reports [`Measure::Absent`] — no reading, ask
+/// again — rather than pretending to a number.
+///
+/// Every entry's own size, directories included, which is the sum
+/// `du --apparent-size` produces on the volume side. Counting only files
+/// would measure a tree by one definition here and another one there, and a
+/// directory of 200 subdirectories would finish at half a bar.
+///
+/// Entries that cannot be read are skipped rather than fatal — a mode-000
+/// cache directory is the ordinary case on a volume, and `du` keeps its
+/// partial total for the same reason. Symlinks are counted at their own size
+/// and never followed, which is what `tar` puts on the wire and the only way
+/// a cycle terminates.
+///
+/// Two things it cannot make identical, both absorbed by the clamp: what two
+/// filesystems charge for a directory inode (4 KiB on ext4, a couple of
+/// hundred bytes on APFS), and hard links, counted once per link here and
+/// once per inode by `du`.
+pub fn local_size_capped(path: &Path, cap: usize, stop: &AtomicBool) -> Measure {
+    let Ok(root) = std::fs::symlink_metadata(path) else {
+        return Measure::Absent;
+    };
+    let mut total: u64 = root.len();
+    let mut walked: usize = 1;
+    // Only directories are stacked, and every entry is counted as it is
+    // seen: one flat directory of a few million files would otherwise sit on
+    // the stack in full, rebuilt on every sample.
+    let mut stack = if root.is_dir() {
+        vec![path.to_path_buf()]
+    } else {
+        Vec::new()
+    };
+    while let Some(next) = stack.pop() {
+        // Asked to stop — the caller timed out, or is gone. Checked per
+        // directory rather than per entry: it is the `read_dir` that is slow
+        // on the mounts this protects against, not the arithmetic.
+        if stop.load(Ordering::Relaxed) {
+            return Measure::Absent;
+        }
+        let Ok(entries) = std::fs::read_dir(&next) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            walked += 1;
+            if walked > cap {
+                return Measure::TooBig;
+            }
+            // Also mid-directory: one flat directory can hold the whole cap,
+            // and a walk nobody is waiting for should not run to the end of
+            // it before noticing.
+            if walked.is_multiple_of(4_096) && stop.load(Ordering::Relaxed) {
+                return Measure::Absent;
+            }
+            // `metadata()` on a `DirEntry` does not follow symlinks, which
+            // is what makes a link to a parent finite and a link to a
+            // sibling count once.
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            total = total.saturating_add(meta.len());
+            if meta.is_dir() {
+                stack.push(entry.path());
+            }
+        }
+    }
+    Measure::Bytes(total)
+}
+
+/// Whole percent of `total` that `done` is.
+///
+/// Clamped, because a total can be an under-estimate: a `du` that could not
+/// read every subdirectory, or a local walk that skipped one, reports less
+/// than the copy then moves. (An over-estimate — the whole-block `-k`
+/// fallback — needs no clamp; it only keeps the bar short of the end.)
+pub fn progress_pct(done: u64, total: u64) -> u8 {
+    if total == 0 {
+        return 0;
+    }
+    // Floored, not rounded: a copy with 4 MB of a 1 GB file still to move is
+    // not finished, and a status bar that says 100% while the bar is still
+    // filling is the one number a reader would call a bug.
+    let pct = (done as f64 / total as f64 * 100.0).floor();
+    pct.clamp(0.0, 100.0) as u8
+}
+
+/// The two halves of a `width`-cell progress bar: the cells `done` of `total`
+/// bytes has filled, and the track behind the rest. Two pieces because they
+/// are drawn in different colors; together they are always exactly `width`
+/// columns, so a row wearing one stays aligned with the rows that are not.
+///
+/// Eighth-blocks, not whole cells: the size column is 8 wide, and a 5 GB copy
+/// that redrew once every 640 MB would look stuck.
+pub fn progress_bar(done: u64, total: u64, width: usize) -> (String, String) {
+    const PARTIALS: [&str; 8] = [
+        "", "\u{258f}", "\u{258e}", "\u{258d}", "\u{258c}", "\u{258b}", "\u{258a}", "\u{2589}",
+    ];
+    // Zero says "nothing of it has moved", which is the truthful reading of
+    // a total nobody could measure. Totals are refused before they get here,
+    // but by accident this would divide to `NaN` and render the same.
+    if total == 0 {
+        return (String::new(), "\u{2591}".repeat(width));
+    }
+    let ratio = (done as f64 / total as f64).clamp(0.0, 1.0);
+    // Floored, for the reason [`progress_pct`] floors: a bar that fills its
+    // last eighth while bytes are still moving says the copy is done.
+    let eighths = (ratio * (width * 8) as f64).floor() as usize;
+    let full = eighths / 8;
+    let partial = PARTIALS[eighths % 8];
+    let mut fill = "\u{2588}".repeat(full);
+    fill.push_str(partial);
+    let cells = full + usize::from(!partial.is_empty());
+    let track = "\u{2591}".repeat(width.saturating_sub(cells));
+    (fill, track)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1544,5 +1895,393 @@ mod tests {
             HELPER_MOUNT
         );
         assert_eq!(spec["metadata"]["generateName"], HELPER_PREFIX);
+    }
+
+    /// Run a generated script under a real `sh` with `du` shimmed.
+    #[cfg(unix)]
+    fn probe_with_du(du: &str, path: &str) -> String {
+        use std::os::unix::fs::PermissionsExt;
+        static NEXT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let nth = NEXT.fetch_add(1, Ordering::Relaxed);
+        let bin = std::env::temp_dir().join(format!("sofka-du-{}-{nth}", std::process::id()));
+        std::fs::remove_dir_all(&bin).ok();
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("du"), du).unwrap();
+        std::fs::set_permissions(bin.join("du"), std::fs::Permissions::from_mode(0o755)).unwrap();
+        for tool in ["sh", "printf"] {
+            let real = ["/bin", "/usr/bin"]
+                .iter()
+                .map(|d| std::path::Path::new(d).join(tool))
+                .find(|p| p.exists());
+            if let Some(real) = real {
+                std::os::unix::fs::symlink(real, bin.join(tool)).ok();
+            }
+        }
+        let out = std::process::Command::new("env")
+            .arg(format!("PATH={}", bin.display()))
+            .args(["sh", "-c", &size_probe(), "sh", path])
+            .output()
+            .expect("running the probe");
+        std::fs::remove_dir_all(&bin).ok();
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_du_without_b_falls_back_to_whole_blocks() {
+        // The branch CI never takes: GNU `du -b` always works on Linux, so
+        // without a shim the `-k` half of the unit negotiation — and the
+        // multiplier that makes it readable — is never run.
+        let blocks = "#!/bin/sh\nfor a in \"$@\"; do [ \"$a\" = -b ] && exit 1; done\nprintf '4\\t%s\\n' \"$3\"\n";
+        assert_eq!(probe_with_du(blocks, "/"), "sofka-size:1024:4");
+        assert_eq!(parse_size("sofka-size:1024:4"), Some(4096));
+    }
+
+    /// Run the watcher under a real `sh` with `du` shimmed, holding its
+    /// stdin open so that only its own bounds can end it. Bounded here too:
+    /// a bound that stopped working would otherwise hang the suite instead
+    /// of failing it.
+    #[cfg(unix)]
+    fn watch_with_du(du: &str, path: &str) -> Vec<String> {
+        use std::os::unix::fs::PermissionsExt;
+        static NEXT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let nth = NEXT.fetch_add(1, Ordering::Relaxed);
+        let bin = std::env::temp_dir().join(format!("sofka-watch-{}-{nth}", std::process::id()));
+        std::fs::remove_dir_all(&bin).ok();
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("du"), du).unwrap();
+        std::fs::set_permissions(bin.join("du"), std::fs::Permissions::from_mode(0o755)).unwrap();
+        for tool in ["sh", "printf", "sleep", "cat", "date"] {
+            if let Some(real) = ["/bin", "/usr/bin"]
+                .iter()
+                .map(|dir| std::path::Path::new(dir).join(tool))
+                .find(|tool| tool.exists())
+            {
+                std::os::unix::fs::symlink(real, bin.join(tool)).ok();
+            }
+        }
+        let mut child = std::process::Command::new("env")
+            .arg(format!("PATH={}", bin.display()))
+            .args(["sh", "-c", &size_watch(), "sh", path])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("running the watcher");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let ended = loop {
+            match child.try_wait().expect("waiting on the watcher") {
+                Some(status) => break Some(status),
+                None if std::time::Instant::now() >= deadline => {
+                    child.kill().ok();
+                    break None;
+                }
+                None => std::thread::sleep(std::time::Duration::from_millis(50)),
+            }
+        };
+        let out = child.wait_with_output().expect("reading the watcher");
+        std::fs::remove_dir_all(&bin).ok();
+        let status = ended.expect("the watcher never gave up on its own");
+        assert!(status.success(), "the watcher exited badly: {status}");
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_watcher_whose_du_cannot_answer_gives_up_rather_than_streaming() {
+        // Driven, not grepped: the bound has to be a number of passes the
+        // loop really stops after, or a container whose `du` is present but
+        // cannot run keeps one going once a second for the whole copy.
+        let broken = "#!/bin/sh\nexit 1\n";
+        let samples = watch_with_du(broken, "/");
+        assert!(
+            samples.is_empty(),
+            "a `du` that answered nothing was reported as a size: {samples:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_du_that_answers_with_words_is_not_read_as_a_size() {
+        // Both guards, driven rather than grepped: a `du` that writes usage
+        // to *stdout* would otherwise have its first word parsed, and the
+        // fallback would inherit it.
+        let usage = "#!/bin/sh\necho 'Usage: du [-abck] [FILE]...'\nexit 1\n";
+        assert_eq!(
+            probe_with_du(usage, "/"),
+            "",
+            "usage text was read as a size"
+        );
+
+        // A `du` that answers properly is still read.
+        let real = "#!/bin/sh\nprintf '4096\\t%s\\n' \"$3\"\n";
+        assert_eq!(probe_with_du(real, "/"), "sofka-size:1:4096");
+    }
+
+    #[test]
+    fn a_size_sample_carries_the_unit_that_measured_it() {
+        // The multiplier says which `du` answered.
+        assert_eq!(
+            parse_size_sample("sofka-size:1:5368709120"),
+            Some(5_368_709_120)
+        );
+        assert_eq!(parse_size_sample("sofka-size:1024:4"), Some(4096));
+        // `du` could not read the path yet — the first second of an upload.
+        assert_eq!(parse_size_sample("sofka-size:1024:"), None);
+        assert_eq!(parse_size_sample("total 4"), None);
+        // Zero is a reading, not a non-answer: a destination that is not
+        // there yet measures zero, and a copy starting from zero is the
+        // whole point. (Zero as a *total* is refused where totals are
+        // decided — a bar against it would sit there looking finished.)
+        assert_eq!(parse_size_sample("sofka-size:1:0"), Some(0));
+        // A line cut off mid-write is not a sample.
+        assert_eq!(parse_size_sample("sofka-siz"), None);
+        // A count that cannot be multiplied is no sample: wrapping it would
+        // turn a huge number into a small and plausible one.
+        assert_eq!(
+            parse_size_sample("sofka-size:1024:18446744073709551615"),
+            None
+        );
+        // A `du` that answered with usage text rather than a number falls
+        // through to the fallback, and then to a zero — never to a sample
+        // built out of whatever word came first.
+        assert!(size_probe().contains("*[!0-9]*"), "{}", size_probe());
+        assert_eq!(parse_size("sofka-size:1:40\nsofka-size:1:"), Some(40));
+    }
+
+    #[test]
+    fn only_the_number_reaches_stdout_so_a_name_cannot_forge_a_sample() {
+        // `set -- $out` takes du's leading field and drops the path, which is
+        // the only thing on that line a volume controls.
+        assert!(size_probe().contains("set -- $($dl du -s -b"));
+        let printed = size_probe()
+            .lines()
+            .find(|l| l.starts_with("printf"))
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            !printed.contains("$p"),
+            "the path must not be echoed: {printed}"
+        );
+        // A completed run's own last sample is the one that counts.
+        let output = "sofka-size:1:120\nsofka-size:1024:999999";
+        assert_eq!(parse_size(output), Some(1024 * 999_999));
+    }
+
+    #[test]
+    fn the_watcher_is_one_exec_that_stops_when_its_reader_goes_away() {
+        let script = size_watch();
+        // A pass, then at least a second's rest — and more when the `du`
+        // itself took longer, so a slow tree is not measured back to back
+        // in somebody's production pod.
+        assert!(script.contains(r#"sleep "$rest""#), "{script}");
+        assert!(
+            script.contains(r#"[ "$rest" -gt 1 ] || rest=1"#),
+            "{script}"
+        );
+        // Writes into an abandoned exec stream keep succeeding, so the only
+        // signal that reaches the container is stdin closing. The reader
+        // waits for it in the background; the loop checks each pass that the
+        // reader is still there, and kills it on the way out — so neither
+        // half can outlive the other by more than a pass.
+        // Explicitly from a dup of stdin: a background command's stdin is
+        // /dev/null unless it says otherwise, and that reads EOF at once.
+        assert!(script.contains("exec 3<&0"), "{script}");
+        assert!(script.contains("cat <&3 > /dev/null &"), "{script}");
+        assert!(
+            script.contains(r#"kill -0 "$reader" 2>/dev/null || break"#),
+            "{script}"
+        );
+        assert!(script.contains(r#"kill "$reader""#), "{script}");
+        assert!(
+            script.contains(&format!("lim={SIZE_SAMPLES}")),
+            "an unbounded watcher could outlive the copy in somebody's pod"
+        );
+        // A sample count is not a duration — one `du` over a large tree can
+        // take tens of seconds — so the loop watches the clock as well.
+        assert!(script.contains("date +%s"), "{script}");
+        // And a much shorter one when the container has no clock to bound
+        // itself by, since a pass then costs a `du` rather than a second.
+        assert!(script.contains(&format!("lim={BLIND_SAMPLES}")), "{script}");
+        // And it stops altogether when `du` is there but answers nothing:
+        // streaming zeros would pin a bar at zero for the whole copy, while
+        // ending the stream tells the sampler to drop the bar.
+        assert!(
+            script.contains(&format!(r#"[ "$bad" -lt {GIVE_UP} ] || break"#)),
+            "{script}"
+        );
+        // A destination that never appears is the same problem wearing
+        // another hat: a parent the container cannot search answers "not
+        // there" exactly like a path that is not there.
+        assert!(
+            script.contains(&format!(
+                r#"[ "$gone" -lt {ABSENT_PASSES} ] || bad={GIVE_UP}"#
+            )),
+            "{script}"
+        );
+        // A clock that steps forward mid-`du` must not park the loop.
+        assert!(
+            script.contains(r#"[ "$rest" -lt 30 ] || rest=30"#),
+            "{script}"
+        );
+        // A destination that comes back clears both counters, so a copy
+        // that is merely intermittent keeps its bar.
+        assert!(script.contains("*) bad=0; gone=0 ;;"), "{script}");
+        // And the wall clock ends it even with passes left over.
+        assert!(script.contains(r#"-ge "$end""#), "{script}");
+        // The word-splitting that reads `du`'s number must not glob a
+        // destination path containing a `*` against the working directory.
+        assert!(script.contains("set -f"), "{script}");
+        // Its ordinary end — the reader gone — is not a failure, and kubectl
+        // reports a non-zero exit as an error the copy did not have.
+        assert!(script.trim_end().ends_with("exit 0"), "{script}");
+        // A container with no `du` cannot be measured at all: no samples,
+        // and so no bar, rather than a bar pinned at zero.
+        assert!(script.contains("command -v du"), "{script}");
+        // Bounded inside the container too, where killing the local
+        // `kubectl` cannot reach: a `du` on a wedged mount would otherwise
+        // outlive the session that asked for it.
+        assert!(
+            script.contains(&format!("timeout {DU_TIMEOUT}")),
+            "{script}"
+        );
+    }
+
+    #[test]
+    fn a_progress_bar_is_always_its_full_width() {
+        use unicode_width::UnicodeWidthStr;
+        for done in [0u64, 1, 500, 2_500, 5_000] {
+            let (fill, track) = progress_bar(done, 5_000, 8);
+            assert_eq!(
+                fill.chars().count() + track.chars().count(),
+                8,
+                "{done}: {fill}|{track}"
+            );
+            // Columns, not characters: the bar sits in a column the pane
+            // measures with `unicode_width`, so a cell that counts as two
+            // would push the row through the border.
+            assert_eq!(
+                fill.width() + track.width(),
+                8,
+                "{done}: {fill}|{track} is not 8 columns wide"
+            );
+        }
+        assert_eq!(progress_bar(0, 5_000, 8).0, "");
+        assert_eq!(progress_bar(5_000, 5_000, 8).1, "");
+        // A pane too narrow for a size column is too narrow for a bar.
+        assert_eq!(progress_bar(1, 2, 0), (String::new(), String::new()));
+    }
+
+    #[test]
+    fn a_progress_bar_moves_in_eighths_of_a_cell() {
+        // A 5 GB copy across 8 cells: whole cells alone would redraw once
+        // every 640 MB.
+        let total = 5 * 1024 * 1024 * 1024;
+        let (early, _) = progress_bar(total / 64, total, 8);
+        assert_eq!(early, "\u{258f}", "the first 80 MB already show");
+        let (eighth, _) = progress_bar(total / 8, total, 8);
+        assert_eq!(eighth, "\u{2588}", "an eighth of the way is one whole cell");
+        let (half, track) = progress_bar(total / 2, total, 8);
+        assert_eq!(half, "\u{2588}\u{2588}\u{2588}\u{2588}");
+        assert_eq!(track, "\u{2591}\u{2591}\u{2591}\u{2591}");
+    }
+
+    #[test]
+    fn an_over_estimated_total_still_reports_a_sane_percentage() {
+        // Over 100% is the under-estimated total: a subdirectory `du` could
+        // not read is missing from it, and the copy moves those bytes anyway.
+        // (The whole-block `-k` fallback errs the other way, and only ever
+        // leaves the bar short.)
+        assert_eq!(progress_pct(120, 100), 100);
+        assert_eq!(progress_pct(0, 100), 0);
+        assert_eq!(progress_pct(50, 100), 50);
+        // Floored: still moving is never 100%.
+        assert_eq!(progress_pct(999_999_999, 1_000_000_000), 99);
+        // And the bar floors with it: the last cell only becomes a whole
+        // block when the copy is actually over, so "solid to the edge" is
+        // never something a copy still moving can show.
+        let (nearly, _) = progress_bar(999_999_999, 1_000_000_000, 8);
+        assert!(
+            !nearly.ends_with('\u{2588}'),
+            "the bar filled before the copy did: {nearly}"
+        );
+        let (done, track) = progress_bar(1_000_000_000, 1_000_000_000, 8);
+        assert!(
+            done.ends_with('\u{2588}') && track.is_empty(),
+            "{done}|{track}"
+        );
+        // Nothing of nothing: a total of zero is refused where totals are
+        // decided, and claiming "complete" would be the wrong answer anyway.
+        assert_eq!(progress_pct(1, 0), 0);
+        assert_eq!(progress_bar(1, 0, 3), (String::new(), "░░░".to_string()));
+        assert_eq!(
+            progress_bar(120, 100, 4).0,
+            "\u{2588}\u{2588}\u{2588}\u{2588}"
+        );
+    }
+
+    #[test]
+    fn sizing_a_local_tree_counts_what_du_counts() {
+        let dir = std::env::temp_dir().join(format!("sofka-size-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        std::fs::write(dir.join("a"), b"0123456789").unwrap();
+        std::fs::write(dir.join("sub/b"), b"012345").unwrap();
+        // Files *and* the directories' own inodes, which is what
+        // `du --apparent-size` sums on the volume side. Their size is the
+        // filesystem's business, so the expectation asks it rather than
+        // hard-coding ext4's 4096 or APFS's couple of hundred bytes.
+        let inode = |p: &std::path::Path| std::fs::symlink_metadata(p).unwrap().len();
+        let go = AtomicBool::new(false);
+        let sized = |p: &std::path::Path| local_size_capped(p, MAX_SIZE_ENTRIES, &go);
+        let dirs = inode(&dir) + inode(&dir.join("sub"));
+        assert_eq!(sized(&dir), Measure::Bytes(16 + dirs));
+        assert_eq!(sized(&dir.join("a")), Measure::Bytes(10));
+        // Not there is its own answer: a copy's destination is like this
+        // until `cp` creates it, and it is worth asking about again.
+        assert_eq!(sized(&dir.join("nope")), Measure::Absent);
+        // A symlink counts as itself and is never followed, which is what
+        // `tar` puts on the wire — and the only way to walk a cycle.
+        std::os::unix::fs::symlink(&dir, dir.join("loop")).unwrap();
+        let link = inode(&dir.join("loop"));
+        assert_eq!(sized(&dir.join("loop")), Measure::Bytes(link));
+        // And inside a tree: counted once at its own size, never followed —
+        // following it would both double-count and, here, never finish.
+        assert_eq!(
+            sized(&dir),
+            Measure::Bytes(16 + inode(&dir) + inode(&dir.join("sub")) + link),
+            "a symlink in the tree was followed"
+        );
+        std::fs::remove_file(dir.join("loop")).unwrap();
+        // And a tree past the cap is a third answer, not a size.
+        assert_eq!(local_size_capped(&dir, 2, &go), Measure::TooBig);
+        // Asked to stop, it stops — with no reading rather than a partial
+        // one, which is the answer that gets asked again.
+        let stopped = AtomicBool::new(true);
+        assert_eq!(
+            local_size_capped(&dir, MAX_SIZE_ENTRIES, &stopped),
+            Measure::Absent
+        );
+
+        // One subdirectory nobody can enter is the ordinary case on a volume,
+        // and it must not cost the whole total — `du` keeps its partial one.
+        std::fs::create_dir(dir.join("locked")).unwrap();
+        std::fs::write(dir.join("locked/c"), b"01234").unwrap();
+        let mut perms = std::fs::metadata(dir.join("locked")).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o000);
+        std::fs::set_permissions(dir.join("locked"), perms).unwrap();
+        // Re-read: adding an entry grows the parent directory's own inode.
+        let reachable = 16 + inode(&dir) + inode(&dir.join("sub")) + inode(&dir.join("locked"));
+        assert_eq!(
+            sized(&dir),
+            Measure::Bytes(reachable),
+            "an unreadable subtree ate the total"
+        );
+        let mut perms = std::fs::metadata(dir.join("locked")).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(dir.join("locked"), perms).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -178,6 +178,15 @@ pub enum Msg {
         title: String,
         lines: Vec<String>,
     },
+    /// How far a background `kubectl cp` has got: bytes that have landed at
+    /// the destination, and the source's total when anything could measure
+    /// it. Sent repeatedly for one copy, and never after its `TransferDone`.
+    TransferProgress {
+        generation: u64,
+        claim: StatusClaim,
+        done: u64,
+        total: Option<u64>,
+    },
     /// Result of a background `kubectl cp` transfer (`t` on a pod): a
     /// "copied …" summary, or kubectl's error.
     TransferDone {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4075,17 +4075,23 @@ fn draw_pvc_explore(frame: &mut Frame, app: &mut App, area: Rect) {
         remote_title.push_str("· loading… ");
     }
 
+    // A copy in flight replaces its row's size with a bar. Looked up per
+    // pane *and* directory, so a copy out of a directory the browser has
+    // since left does not leave a bar on a same-named row here.
+    let local_dir = app.pvc.local_path.to_string_lossy().into_owned();
     let local_items = pvc_pane_items(
         &app.pvc.local,
         app.pvc.local_error.as_deref(),
         cols[0].width,
         app.pvc.local_truncated,
+        &app.pane_transfers(Pane::Local, &local_dir),
     );
     let remote_items = pvc_pane_items(
         &app.pvc.remote,
         app.pvc.remote_error.as_deref(),
         cols[1].width,
         app.pvc.truncated,
+        &app.pane_transfers(Pane::Remote, app.pvc.current_dir()),
     );
     let focus = app.pvc.focus;
 
@@ -4148,6 +4154,7 @@ fn pvc_pane_items(
     error: Option<&str>,
     width: u16,
     truncated: bool,
+    copying: &[(&str, u64, u64)],
 ) -> Vec<ListItem<'static>> {
     use crate::pvcexplore::EntryKind;
 
@@ -4190,13 +4197,29 @@ fn pvc_pane_items(
                 // Nothing could stat it — not the same as an empty file.
                 (_, None) => "?".to_string(),
             };
-            ListItem::new(Line::from(vec![
-                Span::styled(
-                    format!("{label}{:pad$}", "", pad = pad),
-                    Style::default().fg(color),
-                ),
-                Span::styled(format!(" {size:>size_width$}"), theme::dim()),
-            ]))
+            let name = Span::styled(
+                format!("{label}{:pad$}", "", pad = pad),
+                Style::default().fg(color),
+            );
+            // A copy of this entry is running: the size is what the bar
+            // measures against, so the bar goes where the size was. Both
+            // halves together are exactly `size_width` columns, so the rows
+            // around it stay aligned.
+            match copying.iter().find(|(n, _, _)| *n == e.name) {
+                Some(&(_, done, total)) => {
+                    let (fill, track) = crate::pvcexplore::progress_bar(done, total, size_width);
+                    ListItem::new(Line::from(vec![
+                        name,
+                        Span::raw(" "),
+                        Span::styled(fill, Style::default().fg(theme::peach())),
+                        Span::styled(track, Style::default().fg(theme::surface1())),
+                    ]))
+                }
+                None => ListItem::new(Line::from(vec![
+                    name,
+                    Span::styled(format!(" {size:>size_width$}"), theme::dim()),
+                ])),
+            }
         })
         .collect();
     if truncated {
@@ -5095,6 +5118,133 @@ mod tests {
         );
 
         theme::set_background(false); // don't leak global state to other tests
+    }
+
+    #[tokio::test]
+    async fn a_running_copy_draws_its_bar_in_the_size_column() {
+        use crate::app::{TransferAnchor, TransferProgress};
+        use crate::k8s::Cluster;
+        use crate::pvcexplore::{Entry, EntryKind};
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let mut app = App::new(Cluster::fake(), tx);
+        let entry = |name: &str, size| Entry {
+            name: name.into(),
+            kind: EntryKind::File,
+            size: Some(size),
+            link_target: String::new(),
+        };
+        app.mode = Mode::PvcExplore;
+        app.pvc.active = true;
+        app.pvc.claim = "data".into();
+        app.pvc.namespace = "default".into();
+        app.pvc.remote_path = "/srv".into();
+        app.pvc.remote = vec![entry("big.tar", 5_368_709_120), entry("small.txt", 12)];
+        app.pvc.remote_state.select(Some(0));
+        app.transfers.push(TransferProgress::fake(
+            app.generation,
+            TransferAnchor {
+                pane: crate::app::Pane::Remote,
+                claim: "default/data".into(),
+                dir: "/srv".into(),
+                name: "big.tar".into(),
+            },
+            5_368_709_120 / 2,
+            5_368_709_120,
+        ));
+
+        let mut term = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let buffer = term.backend().buffer().clone();
+        let row = |y: u16| {
+            (0..buffer.area.width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        };
+        // The volume pane is the right half; find the two rows in it.
+        let copying = (0..buffer.area.height)
+            .map(row)
+            .find(|line| line.contains("big.tar"))
+            .unwrap_or_default();
+        let idle = (0..buffer.area.height)
+            .map(row)
+            .find(|line| line.contains("small.txt"))
+            .unwrap_or_default();
+
+        // Half of a 5 GB copy: four filled cells and four of track, in the
+        // eight columns the size would have occupied.
+        assert!(
+            copying.contains("\u{2588}\u{2588}\u{2588}\u{2588}\u{2591}\u{2591}\u{2591}\u{2591}"),
+            "{copying:?}"
+        );
+        assert!(!copying.contains("5.0G"), "the bar replaces the size");
+        // And the row next to it is untouched, so the column still lines up.
+        assert!(idle.contains("12B"), "{idle:?}");
+        // Char columns, not byte offsets: a box-drawing cell is three bytes.
+        let column = |line: &str, needle: &str| {
+            line.find(needle)
+                .map(|at| line[..at].chars().count())
+                .unwrap_or_default()
+        };
+        assert_eq!(
+            column(&copying, "\u{2588}\u{2588}\u{2588}\u{2588}"),
+            column(&idle, "     12B"),
+            "the bar starts where the size column does"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_local_row_wears_its_bar_too() {
+        // The two panes are looked up by different strings — the volume's
+        // directory and the local path — so a renderer that asked for one
+        // when it meant the other would lose every upload's bar.
+        use crate::app::{TransferAnchor, TransferProgress};
+        use crate::k8s::Cluster;
+        use crate::pvcexplore::{Entry, EntryKind};
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let mut app = App::new(Cluster::fake(), tx);
+        app.mode = Mode::PvcExplore;
+        app.pvc.active = true;
+        app.pvc.claim = "data".into();
+        app.pvc.namespace = "default".into();
+        app.pvc.remote_path = "/srv".into();
+        app.pvc.local_path = std::path::PathBuf::from("/tmp/here");
+        app.pvc.local = vec![Entry {
+            name: "notes.txt".into(),
+            kind: EntryKind::File,
+            size: Some(4_000),
+            link_target: String::new(),
+        }];
+        app.transfers.push(TransferProgress::fake(
+            app.generation,
+            TransferAnchor {
+                pane: crate::app::Pane::Local,
+                claim: "default/data".into(),
+                dir: "/tmp/here".into(),
+                name: "notes.txt".into(),
+            },
+            2_000,
+            4_000,
+        ));
+
+        let mut term = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let buffer = term.backend().buffer().clone();
+        let row = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .find(|line| line.contains("notes.txt"))
+            .unwrap_or_default();
+        assert!(
+            row.contains("\u{2588}\u{2588}\u{2588}\u{2588}\u{2591}\u{2591}\u{2591}\u{2591}"),
+            "{row:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`c` in the PVC browser starts a `kubectl cp` and then says nothing until it is over. `cp` reports nothing between "started" and "finished" and nothing at all on success, so "copying …" on the status bar was the only state a copy had: a 5 GB image off a volume, or a directory of a few thousand files, sat on one unchanging line for minutes with nothing to tell a copy moving at 80 MB/s from one stalled on an unresponsive backend.

Since `cp` will not say, the destination does — bytes that have landed there are bytes that moved.

```
  backup-2026-09-01.tar.zst        ████▌░░░
  cache/
  postgres.dump                        1.4G
```

## What it does

- **The row the copy started from fills a bar** where its size was, and the status bar carries the percentage — which is also how a copy started by `t` on a pod, with typed paths and no row to draw on, reports itself.
- **A download is sampled locally**, four times a second, and costs the cluster nothing. A walk that costs real work rests three times as long before the next one, since it is a recursive `stat` of everything copied so far against the disk `tar` is writing to.
- **An upload is sampled by one long-lived `kubectl exec`** that prints the destination's size once a second — one exec for the whole copy, not one per sample against somebody's pod.
- **A folder is measured whole**, so its bar is the recursive total rather than one file at a time.

## What it measures, and how carefully

The copy starts before it is sized, and everything else watches it happen: sizing ahead of it would leave the child spawned but unpolled for as long as a `du` over a whole tree takes, its stderr pipe filling unread. What *is* measured before the copy starts is the destination — one local walk for a download, one exec's setup for an upload — because whatever was already there is not progress, or an overwrite would open at 100%. That baseline ratchets down to the lowest reading, so a file `cp` truncates is measured from zero.

Both ends are measured by one definition — every entry's own apparent size, directories included, which is what `du --apparent-size` sums — so a folder copy agrees end to end instead of comparing file bytes against a total that counted directory inodes too. The total comes from the listing for a single file and from `du -b` for a directory, that being the one spelling GNU coreutils and busybox agree on; the long forms are rejected by busybox and so by the default helper image. A `du` with neither answers in KiB blocks, so the sample line carries the multiplier it answered in, and the branch is on whether a *number* came back rather than on `du`'s exit status: a directory the serving pod cannot read is ordinary on a volume, and `du` prints the total it reached and then exits non-zero.

Only that leading number is ever echoed, so a file named like a sample cannot forge one — the path is a positional parameter and never text in the script, as in the listing.

## When it cannot measure, it says so

A bar frozen at 40% reads as a copy that stopped there. So when the destination stops being measurable — no `du` in the container, a `du` that cannot run, an exec that was denied, a tree past 200,000 entries, a walk that outruns its ceiling — the sampler retires and the bar is taken away rather than left. A total of zero counts as no total for the same reason.

Two limits are documented rather than hidden: a folder copied over a copy of itself under-reports, because almost nothing new lands and no reading of the destination can reach the source's total; and the last sample is up to one period stale, since a closing report would share a frame with the row's removal and never be drawn.

## Stopping the pod-side watcher

Killing the local `kubectl` does not reach the container: writes into an abandoned exec stream keep succeeding, so a loop watching its own output fail carried on sampling in the pod after the copy was over. Measured, not theorised — I left two of them running in a pod finding this out.

What does reach it is stdin closing, which is why the watcher's exec asks for `-i`. A reader waits on end-of-input from a dup of stdin (a background command's own stdin is `/dev/null`, hence the dup) while the sampling loop checks each pass that the reader is still there and kills it on the way out, so neither half outlives the other by more than a pass. Its stderr is drained rather than sampled, because closing that pipe early hands kubectl a SIGPIPE on its next write, and a kubectl killed rather than closed abandons the exec instead of ending it. Each `du` carries its own `timeout` inside the container for the same reason: the local half of a bound is not a bound. Behind all of it sit a wall clock and a pass count, for the session that is killed and can close nothing.

## Safety

`kubectl cp` still does the copying: the direction, both upload guardrails, read-only mode and the overwrite confirmation are untouched, and quitting mid-copy still leaves a copy to finish rather than truncating a file. Measuring is an exec of its own and is gated no further than the copy it belongs to, on the reasoning that a `du` reaches nothing a permitted copy could not already reach — `cp` has always run `tar` there. `docs/safety.md` says which direction pays what, including that an upload leaves a loop running for up to fifteen minutes if sofka is killed rather than closed.

## Notes

- The pod needs `du` alongside the `ls` a listing needs and the `tar` a copy needs; without it the copy runs with no bar.
- Docs updated per AGENTS.md: `docs/features.md`, `docs/safety.md`, `docs/architecture.md`.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings` and `cargo test --locked` are clean on this branch — 1261 tests pass, and clippy reports the same lints as `main` (all in files this branch does not touch, under a newer toolchain than CI's).

The pure half (the `du` scripts and their parser, the local walk, the bar arithmetic, the baseline ratchet) is unit-tested without a cluster; the app half is driven through `handle_key`. The shell scripts are run for real in tests — an empty exec prefix leaves them running under a local `sh`, with `du` shimmed to fail or to answer in blocks — and by hand under `busybox:1.37` with no clock, no `du`, a failing `du`, a `du` printing usage, and a missing path. Against a real cluster: a 22 MB folder download, a 667 MB file download and a 100 MB upload, plus an overwrite of an existing 667 MB copy (opens at 0, ends at 100%), leaving no processes behind in the pod.

Closes #452
