### PR TITLE
feat: open the context picker at launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ sofka [RESOURCE] [-n NAMESPACE] [-A] [--context NAME] [--kubeconfig PATH] [--rea
   --write           force write mode, overriding any config `readonly`
 ```
 
+Use `sofka ctx` or `sofka contexts` to open the context picker before connecting.
+Select a context to connect and open its configured default resource, or pods.
+`--context NAME` selects the initial context in the picker. These launch commands
+require interactive mode and cannot be used with `--check` or `--snapshot`.
+
 `--readonly` and `--write` set the mode for the whole session and win over the
 config `readonly` option, including per-cluster and per-context overrides, on
 every `:ctx` switch. With no flag, switching into a context whose config sets

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ sofka [RESOURCE] [-n NAMESPACE] [-A] [--context NAME] [--kubeconfig PATH] [--rea
 
 Use `sofka ctx` or `sofka contexts` to open the context picker before connecting.
 Select a context to connect and open its configured default resource, or pods.
-`--context NAME` selects the initial context in the picker. These launch commands
+`--context NAME` selects the initial context in the picker. An unknown name
+returns an error. `-n` and `-A` apply to the first successful selection only. These launch commands
 require interactive mode and cannot be used with `--check` or `--snapshot`.
 
 `--readonly` and `--write` set the mode for the whole session and win over the

--- a/docs/features.md
+++ b/docs/features.md
@@ -202,6 +202,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **RBAC-aware palette browse** - the empty `:` list hides kinds you cannot
   `list`. An explicit search checks the full discovery catalog, because some
   delegated authorizers return incomplete rule reviews.
+- **Context picker at launch** - `sofka ctx` and `sofka contexts` open the picker
+  before connecting to a cluster. Enter connects to the selected context and
+  opens its configured default resource, or pods. `--context NAME` selects the
+  initial context in the picker. These commands require interactive mode.
 - **Namespace switcher** (`n`) with pinned favourites (★) and per-context
   session recents (·) above the rest, plus a context switcher (`:ctx`). In the
   resource table, `1` to `9` select the first nine configured favourites in fixed

--- a/docs/features.md
+++ b/docs/features.md
@@ -205,7 +205,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Context picker at launch** - `sofka ctx` and `sofka contexts` open the picker
   before connecting to a cluster. Enter connects to the selected context and
   opens its configured default resource, or pods. `--context NAME` selects the
-  initial context in the picker. These commands require interactive mode.
+  initial context in the picker. An unknown name returns an error. `-n` and `-A`
+  apply to the first successful selection only. These commands require
+  interactive mode.
 - **Namespace switcher** (`n`) with pinned favourites (★) and per-context
   session recents (·) above the rest, plus a context switcher (`:ctx`). In the
   resource table, `1` to `9` select the first nine configured favourites in fixed

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -9,6 +9,10 @@ pickers keep both characters available as input.
 
 ## Table views
 
+At launch, `sofka ctx` or `sofka contexts` opens the context picker before
+connecting. Press Enter to connect to the selected context and open its default
+resource, or pods if none is set.
+
 Use `:resource -n namespace --context context /filter` to apply a complete query.
 Use `:resource @context [namespace]` for cross-context navigation. Context names
 fuzzy-complete after `@`; Tab/Shift-Tab select a suggestion and Enter opens it.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1758,6 +1758,8 @@ pub struct App {
     /// Context currently being connected to, paired with the generation that
     /// owns its eventual result.
     context_switch_target: Option<(u64, String)>,
+    /// Explicit launch scope, consumed by the first successful picker connection.
+    launch_namespace: Option<String>,
     pub tasks: Vec<JoinHandle<()>>,
     pub tx: Sender<Msg>,
     /// Ordered off-thread persistence for small UI state files. `None` keeps
@@ -2236,6 +2238,7 @@ impl App {
             generation: 0,
             gen_flag: Arc::new(AtomicU64::new(0)),
             context_switch_target: None,
+            launch_namespace: None,
             tasks: Vec::new(),
             tx,
             state_writer: None,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -534,13 +534,13 @@ impl App {
     /// Start the session in the context picker because the current context's
     /// API server was unreachable at launch (k9s behavior). The connect error
     /// stays visible in the status line while picking.
-    pub fn start_disconnected(&mut self, error: &str) {
+    pub fn start_disconnected(&mut self, error: &str, namespace: Option<String>) {
         let label = if self.cluster.context.is_empty() {
             "cannot connect".to_string()
         } else {
             format!("cannot connect to '{}'", self.cluster.context)
         };
-        self.open_contexts();
+        self.start_context_picker(namespace);
         self.flash_warn(&format!("{label}: {error} — pick another context"));
     }
 

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -544,7 +544,8 @@ impl App {
         self.flash_warn(&format!("{label}: {error} — pick another context"));
     }
 
-    pub(super) fn open_contexts(&mut self) {
+    /// Open the context picker without starting a cluster connection.
+    pub fn open_contexts(&mut self) {
         self.ctx_filter.clear();
         self.ctx_filtering = false;
         self.ctx_list.clear();

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -544,8 +544,13 @@ impl App {
         self.flash_warn(&format!("{label}: {error} — pick another context"));
     }
 
-    /// Open the context picker without starting a cluster connection.
-    pub fn open_contexts(&mut self) {
+    /// Keep an explicit launch namespace until the first successful connection.
+    pub fn start_context_picker(&mut self, namespace: Option<String>) {
+        self.launch_namespace = namespace;
+        self.open_contexts();
+    }
+
+    pub(super) fn open_contexts(&mut self) {
         self.ctx_filter.clear();
         self.ctx_filtering = false;
         self.ctx_list.clear();
@@ -871,10 +876,12 @@ impl App {
         self.readonly = self.readonly_override.unwrap_or(resolved.config.readonly);
         cluster.add_aliases(&self.user_aliases);
         self.bump_generation();
-        // Where you last were in this context beats its config default.
+        // The launch scope applies once. Later switches use namespace memory,
+        // then the context default.
         self.namespace = self
-            .namespace_memory
-            .get(&cluster.context)
+            .launch_namespace
+            .take()
+            .or_else(|| self.namespace_memory.get(&cluster.context))
             .or(resolved.config.default_namespace)
             .unwrap_or_else(|| cluster.default_namespace.clone());
         self.cluster = *cluster;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12370,11 +12370,19 @@ async fn context_picker_launch_connects_on_enter_and_opens_default_resource() {
 
 #[tokio::test]
 async fn context_picker_launch_namespace_survives_failure_and_applies_only_once() {
-    for scope in [None, Some("payments"), Some("")] {
+    for (scope, disconnected) in [None, Some("payments"), Some("")]
+        .into_iter()
+        .flat_map(|scope| [false, true].map(|disconnected| (scope, disconnected)))
+    {
         let (mut app, _rx) = test_app();
         app.cluster.connected = false;
         app.namespace_memory.set("test", "remembered");
-        app.start_context_picker(scope.map(str::to_owned));
+        if disconnected {
+            app.start_disconnected("connection refused", scope.map(str::to_owned));
+            assert!(app.flash_err);
+        } else {
+            app.start_context_picker(scope.map(str::to_owned));
+        }
         app.handle_msg(Msg::Contexts {
             generation: app.generation,
             list: vec!["test".into()],
@@ -12426,7 +12434,7 @@ async fn disconnected_start_opens_context_picker() {
     cluster.connected = false;
     let mut app = App::new(cluster, tx);
 
-    app.start_disconnected("tcp connect error: Connection refused");
+    app.start_disconnected("tcp connect error: Connection refused", None);
     assert_eq!(app.mode, Mode::Contexts);
     assert!(app.flash_err);
     assert!(
@@ -12453,7 +12461,7 @@ async fn expired_sso_keeps_context_picker_usable() {
         .unwrap();
     let (mut app, _rx) = test_app();
     app.cluster.connected = false;
-    app.start_disconnected(&error.to_string());
+    app.start_disconnected(&error.to_string(), None);
     assert_eq!(app.mode, Mode::Contexts);
     assert!(app.flash_err);
     assert!(app.flash.contains("aws sso login"), "{}", app.flash);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12341,7 +12341,7 @@ async fn context_picker_launch_connects_on_enter_and_opens_default_resource() {
             .unwrap();
         }
         app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
-        app.open_contexts();
+        app.start_context_picker(None);
         assert_eq!(app.mode, Mode::Contexts);
         assert!(!app.flash_err);
         assert!(app.context_switch_target.is_none());
@@ -12365,6 +12365,57 @@ async fn context_picker_launch_connects_on_enter_and_opens_default_resource() {
             default.unwrap_or("pods")
         );
         std::fs::remove_dir_all(dir).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn context_picker_launch_namespace_survives_failure_and_applies_only_once() {
+    for scope in [None, Some("payments"), Some("")] {
+        let (mut app, _rx) = test_app();
+        app.cluster.connected = false;
+        app.namespace_memory.set("test", "remembered");
+        app.start_context_picker(scope.map(str::to_owned));
+        app.handle_msg(Msg::Contexts {
+            generation: app.generation,
+            list: vec!["test".into()],
+        });
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        app.handle_msg(Msg::ContextSwitched {
+            generation: app.generation,
+            name: "test".into(),
+            result: Err("connection refused".into()),
+        });
+        assert_eq!(app.mode, Mode::Contexts);
+        app.handle_msg(Msg::Contexts {
+            generation: app.generation,
+            list: vec!["test".into()],
+        });
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        app.handle_msg(Msg::ContextSwitched {
+            generation: app.generation,
+            name: "test".into(),
+            result: Ok(Box::new(Cluster::fake())),
+        });
+        assert_eq!(app.namespace, scope.unwrap_or("remembered"));
+        assert!(app.launch_namespace.is_none());
+        app.namespace_memory.set("other", "other-scope");
+        for ch in ":ctx".chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        app.handle_msg(Msg::Contexts {
+            generation: app.generation,
+            list: vec!["other".into()],
+        });
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        let mut cluster = Cluster::fake();
+        cluster.context = "other".into();
+        app.handle_msg(Msg::ContextSwitched {
+            generation: app.generation,
+            name: "other".into(),
+            result: Ok(Box::new(cluster)),
+        });
+        assert_eq!(app.namespace, "other-scope");
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12323,6 +12323,52 @@ async fn context_switch_resolves_readonly_and_cli_pin_wins() {
 }
 
 #[tokio::test]
+async fn context_picker_launch_connects_on_enter_and_opens_default_resource() {
+    for default in [None, Some("deployments")] {
+        let (mut app, _rx) = test_app();
+        app.cluster.connected = false;
+        let dir = std::env::temp_dir().join(format!(
+            "sofka-context-launch-{}-{}",
+            std::process::id(),
+            default.unwrap_or("pods")
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        if let Some(resource) = default {
+            std::fs::write(
+                dir.join("config.toml"),
+                format!("default_resource = \"{resource}\"\n"),
+            )
+            .unwrap();
+        }
+        app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+        app.open_contexts();
+        assert_eq!(app.mode, Mode::Contexts);
+        assert!(!app.flash_err);
+        assert!(app.context_switch_target.is_none());
+        app.handle_msg(Msg::Contexts {
+            generation: app.generation,
+            list: vec!["test".into()],
+        });
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(
+            app.context_switch_target,
+            Some((app.generation, "test".into()))
+        );
+        app.handle_msg(Msg::ContextSwitched {
+            generation: app.generation,
+            name: "test".into(),
+            result: Ok(Box::new(Cluster::fake())),
+        });
+        assert_eq!(app.mode, Mode::Table);
+        assert_eq!(
+            app.kind.as_ref().unwrap().ar.plural,
+            default.unwrap_or("pods")
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}
+
+#[tokio::test]
 async fn disconnected_start_opens_context_picker() {
     let (tx, _rx) = mpsc::channel(1024);
     let mut cluster = Cluster::fake();

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,24 @@ fn main() -> Result<()> {
 }
 
 impl Args {
+    fn launch_namespace(&self) -> Option<String> {
+        if self.all_namespaces {
+            Some(String::new())
+        } else {
+            self.namespace.clone()
+        }
+    }
+
+    fn validate_picker_context(&self, contexts: &[String]) -> Result<()> {
+        if let Some(name) = &self.context {
+            anyhow::ensure!(
+                contexts.contains(name),
+                "context '{name}' not found in kubeconfig"
+            );
+        }
+        Ok(())
+    }
+
     fn context_picker(&self) -> Result<bool> {
         let picker = matches!(self.resource.as_deref(), Some("ctx" | "contexts"));
         anyhow::ensure!(
@@ -208,6 +226,9 @@ async fn run_main(args: Args) -> Result<()> {
     // in the context picker instead (k9s behavior). Headless modes still exit
     // with the error, since there is no picker to fall back to.
     let (mut cluster, connect_error) = if context_picker {
+        if args.context.is_some() {
+            args.validate_picker_context(&Cluster::list_contexts().map_err(anyhow::Error::msg)?)?;
+        }
         (Cluster::disconnected(args.context.as_deref()), None)
     } else {
         eprintln!("Connecting to cluster…");
@@ -428,10 +449,9 @@ async fn run_main(args: Args) -> Result<()> {
     app.readonly = app.readonly_override.unwrap_or(cfg.readonly);
     // CLI flags win; then the namespace remembered for this context from the
     // last session; then the config default; then the kubeconfig's.
-    if args.all_namespaces {
-        app.namespace = String::new();
-    } else if let Some(ns) = args.namespace {
-        app.namespace = ns;
+    let launch_namespace = args.launch_namespace();
+    if let Some(ns) = &launch_namespace {
+        app.namespace = ns.clone();
     } else if let Some(ns) = app.namespace_memory.get(&app.cluster.context) {
         app.namespace = ns;
     } else if let Some(ns) = cfg.default_namespace.clone() {
@@ -445,7 +465,7 @@ async fn run_main(args: Args) -> Result<()> {
         // No cluster to watch — open the context picker over the empty table;
         // a successful pick connects and lands on the default resource.
         Some(err) => app.start_disconnected(err),
-        None if context_picker => app.open_contexts(),
+        None if context_picker => app.start_context_picker(launch_namespace),
         None => {
             app.switch_kind(&resource);
             app.start_autostart_forwards();
@@ -1111,6 +1131,35 @@ async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn context_picker_launch_validates_explicit_context() {
+        for alias in ["ctx", "contexts"] {
+            let args = Args::try_parse_from(["sofka", alias, "--context", "prod"]).unwrap();
+            assert!(args.validate_picker_context(&["prod".into()]).is_ok());
+            for contexts in [vec![], vec!["other".into()]] {
+                let error = args.validate_picker_context(&contexts).unwrap_err();
+                assert!(error.to_string().contains("context 'prod' not found"));
+            }
+            let args = Args::try_parse_from(["sofka", alias]).unwrap();
+            assert!(args.validate_picker_context(&["other".into()]).is_ok());
+        }
+    }
+
+    #[test]
+    fn context_picker_launch_namespace_flags() {
+        for alias in ["ctx", "contexts"] {
+            for (flags, expected) in [
+                (vec![], None),
+                (vec!["--namespace", "payments"], Some("payments")),
+                (vec!["--all-namespaces"], Some("")),
+                (vec!["-n", "payments", "-A"], Some("")),
+            ] {
+                let args = Args::try_parse_from(["sofka", alias].into_iter().chain(flags)).unwrap();
+                assert_eq!(args.launch_namespace().as_deref(), expected);
+            }
+        }
+    }
 
     #[test]
     fn context_picker_launch_aliases_and_context_flag() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ struct Args {
     command: Option<Command>,
 
     /// Resource to open on launch (alias/plural/kind), e.g. pods, svc, dp.
+    /// Use ctx or contexts to choose a context before connecting.
     /// Defaults to config `default_resource`, then "pods".
     resource: Option<String>,
 
@@ -145,6 +146,17 @@ fn main() -> Result<()> {
         .block_on(run_main(args))
 }
 
+impl Args {
+    fn context_picker(&self) -> Result<bool> {
+        let picker = matches!(self.resource.as_deref(), Some("ctx" | "contexts"));
+        anyhow::ensure!(
+            !picker || !(self.check || self.snapshot),
+            "ctx and contexts require interactive mode; remove --check or --snapshot"
+        );
+        Ok(picker)
+    }
+}
+
 async fn run_main(args: Args) -> Result<()> {
     // Before anything else: an adapter run owns stdout for its report and must
     // never load config, connect, or touch the terminal.
@@ -189,30 +201,37 @@ async fn run_main(args: Args) -> Result<()> {
         return result;
     }
 
+    let context_picker = args.context_picker()?;
+
     // Connect before taking over the terminal so errors are readable. An
     // unreachable current context isn't fatal for the interactive TUI: start
     // in the context picker instead (k9s behavior). Headless modes still exit
     // with the error, since there is no picker to fall back to.
-    eprintln!("Connecting to cluster…");
-    let connect = match args.context.as_deref() {
-        Some(name) => {
-            Cluster::connect_context(name, args.allow_v1_client_cert, args.no_tls_resumption).await
-        }
-        None => Cluster::connect(args.allow_v1_client_cert, args.no_tls_resumption).await,
-    };
-    let (mut cluster, connect_error) = match connect {
-        Ok(c) => (c, None),
-        Err(e) if args.check || args.snapshot => {
-            eprintln!("\x1b[31merror:\x1b[0m {e:#}");
-            applog::shutdown();
-            std::process::exit(1);
-        }
-        Err(e) => {
-            eprintln!("\x1b[33mwarning:\x1b[0m {e:#}");
-            (
-                Cluster::disconnected(args.context.as_deref()),
-                Some(format!("{e:#}")),
-            )
+    let (mut cluster, connect_error) = if context_picker {
+        (Cluster::disconnected(args.context.as_deref()), None)
+    } else {
+        eprintln!("Connecting to cluster…");
+        let connect = match args.context.as_deref() {
+            Some(name) => {
+                Cluster::connect_context(name, args.allow_v1_client_cert, args.no_tls_resumption)
+                    .await
+            }
+            None => Cluster::connect(args.allow_v1_client_cert, args.no_tls_resumption).await,
+        };
+        match connect {
+            Ok(c) => (c, None),
+            Err(e) if args.check || args.snapshot => {
+                eprintln!("\x1b[31merror:\x1b[0m {e:#}");
+                applog::shutdown();
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("\x1b[33mwarning:\x1b[0m {e:#}");
+                (
+                    Cluster::disconnected(args.context.as_deref()),
+                    Some(format!("{e:#}")),
+                )
+            }
         }
     };
     cluster.allow_v1_client_cert = args.allow_v1_client_cert;
@@ -426,6 +445,7 @@ async fn run_main(args: Args) -> Result<()> {
         // No cluster to watch — open the context picker over the empty table;
         // a successful pick connects and lands on the default resource.
         Some(err) => app.start_disconnected(err),
+        None if context_picker => app.open_contexts(),
         None => {
             app.switch_kind(&resource);
             app.start_autostart_forwards();
@@ -1091,6 +1111,31 @@ async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn context_picker_launch_aliases_and_context_flag() {
+        for alias in ["ctx", "contexts"] {
+            let args = Args::try_parse_from(["sofka", alias, "--context", "prod"]).unwrap();
+            assert!(args.context_picker().unwrap());
+            assert_eq!(args.context.as_deref(), Some("prod"));
+            for flag in ["--check", "--snapshot"] {
+                let args = Args::try_parse_from(["sofka", alias, flag]).unwrap();
+                assert!(args.context_picker().is_err());
+            }
+        }
+        for argv in [
+            vec!["sofka"],
+            vec!["sofka", "dp"],
+            vec!["sofka", "--context", "prod"],
+        ] {
+            assert!(
+                !Args::try_parse_from(argv)
+                    .unwrap()
+                    .context_picker()
+                    .unwrap()
+            );
+        }
+    }
 
     #[test]
     fn tls_resumption_is_disabled_only_when_requested() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,7 +464,7 @@ async fn run_main(args: Args) -> Result<()> {
     match &connect_error {
         // No cluster to watch — open the context picker over the empty table;
         // a successful pick connects and lands on the default resource.
-        Some(err) => app.start_disconnected(err),
+        Some(err) => app.start_disconnected(err, launch_namespace),
         None if context_picker => app.start_context_picker(launch_namespace),
         None => {
             app.switch_kind(&resource);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2645,7 +2645,7 @@ fn build_help(app: &App, width: usize) -> (Vec<Line<'static>>, String) {
     ));
     lines.push(bind(
         ":ctx · :pulse",
-        "switch context · cluster-health dashboard",
+        "switch context (launch: sofka ctx) · cluster-health dashboard",
     ));
     lines.push(bind(
         ":fleet",


### PR DESCRIPTION
`sofka ctx` and `sofka contexts` now open the existing context picker before connecting to a cluster. Enter connects to the selected context and opens its configured default resource, with pods as the fallback. This lets users choose a context without waiting for the current cluster to respond.

`--context NAME` keeps its existing behavior for resource launches and selects the initial context for picker launches. An unknown context returns an error before the picker opens. Explicit `-n` and `-A` scope applies to the first successful connection, including after a failed attempt. Later context changes use normal namespace settings. Picker launches reject `--check` and `--snapshot`, which require a resource view. CLI help, in-app help, and documentation describe the new commands.

Validation:
- `just check` passed: formatting, Clippy with warnings denied, and 1,351 tests passed (two existing tests ignored).
- Required commit hooks passed.
- Added tests for both aliases, headless mode rejection, keyboard selection, the default resource, launch namespace scope across retries and later context changes, and unknown context rejection.
- An extra terminal test with a local server stalled and was stopped. Full terminal validation remains incomplete.

Closes #492

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/487#discussioncomment-18390014

