### PR TITLE
fix: let users change local ports after port-forward conflicts

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -372,7 +372,8 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   forwards** that show up in `:pf` even while stopped, with optional autostart.
   Pressing `f` on a pod or service opens a picker listing the manifest's
   declared ports; select one to forward immediately, or choose "Custom…" for
-  manual `LOCAL:REMOTE` input. Active forwards show a teal `●` in a dedicated
+  manual `LOCAL:REMOTE` input. If the local port is in use, the input stays open
+  and shows an error so you can choose another port. Active forwards show a teal `●` in a dedicated
   indicator column next to the row name. See [Saved forwards](plugins.md#saved-forwards).
 - **File transfer** (`t` on a pod, or `t` in the container picker for one
   container) - download from or upload to a pod via `kubectl cp`, off-thread

--- a/docs/features.md
+++ b/docs/features.md
@@ -372,7 +372,7 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   forwards** that show up in `:pf` even while stopped, with optional autostart.
   Pressing `f` on a pod or service opens a picker listing the manifest's
   declared ports; select one to forward immediately, or choose "Custom…" for
-  manual `LOCAL:REMOTE` input. If the local port is in use, the input stays open
+  manual `LOCAL:REMOTE` input. If the local port cannot bind to either loopback address, the input stays open
   and shows an error so you can choose another port. Active forwards show a teal `●` in a dedicated
   indicator column next to the row name. See [Saved forwards](plugins.md#saved-forwards).
 - **File transfer** (`t` on a pod, or `t` in the container picker for one

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1241,6 +1241,35 @@ impl App {
         }
     }
 
+    pub(super) fn local_forward_port_available(&mut self, ports: &str) -> bool {
+        let local = ports.split_once(':').map_or(ports, |(local, _)| local);
+        let Ok(port) = local.parse::<u16>() else {
+            return true;
+        };
+        if port == 0 {
+            return true;
+        }
+        let mut available = false;
+        let mut last_error = None;
+        for address in [
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+        ] {
+            match std::net::TcpListener::bind((address, port)) {
+                Ok(_listener) => available = true,
+                Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+                    self.flash_warn(&format!("port {port} is already in use"));
+                    return false;
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+        if !available && let Some(error) = last_error {
+            self.flash_warn(&format!("cannot bind local port {port}: {error}"));
+        }
+        available
+    }
+
     pub(super) fn start_port_forward(&mut self, ns: String, target: String, ports: String) {
         self.start_port_forward_named(ns, target, ports, None);
     }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1250,6 +1250,7 @@ impl App {
             return true;
         }
         let mut available = false;
+        let mut in_use = false;
         let mut last_error = None;
         for address in [
             std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
@@ -1257,15 +1258,16 @@ impl App {
         ] {
             match std::net::TcpListener::bind((address, port)) {
                 Ok(_listener) => available = true,
-                Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
-                    self.flash_warn(&format!("port {port} is already in use"));
-                    return false;
-                }
+                Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => in_use = true,
                 Err(error) => last_error = Some(error),
             }
         }
-        if !available && let Some(error) = last_error {
-            self.flash_warn(&format!("cannot bind local port {port}: {error}"));
+        if !available {
+            if in_use {
+                self.flash_warn(&format!("port {port} is already in use"));
+            } else if let Some(error) = last_error {
+                self.flash_warn(&format!("cannot bind local port {port}: {error}"));
+            }
         }
         available
     }

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -276,6 +276,11 @@ impl App {
             }
             (Some(Action::Accept), _) => {
                 let input = self.prompt_input.trim().to_string();
+                if matches!(self.prompt_kind, Some(PromptKind::PortForward { .. }))
+                    && !self.local_forward_port_available(&input)
+                {
+                    return;
+                }
                 self.mode = if self.prompt_over_logs() {
                     Mode::Logs
                 } else if self.prompt_over_contexts() {
@@ -428,6 +433,9 @@ impl App {
                     self.mode = Mode::Prompt;
                 } else {
                     let ports = item.split_whitespace().next().unwrap_or(&item).to_string();
+                    if !self.local_forward_port_available(&ports) {
+                        return;
+                    }
                     let target = forward_target(&self.kind_plural, &name);
                     self.start_port_forward(ns, target, ports);
                     self.mode = Mode::Table;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1951,10 +1951,28 @@ async fn port_forward_picker_select_port_starts_forward() {
     assert_eq!(app.port_forwards[0].target, "svc/web");
 }
 
+fn occupy_forward_port() -> (std::net::TcpListener, Option<std::net::TcpListener>) {
+    let ipv4 = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = ipv4.local_addr().unwrap().port();
+    let ipv6 = match std::net::TcpListener::bind((std::net::Ipv6Addr::LOCALHOST, port)) {
+        Ok(listener) => Some(listener),
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
+            ) =>
+        {
+            None
+        }
+        Err(error) => panic!("IPv6 listener failed: {error}"),
+    };
+    (ipv4, ipv6)
+}
+
 #[tokio::test]
 async fn port_forward_picker_keeps_selection_when_local_port_is_in_use() {
-    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let port = listener.local_addr().unwrap().port();
+    let listeners = occupy_forward_port();
+    let port = listeners.0.local_addr().unwrap().port();
     let (mut app, _rx) = test_app();
     app.switch_kind("services");
     apply(
@@ -1975,7 +1993,7 @@ async fn port_forward_picker_keeps_selection_when_local_port_is_in_use() {
     assert!(app.flash_err);
     assert!(app.port_forwards.is_empty());
 
-    drop(listener);
+    drop(listeners);
     app.handle_key(press(KeyCode::Enter)).unwrap();
     assert_eq!(app.mode, Mode::Table);
     assert_eq!(app.port_forwards.len(), 1);
@@ -1984,8 +2002,8 @@ async fn port_forward_picker_keeps_selection_when_local_port_is_in_use() {
 
 #[tokio::test]
 async fn port_forward_prompt_preserves_input_and_allows_correction() {
-    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let port = listener.local_addr().unwrap().port();
+    let listeners = occupy_forward_port();
+    let port = listeners.0.local_addr().unwrap().port();
     let (mut app, _rx) = test_app();
     app.switch_kind("services");
     apply(
@@ -2032,38 +2050,38 @@ async fn port_forward_prompt_preserves_input_and_allows_correction() {
 }
 
 #[tokio::test]
-async fn port_forward_picker_rejects_occupied_ipv6_port() {
-    let listener = match std::net::TcpListener::bind((std::net::Ipv6Addr::LOCALHOST, 0)) {
-        Ok(listener) => listener,
-        Err(error)
-            if matches!(
-                error.kind(),
-                std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
-            ) =>
-        {
+async fn port_forward_picker_allows_one_available_loopback_family() {
+    for occupy_ipv4 in [true, false] {
+        let (ipv4, ipv6) = occupy_forward_port();
+        let Some(ipv6) = ipv6 else {
             return;
-        }
-        Err(error) => panic!("IPv6 listener failed: {error}"),
-    };
-    let port = listener.local_addr().unwrap().port();
-    let (mut app, _rx) = test_app();
-    app.switch_kind("pods");
-    apply(
-        &mut app,
-        json!({
-            "apiVersion": "v1", "kind": "Pod",
-            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
-            "spec": {"containers": [{"name": "web", "ports": [{"containerPort": port}]}]}
-        }),
-    );
-    app.table_state.select(Some(0));
-    app.handle_key(press(KeyCode::Char('f'))).unwrap();
-    app.handle_key(press(KeyCode::Enter)).unwrap();
-    assert_eq!(app.mode, Mode::PortForwardPicker);
-    assert_eq!(app.flash, format!("port {port} is already in use"));
-    assert!(app.port_forwards.is_empty());
-    app.handle_key(press(KeyCode::Esc)).unwrap();
-    assert_eq!(app.mode, Mode::Table);
+        };
+        let port = ipv4.local_addr().unwrap().port();
+        let _occupied = if occupy_ipv4 {
+            drop(ipv6);
+            ipv4
+        } else {
+            drop(ipv4);
+            ipv6
+        };
+        let (mut app, _rx) = test_app();
+        app.switch_kind("pods");
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+                "spec": {"containers": [{"name": "web", "ports": [{"containerPort": port}]}]}
+            }),
+        );
+        app.table_state.select(Some(0));
+        app.handle_key(press(KeyCode::Char('f'))).unwrap();
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.mode, Mode::Table);
+        assert_eq!(app.port_forwards.len(), 1);
+        assert_eq!(app.port_forwards[0].ports, format!("{port}:{port}"));
+        assert!(!app.flash_err);
+    }
 }
 
 #[tokio::test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1928,6 +1928,9 @@ async fn port_forward_handle_key_f_opens_picker() {
 
 #[tokio::test]
 async fn port_forward_picker_select_port_starts_forward() {
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
     let (mut app, _rx) = test_app();
     app.switch_kind("services");
     apply(
@@ -1935,7 +1938,7 @@ async fn port_forward_picker_select_port_starts_forward() {
         json!({
             "apiVersion": "v1", "kind": "Service",
             "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
-            "spec": {"ports": [{"port": 8080}]}
+            "spec": {"ports": [{"port": port}]}
         }),
     );
     app.table_state.select(Some(0));
@@ -1944,12 +1947,130 @@ async fn port_forward_picker_select_port_starts_forward() {
     assert_eq!(app.mode, Mode::Table);
     assert!(app.flash.contains("port-forwarding"), "{}", app.flash);
     assert_eq!(app.port_forwards.len(), 1);
-    assert_eq!(app.port_forwards[0].ports, "8080:8080");
+    assert_eq!(app.port_forwards[0].ports, format!("{port}:{port}"));
     assert_eq!(app.port_forwards[0].target, "svc/web");
 }
 
 #[tokio::test]
+async fn port_forward_picker_keeps_selection_when_local_port_is_in_use() {
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Service",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"ports": [{"port": port}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('f'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::PortForwardPicker);
+    assert_eq!(app.pf_picker_state.selected(), Some(0));
+    assert_eq!(app.pf_picker_target, Some(("default".into(), "web".into())));
+    assert_eq!(app.flash, format!("port {port} is already in use"));
+    assert!(app.flash_err);
+    assert!(app.port_forwards.is_empty());
+
+    drop(listener);
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.port_forwards.len(), 1);
+    assert_eq!(app.port_forwards[0].ports, format!("{port}:{port}"));
+}
+
+#[tokio::test]
+async fn port_forward_prompt_preserves_input_and_allows_correction() {
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Service",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"ports": []}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('f'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    for input in [
+        port.to_string(),
+        format!("{port}:80"),
+        format!("{port}:http"),
+    ] {
+        app.prompt_input.clear();
+        for ch in input.chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.mode, Mode::Prompt);
+        assert_eq!(app.prompt_input, input);
+        assert!(matches!(
+            &app.prompt_kind,
+            Some(PromptKind::PortForward { ns, name }) if ns == "default" && name == "web"
+        ));
+        assert_eq!(app.flash, format!("port {port} is already in use"));
+        assert!(app.port_forwards.is_empty());
+    }
+    for _ in 0..app.prompt_input.len() {
+        app.handle_key(press(KeyCode::Backspace)).unwrap();
+    }
+    for ch in ":80".chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.port_forwards.len(), 1);
+    assert_eq!(app.port_forwards[0].ports, ":80");
+}
+
+#[tokio::test]
+async fn port_forward_picker_rejects_occupied_ipv6_port() {
+    let listener = match std::net::TcpListener::bind((std::net::Ipv6Addr::LOCALHOST, 0)) {
+        Ok(listener) => listener,
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
+            ) =>
+        {
+            return;
+        }
+        Err(error) => panic!("IPv6 listener failed: {error}"),
+    };
+    let port = listener.local_addr().unwrap().port();
+    let (mut app, _rx) = test_app();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"containers": [{"name": "web", "ports": [{"containerPort": port}]}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('f'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::PortForwardPicker);
+    assert_eq!(app.flash, format!("port {port} is already in use"));
+    assert!(app.port_forwards.is_empty());
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
 async fn port_forward_picker_pod_target_no_svc_prefix() {
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
     let (mut app, _rx) = test_app();
     app.switch_kind("pods");
     apply(
@@ -1957,7 +2078,7 @@ async fn port_forward_picker_pod_target_no_svc_prefix() {
         json!({
             "apiVersion": "v1", "kind": "Pod",
             "metadata": {"name": "db", "namespace": "default", "resourceVersion": "1"},
-            "spec": {"containers": [{"name": "pg", "ports": [{"containerPort": 5432}]}]}
+            "spec": {"containers": [{"name": "pg", "ports": [{"containerPort": port}]}]}
         }),
     );
     app.table_state.select(Some(0));
@@ -2222,6 +2343,9 @@ async fn port_forward_marker_renders_in_table() {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
     let (mut app, _rx) = test_app();
     app.switch_kind("services");
     apply(
@@ -2229,7 +2353,7 @@ async fn port_forward_marker_renders_in_table() {
         json!({
             "apiVersion": "v1", "kind": "Service",
             "metadata": {"name": "alpha", "namespace": "default", "resourceVersion": "1"},
-            "spec": {"ports": [{"port": 80}]}
+            "spec": {"ports": [{"port": port}]}
         }),
     );
     apply(


### PR DESCRIPTION
When a local port cannot bind to either loopback address, sofka now shows a clear error and keeps the port-forward picker or prompt open. Press `e` on a declared mapping to edit only its local port. For example, select `8080:8080`, press `e`, enter `8081`, then press Enter to start `8081:8080`.

Enter still starts a declared mapping directly. The local-port prompt contains the current value, preserves the target and remote port, and returns to the same picker row on Escape. Invalid or unavailable local ports keep the prompt open. Custom mappings remain available through `Custom…`. The new action supports key bindings and appears in the navigation hint, help, and documentation.

The availability check matches kubectl: either IPv4 or IPv6 loopback may bind successfully. Another process can still take the port between the check and kubectl binding it.

Validation: `just check` (format check, Clippy with warnings denied, and the full test suite). Tests drive conflict recovery, local-port editing, invalid input, cancellation, custom key bindings, and loopback availability through `handle_key`.

Closes #490

Discussions:
- https://github.com/nklmilojevic/sofka/discussions/488
- https://github.com/nklmilojevic/sofka/discussions/489
