### PR TITLE
fix: add an opt-in TLS resumption workaround

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -291,6 +291,56 @@ Sofka cannot skip the core API group. If it cannot read `v1`, the connection
 fails with the reason. If aggregated discovery fails, sofka shows the reason
 and reads each API group separately.
 
+## TLS session resumption and HTTP 401
+
+Some endpoints, including the AKS endpoints reported in
+[issue #479](https://github.com/nklmilojevic/sofka/issues/479), return HTTP 401
+on resumed TLS connections when authentication uses a client certificate.
+Sofka can show `watch stream failed: ApiError: Unauthorized` at startup or
+when you change context. Other requests, including metrics requests, can fail too.
+
+For an affected cluster, disable TLS session resumption for this run:
+
+```sh
+sofka --no-tls-resumption --context my-aks
+sofka --no-tls-resumption --context my-aks --check
+sofka --no-tls-resumption --context my-aks --snapshot -A pods
+```
+
+This option is off by default. When selected, it applies to all contexts used
+in the run, including fleet queries and the bundled sanitizer. Each new cluster
+TLS connection uses a full handshake. Existing connections can still be reused.
+Server certificate and hostname checks remain enabled. This option is separate
+from `--allow-v1-client-cert` and does not permit v1 certificates by itself.
+Full handshakes add work on new connections, including later reconnects.
+
+A 401 alone does not identify this problem. Expired or missing credentials can
+also cause it. To check session resumption, use OpenSSL with the certificate,
+key, and CA for the affected context. Use the API hostname for `HOST`, or its
+`tls-server-name` override, and the API address with its port for `ADDR`:
+
+```sh
+HOST=api.example.com
+ADDR=api.example.com:443
+umask 077
+printf 'GET /version HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n' "$HOST" > req.txt
+openssl s_client -tls1_3 -connect "$ADDR" -servername "$HOST" \
+  -cert tls.crt -key tls.key -CAfile ca.crt \
+  -sess_out sess.pem -ign_eof < req.txt
+openssl s_client -tls1_3 -connect "$ADDR" -servername "$HOST" \
+  -cert tls.crt -key tls.key -CAfile ca.crt \
+  -sess_in sess.pem -ign_eof < req.txt
+```
+
+Compare `New` or `Reused` with the HTTP status. Full handshakes that return 200
+and resumed handshakes that return 401 support this diagnosis. A server can
+reject a ticket and use a full handshake, so more than one attempt can be needed.
+Keep private keys and session files private. Remove the temporary files after
+the check.
+
+Watch errors use increasing retry delays to limit repeated requests. This delay
+is always enabled and does not correct an authentication failure.
+
 ## X.509 v1 client certificates
 
 Some MicroK8s kubeconfigs contain an X.509 v1 client certificate. The standard

--- a/docs/features.md
+++ b/docs/features.md
@@ -52,6 +52,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 
 - **Connect** to the current kubeconfig context, including exec credential
   plugins (GKE, EKS, and friends).
+- **Optional TLS session resumption workaround** through `--no-tls-resumption`
+  for clusters that reject resumed connections with HTTP 401. The default is
+  unchanged. See [TLS session resumption](debugging.md#tls-session-resumption-and-http-401).
 - **Optional v1 client certificates** through `--allow-v1-client-cert`, disabled
   by default. See [certificate compatibility](debugging.md#x509-v1-client-certificates).
 - **Teleport local proxy certificates** work when the server certificate exactly

--- a/src/app/fleet.rs
+++ b/src/app/fleet.rs
@@ -112,6 +112,7 @@ impl App {
 
     fn spawn_fleet_gathers(&mut self) {
         let allow_v1_client_cert = self.cluster.allow_v1_client_cert;
+        let no_tls_resumption = self.cluster.no_tls_resumption;
         let sema = Arc::new(tokio::sync::Semaphore::new(FLEET_CONCURRENCY));
         for row in &self.fleet_rows {
             let ctx = row.context.clone();
@@ -125,7 +126,7 @@ impl App {
                 let dur = Duration::from_secs(FLEET_TIMEOUT_SECS);
                 let row = match tokio::time::timeout(
                     dur,
-                    gather_context(&ctx, readonly, allow_v1_client_cert),
+                    gather_context(&ctx, readonly, allow_v1_client_cert, no_tls_resumption),
                 )
                 .await
                 {
@@ -192,9 +193,15 @@ impl App {
 /// Gather one context's summary: connect, then read version, node readiness,
 /// unhealthy pods, and Flux failures. Any connection/auth error becomes an
 /// `Error` row rather than propagating.
-async fn gather_context(ctx: &str, readonly: bool, allow_v1_client_cert: bool) -> FleetRow {
+async fn gather_context(
+    ctx: &str,
+    readonly: bool,
+    allow_v1_client_cert: bool,
+    no_tls_resumption: bool,
+) -> FleetRow {
     let mut row = FleetRow::connecting(ctx.to_string(), readonly);
-    let cluster = match Cluster::connect_context(ctx, allow_v1_client_cert).await {
+    let cluster = match Cluster::connect_context(ctx, allow_v1_client_cert, no_tls_resumption).await
+    {
         Ok(c) => c,
         Err(e) => {
             row.status = FleetStatus::Error(short_error(&format!("{e:#}")));

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -802,8 +802,9 @@ impl App {
         let tx = self.tx.clone();
         let genr = self.generation;
         let allow_v1_client_cert = self.cluster.allow_v1_client_cert;
+        let no_tls_resumption = self.cluster.no_tls_resumption;
         tokio::spawn(async move {
-            let result = Cluster::connect_context(&name, allow_v1_client_cert)
+            let result = Cluster::connect_context(&name, allow_v1_client_cert, no_tls_resumption)
                 .await
                 .map(Box::new)
                 .map_err(|e| e.to_string());

--- a/src/app/plugins.rs
+++ b/src/app/plugins.rs
@@ -145,6 +145,9 @@ impl App {
                     }]
                 };
                 argv.extend(plugin.args.iter().map(|a| subst(a)));
+                if plugin.bundled && self.cluster.no_tls_resumption {
+                    argv.push("--no-tls-resumption".into());
+                }
                 if plugin.bundled && self.cluster.allow_v1_client_cert {
                     argv.push("--allow-v1-client-cert".into());
                 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -396,7 +396,7 @@ fn mock_cluster(url: &str) -> Cluster {
     // this test is about the app's fallback, not the client's retries.
     config.default_retry = false;
     let mut cluster = Cluster::fake();
-    cluster.client = crate::k8s::build_client(config, false).expect("mock client");
+    cluster.client = crate::k8s::build_client(config, false, false).expect("mock client");
     cluster.cluster_url = url.into();
     cluster
 }
@@ -12351,7 +12351,9 @@ async fn expired_sso_keeps_context_picker_usable() {
         }))
         .unwrap(),
     );
-    let error = crate::k8s::build_client(config, false).err().unwrap();
+    let error = crate::k8s::build_client(config, false, false)
+        .err()
+        .unwrap();
     let (mut app, _rx) = test_app();
     app.cluster.connected = false;
     app.start_disconnected(&error.to_string());
@@ -12396,7 +12398,7 @@ printf '%s' '{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredent
             }))
             .unwrap(),
         );
-        let client = crate::k8s::build_client(config, false).unwrap();
+        let client = crate::k8s::build_client(config, false, false).unwrap();
         std::fs::write(
             &marker,
             format!("{provider_error}: private-provider-output"),
@@ -21919,6 +21921,79 @@ async fn bundled_plugin_receives_v1_consent_only_when_enabled() {
 }
 
 #[tokio::test]
+async fn refresh_key_reports_auth_errors_without_a_retry_loop() {
+    let (mut app, mut rx) = test_app();
+    let (request_tx, mut requests) = mpsc::unbounded_channel();
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            if request
+                .uri()
+                .query()
+                .is_some_and(|query| query.contains("watch=true"))
+            {
+                let _ = request_tx.send(());
+            }
+            async {
+                Ok::<_, std::convert::Infallible>(http::Response::builder()
+                    .status(401)
+                    .body(http_body_util::Full::new(hyper::body::Bytes::from_static(
+                        br#"{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"Unauthorized","message":"Unauthorized","code":401}"#
+                    )))
+                    .unwrap())
+            }
+        }),
+        "default",
+    );
+    app.kind = app.cluster.resolve("pods");
+    app.kind_plural = "pods".into();
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let failed = matches!(&msg, Msg::Error { error, .. } if error.contains("Unauthorized"));
+        app.handle_msg(msg);
+        if failed {
+            break;
+        }
+    }
+    assert!(app.flash_err);
+    assert!(requests.try_recv().is_ok());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), requests.recv())
+            .await
+            .is_err()
+    );
+    app.handle_key(press(KeyCode::Char('q'))).unwrap();
+}
+
+#[tokio::test]
+async fn bundled_plugin_receives_tls_resumption_option_only_when_enabled() {
+    for allow in [false, true] {
+        let (mut app, _rx) = app_with_pod();
+        app.cluster.no_tls_resumption = allow;
+        app.plugins = crate::plugins::bundled()
+            .into_iter()
+            .map(Result::unwrap)
+            .collect();
+        plugin_command(&mut app, "sanitize");
+        let Some(ConfirmAction::Plugin { jobs, .. }) = app.confirm_action.as_ref() else {
+            panic!("expected plugin confirmation");
+        };
+        assert!(!jobs.is_empty());
+        for job in jobs {
+            assert_eq!(
+                job.argv.iter().any(|arg| arg == "--no-tls-resumption"),
+                allow
+            );
+        }
+        app.handle_key(press(KeyCode::Char('n'))).unwrap();
+        assert_eq!(app.mode, Mode::Table);
+    }
+}
+
+#[tokio::test]
 async fn refresh_key_reads_pods_through_a_configured_ca_server_certificate() {
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -21975,7 +22050,7 @@ async fn refresh_key_reads_pods_through_a_configured_ca_server_certificate() {
         }
     });
     let (mut app, mut rx) = test_app();
-    app.cluster.client = crate::k8s::build_client(config, false).unwrap();
+    app.cluster.client = crate::k8s::build_client(config, false, false).unwrap();
     app.kind = app.cluster.resolve("pods");
     app.kind_plural = "pods".into();
     app.handle_key(press(KeyCode::Char('r'))).unwrap();

--- a/src/app/tests/proxy.rs
+++ b/src/app/tests/proxy.rs
@@ -19,7 +19,9 @@ async fn proxy_exclusions_apply_on_startup_and_context_switch() {
     if let Ok(phase) = std::env::var(CHILD) {
         let (mut app, mut rx) = test_app();
         if phase == "startup" {
-            app.cluster = Cluster::connect(false).await.expect("connect at startup");
+            app.cluster = Cluster::connect(false, false)
+                .await
+                .expect("connect at startup");
             app.kind = app.cluster.resolve("pods");
             app.kind_plural = "pods".into();
             app.handle_key(press(KeyCode::Char('r'))).unwrap();

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -15,7 +15,7 @@ use kube::api::{Api, ListParams};
 use kube::config::{KubeConfigOptions, Kubeconfig};
 use kube::core::{DynamicObject, GroupVersionResource};
 use kube::discovery::ApiResource;
-use kube::runtime::{WatchStreamExt, watcher};
+use kube::runtime::{WatchStreamExt, utils::Backoff, watcher};
 use kube::{Client, Config, ResourceExt};
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
@@ -27,18 +27,21 @@ mod discovery;
 mod proxy;
 mod table;
 
-pub(crate) fn build_client(mut config: Config, allow_v1_client_cert: bool) -> Result<Client> {
+pub(crate) fn build_client(
+    mut config: Config,
+    allow_v1_client_cert: bool,
+    no_tls_resumption: bool,
+) -> Result<Client> {
     if let Some(exec) = &mut config.auth_info.exec {
         // Authentication commands must not read from or write to the TUI terminal.
         exec.interactive_mode = Some(kube::config::ExecInteractiveMode::Never);
     }
     let builder =
-        crate::legacy_tls::client_builder(config, allow_v1_client_cert).map_err(|error| {
-            match exec_auth_message(error.as_ref()) {
+        crate::legacy_tls::client_builder(config, allow_v1_client_cert, no_tls_resumption)
+            .map_err(|error| match exec_auth_message(error.as_ref()) {
                 Some(message) => anyhow::anyhow!(message),
                 None => error,
-            }
-        })?;
+            })?;
     let layer =
         tower::util::MapRequestLayer::new(|mut request: http::Request<kube::client::Body>| {
             let watch = request.uri().query().is_some_and(|query| {
@@ -290,6 +293,8 @@ pub struct Cluster {
     pub connected: bool,
     /// Explicit consent for v1 client certificates, retained for this run.
     pub allow_v1_client_cert: bool,
+    /// Disable TLS session resumption for all clients in this run.
+    pub no_tls_resumption: bool,
     /// Per-cluster support for Kubernetes streaming-list watch startup:
     /// unknown, supported, or unsupported. Shared by all view watches so one
     /// negotiation failure avoids retrying the extension on every switch.
@@ -317,7 +322,7 @@ fn sanitize_server_version(version: &str) -> String {
 }
 
 impl Cluster {
-    pub async fn connect(allow_v1_client_cert: bool) -> Result<Self> {
+    pub async fn connect(allow_v1_client_cert: bool, no_tls_resumption: bool) -> Result<Self> {
         let mut config = Config::infer()
             .await
             .context("loading kubeconfig (is KUBECONFIG / ~/.kube/config present?)")?;
@@ -329,11 +334,22 @@ impl Cluster {
         }
         let cli_context = kubeconfig.and_then(|config| config.current_context);
         let context = cli_context.clone().unwrap_or_else(|| "default".into());
-        Self::from_config(config, context, cli_context, allow_v1_client_cert).await
+        Self::from_config(
+            config,
+            context,
+            cli_context,
+            allow_v1_client_cert,
+            no_tls_resumption,
+        )
+        .await
     }
 
     /// Connect using a specific kubeconfig context (for the `:ctx` switcher).
-    pub async fn connect_context(name: &str, allow_v1_client_cert: bool) -> Result<Self> {
+    pub async fn connect_context(
+        name: &str,
+        allow_v1_client_cert: bool,
+        no_tls_resumption: bool,
+    ) -> Result<Self> {
         let kubeconfig = Kubeconfig::read().context("reading kubeconfig")?;
         let opts = KubeConfigOptions {
             context: Some(name.to_string()),
@@ -349,6 +365,7 @@ impl Cluster {
             name.to_string(),
             Some(name.to_string()),
             allow_v1_client_cert,
+            no_tls_resumption,
         )
         .await
     }
@@ -358,10 +375,12 @@ impl Cluster {
         context: String,
         cli_context: Option<String>,
         allow_v1_client_cert: bool,
+        no_tls_resumption: bool,
     ) -> Result<Self> {
         let cluster_url = config.cluster_url.to_string();
         let default_namespace = config.default_namespace.clone();
-        let client = build_client(config, allow_v1_client_cert).context("building kube client")?;
+        let client = build_client(config, allow_v1_client_cert, no_tls_resumption)
+            .context("building kube client")?;
         let version_client = client.clone();
 
         let cluster_name = cluster_name_for(&context).unwrap_or_default();
@@ -377,6 +396,7 @@ impl Cluster {
             catalog: Vec::new(),
             connected: true,
             allow_v1_client_cert,
+            no_tls_resumption,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
             child_kinds: Vec::new(),
             discovery_warnings: Vec::new(),
@@ -462,6 +482,7 @@ impl Cluster {
             catalog: Vec::new(),
             connected: false,
             allow_v1_client_cert: false,
+            no_tls_resumption: false,
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
             child_kinds: Vec::new(),
             discovery_warnings: Vec::new(),
@@ -823,6 +844,7 @@ fn spawn_watch_task(
             return;
         }
 
+        let mut backoff = watcher::DefaultBackoff::default();
         while let Some(event) = stream.next().await {
             if using_streaming
                 && initializing
@@ -835,6 +857,15 @@ fn spawn_watch_task(
                     .boxed();
                 continue;
             }
+            // Initialisation events can repeat before each failed list request.
+            // Reset the delay only after the watch makes progress.
+            if matches!(
+                event,
+                Ok(watcher::Event::Apply(_) | watcher::Event::Delete(_) | watcher::Event::InitDone)
+            ) {
+                backoff.reset();
+            }
+            let mut retry_delay = None;
             let msg = match event {
                 Ok(watcher::Event::Apply(obj)) | Ok(watcher::Event::InitApply(obj)) => {
                     Msg::Applied {
@@ -882,6 +913,7 @@ fn spawn_watch_task(
                 }
                 Err(e) => {
                     crate::log_warn!("watch.error", kind = kind, error = e);
+                    retry_delay = Some(backoff.next().unwrap_or(Duration::from_secs(30)));
                     Msg::Error {
                         generation,
                         error: e.to_string(),
@@ -890,6 +922,12 @@ fn spawn_watch_task(
             };
             if tx.send(msg).await.is_err() {
                 break; // UI gone
+            }
+            if let Some(delay) = retry_delay {
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = tx.closed() => break,
+                }
             }
         }
     })
@@ -1031,6 +1069,7 @@ impl Cluster {
             cli_context: Some("test".into()),
             connected: true,
             allow_v1_client_cert: false,
+            no_tls_resumption: false,
             registry: HashMap::new(),
             catalog: Vec::new(),
             streaming_lists: Arc::new(AtomicU8::new(STREAMING_UNKNOWN)),
@@ -1156,7 +1195,7 @@ pub(crate) mod tests {
                 }))
                 .unwrap(),
             );
-            let error = super::build_client(config, false).err().unwrap();
+            let error = super::build_client(config, false, false).err().unwrap();
             assert_eq!(
                 error.to_string(),
                 "Authentication failed. Run 'aws sso login' for the active AWS profile, then retry.",
@@ -1495,6 +1534,49 @@ clusters:
     }
 
     #[tokio::test]
+    async fn watch_retries_slow_down_after_repeated_auth_errors() {
+        for streaming in [true, false] {
+            let error = r#"{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"Unauthorized","code":401}"#.to_string();
+            let listed = r#"{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"10"},"items":[]}"#.to_string();
+            let bookmark = "{\"type\":\"BOOKMARK\",\"object\":{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"resourceVersion\":\"10\",\"annotations\":{\"k8s.io/initial-events-end\":\"true\"}}}}\n".to_string();
+            let (url, requests) = mock_watch_server(vec![
+                ("401 Unauthorized", error.clone()),
+                ("401 Unauthorized", error.clone()),
+                ("401 Unauthorized", error),
+                ("200 OK", if streaming { bookmark } else { listed }),
+            ])
+            .await;
+            let cluster = watch_cluster(&url);
+            if !streaming {
+                cluster
+                    .streaming_lists
+                    .store(STREAMING_UNSUPPORTED, Ordering::Release);
+            }
+            let kind = cluster.resolve("pods").unwrap();
+            let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+            let task = cluster.spawn_watch(&kind, "default", None, None, 1, tx);
+            let mut failures = Vec::new();
+            loop {
+                match tokio::time::timeout(Duration::from_secs(10), rx.recv())
+                    .await
+                    .unwrap()
+                    .unwrap()
+                {
+                    Msg::Error { .. } => failures.push(Instant::now()),
+                    Msg::Synced { .. } => break,
+                    _ => {}
+                }
+            }
+            task.abort();
+            assert_eq!(failures.len(), 3);
+            assert!(failures[1].duration_since(failures[0]) >= Duration::from_millis(800));
+            assert!(failures[2].duration_since(failures[1]) >= Duration::from_millis(1600));
+            assert!(failures[2].elapsed() >= Duration::from_millis(3200));
+            assert!(requests.lock().unwrap().len() >= 4);
+        }
+    }
+
+    #[tokio::test]
     async fn streaming_watch_initializes_from_initial_events() {
         let body = concat!(
             "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"name\":\"a\",\"namespace\":\"default\",\"resourceVersion\":\"10\"}}}\n",
@@ -1778,7 +1860,7 @@ clusters:
         // backoff) turns the mock's deliberate 503 into a ~4-minute stall;
         // retrying is not what these tests exercise.
         config.default_retry = false;
-        Cluster::from_config(config, "test".into(), None, false).await
+        Cluster::from_config(config, "test".into(), None, false, false).await
     }
 
     #[tokio::test]

--- a/src/legacy_tls.rs
+++ b/src/legacy_tls.rs
@@ -17,7 +17,7 @@ use hyper_util::{
 };
 use kube::{
     Config,
-    client::{Body, ClientBuilder, ConfigExt, DynBody, retry::RetryPolicy},
+    client::{Body, ClientBuilder, ConfigExt, DynBody, middleware::AuthLayer, retry::RetryPolicy},
 };
 use rustls::{
     ClientConfig,
@@ -31,21 +31,44 @@ use x509_parser::prelude::*;
 
 type Builder = ClientBuilder<BoxService<Request<Body>, Response<Box<DynBody>>, BoxError>>;
 
-pub(crate) fn client_builder(config: Config, allow_v1: bool) -> Result<Builder> {
-    let tls = if let Some(roots) = crate::server_tls::configured_roots(&config) {
-        let mut tls = match config.rustls_client_config() {
-            Ok(tls) => tls,
-            Err(error) => v1_config(&config, allow_v1, error)?,
+pub(crate) fn client_builder(
+    config: Config,
+    allow_v1: bool,
+    no_tls_resumption: bool,
+) -> Result<Builder> {
+    let roots = crate::server_tls::configured_roots(&config);
+    if roots.is_none() && !no_tls_resumption {
+        return match ClientBuilder::try_from(config.clone()) {
+            Ok(builder) => Ok(builder),
+            Err(error) => {
+                let tls = v1_config(&config, allow_v1, error)?;
+                let auth = config.auth_layer()?;
+                connect(config, tls, auth)
+            }
         };
-        crate::server_tls::install(&mut tls, roots)?;
-        tls
-    } else {
-        match ClientBuilder::try_from(config.clone()) {
-            Ok(builder) => return Ok(builder),
-            Err(error) => v1_config(&config, allow_v1, error)?,
-        }
+    }
+    // Resolve auth before the TLS identity, as kube-rs does.
+    let auth = config.auth_layer()?;
+    let mut tls = match config.rustls_client_config() {
+        Ok(tls) => tls,
+        Err(error) => v1_config(&config, allow_v1, error)?,
     };
-    connect(config, tls)
+    if let Some(roots) = roots {
+        crate::server_tls::install(&mut tls, roots)?;
+    }
+    if no_tls_resumption {
+        tls.resumption = rustls::client::Resumption::disabled();
+    }
+    // Kube-rs exposes exec expiry only through its standard client builder.
+    // Retain that metadata when the opt-in path needs a custom transport.
+    let expiration = if config.auth_info.exec.is_some() {
+        *ClientBuilder::try_from(config.clone())?
+            .build()
+            .valid_until()
+    } else {
+        None
+    };
+    Ok(connect(config, tls, auth)?.with_valid_until(expiration))
 }
 
 fn v1_config(config: &Config, allow_v1: bool, original_error: kube::Error) -> Result<ClientConfig> {
@@ -77,17 +100,17 @@ fn v1_config(config: &Config, allow_v1: bool, original_error: kube::Error) -> Re
     legacy_config(config, chain)
 }
 
-fn connect(config: Config, tls: ClientConfig) -> Result<Builder> {
+fn connect(config: Config, tls: ClientConfig, auth: Option<AuthLayer>) -> Result<Builder> {
     let mut connector = HttpConnector::new();
     connector.enforce_http(false);
     match config.proxy_url.as_ref() {
-        None => transport(connector, config, tls),
+        None => transport(connector, config, tls, auth),
         Some(proxy) if proxy.scheme_str() == Some("socks5") => {
-            transport(SocksV5::new(proxy.clone(), connector), config, tls)
+            transport(SocksV5::new(proxy.clone(), connector), config, tls, auth)
         }
         Some(proxy) if proxy.scheme_str() == Some("http") => {
             let connector = proxy_auth(proxy, Tunnel::new(proxy.clone(), connector))?;
-            transport(connector, config, tls)
+            transport(connector, config, tls, auth)
         }
         Some(proxy) if proxy.scheme_str() == Some("https") => {
             // Use the configured trust settings for the proxy, without sending
@@ -96,7 +119,7 @@ fn connect(config: Config, tls: ClientConfig) -> Result<Builder> {
             proxy_config.tls_server_name = None;
             let connector = proxy_config.rustls_https_connector_with_connector(connector)?;
             let connector = proxy_auth(proxy, Tunnel::new(proxy.clone(), connector))?;
-            transport(connector, config, tls)
+            transport(connector, config, tls, auth)
         }
         Some(proxy) => bail!("unsupported proxy protocol: {:?}", proxy.scheme_str()),
     }
@@ -211,7 +234,12 @@ fn https<H>(connector: H, config: &Config, tls: ClientConfig) -> Result<HttpsCon
     Ok(builder.enable_http1().wrap_connector(connector))
 }
 
-fn transport<H>(connector: H, config: Config, tls: ClientConfig) -> Result<Builder>
+fn transport<H>(
+    connector: H,
+    config: Config,
+    tls: ClientConfig,
+    auth: Option<AuthLayer>,
+) -> Result<Builder>
 where
     H: 'static + Clone + Send + Sync + Service<Uri>,
     H::Response: 'static + Connection + Read + Write + Send + Unpin,
@@ -237,7 +265,7 @@ where
                 .default_retry
                 .then_some(RetryLayer::new(RetryPolicy::server_retry())),
         )
-        .option_layer(config.auth_layer()?)
+        .option_layer(auth)
         .layer(config.extra_headers_layer()?)
         .layer(TraceLayer::new_for_http())
         .map_err(BoxError::from)
@@ -291,11 +319,14 @@ mod tests {
         for insecure in [false, true] {
             let mut config = config();
             config.accept_invalid_certs = insecure;
-            let error = client_builder(config, false).err().unwrap().to_string();
+            let error = client_builder(config, false, false)
+                .err()
+                .unwrap()
+                .to_string();
             assert!(error.contains("client certificate is X.509 v1"), "{error}");
             assert!(error.contains("--allow-v1-client-cert"), "{error}");
         }
-        assert!(client_builder(config(), true).is_ok());
+        assert!(client_builder(config(), true, false).is_ok());
     }
 
     #[tokio::test]
@@ -303,11 +334,14 @@ mod tests {
         for key in [SERVER_KEY, b"invalid key"] {
             let mut config = config();
             config.auth_info.client_key_data = Some(STANDARD.encode(key).into());
-            assert!(client_builder(config, true).is_err());
+            assert!(client_builder(config, true, false).is_err());
         }
         let mut config = config();
         config.auth_info.client_key_data = Some(STANDARD.encode(SERVER_KEY).into());
-        let error = client_builder(config, true).err().unwrap().to_string();
+        let error = client_builder(config, true, false)
+            .err()
+            .unwrap()
+            .to_string();
         assert!(error.contains("does not match its private key"), "{error}");
     }
 
@@ -316,9 +350,9 @@ mod tests {
         for allow in [false, true] {
             let mut config = config();
             config.auth_info.client_certificate_data = Some(STANDARD.encode(CLIENT_V3));
-            assert!(client_builder(config.clone(), allow).is_ok());
+            assert!(client_builder(config.clone(), allow, false).is_ok());
             config.auth_info.client_key_data = Some(STANDARD.encode(SERVER_KEY).into());
-            assert!(client_builder(config, allow).is_err());
+            assert!(client_builder(config, allow, false).is_err());
         }
     }
 
@@ -330,9 +364,9 @@ mod tests {
                 config.accept_invalid_certs = insecure;
                 config.auth_info.client_certificate_data = Some(STANDARD.encode(CLIENT_P521));
                 config.auth_info.client_key_data = Some(STANDARD.encode(CLIENT_P521_KEY).into());
-                assert!(client_builder(config.clone(), allow_v1).is_ok());
+                assert!(client_builder(config.clone(), allow_v1, false).is_ok());
                 config.auth_info.client_key_data = Some(STANDARD.encode(KEY).into());
-                assert!(client_builder(config, allow_v1).is_err());
+                assert!(client_builder(config, allow_v1, false).is_err());
             }
         }
     }
@@ -349,7 +383,7 @@ mod tests {
         for cert in [pem.as_bytes(), b"invalid certificate"] {
             let mut config = config();
             config.auth_info.client_certificate_data = Some(STANDARD.encode(cert));
-            assert!(client_builder(config, true).is_err());
+            assert!(client_builder(config, true, false).is_err());
         }
     }
 
@@ -361,13 +395,13 @@ mod tests {
         let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/tls/");
         config.auth_info.client_certificate = Some(format!("{dir}client-v1.pem"));
         config.auth_info.client_key = Some(format!("{dir}client.key"));
-        assert!(client_builder(config.clone(), true).is_ok());
-        assert!(client_builder(config.clone(), false).is_err());
+        assert!(client_builder(config.clone(), true, false).is_ok());
+        assert!(client_builder(config.clone(), false, false).is_err());
         config.auth_info.client_certificate = Some("/missing/certificate".into());
         config.auth_info.client_key = Some("/missing/key".into());
         config.auth_info.client_certificate_data = Some(STANDARD.encode(CLIENT));
         config.auth_info.client_key_data = Some(STANDARD.encode(KEY).into());
-        assert!(client_builder(config, true).is_ok());
+        assert!(client_builder(config, true, false).is_ok());
     }
 
     // The test server trusts only the exact test certificates. It checks the
@@ -464,6 +498,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabling_resumption_keeps_client_auth_on_new_connections() {
+        for version in [&rustls::version::TLS12, &rustls::version::TLS13] {
+            for (server_pem, ca, client_pem) in [
+                (SERVER, CA, CLIENT_V3),
+                (SERVER, CA, CLIENT),
+                (PROXY, PROXY, CLIENT_V3),
+            ] {
+                for disabled in [false, true] {
+                    let tls = ServerConfig::builder_with_protocol_versions(&[version])
+                        .with_client_cert_verifier(Arc::new(PinnedClient))
+                        .with_single_cert(
+                            vec![CertificateDer::from_pem_slice(server_pem).unwrap()],
+                            PrivateKeyDer::from_pem_slice(SERVER_KEY).unwrap(),
+                        )
+                        .unwrap();
+                    let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(tls));
+                    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                    let mut config = config();
+                    config.cluster_url = format!("https://{}", listener.local_addr().unwrap())
+                        .parse()
+                        .unwrap();
+                    config.root_cert =
+                        Some(vec![CertificateDer::from_pem_slice(ca).unwrap().to_vec()]);
+                    config.auth_info.client_certificate_data = Some(STANDARD.encode(client_pem));
+                    let task = tokio::spawn(async move {
+                        let mut resumed = Vec::new();
+                        for _ in 0..3 {
+                            let (socket, _) = listener.accept().await.unwrap();
+                            let mut stream = acceptor.accept(socket).await.unwrap();
+                            let reused = stream.get_ref().1.handshake_kind()
+                                == Some(rustls::HandshakeKind::Resumed);
+                            resumed.push(reused);
+                            let mut request = Vec::new();
+                            while !request.ends_with(b"\r\n\r\n") {
+                                request.push(stream.read_u8().await.unwrap());
+                                assert!(request.len() < 16384);
+                            }
+                            // Model an endpoint that loses the client identity on resumption.
+                            let (status, body) = if reused {
+                                (
+                                    "401 Unauthorized",
+                                    r#"{"kind":"Status","status":"Failure","reason":"Unauthorized","code":401}"#,
+                                )
+                            } else {
+                                ("200 OK", "{}")
+                            };
+                            stream.write_all(format!("HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes()).await.unwrap();
+                            stream.shutdown().await.unwrap();
+                        }
+                        resumed
+                    });
+                    let client =
+                        crate::k8s::build_client(config, client_pem == CLIENT, disabled).unwrap();
+                    for attempt in 0..3 {
+                        let request = Request::get("/version").body(Vec::new()).unwrap();
+                        let result = tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            client.request::<serde_json::Value>(request),
+                        )
+                        .await
+                        .unwrap();
+                        if disabled || attempt == 0 {
+                            assert!(result.is_ok(), "{result:?}");
+                        } else {
+                            assert!(
+                                matches!(result, Err(kube::Error::Api(status)) if status.code == 401)
+                            );
+                        }
+                    }
+                    assert_eq!(task.await.unwrap(), vec![false, !disabled, !disabled]);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn v1_and_v3_authenticate_with_tls12_and_tls13() {
         for version in [&rustls::version::TLS12, &rustls::version::TLS13] {
             for pem in [CLIENT, CLIENT_V3] {
@@ -472,7 +582,7 @@ mod tests {
                 config.cluster_url = url;
                 config.auth_info.client_certificate_data = Some(STANDARD.encode(pem));
                 config.auth_info.impersonate = Some("test-user".into());
-                let client = crate::k8s::build_client(config, true).unwrap();
+                let client = crate::k8s::build_client(config, true, false).unwrap();
                 assert_eq!(client.default_namespace(), "test-ns");
                 let info = tokio::time::timeout(
                     std::time::Duration::from_secs(5),
@@ -497,7 +607,7 @@ mod tests {
             config.cluster_url = url;
             config.auth_info.client_certificate_data = Some(STANDARD.encode(CLIENT_P521));
             config.auth_info.client_key_data = Some(STANDARD.encode(CLIENT_P521_KEY).into());
-            let client = crate::k8s::build_client(config, false).unwrap();
+            let client = crate::k8s::build_client(config, false, false).unwrap();
             let info = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 client.apiserver_version(),
@@ -523,7 +633,7 @@ mod tests {
                 ]);
                 config.auth_info.client_certificate_data = Some(STANDARD.encode(pem));
                 config.auth_info.client_key_data = Some(STANDARD.encode(key).into());
-                let client = crate::k8s::build_client(config, pem == CLIENT).unwrap();
+                let client = crate::k8s::build_client(config, pem == CLIENT, false).unwrap();
                 let info = tokio::time::timeout(
                     std::time::Duration::from_secs(5),
                     client.apiserver_version(),
@@ -565,7 +675,7 @@ mod tests {
             let config = Config::from_custom_kubeconfig(kubeconfig, &Default::default())
                 .await
                 .unwrap();
-            let client = crate::k8s::build_client(config, false).unwrap();
+            let client = crate::k8s::build_client(config, false, false).unwrap();
             tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 client.apiserver_version(),
@@ -580,36 +690,37 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn exec_credentials_keep_standard_resolution_and_expiration() {
-        let (url, task) = server(SERVER, &rustls::version::TLS13).await;
-        let directory = std::env::temp_dir().join(format!(
-            "sofka-exec-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
+        for disabled in [false, true] {
+            let (url, task) = server(SERVER, &rustls::version::TLS13).await;
+            let directory = std::env::temp_dir().join(format!(
+                "sofka-exec-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir(&directory).unwrap();
+            let counter = directory.join("count");
+            let credential = |expiration| {
+                serde_json::json!({
+                    "apiVersion": "client.authentication.k8s.io/v1", "kind": "ExecCredential",
+                    "status": {
+                        "expirationTimestamp": expiration,
+                        "clientCertificateData": std::str::from_utf8(CLIENT_V3).unwrap(),
+                        "clientKeyData": std::str::from_utf8(KEY).unwrap()
+                    }
+                })
+                .to_string()
+            };
+            let mut config = without_identity(&config());
+            config.cluster_url = url;
+            config
+                .root_cert
+                .as_mut()
                 .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir(&directory).unwrap();
-        let counter = directory.join("count");
-        let credential = |expiration| {
-            serde_json::json!({
-                "apiVersion": "client.authentication.k8s.io/v1", "kind": "ExecCredential",
-                "status": {
-                    "expirationTimestamp": expiration,
-                    "clientCertificateData": std::str::from_utf8(CLIENT_V3).unwrap(),
-                    "clientKeyData": std::str::from_utf8(KEY).unwrap()
-                }
-            })
-            .to_string()
-        };
-        let mut config = without_identity(&config());
-        config.cluster_url = url;
-        config
-            .root_cert
-            .as_mut()
-            .unwrap()
-            .push(CertificateDer::from_pem_slice(PROXY).unwrap().to_vec());
-        config.auth_info.exec = Some(
+                .push(CertificateDer::from_pem_slice(PROXY).unwrap().to_vec());
+            config.auth_info.exec = Some(
             serde_json::from_value(serde_json::json!({
                 "apiVersion": "client.authentication.k8s.io/v1", "command": "sh",
                 "args": ["-c", r#"
@@ -620,7 +731,7 @@ count=$((count + 1))
 printf '%s\n' "$count" > "$1"
 case "$count" in
     1|2) printf '%s' "$SOFKA_TEST_EXEC_FIRST" ;;
-    3) printf '%s' "$SOFKA_TEST_EXEC_LAST" ;;
+    3|4|5) printf '%s' "$SOFKA_TEST_EXEC_LAST" ;;
     *) exit 1 ;;
 esac
 "#, "sofka-exec-test", counter.to_str().unwrap()],
@@ -632,25 +743,26 @@ esac
             }))
             .unwrap(),
         );
-        let result = crate::k8s::build_client(config, false);
-        let count = std::fs::read_to_string(&counter).unwrap();
-        std::fs::remove_dir_all(&directory).unwrap();
-        let client = result.unwrap();
-        // The kube builder resolves auth, TLS identity, and expiration. The
-        // configured CA must not add another credential-plugin invocation.
-        assert_eq!(count.trim(), "3");
-        assert_eq!(
-            client.valid_until().unwrap().to_string(),
-            "2098-01-01T00:00:00Z"
-        );
-        tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            client.apiserver_version(),
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        task.await.unwrap().unwrap();
+            let result = crate::k8s::build_client(config, false, disabled);
+            let count = std::fs::read_to_string(&counter).unwrap();
+            std::fs::remove_dir_all(&directory).unwrap();
+            let client = result.unwrap();
+            // The default path resolves auth, TLS identity, and expiry once.
+            // The opt-in path also needs the standard builder for expiry.
+            assert_eq!(count.trim(), if disabled { "5" } else { "3" });
+            assert_eq!(
+                client.valid_until().unwrap().to_string(),
+                "2098-01-01T00:00:00Z"
+            );
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                client.apiserver_version(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            task.await.unwrap().unwrap();
+        }
     }
 
     #[tokio::test]
@@ -682,7 +794,7 @@ esac
                     .accept(stream)
                     .await
             });
-            let client = crate::k8s::build_client(config, false).unwrap();
+            let client = crate::k8s::build_client(config, false, false).unwrap();
             let error = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 client.apiserver_version(),
@@ -697,32 +809,34 @@ esac
 
     #[tokio::test]
     async fn consent_preserves_server_trust_hostname_and_expiry_checks() {
-        for failure in ["trust", "hostname", "expiry"] {
-            let pem = if failure == "expiry" { EXPIRED } else { SERVER };
-            let (url, task) = server(pem, &rustls::version::TLS13).await;
-            let mut config = config();
-            config.cluster_url = url;
-            match failure {
-                "trust" => config.root_cert = Some(vec![]),
-                "hostname" => config.tls_server_name = Some("wrong.example".into()),
-                _ => {}
+        for disabled in [false, true] {
+            for failure in ["trust", "hostname", "expiry"] {
+                let pem = if failure == "expiry" { EXPIRED } else { SERVER };
+                let (url, task) = server(pem, &rustls::version::TLS13).await;
+                let mut config = config();
+                config.cluster_url = url;
+                match failure {
+                    "trust" => config.root_cert = Some(vec![]),
+                    "hostname" => config.tls_server_name = Some("wrong.example".into()),
+                    _ => {}
+                }
+                let client = crate::k8s::build_client(config, true, disabled).unwrap();
+                let error = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    client.apiserver_version(),
+                )
+                .await
+                .unwrap()
+                .unwrap_err();
+                let error = format!("{:#}", anyhow::Error::new(error));
+                let expected = match failure {
+                    "trust" => "UnknownIssuer",
+                    "hostname" => "not valid for name",
+                    _ => "expired",
+                };
+                assert!(error.contains(expected), "{failure}: {error}");
+                assert!(task.await.unwrap().is_err());
             }
-            let client = crate::k8s::build_client(config, true).unwrap();
-            let error = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                client.apiserver_version(),
-            )
-            .await
-            .unwrap()
-            .unwrap_err();
-            let error = format!("{:#}", anyhow::Error::new(error));
-            let expected = match failure {
-                "trust" => "UnknownIssuer",
-                "hostname" => "not valid for name",
-                _ => "expired",
-            };
-            assert!(error.contains(expected), "{failure}: {error}");
-            assert!(task.await.unwrap().is_err());
         }
     }
     #[tokio::test]
@@ -785,7 +899,7 @@ esac
                 config.root_cert = Some(vec![CertificateDer::from_pem_slice(ca).unwrap().to_vec()]);
                 config.auth_info.client_certificate_data = Some(STANDARD.encode(client_pem));
                 config.auth_info.client_key_data = Some(STANDARD.encode(client_key).into());
-                let client = crate::k8s::build_client(config, true).unwrap();
+                let client = crate::k8s::build_client(config, true, false).unwrap();
                 let version = tokio::time::timeout(
                     std::time::Duration::from_secs(5),
                     client.apiserver_version(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,10 @@ struct Args {
     #[arg(long)]
     allow_v1_client_cert: bool,
 
+    /// Disable TLS session resumption for this run, including context changes.
+    #[arg(long)]
+    no_tls_resumption: bool,
+
     /// Disable every action that could modify the cluster (delete, edit,
     /// scale, shell, plugins, …). Overrides the config `readonly` option,
     /// including per-cluster/per-context overrides, for the whole session.
@@ -146,7 +150,9 @@ async fn run_main(args: Args) -> Result<()> {
     // never load config, connect, or touch the terminal.
     if let Some(name) = &args.plugin_adapter {
         return match name.as_str() {
-            "sanitize" => sofka::sanitize::run(args.allow_v1_client_cert).await,
+            "sanitize" => {
+                sofka::sanitize::run(args.allow_v1_client_cert, args.no_tls_resumption).await
+            }
             other => Err(anyhow::anyhow!("unknown core plugin adapter '{other}'")),
         };
     }
@@ -189,8 +195,10 @@ async fn run_main(args: Args) -> Result<()> {
     // with the error, since there is no picker to fall back to.
     eprintln!("Connecting to cluster…");
     let connect = match args.context.as_deref() {
-        Some(name) => Cluster::connect_context(name, args.allow_v1_client_cert).await,
-        None => Cluster::connect(args.allow_v1_client_cert).await,
+        Some(name) => {
+            Cluster::connect_context(name, args.allow_v1_client_cert, args.no_tls_resumption).await
+        }
+        None => Cluster::connect(args.allow_v1_client_cert, args.no_tls_resumption).await,
     };
     let (mut cluster, connect_error) = match connect {
         Ok(c) => (c, None),
@@ -208,6 +216,7 @@ async fn run_main(args: Args) -> Result<()> {
         }
     };
     cluster.allow_v1_client_cert = args.allow_v1_client_cert;
+    cluster.no_tls_resumption = args.no_tls_resumption;
     for w in cluster
         .discovery_fallback
         .iter()
@@ -703,8 +712,11 @@ async fn run_info(
     } else {
         eprintln!("Connecting to cluster…");
         match args.context.as_deref() {
-            Some(name) => Cluster::connect_context(name, args.allow_v1_client_cert).await,
-            None => Cluster::connect(args.allow_v1_client_cert).await,
+            Some(name) => {
+                Cluster::connect_context(name, args.allow_v1_client_cert, args.no_tls_resumption)
+                    .await
+            }
+            None => Cluster::connect(args.allow_v1_client_cert, args.no_tls_resumption).await,
         }
         .inspect_err(|e| {
             eprintln!(
@@ -1077,6 +1089,24 @@ async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tls_resumption_is_disabled_only_when_requested() {
+        assert!(!Args::try_parse_from(["sofka"]).unwrap().no_tls_resumption);
+        for mode in ["--check", "--snapshot", "pods"] {
+            let args = Args::try_parse_from(["sofka", mode, "--no-tls-resumption"]).unwrap();
+            assert!(args.no_tls_resumption);
+            assert!(!args.allow_v1_client_cert);
+        }
+        let args = Args::try_parse_from([
+            "sofka",
+            "--no-tls-resumption",
+            "--plugin-adapter",
+            "sanitize",
+        ])
+        .unwrap();
+        assert!(args.no_tls_resumption);
+    }
 
     #[test]
     fn v1_client_cert_requires_an_explicit_cli_flag() {

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -114,7 +114,7 @@ struct Target {
 
 /// Read the request, sanitize, and write the report. Errors here are execution
 /// errors: the runner shows them and no report is produced.
-pub async fn run(allow_v1_client_cert: bool) -> Result<()> {
+pub async fn run(allow_v1_client_cert: bool, no_tls_resumption: bool) -> Result<()> {
     let request: Value = serde_json::from_reader(std::io::stdin().lock())
         .context("reading the plugin request from stdin")?;
     if request.get("schema_version").and_then(Value::as_u64) != Some(1) {
@@ -123,6 +123,7 @@ pub async fn run(allow_v1_client_cert: bool) -> Result<()> {
     let client = client_for(
         request.get("context").and_then(Value::as_str),
         allow_v1_client_cert,
+        no_tls_resumption,
     )
     .await?;
     let report = sanitize(client, &request, &guardrails_for(&request)).await?;
@@ -396,7 +397,11 @@ fn selectors(filter: Option<&str>) -> Result<(Option<String>, Option<String>)> {
 
 /// Build a client for the request's context. A null context means sofka had no
 /// explicit kubeconfig context name, so let the usual inference apply.
-async fn client_for(context: Option<&str>, allow_v1_client_cert: bool) -> Result<Client> {
+async fn client_for(
+    context: Option<&str>,
+    allow_v1_client_cert: bool,
+    no_tls_resumption: bool,
+) -> Result<Client> {
     let config = match context {
         Some(name) => {
             let options = kube::config::KubeConfigOptions {
@@ -411,7 +416,8 @@ async fn client_for(context: Option<&str>, allow_v1_client_cert: bool) -> Result
         }
         None => Config::infer().await.context("loading kubeconfig")?,
     };
-    crate::k8s::build_client(config, allow_v1_client_cert).context("building a Kubernetes client")
+    crate::k8s::build_client(config, allow_v1_client_cert, no_tls_resumption)
+        .context("building a Kubernetes client")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Some AKS endpoints return HTTP 401 when TLS session resumption loses the client certificate identity. Add `--no-tls-resumption` for affected runs. The default remains unchanged, and certificate and hostname checks stay enabled. The option applies across startup, context changes, fleet queries, and the bundled sanitizer.

Add increasing watch retry delays to limit repeated requests after errors. Reset the delay after successful progress, including a completed initial sync, so failed list requests cannot keep the delay at its minimum.

The custom exec credential path retains expiry metadata through the standard kube-rs builder. With the option enabled, this requires additional credential plugin calls during client construction.

Validation: `just check` passed. Tests cover TLS 1.2 and TLS 1.3 resumption, certificate verification, exec credential expiry, CLI and plugin option handling, and retry delays for streaming and list-based watches. Not tested against an affected AKS cluster.

Closes #479
