### PR TITLE
feat: add a complete Home Manager module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 name: CI
 
-# PRs only — pushes to main run no CI. The Nix packaging is exercised (and
-# Cachix warmed, for all four platforms) by the release workflow's nix-cache
-# job, so packaging breakage surfaces at tag time instead of on every merge.
+# PRs only. Pushes to main run no CI. Home Manager tests run here.
+# The release workflow builds Nix packages for all four platforms and updates
+# the Cachix cache. Package build failures can still first appear at release.
 on:
   pull_request:
 
@@ -10,6 +10,23 @@ permissions:
   contents: read
 
 jobs:
+  home-manager:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Nix
+        uses: $/.github/actions/setup-nix
+
+      - name: Check flake outputs on all supported systems
+        run: nix flake check --no-build --all-systems
+
+      - name: Test Home Manager module
+        run: nix build .#checks.x86_64-linux.home-manager --no-link --print-build-logs
+
   rust:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ cargo install sofka                     # Cargo
 Or build from source: `cargo build --release` (see
 [Development](docs/architecture.md#development)).
 
+Use the [Home Manager module](docs/home-manager.md) to install Sofka and manage
+its configuration with Nix.
+
 ### macOS: "cannot be opened because the developer cannot be verified"
 
 The release binaries aren't signed or notarized yet, so Gatekeeper refuses a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,9 @@ See [palette migration](keybindings.md#legacy-palette-migration).
 
 Everything below is optional. An empty config behaves exactly like no config.
 
+The [Home Manager module](home-manager.md) can manage the full configuration,
+dedicated section options, and cluster and context override files.
+
 ## Base options
 
 ```toml

--- a/docs/home-manager.md
+++ b/docs/home-manager.md
@@ -1,0 +1,162 @@
+# Home Manager
+
+The Sofka flake exports `homeManagerModules.sofka` and
+`homeManagerModules.default`. Both names select the same module. No overlay is
+required. The module supports Linux and macOS.
+
+Add Sofka to your flake inputs:
+
+```nix
+inputs.sofka.url = "github:nklmilojevic/sofka";
+```
+
+Add the module to your Home Manager configuration. Here, `inputs` is the input
+set from your flake outputs function. You can pass it to Home Manager through
+`extraSpecialArgs = { inherit inputs; };`.
+
+```nix
+{ inputs, ... }:
+{
+  imports = [ inputs.sofka.homeManagerModules.default ];
+
+  programs.sofka = {
+    enable = true;
+    settings = {
+      default_namespace = "default";
+      default_resource = "deployments";
+      readonly = true;
+      favorite_namespaces = [ "kube-system" "monitoring" ];
+    };
+    aliases.dep = "deployments";
+    keys.table.sort_age = "A";
+    keys.logs.log_marker = "m";
+    skin = {
+      name = "gruvbox-dark";
+      colors.red = "#fb4934";
+    };
+    views."*".sort = "AGE:desc";
+    plugins = [
+      {
+        name = "Get pods";
+        palette = "get-pods";
+        command = "kubectl";
+        args = [ "get" "pods" "--context" "$CONTEXT" "-n" "$NAMESPACE" ];
+        target = "context";
+        mutating = false;
+        output = "popup";
+      }
+    ];
+  };
+}
+```
+
+## Options
+
+All options are under `programs.sofka`.
+
+| Option       | Default                      | Purpose                                                  |
+| ------------ | ---------------------------- | -------------------------------------------------------- |
+| `enable`     | `false`                      | Install Sofka and manage the selected files.             |
+| `package`    | Package from the Sofka flake | Select a package, or use `null` to skip installation.    |
+| `settings`   | `{ }`                        | Set any field in the complete Sofka TOML configuration.  |
+| `aliases`    | `{ }`                        | Merge into `settings.aliases`.                           |
+| `keys`       | `{ }`                        | Merge into `settings.keys`.                              |
+| `plugins`    | `[ ]`                        | Merge into `settings.plugins`.                           |
+| `views`      | `{ }`                        | Merge into `settings.views`.                             |
+| `skin`       | `{ }`                        | Merge into `settings.skin`.                              |
+| `configFile` | `null`                       | Use an existing TOML file instead of generated settings. |
+| `clusters`   | `{ }`                        | Manage cluster and context override files.               |
+
+`settings` accepts the full [configuration](configuration.md), including
+providers, logging, guardrails, bookmarks, and new settings added to Sofka.
+The module checks TOML value types. Sofka checks application settings when it
+loads the file.
+
+Dedicated options and `settings` use normal Nix module merging: tables merge by
+key, lists combine in module order, and conflicting scalar values produce an
+error. Use `lib.mkBefore` or `lib.mkAfter` on lists in `settings` to control
+their order. Use `lib.mkForce` on a field in `settings` to replace other
+definitions, including values from dedicated options.
+
+```nix
+{ lib, ... }:
+{
+  programs.sofka.settings.skin.name = lib.mkForce "nord";
+}
+```
+
+Sofka keeps aliases, keys, plugins, views, and skin settings in one TOML file.
+The module uses the native names `keys` and `skin`; it does not generate k9s
+hotkey or skin files.
+
+## Existing files and package selection
+
+To manage an existing complete TOML file:
+
+```nix
+programs.sofka = {
+  enable = true;
+  configFile = ./sofka.toml;
+};
+```
+
+`configFile` cannot be combined with nonempty `settings` or dedicated options
+for the same file. It can be combined with cluster and context overrides.
+
+To manage configuration without installing a package, set
+`programs.sofka.package = null;`. To select another package, set
+`programs.sofka.package = pkgs.sofka;` if your package set provides it.
+
+With only `enable = true`, the module installs Sofka and leaves the main config
+file unmanaged. When the module is disabled, it installs no package and manages
+no files.
+
+## Cluster and context overrides
+
+Each cluster and context accepts `settings` or `configFile`. Clusters also
+accept `contexts`:
+
+```nix
+programs.sofka.clusters = {
+  prod-cluster = {
+    settings.readonly = true;
+    contexts.prod-admin.settings.skin.name = "catppuccin-latte";
+  };
+  staging = {
+    configFile = ./staging.toml;
+    contexts.staging-admin.configFile = ./staging-admin.toml;
+  };
+};
+```
+
+This creates files under `sofka/clusters/<cluster>/config.toml` and
+`sofka/clusters/<cluster>/<context>/config.toml`. Empty settings create no file.
+A context file does not require a cluster file.
+
+Attribute names must be directory names after
+[Sofka's name conversion](configuration.md#per-cluster-and-per-context-overrides).
+Replace each character outside `A-Z`, `a-z`, `0-9`, `.`, `_`, and `-` with `-`.
+For example, `arn:aws:eks:eu-west-1:123:cluster/prod` becomes
+`arn-aws-eks-eu-west-1-123-cluster-prod`. The module rejects unsafe names, empty
+names, and names made only of dots. For an empty kubeconfig name, Sofka's
+conversion produces `-`; for a name made only of dots, replace each dot with
+`-`.
+
+At runtime, Sofka applies the main config, then the cluster override, then the
+context override. This is separate from Nix module merging: Sofka merges tables
+by key and replaces other values, including arrays.
+
+## Apply changes
+
+Apply your Home Manager configuration, then enter `:reload` in Sofka. Settings
+that require a restart retain that requirement.
+
+Home Manager links files under `$XDG_CONFIG_HOME/sofka`, normally
+`~/.config/sofka`, on both Linux and macOS. A custom `xdg.configHome` changes
+this location. Managed files are read-only; edit the Nix settings or source
+TOML file and apply Home Manager again. Sofka keeps session state separate from
+these files.
+
+The module checks are available through
+`nix build .#checks.<system>.home-manager`. The specification is in
+[issue #482](https://github.com/nklmilojevic/sofka/issues/482).

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788642154,
+        "narHash": "sha256-sPpQFVaFTDqO/4vvCAhuAhqTgqN/ygu+9eJcs5eB0js=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "fd0956c99c41ae3c13a73a638f1f7e963aebc4ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-26.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1788807765,
@@ -18,6 +39,7 @@
     },
     "root": {
       "inputs": {
+        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,14 @@
     # after 26.05), this branch still covers all four platforms the release
     # workflow builds for, so a single input suffices.
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    home-manager = {
+      url = "github:nix-community/home-manager/release-26.05";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
-    { self, nixpkgs }:
+    { self, nixpkgs, home-manager }:
     let
       inherit (nixpkgs) lib;
 
@@ -36,6 +40,14 @@
     in
     {
       overlays.default = overlay;
+
+      homeManagerModules = {
+        sofka = { pkgs, lib, ... }: {
+          imports = [ ./nix/home-manager.nix ];
+          programs.sofka.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.sofka;
+        };
+        default = self.homeManagerModules.sofka;
+      };
 
       packages = forAllSystems (pkgs: {
         default = pkgs.sofka;
@@ -89,6 +101,11 @@
         self.packages.${system}
         // lib.mapAttrs' (name: drv: lib.nameValuePair "devshell-${name}" drv) self.devShells.${system}
         // {
+          home-manager = import ./nix/tests/home-manager.nix {
+            inherit pkgs home-manager;
+            module = self.homeManagerModules.default;
+            package = self.packages.${system}.sofka;
+          };
           fmt =
             pkgs.runCommand "sofka-fmt-check"
               {

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,0 +1,103 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.sofka;
+  toml = pkgs.formats.toml { };
+
+  fileOptions = {
+    settings = lib.mkOption {
+      type = toml.type;
+      default = { };
+      description = "Sofka settings to write as TOML. Tables merge by key and lists combine in module order.";
+    };
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Existing TOML file to use instead of generated settings at this level.";
+    };
+  };
+
+  directoryType = lib.types.addCheck lib.types.str
+    (name: builtins.match "[A-Za-z0-9._-]+" name != null && builtins.match "[.]+" name == null);
+
+  namedFiles = options: lib.types.attrsOf (lib.types.submodule ({ name, ... }: {
+    options = options // {
+      directory = lib.mkOption {
+        type = directoryType;
+        default = name;
+        readOnly = true;
+        internal = true;
+        description = "Directory name after Sofka's kubeconfig name conversion.";
+      };
+    };
+  }));
+
+  files = [{ path = "sofka/config.toml"; value = cfg; }]
+    ++ lib.concatLists (lib.mapAttrsToList
+    (_: cluster:
+      [{ path = "sofka/clusters/${cluster.directory}/config.toml"; value = cluster; }]
+        ++ lib.mapAttrsToList
+        (_: context: {
+          path = "sofka/clusters/${cluster.directory}/${context.directory}/config.toml";
+          value = context;
+        })
+        cluster.contexts)
+    cfg.clusters);
+
+  sectionOption = section: type: default: lib.mkOption {
+    inherit type default;
+    description = "Settings to merge into programs.sofka.settings.${section}.";
+  };
+in
+{
+  options.programs.sofka = fileOptions // {
+    enable = lib.mkEnableOption "Sofka";
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = pkgs.callPackage ../package.nix { };
+      defaultText = lib.literalExpression "the Sofka package from this flake";
+      description = "Sofka package to install. Set null to manage configuration only.";
+    };
+    aliases = sectionOption "aliases" toml.type { };
+    keys = sectionOption "keys" toml.type { };
+    plugins = sectionOption "plugins" (lib.types.listOf toml.type) [ ];
+    views = sectionOption "views" toml.type { };
+    skin = sectionOption "skin" toml.type { };
+    clusters = lib.mkOption {
+      type = namedFiles (fileOptions // {
+        contexts = lib.mkOption {
+          type = namedFiles fileOptions;
+          default = { };
+          description = "Context overrides, keyed by directory name after Sofka's name conversion.";
+        };
+      });
+      default = { };
+      description = "Cluster overrides, keyed by directory name after Sofka's name conversion.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.sofka.settings = lib.mkMerge (map
+      (section:
+        lib.mkIf (cfg.${section} != (if section == "plugins" then [ ] else { })) {
+          ${section} = cfg.${section};
+        }) [ "aliases" "keys" "plugins" "views" "skin" ]);
+
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+
+    assertions = map
+      (file: {
+        assertion = file.value.configFile == null || file.value.settings == { };
+        message = "programs.sofka: ${file.path} cannot use both configFile and generated settings.";
+      })
+      files;
+
+    xdg.configFile = builtins.listToAttrs (map
+      (file: lib.nameValuePair file.path {
+        source =
+          if file.value.configFile != null then file.value.configFile
+          else toml.generate "sofka-config.toml" file.value.settings;
+      })
+      (builtins.filter (file: file.value.configFile != null || file.value.settings != { }) files));
+  };
+}

--- a/nix/tests/config.toml
+++ b/nix/tests/config.toml
@@ -1,0 +1,5 @@
+readonly = true
+default_namespace = "from-file"
+
+[skin]
+name = "nord"

--- a/nix/tests/home-manager.nix
+++ b/nix/tests/home-manager.nix
@@ -1,0 +1,126 @@
+{ pkgs, home-manager, module, package }:
+
+let
+  inherit (pkgs) lib;
+  evaluate = extra: (home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [
+      module
+      {
+        home.username = "sofka-test";
+        home.homeDirectory = if pkgs.stdenv.hostPlatform.isDarwin then "/Users/sofka-test" else "/home/sofka-test";
+        home.stateVersion = "26.05";
+      }
+      extra
+    ];
+  }).config;
+  enabled = settings: evaluate { programs.sofka = { enable = true; package = null; } // settings; };
+  fails = settings: !(builtins.tryEval (builtins.deepSeq (enabled settings).xdg.configFile true)).success;
+  disabled = evaluate { programs.sofka.settings.readonly = true; };
+  default = evaluate { programs.sofka.enable = true; };
+  empty = enabled { };
+  replacement = pkgs.writeShellScriptBin "sofka" "exit 0";
+  overridden = enabled { package = replacement; };
+  full = evaluate {
+    xdg.configHome = "/custom/sofka-config";
+    programs.sofka = {
+      enable = true;
+      package = null;
+      settings = {
+        readonly = true;
+        favorite_namespaces = [ "kube-system" "monitoring" ];
+        aliases.po = "pods";
+        keys.table.sort_age = "A";
+        providers.metrics.url = "https://metrics.example.test";
+        plugins = lib.mkBefore [{ name = "first"; command = "true"; }];
+      };
+      aliases.dep = "deployments";
+      keys.logs.log_marker = "m";
+      keys.table.favorite_namespace_2 = [ ];
+      plugins = [{ name = "second"; command = "kubectl"; args = [ "get" "pods" ]; }];
+      views."*".sort = "AGE:desc";
+      skin = { name = "gruvbox-dark"; colors.red = "#fb4934"; };
+      clusters.prod = {
+        settings.readonly = true;
+        contexts.admin.settings.skin.name = "catppuccin-latte";
+      };
+      clusters.arn-aws-eks-eu-west-1-123-cluster-prod.contexts.team.settings.default_namespace = "team";
+    };
+  };
+  raw = enabled {
+    configFile = ./config.toml;
+    clusters.prod = {
+      configFile = ./config.toml;
+      contexts.admin.configFile = ./config.toml;
+    };
+  };
+  forced = enabled {
+    settings.skin.name = lib.mkForce "nord";
+    skin.name = "gruvbox-dark";
+  };
+  fixtures = {
+    main = {
+      source = full.xdg.configFile."sofka/config.toml".source;
+      expected = {
+        readonly = true;
+        favorite_namespaces = [ "kube-system" "monitoring" ];
+        aliases = { po = "pods"; dep = "deployments"; };
+        keys = { table = { sort_age = "A"; favorite_namespace_2 = [ ]; }; logs.log_marker = "m"; };
+        providers.metrics.url = "https://metrics.example.test";
+        plugins = [{ name = "first"; command = "true"; } { name = "second"; command = "kubectl"; args = [ "get" "pods" ]; }];
+        views."*".sort = "AGE:desc";
+        skin = { name = "gruvbox-dark"; colors.red = "#fb4934"; };
+      };
+    };
+    cluster = { source = full.xdg.configFile."sofka/clusters/prod/config.toml".source; expected.readonly = true; };
+    context = { source = full.xdg.configFile."sofka/clusters/prod/admin/config.toml".source; expected.skin.name = "catppuccin-latte"; };
+    contextOnly = { source = full.xdg.configFile."sofka/clusters/arn-aws-eks-eu-west-1-123-cluster-prod/team/config.toml".source; expected.default_namespace = "team"; };
+    forced = { source = forced.xdg.configFile."sofka/config.toml".source; expected.skin.name = "nord"; };
+    raw = {
+      source = raw.xdg.configFile."sofka/config.toml".source;
+      expected = { readonly = true; default_namespace = "from-file"; skin.name = "nord"; };
+    };
+  };
+  noSofkaFiles = cfg: builtins.all (name: !(lib.hasPrefix "sofka/" name)) (builtins.attrNames cfg.xdg.configFile);
+in
+assert noSofkaFiles disabled;
+assert !(builtins.elem package disabled.home.packages);
+assert noSofkaFiles default;
+assert builtins.elem package default.home.packages;
+assert noSofkaFiles empty;
+assert !(builtins.elem package empty.home.packages);
+assert builtins.elem replacement overridden.home.packages;
+assert !(builtins.elem package overridden.home.packages);
+assert full.xdg.configFile."sofka/config.toml".target == "/custom/sofka-config/sofka/config.toml";
+assert !(full.xdg.configFile ? "sofka/clusters/arn-aws-eks-eu-west-1-123-cluster-prod/config.toml");
+assert builtins.all (name: raw.xdg.configFile.${name}.source == ./config.toml) [
+  "sofka/config.toml"
+  "sofka/clusters/prod/config.toml"
+  "sofka/clusters/prod/admin/config.toml"
+];
+assert fails { configFile = ./config.toml; settings.readonly = true; };
+assert fails { configFile = ./config.toml; aliases.dep = "deployments"; };
+assert fails { clusters.prod = { configFile = ./config.toml; settings.readonly = true; }; };
+assert fails { clusters.prod.contexts.admin = { configFile = ./config.toml; settings.readonly = true; }; };
+assert fails { settings.skin.name = "nord"; skin.name = "gruvbox-dark"; };
+assert builtins.all (name: fails { clusters.${name}.settings.readonly = true; }) [ "" "." ".." "..." "../prod" "arn:aws:eks" ];
+assert fails { clusters.prod.contexts."../admin".settings.readonly = true; };
+pkgs.runCommand "sofka-home-manager-check"
+{
+  nativeBuildInputs = [ pkgs.python3 ];
+  manifest = pkgs.writeText "sofka-home-manager-fixtures.json" (builtins.toJSON fixtures);
+} ''
+  python - "$manifest" <<'PY'
+  import json
+  import sys
+  import tomllib
+
+  with open(sys.argv[1]) as manifest:
+      fixtures = json.load(manifest)
+  for name, fixture in fixtures.items():
+      with open(fixture["source"], "rb") as source:
+          actual = tomllib.load(source)
+      assert actual == fixture["expected"], (name, actual, fixture["expected"])
+  PY
+  touch "$out"
+''


### PR DESCRIPTION
Sofka users currently install the Nix package and manage config files separately. This adds a Home Manager module that installs Sofka and manages its main, cluster, and context configuration files.

The module exports `homeManagerModules.sofka` and `homeManagerModules.default`. It supports full TOML settings, dedicated aliases/keys/plugins/views/skin options, existing config files, and package overrides or configuration-only use. It reports conflicting settings and rejects unsafe override directory names. Documentation includes import and configuration examples.

Home Manager tests check generated TOML, merging, file paths, package selection, and invalid configurations. A new CI job evaluates all four supported Nix platforms and builds the module tests on Linux.

Validation passed locally:

- `just check`: Rust formatting, Clippy, and 1,343 tests.
- `just nix-check` and `nix flake check --no-build --all-systems`.
- `nix build .#checks.aarch64-darwin.home-manager --no-link --print-build-logs`.
- Nix, Markdown, and YAML formatting; workflow checks with zizmor; commit hooks.

The module tests were built locally on Apple silicon macOS. The Linux build will run in CI. The maintainer approved this scope and requested implementation in the work session recorded in the issue.

Closes #482
