### PR TITLE
chore: publish via trusted publishing and attest release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # gh release upload
+      id-token: write # Sigstore signing for the provenance attestation
+      attestations: write # record the attestation against the repo
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
@@ -129,6 +131,16 @@ jobs:
       - name: Generate checksums
         working-directory: dist
         run: shasum -a 256 -- *.tar.gz > SHA256SUMS
+
+      # Binds every tarball's digest to this workflow, at this commit, in a
+      # Sigstore-signed statement GitHub stores outside the release. Release
+      # assets stay mutable and SHA256SUMS is only as trustworthy as whoever
+      # can rewrite it; `gh attestation verify` is what actually detects a
+      # binary swapped in after the fact.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/*.tar.gz
 
       - name: Upload release assets
         run: gh release upload "$RELEASE_TAG" dist/*.tar.gz dist/SHA256SUMS --clobber
@@ -150,22 +162,39 @@ jobs:
             -R nklmilojevic/homebrew-sofka \
             -f tag="$RELEASE_TAG"
 
+  # Publishes through crates.io Trusted Publishing: the job exchanges a
+  # short-lived OIDC token for a registry token scoped to this crate, so
+  # crates.io verifies the publish came from this repo and this workflow.
+  # No long-lived CARGO_REGISTRY_TOKEN secret exists to leak or misuse.
+  # Requires the Trusted Publisher registered on crates.io (repo
+  # nklmilojevic/sofka, workflow release.yaml, environment release) and a
+  # `release` environment on this repo.
   crates-publish:
     needs: upload-assets
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # OIDC token exchanged for the crates.io token
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish --locked
 
   # Warms the nkl-sofka Cachix cache for the tagged rev, so `nix build


### PR DESCRIPTION
The crates.io publish authenticated with a long-lived registry token, so the registry recorded the publish as coming from a user account with no evidence tying it to this workflow: a publish from anywhere else, or from anyone holding the token, was indistinguishable from a CI publish. Trusted Publishing exchanges a short-lived OIDC token instead, letting crates.io verify the repository and workflow that asked to publish.

Release binaries had no signature or attestation, and SHA256SUMS is an unsigned file stored beside the tarballs it covers, so whoever could replace an asset could regenerate the checksums with it. Attesting the tarballs binds each digest to this workflow and commit in a signed statement held outside the release, which `gh attestation verify` checks.

Requires a Trusted Publisher registered on crates.io and a `release` environment on the repository before the next release.