### PR TITLE
feat: save action journal to a file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,44 @@ Each of these is documented where the feature itself is:
 | `[providers.logs]`    | VictoriaLogs backend for `L`                | [Providers](providers.md#log-provider-victorialogs)        |
 | `[fleet]`             | contexts in the cross-cluster dashboard     | [Providers](providers.md#fleet-dashboard)                  |
 
+## Action journal files
+
+The journal keeps the latest 500 entries in memory. To also save entries to disk:
+
+```toml
+[journal]
+enabled = true
+# file = "/path/to/journal.jsonl"
+max_size_mb = 8
+```
+
+`enabled` defaults to `false`. No journal file is created when it is disabled.
+`file` defaults to `<state-dir>/journal.jsonl`. An empty path uses the default.
+Relative paths start at the working directory. The file is created on the first
+recorded action. Restart sofka to apply changes to these settings.
+
+`max_size_mb` limits each file to 8 MiB by default, with a minimum of 64 KiB.
+The writer appends one JSON object per line. Before the next entry exceeds the
+limit, it rotates the file to `<file>.1` and replaces the previous backup.
+An entry larger than the limit is not saved and produces a warning.
+A `<file>.lock` file coordinates writes from multiple sessions.
+Use a separate path from the application log and other sofka state files.
+
+Each entry has `at` (full UTC timestamp), `context`, `action`, and `target`.
+Entries record actions started, not confirmed results. The journal view still
+shows only the current session. It does not load saved entries.
+
+File writes run on a background thread. Failed writes and a full queue produce
+a status warning, also kept in `:info`. Failed entries are not retried; later
+entries can still be saved. At exit, sofka waits up to 300 ms for pending writes
+and reports a warning if they do not finish. Entries can be lost on a crash or
+a stalled disk. This is local action history, not a complete audit record.
+
+Secret inputs are excluded. File output uses the same credential and IP address
+redaction as the application log. Resource names and contexts remain visible.
+Application logging at `info` or above also records actions, independently of
+`[journal]`.
+
 ## Per-cluster and per-context overrides
 
 Any option can be overridden for a specific cluster or kubeconfig context, like

--- a/docs/features.md
+++ b/docs/features.md
@@ -525,7 +525,8 @@ pod is rejected; browse through a pod that already mounts the claim instead.
 ## Safety
 
 - **Read-only mode**, **declarative guardrails**, **action-aware authorization**
-  (`:can-i`), and a session-local **action journal** (`:journal`). See
+  (`:can-i`), and a session-local **action journal** (`:journal`) with optional
+  [file persistence](configuration.md#action-journal-files). See
   [Safety](safety.md).
 
 ## Extensibility

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -89,8 +89,10 @@ incomplete rule reviews. The API still enforces access when you open the kind.
 
 `:journal` (or `:audit`) is a session-local in-memory log of every mutating
 action you took - the action, the target, the context, the time - newest first.
-It records identifiers only, never secret input or decoded values, and never
-writes to disk.
+Entries record actions started, not confirmed results. They contain identifiers
+only, never secret input or decoded values. Optional [journal file
+settings](configuration.md#action-journal-files) save entries to disk. Application
+logging at `info` or above also records these actions.
 
 ## Plugin actions
 

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -8,6 +8,15 @@ impl App {
         self.journal.record(&ctx, action, target);
     }
 
+    pub fn check_journal_error(&mut self) {
+        if let Some(error) = self.journal.take_error() {
+            self.borrow_status(error.clone(), true);
+            if !self.config_warnings.contains(&error) {
+                self.config_warnings.push(error);
+            }
+        }
+    }
+
     /// A compact "name" / "N kind" target label for a bulk-or-single action.
     pub(super) fn action_label(&self, targets: &[(String, String)]) -> String {
         match targets {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -25133,3 +25133,83 @@ async fn log_marker_shortcut_handles_stopped_provider_and_replaced_buffers() {
     assert!(app.logs.markers.is_empty());
     assert_eq!(app.logs.refresh_index(0).total_rows(), 0);
 }
+
+#[tokio::test]
+async fn journal_persistence_follows_edit_key_and_appends_across_sessions() {
+    let dir = std::env::temp_dir().join(format!("sofka-journal-app-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let path = dir.join("actions.jsonl");
+    for enabled in [false, true, true] {
+        let (mut app, _rx) = app_with_pod();
+        app.journal
+            .configure(&crate::config::JournalConfig {
+                enabled,
+                file: Some(path.clone()),
+                ..Default::default()
+            })
+            .unwrap();
+        app.handle_key(press(KeyCode::Char('e'))).unwrap();
+        assert_eq!(app.journal.len(), 1);
+        assert!(app.journal.shutdown().is_none());
+        if !enabled {
+            assert!(!dir.exists());
+        }
+    }
+    let text = std::fs::read_to_string(&path).unwrap();
+    let entries: Vec<serde_json::Value> = text
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(entries.len(), 2);
+    for entry in entries {
+        assert_eq!(entry["action"], "edit");
+        assert!(entry["context"].is_string());
+        assert!(!entry["target"].as_str().unwrap().is_empty());
+        let at = entry["at"].as_str().unwrap();
+        assert!(at.ends_with('Z'));
+        assert!(at.parse::<k8s_openapi::jiff::Timestamp>().is_ok());
+    }
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[tokio::test]
+async fn journal_write_failure_is_visible_after_edit_key() {
+    let dir = std::env::temp_dir().join(format!("sofka-journal-fail-app-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (mut app, _rx) = app_with_pod();
+    app.journal
+        .configure(&crate::config::JournalConfig {
+            enabled: true,
+            file: Some(dir.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+    app.handle_key(press(KeyCode::Char('e'))).unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            app.check_journal_error();
+            if app.flash.contains("journal entry not saved") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    assert!(app.flash_err);
+    assert!(
+        app.config_warnings
+            .iter()
+            .any(|w| w.contains("journal entry not saved"))
+    );
+    assert!(!app.should_quit);
+    assert_eq!(app.journal.len(), 1);
+    assert!(app.journal.shutdown().is_none());
+    std::fs::remove_dir_all(&dir).unwrap();
+    std::fs::remove_file(dir.with_file_name(format!(
+        "sofka-journal-fail-app-{}.lock",
+        std::process::id()
+    )))
+    .unwrap();
+}

--- a/src/applog.rs
+++ b/src/applog.rs
@@ -273,7 +273,7 @@ fn push_value(out: &mut String, raw: &str) {
 
 /// The log file and its rotation. All sessions use the same lock file.
 /// Only writer threads wait for this lock.
-struct Writer {
+pub(crate) struct Writer {
     path: PathBuf,
     max_bytes: u64,
     file: File,
@@ -282,7 +282,7 @@ struct Writer {
 }
 
 impl Writer {
-    fn open(path: &Path, max_bytes: u64) -> std::io::Result<Self> {
+    pub(crate) fn open(path: &Path, max_bytes: u64) -> std::io::Result<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -303,7 +303,7 @@ impl Writer {
         })
     }
 
-    fn write(&mut self, line: &str) -> std::io::Result<()> {
+    pub(crate) fn write(&mut self, line: &str) -> std::io::Result<()> {
         // The lock file stays in place when any session rotates the log.
         self.lock.lock()?;
         let result = self.write_locked(line);

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,7 @@ pub struct Config {
     pub keys: KeysConfig,
     /// Structured application logging — see [`LoggingConfig`].
     pub logging: LoggingConfig,
+    pub journal: JournalConfig,
 }
 
 /// Delivery for `:notify` events, besides the status-line flash.
@@ -307,6 +308,38 @@ impl Default for LogsConfig {
             since: None,
             fullscreen: false,
         }
+    }
+}
+
+/// Optional action history on disk. Changes take effect on restart.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct JournalConfig {
+    pub enabled: bool,
+    pub file: Option<PathBuf>,
+    pub max_size_mb: u64,
+}
+
+impl Default for JournalConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            file: None,
+            max_size_mb: 8,
+        }
+    }
+}
+
+impl JournalConfig {
+    pub fn path(&self) -> PathBuf {
+        self.file
+            .clone()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| crate::diagnostics::state_dir().join("journal.jsonl"))
+    }
+
+    pub fn max_bytes(&self) -> u64 {
+        self.max_size_mb.saturating_mul(1024 * 1024).max(64 * 1024)
     }
 }
 
@@ -1441,6 +1474,23 @@ fn config_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn journal_config_defaults_and_overrides() {
+        let cfg = Config::default();
+        assert!(!cfg.journal.enabled);
+        assert_eq!(
+            cfg.journal.path(),
+            crate::diagnostics::state_dir().join("journal.jsonl")
+        );
+        assert_eq!(cfg.journal.max_bytes(), 8 * 1024 * 1024);
+        let cfg: Config =
+            toml::from_str("[journal]\nenabled = true\nfile = 'actions.jsonl'\nmax_size_mb = 0")
+                .unwrap();
+        assert!(cfg.journal.enabled);
+        assert_eq!(cfg.journal.path(), PathBuf::from("actions.jsonl"));
+        assert_eq!(cfg.journal.max_bytes(), 64 * 1024);
+    }
 
     #[test]
     fn compact_mode_defaults_false_and_accepts_booleans() {

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,13 +1,74 @@
 //! Session-local action journal.
 //!
-//! A bounded, in-memory log of the mutating actions taken this session — what,
-//! against which target, in which context, and when — for a quick audit trail
-//! (`:journal`). It records identifiers only (names, verbs), never secret
-//! inputs or decoded Secret values, and is never written to disk.
+//! A bounded session history with optional JSON Lines persistence.
+//! Entries record actions started, not confirmed results. Callers supply
+//! identifiers only. File output uses the standard redaction rules.
 
 use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::Duration;
 
+use crate::config::JournalConfig;
 use k8s_openapi::jiff::Timestamp;
+
+struct Sink {
+    tx: Option<mpsc::SyncSender<String>>,
+    done: mpsc::Receiver<()>,
+    error: Arc<Mutex<Option<String>>>,
+    max_bytes: u64,
+}
+
+impl Sink {
+    fn new(cfg: &JournalConfig) -> Result<Self, String> {
+        let (tx, rx) = mpsc::sync_channel::<String>(4096);
+        let (done_tx, done) = mpsc::channel();
+        let error = Arc::new(Mutex::new(None));
+        let worker_error = error.clone();
+        let path = cfg.path();
+        let max_bytes = cfg.max_bytes();
+        std::thread::Builder::new()
+            .name("sofka-journal".into())
+            .spawn(move || {
+                let mut writer = None;
+                for line in rx {
+                    let result = (|| {
+                        if writer.is_none() {
+                            writer = Some(crate::applog::Writer::open(&path, max_bytes)?);
+                        }
+                        writer.as_mut().unwrap().write(&line)
+                    })();
+                    if let Err(e) = result {
+                        *worker_error.lock().unwrap() = Some(format!(
+                            "journal entry not saved: {}",
+                            crate::redact::text(&e.to_string())
+                        ));
+                    }
+                }
+                let _ = done_tx.send(());
+            })
+            .map_err(|e| format!("journal writer could not start: {e}"))?;
+        Ok(Self {
+            tx: Some(tx),
+            done,
+            error,
+            max_bytes,
+        })
+    }
+
+    fn take_error(&self) -> Option<String> {
+        self.error.lock().unwrap().take()
+    }
+}
+
+impl Drop for Sink {
+    fn drop(&mut self) {
+        self.tx.take();
+        if self.done.recv_timeout(Duration::from_millis(300)).is_err() {
+            *self.error.lock().unwrap() =
+                Some("journal shutdown timed out; some entries may not be saved".into());
+        }
+    }
+}
 
 /// How many entries to keep before dropping the oldest.
 const MAX_ENTRIES: usize = 500;
@@ -28,9 +89,31 @@ pub struct Entry {
 #[derive(Default)]
 pub struct Journal {
     entries: VecDeque<Entry>,
+    sink: Option<Sink>,
 }
 
 impl Journal {
+    pub fn configure(&mut self, cfg: &JournalConfig) -> Result<(), String> {
+        if let Some(error) = self.shutdown() {
+            return Err(error);
+        }
+        if cfg.enabled {
+            self.sink = Some(Sink::new(cfg)?);
+        }
+        Ok(())
+    }
+
+    pub fn take_error(&self) -> Option<String> {
+        self.sink.as_ref().and_then(Sink::take_error)
+    }
+
+    pub fn shutdown(&mut self) -> Option<String> {
+        let sink = self.sink.take()?;
+        let error = sink.error.clone();
+        drop(sink);
+        error.lock().unwrap().take()
+    }
+
     /// Record an action. Callers pass only identifiers — never secret input or
     /// decoded Secret values.
     pub fn record(&mut self, context: &str, action: impl Into<String>, target: impl Into<String>) {
@@ -41,12 +124,30 @@ impl Journal {
             action = action,
             target = target
         );
-        self.entries.push_back(Entry {
+        let entry = Entry {
             at: Timestamp::now().as_second(),
             context: context.to_string(),
             action,
             target,
-        });
+        };
+        if let Some(sink) = &self.sink {
+            let line = serde_json::json!({
+                "at": Timestamp::from_second(entry.at).unwrap().to_string(),
+                "context": crate::redact::text(&entry.context),
+                "action": crate::redact::text(&entry.action),
+                "target": crate::redact::text(&entry.target),
+            })
+            .to_string()
+                + "\n";
+            if line.len() as u64 > sink.max_bytes {
+                *sink.error.lock().unwrap() =
+                    Some("journal entry not saved: entry exceeds the file size limit".into());
+            } else if sink.tx.as_ref().unwrap().try_send(line).is_err() {
+                *sink.error.lock().unwrap() =
+                    Some("journal entry not saved: writer queue is full or closed".into());
+            }
+        }
+        self.entries.push_back(entry);
         while self.entries.len() > MAX_ENTRIES {
             self.entries.pop_front();
         }
@@ -103,6 +204,74 @@ fn clock(at: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_config(name: &str) -> JournalConfig {
+        let dir = std::env::temp_dir().join(format!("sofka-journal-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        JournalConfig {
+            enabled: true,
+            file: Some(dir.join("actions.jsonl")),
+            max_size_mb: 0,
+        }
+    }
+
+    #[test]
+    fn file_redacts_credentials_and_escapes_newlines() {
+        let cfg = test_config("redaction");
+        let mut journal = Journal::default();
+        journal.configure(&cfg).unwrap();
+        journal.record(
+            "https://user:password@example.com",
+            "plugin: test\nnext",
+            "Bearer secret-token",
+        );
+        assert!(journal.shutdown().is_none());
+        let text = std::fs::read_to_string(cfg.path()).unwrap();
+        assert_eq!(text.lines().count(), 1);
+        assert!(!text.contains("password"));
+        assert!(!text.contains("secret-token"));
+        let entry: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(entry["action"], "plugin: test\nnext");
+        std::fs::remove_dir_all(cfg.path().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn journal_rotation_is_bounded_and_keeps_complete_json() {
+        let cfg = test_config("rotation");
+        let mut journal = Journal::default();
+        journal.configure(&cfg).unwrap();
+        for i in 0..150 {
+            journal.record("prod", format!("edit {i}"), "x".repeat(1024));
+        }
+        assert!(journal.shutdown().is_none());
+        let current = std::fs::read_to_string(cfg.path()).unwrap();
+        let previous = std::fs::read_to_string(cfg.path().with_extension("jsonl.1")).unwrap();
+        for text in [&current, &previous] {
+            assert!(text.len() as u64 <= cfg.max_bytes());
+            for line in text.lines() {
+                serde_json::from_str::<serde_json::Value>(line).unwrap();
+            }
+        }
+        assert!(current.contains("edit 149"));
+        assert!(!cfg.path().with_extension("jsonl.2").exists());
+        std::fs::remove_dir_all(cfg.path().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn oversized_entries_report_failure_and_stay_in_memory() {
+        let cfg = test_config("oversize");
+        let mut journal = Journal::default();
+        journal.configure(&cfg).unwrap();
+        journal.record("prod", "edit", "x".repeat(cfg.max_bytes() as usize));
+        assert!(
+            journal
+                .shutdown()
+                .unwrap()
+                .contains("exceeds the file size limit")
+        );
+        assert_eq!(journal.len(), 1);
+        assert!(!cfg.path().exists());
+    }
 
     #[test]
     fn records_and_formats_newest_first() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,10 @@ async fn run_main(args: Args) -> Result<()> {
     let panic_tx = tx.clone();
     let mut app = App::new(cluster, tx);
     app.config = loader;
+    if let Err(error) = app.journal.configure(&cfg.journal) {
+        eprintln!("warning: {error}");
+        config_warnings.push(error);
+    }
     match sofka::state_writer::StateWriter::new(app.tx.clone()) {
         Ok(writer) => app.state_writer = Some(writer),
         Err(e) => {
@@ -448,6 +452,9 @@ async fn run_main(args: Args) -> Result<()> {
     // `restore()` leaves the alternate screen but never re-shows the cursor
     // that `draw` hid, so without this the user's shell prompt has no cursor.
     let _ = crossterm::execute!(std::io::stdout(), crossterm::cursor::Show);
+    if let Some(error) = app.journal.shutdown() {
+        eprintln!("warning: {error}");
+    }
     sofka::log_info!("shutdown", quit = app.should_quit);
     applog::shutdown();
     result
@@ -1053,6 +1060,7 @@ async fn run(
             _ = tick.tick() => {
                 app.reap_port_forwards(); // age columns + drop dead forwards
                 app.expire_flash();
+                app.check_journal_error();
                 dirty = true;
             }
             // A held Esc was a real keypress after all, not the head of a


### PR DESCRIPTION
The action journal was lost at exit unless general application logging was enabled. Add optional `[journal]` settings to save action history to a separate JSON Lines file. Persistence is disabled by default.

Entries contain full UTC time, context, action, and target. The writer uses the existing redaction and file rotation code, keeps one backup, and reports write failures without blocking the UI. The path and size limit are configurable. Documentation explains that entries record actions started, not confirmed results, and that failed writes or shutdown delays can leave entries unsaved.

Validation: `just check` passed. The pre-commit hook also passed formatting, Clippy, and 1,279 tests. New tests cover edit-key persistence, append across sessions, disabled persistence, visible write failures, redaction, rotation, oversized entries, and configuration defaults.

Agreed scope: https://github.com/nklmilojevic/sofka/discussions/433#discussioncomment-18387507

Closes #476
