### PR TITLE
fix: add the missing local-port edit action

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -377,8 +377,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **Background port-forwards** (`f`/`F` to start, `:pf` to manage) plus **saved
   forwards** that show up in `:pf` even while stopped, with optional autostart.
   Pressing `f` on a pod or service opens a picker listing the manifest's
-  declared ports; select one to forward immediately, or choose "Custom…" for
-  manual `LOCAL:REMOTE` input. If the local port cannot bind to either loopback address, the input stays open
+  declared ports. Press `enter` to start the selected mapping, or `e` to edit
+  only its local port. The edit prompt contains the current local port;
+  `esc` returns to the same picker row. Choose "Custom…" for manual
+  `LOCAL:REMOTE` input. If the local port cannot bind to either loopback address, the input stays open
   and shows an error so you can choose another port. Active forwards show a teal `●` in a dedicated
   indicator column next to the row name. See [Saved forwards](plugins.md#saved-forwards).
 - **File transfer** (`t` on a pod, or `t` in the container picker for one

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -105,7 +105,8 @@ and changes to the row order reset the range before the next Shift+Arrow press.
 
 The local-port prompt contains the current value. `enter` starts the forward;
 `esc` returns to the same picker row. Invalid or unavailable ports keep the
-prompt open for correction.
+prompt open for correction. If the forward process cannot start, the prompt
+keeps the edited value so you can retry.
 
 ## PVC explore (`x` on a PVC)
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -94,6 +94,19 @@ the range and keeps separate marks made with `space`. Other keys end the range
 operation. Normal movement keeps marked rows. Filtering, sorting, view changes,
 and changes to the row order reset the range before the next Shift+Arrow press.
 
+## Port-forward picker (`f` on a pod or service)
+
+| Key                  | Action                                                         |
+| -------------------- | -------------------------------------------------------------- |
+| `enter`              | start the selected mapping, or open manual input for "Custom…" |
+| `e`                  | edit only the local port of a declared mapping                 |
+| `j` / `k`, `↓` / `↑` | select a mapping                                               |
+| `esc` / `q`          | close the picker                                               |
+
+The local-port prompt contains the current value. `enter` starts the forward;
+`esc` returns to the same picker row. Invalid or unavailable ports keep the
+prompt open for correction.
+
 ## PVC explore (`x` on a PVC)
 
 A two-pane file browser over a PersistentVolumeClaim: your local filesystem on

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1213,7 +1213,7 @@ impl App {
         target: String,
         ports: String,
         config_name: Option<String>,
-    ) {
+    ) -> bool {
         let mut argv = self.kubectl_base();
         argv.push("port-forward".into());
         if !ns.is_empty() {
@@ -1236,8 +1236,12 @@ impl App {
                 self.flash = format!("port-forwarding {} (:pf to view/stop)", pf.label());
                 self.flash_err = false;
                 self.port_forwards.push(pf);
+                true
             }
-            Err(e) => self.flash_warn(&format!("port-forward failed to start: {e}")),
+            Err(e) => {
+                self.flash_warn(&format!("port-forward failed to start: {e}"));
+                false
+            }
         }
     }
 
@@ -1272,8 +1276,8 @@ impl App {
         available
     }
 
-    pub(super) fn start_port_forward(&mut self, ns: String, target: String, ports: String) {
-        self.start_port_forward_named(ns, target, ports, None);
+    pub(super) fn start_port_forward(&mut self, ns: String, target: String, ports: String) -> bool {
+        self.start_port_forward_named(ns, target, ports, None)
     }
 
     /// Whether the `[[forwards]]` entry named `name` has a live child.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -451,6 +451,11 @@ enum PromptKind {
         ns: String,
         name: String,
     },
+    PortForwardLocal {
+        ns: String,
+        target: String,
+        remote: String,
+    },
     SetImage {
         ns: String,
         name: String,

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -255,7 +255,10 @@ impl App {
                 // Most prompts start at (and return to) the table; the
                 // lookback and rename-context prompts return to the view
                 // they were opened from.
-                self.mode = if self.prompt_over_logs() {
+                self.mode = if matches!(self.prompt_kind, Some(PromptKind::PortForwardLocal { .. }))
+                {
+                    Mode::PortForwardPicker
+                } else if self.prompt_over_logs() {
                     Mode::Logs
                 } else if self.prompt_over_contexts() {
                     Mode::Contexts
@@ -276,8 +279,16 @@ impl App {
             }
             (Some(Action::Accept), _) => {
                 let input = self.prompt_input.trim().to_string();
-                if matches!(self.prompt_kind, Some(PromptKind::PortForward { .. }))
-                    && !self.local_forward_port_available(&input)
+                if matches!(self.prompt_kind, Some(PromptKind::PortForwardLocal { .. }))
+                    && !input.parse::<u16>().is_ok_and(|port| port > 0)
+                {
+                    self.flash_warn("local port must be a number from 1 to 65535");
+                    return;
+                }
+                if matches!(
+                    self.prompt_kind,
+                    Some(PromptKind::PortForward { .. } | PromptKind::PortForwardLocal { .. })
+                ) && !self.local_forward_port_available(&input)
                 {
                     return;
                 }
@@ -302,6 +313,9 @@ impl App {
                             let target = forward_target(&self.kind_plural, &name);
                             self.start_port_forward(ns, target, input);
                         }
+                    }
+                    Some(PromptKind::PortForwardLocal { ns, target, remote }) => {
+                        self.start_port_forward(ns, target, format!("{input}:{remote}"));
                     }
                     Some(PromptKind::SetImage {
                         ns,
@@ -415,7 +429,7 @@ impl App {
             (Some(Action::Back), _) | (Some(Action::Close), _) => self.mode = Mode::Table,
             (Some(Action::Down), _) => list_step(&mut self.pf_picker_state, len, true),
             (Some(Action::Up), _) => list_step(&mut self.pf_picker_state, len, false),
-            (Some(Action::Accept), _) => {
+            (Some(Action::Accept | Action::Edit), _) => {
                 let Some(i) = self.pf_picker_state.selected() else {
                     return;
                 };
@@ -426,6 +440,9 @@ impl App {
                     return;
                 };
                 if item == "Custom…" {
+                    if key.action == Some(Action::Edit) {
+                        return;
+                    }
                     self.prompt_label =
                         format!("Port-forward {name} (LOCAL:REMOTE, e.g. 8080:80):");
                     self.prompt_input.clear();
@@ -433,6 +450,20 @@ impl App {
                     self.mode = Mode::Prompt;
                 } else {
                     let ports = item.split_whitespace().next().unwrap_or(&item).to_string();
+                    if key.action == Some(Action::Edit) {
+                        let Some((local, remote)) = ports.split_once(':') else {
+                            return;
+                        };
+                        self.prompt_label = format!("Local port for {name}, remote {remote}:");
+                        self.prompt_input = local.to_string();
+                        self.prompt_kind = Some(PromptKind::PortForwardLocal {
+                            ns,
+                            target: forward_target(&self.kind_plural, &name),
+                            remote: remote.to_string(),
+                        });
+                        self.mode = Mode::Prompt;
+                        return;
+                    }
                     if !self.local_forward_port_available(&ports) {
                         return;
                     }

--- a/src/app/overlays.rs
+++ b/src/app/overlays.rs
@@ -315,7 +315,15 @@ impl App {
                         }
                     }
                     Some(PromptKind::PortForwardLocal { ns, target, remote }) => {
-                        self.start_port_forward(ns, target, format!("{input}:{remote}"));
+                        if !self.start_port_forward(
+                            ns.clone(),
+                            target.clone(),
+                            format!("{input}:{remote}"),
+                        ) {
+                            self.prompt_kind =
+                                Some(PromptKind::PortForwardLocal { ns, target, remote });
+                            self.mode = Mode::Prompt;
+                        }
                     }
                     Some(PromptKind::SetImage {
                         ns,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2001,6 +2001,108 @@ async fn port_forward_picker_keeps_selection_when_local_port_is_in_use() {
 }
 
 #[tokio::test]
+async fn port_forward_conflict_can_be_fixed_by_editing_only_the_local_port() {
+    let listeners = occupy_forward_port();
+    let remote = listeners.0.local_addr().unwrap().port();
+    let (mut app, _rx) = test_app();
+    app.switch_kind("services");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Service",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"ports": [{"port": remote}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('f'))).unwrap();
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::PortForwardPicker);
+    assert!(app.port_forwards.is_empty());
+
+    app.handle_key(press(KeyCode::Char('e'))).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert_eq!(app.prompt_input, remote.to_string());
+    assert!(app.prompt_label.contains(&format!("remote {remote}")));
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert_eq!(app.prompt_input, remote.to_string());
+    assert_eq!(app.flash, format!("port {remote} is already in use"));
+    assert!(app.port_forwards.is_empty());
+
+    let free = occupy_forward_port();
+    let local = free.0.local_addr().unwrap().port();
+    drop(free);
+    for _ in 0..app.prompt_input.len() {
+        app.handle_key(press(KeyCode::Backspace)).unwrap();
+    }
+    for ch in local.to_string().chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.port_forwards.len(), 1);
+    assert_eq!(app.port_forwards[0].ports, format!("{local}:{remote}"));
+    assert_eq!(app.port_forwards[0].target, "svc/web");
+    assert_eq!(app.port_forwards[0].ns, "default");
+}
+
+#[tokio::test]
+async fn port_forward_local_edit_validates_input_and_returns_to_selected_row() {
+    let (mut app, _rx) = test_app();
+    let cfg: crate::config::Config =
+        toml::from_str("[keys.port_forward_picker]\nedit = 'f24'\n").unwrap();
+    app.keymap = Keymap::compile(&cfg.keys).unwrap();
+    app.switch_kind("pods");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"containers": [{"name": "web", "ports": [{"containerPort": 8080}, {"containerPort": 9090}]}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('f'))).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    app.handle_key(press(KeyCode::F(24))).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert_eq!(app.prompt_input, "9090");
+    assert!(
+        matches!(&app.prompt_kind, Some(PromptKind::PortForwardLocal { target, remote, .. }) if target == "pod/web" && remote == "9090")
+    );
+    for input in ["", "0", "65536", "abc", "8081:9090"] {
+        for _ in 0..app.prompt_input.len() {
+            app.handle_key(press(KeyCode::Backspace)).unwrap();
+        }
+        for ch in input.chars() {
+            app.handle_key(press(KeyCode::Char(ch))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.mode, Mode::Prompt);
+        assert_eq!(app.prompt_input, input);
+        assert_eq!(app.flash, "local port must be a number from 1 to 65535");
+        assert!(app.port_forwards.is_empty());
+    }
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::PortForwardPicker);
+    assert_eq!(app.pf_picker_state.selected(), Some(1));
+    app.handle_key(press(KeyCode::F(24))).unwrap();
+    assert_eq!(app.prompt_input, "9090");
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    app.handle_key(press(KeyCode::F(24))).unwrap();
+    assert_eq!(app.mode, Mode::PortForwardPicker);
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    assert!(matches!(
+        app.prompt_kind,
+        Some(PromptKind::PortForward { .. })
+    ));
+    assert!(app.prompt_input.is_empty());
+}
+
+#[tokio::test]
 async fn port_forward_prompt_preserves_input_and_allows_correction() {
     let listeners = occupy_forward_port();
     let port = listeners.0.local_addr().unwrap().port();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2048,6 +2048,72 @@ async fn port_forward_conflict_can_be_fixed_by_editing_only_the_local_port() {
 }
 
 #[tokio::test]
+async fn port_forward_local_edit_preserves_input_after_spawn_failure() {
+    let (mut app, _rx) = test_app();
+    let successful_spawner = app.pf_spawner;
+    app.pf_spawner = |_| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "kubectl missing",
+        ))
+    };
+    app.switch_kind("services");
+    apply(
+        &mut app,
+        json!({
+            "apiVersion": "v1", "kind": "Service",
+            "metadata": {"name": "web", "namespace": "default", "resourceVersion": "1"},
+            "spec": {"ports": [{"port": 8080}, {"port": 9090}]}
+        }),
+    );
+    app.table_state.select(Some(0));
+    app.handle_key(press(KeyCode::Char('f'))).unwrap();
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    app.handle_key(press(KeyCode::Char('e'))).unwrap();
+    let free = occupy_forward_port();
+    let local = free.0.local_addr().unwrap().port().to_string();
+    drop(free);
+    for _ in 0..app.prompt_input.len() {
+        app.handle_key(press(KeyCode::Backspace)).unwrap();
+    }
+    for ch in local.chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    let label = app.prompt_label.clone();
+    for _ in 0..2 {
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.mode, Mode::Prompt);
+        assert_eq!(app.prompt_input, local);
+        assert_eq!(app.prompt_label, label);
+        assert!(app.flash_err);
+        assert!(app.flash.contains("kubectl missing"));
+        assert!(app.port_forwards.is_empty());
+        assert!(matches!(&app.prompt_kind,
+            Some(PromptKind::PortForwardLocal { ns, target, remote })
+            if ns == "default" && target == "svc/web" && remote == "9090"));
+    }
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::PortForwardPicker);
+    assert_eq!(app.pf_picker_state.selected(), Some(1));
+    app.handle_key(press(KeyCode::Char('e'))).unwrap();
+    for _ in 0..app.prompt_input.len() {
+        app.handle_key(press(KeyCode::Backspace)).unwrap();
+    }
+    for ch in local.chars() {
+        app.handle_key(press(KeyCode::Char(ch))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Prompt);
+    app.pf_spawner = successful_spawner;
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert!(app.prompt_kind.is_none());
+    assert_eq!(app.port_forwards.len(), 1);
+    assert_eq!(app.port_forwards[0].ports, format!("{local}:9090"));
+    assert_eq!(app.port_forwards[0].target, "svc/web");
+}
+
+#[tokio::test]
 async fn port_forward_local_edit_validates_input_and_returns_to_selected_row() {
     let (mut app, _rx) = test_app();
     let cfg: crate::config::Config =

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -398,6 +398,7 @@ const DEFAULTS: &[(&str, Action, &[&str])] = &[
     ("port_forward_picker", Action::Back, &["esc"]),
     ("port_forward_picker", Action::Close, &["q"]),
     ("port_forward_picker", Action::Down, &["j", "down"]),
+    ("port_forward_picker", Action::Edit, &["e"]),
     ("port_forward_picker", Action::Up, &["k", "up"]),
     ("port_forwards", Action::Back, &["esc"]),
     ("port_forwards", Action::Close, &["q"]),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2609,6 +2609,8 @@ fn build_help(app: &App, width: usize) -> (Vec<Line<'static>>, String) {
         }
         let description = if scope == "table" && action == Action::Logs {
             "logs (marked pods, or current row)"
+        } else if scope == "port_forward_picker" && action == Action::Edit {
+            "edit local port of the selected mapping"
         } else if action == Action::LogMarker {
             "add visual marker at the log tail (excluded from copy/save)"
         } else if action == Action::Fullscreen {
@@ -4658,6 +4660,17 @@ fn navigation_hint(app: &App, width: u16) -> String {
             (Action::Back, "back"),
         ]);
         return format!("{cycle}  {}", key_hint(app, scope, &actions));
+    }
+    if scope == "port_forward_picker" {
+        return key_hint(
+            app,
+            scope,
+            &[
+                (Action::Accept, "start"),
+                (Action::Edit, "edit local port"),
+                (Action::Back, "back"),
+            ],
+        );
     }
     let preferred = match scope {
         "logs" => &[


### PR DESCRIPTION
Press `e` on a declared port-forward mapping to edit only its local port. For example, select `8080:8080`, press `e`, enter `8081`, then press Enter to start `8081:8080`.

Enter still starts the selected mapping directly. The edit prompt contains the current local port and preserves the target and remote port. Escape returns to the same picker row. Invalid or unavailable local ports keep the prompt open. The action supports custom key bindings and appears in help, the navigation hint, and documentation.

This brings commit 5e1afc0818803d2aeb799315a06f644fbce4c6e8 onto current main. That commit was pushed after #491 merged, so the local-port edit was missing from main despite the earlier PR description.

Validation: `just check` covers Rust formatting, Clippy with warnings denied, and the full test suite. Keyboard tests cover port conflict recovery, editing, input validation, cancellation, custom key bindings, and the Custom entry.

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/489

Follow-up to #491.
