### PR TITLE
feat: read a ref's target kind from the object

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -304,8 +304,10 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   the objects whose specs name it (the pods mounting a claim, the claims using
   a class). `⏎` opens one in its regular view, `y`/`d` show its YAML or
   describe. Relations are data: a built-in table for core kinds, extended per
-  CRD with `[[views."…".refs]]` and `children`. Reverse lookups stay in the
-  row's namespace unless the rule says `cluster`.
+  CRD with `[[views."…".refs]]` and `children`. A ref whose target kind is a
+  field of the object (an ExternalSecret's `secretStoreRef.kind`) reads it
+  with `kind_path` from a list of candidate `kinds`. Reverse lookups stay in
+  the row's namespace unless the rule says `cluster`.
   Press `c` in this view to discover direct children of a namespaced custom
   resource with a UID, including resources with no configured child kinds.
   Wait for the initial adjacent lookup to finish first. The search uses API

--- a/docs/views.md
+++ b/docs/views.md
@@ -398,17 +398,25 @@ kind      = "secretstores"                # default when the element has no kind
 kind_path = "/spec/secretStoreRef/kind"
 kinds     = ["secretstores", "clustersecretstores"]
 relation  = "reads from"
+reverse   = "cluster"                     # a ClusterSecretStore is used from any namespace
 ```
 
 The value at `kind_path` is matched against each candidate's kind, plural, or
 group-qualified plural, so `SecretStore` and `secretstores` both work. An
 element naming a kind outside `kinds` - a `User` or `Group` among a
 ClusterRoleBinding's subjects - contributes nothing. With `kind` set, an
-element without a kind takes it; without, the element is skipped. Read
-backwards, the rule applies when any candidate is the selected kind, and an
-object matches only when its element names that kind. Candidates that are
-namespaced and cluster-scoped mix freely: `namespace_path` applies to the
-namespaced ones.
+element without a kind takes it; `kind` must then be one of `kinds`. Without
+it, the element is skipped. The `*` segments of `kind_path` and
+`namespace_path` must sit in the same arrays as those of `path`, so each
+element is paired with its own kind and namespace; a pointer that does not is
+reported and the ref skipped. Read backwards, the rule applies when any
+candidate is the selected kind, and an object matches only when its element
+names that kind. Candidates that are namespaced and cluster-scoped mix
+freely: `namespace_path` applies to the namespaced ones, and one `reverse`
+serves both. A cluster-scoped candidate is named from any namespace, so a rule
+that includes one usually wants `reverse = "cluster"`; with `namespace`, a
+selected ClusterSecretStore lists only the ExternalSecrets in the namespace
+the table shows.
 
 Each lookup reads the current source object. Press `r` to include changes to
 its references, such as a new pod node assignment or PVC binding. If the source

--- a/docs/views.md
+++ b/docs/views.md
@@ -387,6 +387,29 @@ A cluster-scoped kind naming a namespaced one must set it - there is no row
 namespace to fall back on - or the view reports the rule as unfollowable
 instead of quietly finding nothing.
 
+When the target kind is itself a field of the object - an ExternalSecret's
+`secretStoreRef` names a SecretStore or a ClusterSecretStore - `kind_path`
+reads it from the same element `path` did, and `kinds` lists what it may be:
+
+```toml
+[[views.externalsecrets.refs]]
+path      = "/spec/secretStoreRef/name"
+kind      = "secretstores"                # default when the element has no kind
+kind_path = "/spec/secretStoreRef/kind"
+kinds     = ["secretstores", "clustersecretstores"]
+relation  = "reads from"
+```
+
+The value at `kind_path` is matched against each candidate's kind, plural, or
+group-qualified plural, so `SecretStore` and `secretstores` both work. An
+element naming a kind outside `kinds` - a `User` or `Group` among a
+ClusterRoleBinding's subjects - contributes nothing. With `kind` set, an
+element without a kind takes it; without, the element is skipped. Read
+backwards, the rule applies when any candidate is the selected kind, and an
+object matches only when its element names that kind. Candidates that are
+namespaced and cluster-scoped mix freely: `namespace_path` applies to the
+namespaced ones.
+
 Each lookup reads the current source object. Press `r` to include changes to
 its references, such as a new pod node assignment or PVC binding. If the source
 was deleted or replaced, the view reports the error. Return to the table to

--- a/docs/views.md
+++ b/docs/views.md
@@ -405,8 +405,9 @@ The value at `kind_path` is matched against each candidate's kind, plural, or
 group-qualified plural, so `SecretStore` and `secretstores` both work. An
 element naming a kind outside `kinds` - a `User` or `Group` among a
 ClusterRoleBinding's subjects - contributes nothing. With `kind` set, an
-element without a kind takes it; `kind` must then be one of `kinds`. Without
-it, the element is skipped. The `*` segments of `kind_path` and
+element without a kind takes it; `kind` must then name one of `kinds`, in any
+spelling the cluster resolves, or the view reports it and the default is not
+used. Without `kind`, the element is skipped. The `*` segments of `kind_path` and
 `namespace_path` must sit in the same arrays as those of `path`, so each
 element is paired with its own kind and namespace; a pointer that does not is
 reported and the ref skipped. Read backwards, the rule applies when any

--- a/src/adjacent.rs
+++ b/src/adjacent.rs
@@ -575,6 +575,7 @@ pub struct Backward {
     pub rule: RefRule,
     pub from: KindRef,
     pub scope: String,
+    pub default: Option<KindRef>,
 }
 
 /// Everything the gather will read for one selection, decided up front on
@@ -688,11 +689,8 @@ pub fn plan(
         if rule.reverse == Reverse::None {
             continue;
         }
-        if !Targets::resolve(kinds, &rule)
-            .all
-            .iter()
-            .any(|t| same_kind(t, source))
-        {
+        let targets = Targets::resolve(kinds, &rule);
+        if !targets.all.iter().any(|t| same_kind(t, source)) {
             continue;
         }
         let Some(from) = resolve_view_key(kinds, &rule.from) else {
@@ -709,7 +707,12 @@ pub fn plan(
             (None, Reverse::Namespace) if from.namespaced => scope_ns.to_string(),
             _ => String::new(),
         };
-        plan.backward.push(Backward { rule, from, scope });
+        plan.backward.push(Backward {
+            rule,
+            from,
+            scope,
+            default: targets.default,
+        });
     }
     plan
 }
@@ -820,13 +823,14 @@ pub fn owned_by(o: &DynamicObject, uid: Option<&str>) -> bool {
 pub fn names_source(
     o: &DynamicObject,
     rule: &RefRule,
+    default: Option<&KindRef>,
     source: &KindRef,
     source_name: &str,
     source_ns: Option<&str>,
 ) -> bool {
     let value = serde_json::to_value(o).unwrap_or(Value::Null);
     rule_hits(&value, rule).into_iter().any(|hit| {
-        if hit.name != source_name || !hit_names_kind(rule, hit.kind.as_deref(), source) {
+        if hit.name != source_name || !hit_names_kind(rule, hit.kind.as_deref(), default, source) {
             return false;
         }
         let Some(source_ns) = source_ns else {
@@ -840,13 +844,18 @@ pub fn names_source(
     })
 }
 
-fn hit_names_kind(rule: &RefRule, named: Option<&str>, source: &KindRef) -> bool {
+fn hit_names_kind(
+    rule: &RefRule,
+    named: Option<&str>,
+    default: Option<&KindRef>,
+    source: &KindRef,
+) -> bool {
     if !rule.is_dynamic() {
         return true;
     }
     match named {
         Some(named) => kind_is_named(source, named),
-        None => !rule.kind.is_empty() && kind_is_named(source, &rule.kind),
+        None => default.is_some_and(|d| same_kind(d, source)),
     }
 }
 
@@ -914,6 +923,18 @@ mod tests {
                     k.ar.kind.eq_ignore_ascii_case(kind) && k.ar.group.eq_ignore_ascii_case(group)
                 })
                 .cloned()
+        }
+    }
+
+    struct Aliased(Table, &'static str, &'static str);
+
+    impl Kinds for Aliased {
+        fn by_name(&self, name: &str) -> Option<KindRef> {
+            let name = if name == self.1 { self.2 } else { name };
+            self.0.by_name(name)
+        }
+        fn by_kind_in_group(&self, kind: &str, group: &str) -> Option<KindRef> {
+            self.0.by_kind_in_group(kind, group)
         }
     }
 
@@ -1379,17 +1400,32 @@ mod tests {
             .unwrap();
         let pvc = kind("", "PersistentVolumeClaim", "persistentvolumeclaims", true);
         // Same name in the same namespace: a match; same name elsewhere: not.
-        assert!(names_source(&pod, &mounts, &pvc, "data-db-0", Some("db")));
+        assert!(names_source(
+            &pod,
+            &mounts,
+            None,
+            &pvc,
+            "data-db-0",
+            Some("db")
+        ));
         assert!(!names_source(
             &pod,
             &mounts,
+            None,
             &pvc,
             "data-db-0",
             Some("other")
         ));
-        assert!(!names_source(&pod, &mounts, &pvc, "wal-db-0", Some("db")));
+        assert!(!names_source(
+            &pod,
+            &mounts,
+            None,
+            &pvc,
+            "wal-db-0",
+            Some("db")
+        ));
         // A cluster-scoped selection has no namespace to match.
-        assert!(names_source(&pod, &mounts, &pvc, "data-db-0", None));
+        assert!(names_source(&pod, &mounts, None, &pvc, "data-db-0", None));
 
         // With a namespace path, the pointed-at namespace decides, not the
         // referencing object's own.
@@ -1404,8 +1440,22 @@ mod tests {
         .into_iter()
         .find(|r| r.namespace_path.is_some())
         .unwrap();
-        assert!(names_source(&pv, &bound, &pvc, "data-db-0", Some("db")));
-        assert!(!names_source(&pv, &bound, &pvc, "data-db-0", Some("other")));
+        assert!(names_source(
+            &pv,
+            &bound,
+            None,
+            &pvc,
+            "data-db-0",
+            Some("db")
+        ));
+        assert!(!names_source(
+            &pv,
+            &bound,
+            None,
+            &pvc,
+            "data-db-0",
+            Some("other")
+        ));
     }
 
     #[test]
@@ -1555,6 +1605,7 @@ mod tests {
         assert!(names_source(
             &names_local,
             rule,
+            back.default.as_ref(),
             &store,
             "local",
             Some("shop")
@@ -1562,6 +1613,7 @@ mod tests {
         assert!(names_source(
             &names_default,
             rule,
+            back.default.as_ref(),
             &store,
             "local",
             Some("shop")
@@ -1569,6 +1621,7 @@ mod tests {
         assert!(!names_source(
             &names_cluster,
             rule,
+            back.default.as_ref(),
             &store,
             "local",
             Some("shop")
@@ -1576,6 +1629,7 @@ mod tests {
         assert!(names_source(
             &names_cluster,
             rule,
+            back.default.as_ref(),
             &cluster_store,
             "local",
             None
@@ -1583,6 +1637,7 @@ mod tests {
         assert!(!names_source(
             &names_default,
             rule,
+            back.default.as_ref(),
             &cluster_store,
             "local",
             None
@@ -1590,6 +1645,7 @@ mod tests {
         assert!(!names_source(
             &names_local,
             rule,
+            back.default.as_ref(),
             &cluster_store,
             "local",
             None
@@ -1757,6 +1813,101 @@ mod tests {
         );
         let plan = self::plan(&views, &kinds, &store, &store_obj, "shop");
         assert!(plan.backward.iter().all(|b| b.rule.relation != "pulls"));
+    }
+
+    #[test]
+    fn an_alias_default_names_the_source_both_ways() {
+        let (views, warnings) = crate::views::compile(
+            &toml::from_str::<crate::config::Config>(
+                r#"
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
+                kind = "css"
+                kind_path = "/spec/secretStoreRef/kind"
+                kinds = ["secretstores", "clustersecretstores"]
+                reverse = "cluster"
+                "#,
+            )
+            .unwrap()
+            .views,
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+        let mut table = cluster();
+        table.0.extend([
+            kind(
+                "external-secrets.io",
+                "ExternalSecret",
+                "externalsecrets",
+                true,
+            ),
+            kind("external-secrets.io", "SecretStore", "secretstores", true),
+            kind(
+                "external-secrets.io",
+                "ClusterSecretStore",
+                "clustersecretstores",
+                false,
+            ),
+        ]);
+        let kinds = Aliased(table, "css", "clustersecretstores");
+        let es = kind(
+            "external-secrets.io",
+            "ExternalSecret",
+            "externalsecrets",
+            true,
+        );
+        let es_obj = obj(
+            json!({"apiVersion": "external-secrets.io/v1", "kind": "ExternalSecret",
+            "metadata": {"name": "db", "namespace": "shop"},
+            "spec": {"secretStoreRef": {"name": "vault"}}}),
+        );
+        let plan = self::plan(&views, &kinds, &es, &es_obj, "shop");
+        assert!(plan.warns.is_empty(), "{:?}", plan.warns);
+        assert_eq!(plan.forward.len(), 1);
+        assert_eq!(plan.forward[0].target.plural, "clustersecretstores");
+
+        let cluster_store = kind(
+            "external-secrets.io",
+            "ClusterSecretStore",
+            "clustersecretstores",
+            false,
+        );
+        let store_obj = obj(
+            json!({"apiVersion": "external-secrets.io/v1", "kind": "ClusterSecretStore",
+            "metadata": {"name": "vault"}}),
+        );
+        let plan = self::plan(&views, &kinds, &cluster_store, &store_obj, "shop");
+        let back = plan
+            .backward
+            .iter()
+            .find(|b| b.from.plural == "externalsecrets")
+            .expect("externalsecrets are listed for a cluster store");
+        assert_eq!(
+            back.default.as_ref().map(|d| d.plural.as_str()),
+            Some("clustersecretstores")
+        );
+        assert!(names_source(
+            &es_obj,
+            &back.rule,
+            back.default.as_ref(),
+            &cluster_store,
+            "vault",
+            None
+        ));
+        let store = kind("external-secrets.io", "SecretStore", "secretstores", true);
+        let plan = self::plan(&views, &kinds, &store, &store_obj, "shop");
+        let back = plan
+            .backward
+            .iter()
+            .find(|b| b.from.plural == "externalsecrets")
+            .unwrap();
+        assert!(!names_source(
+            &es_obj,
+            &back.rule,
+            back.default.as_ref(),
+            &store,
+            "vault",
+            Some("shop")
+        ));
     }
 
     #[test]

--- a/src/adjacent.rs
+++ b/src/adjacent.rs
@@ -733,11 +733,7 @@ impl Targets {
                 all.push(candidate);
             }
         }
-        if let Some(d) = &default
-            && !all.iter().any(|t| same_kind(t, d))
-        {
-            all.push(d.clone());
-        }
+        let default = default.filter(|d| all.iter().any(|t| same_kind(t, d)));
         Self { all, default }
     }
 
@@ -1613,6 +1609,34 @@ mod tests {
 
                 [[views.externalsecrets.refs]]
                 path = "/spec/secretStoreRef/name"
+                kind = "secretstores"
+                kind_path = "/spec/secretStoreRef/kind"
+                kinds = ["clustersecretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/data/*/sourceRef/name"
+                kind_path = "/spec/other/*/kind"
+                kinds = ["secretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/data/*/sourceRef/name"
+                kind_path = "/spec/data/*/sourceRef/*/kind"
+                kinds = ["secretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/data/*/sourceRef/name"
+                namespace_path = "/spec/other/*/namespace"
+                kind_path = "/spec/data/*/sourceRef/kind"
+                kinds = ["secretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/data/*/sourceRef/name"
+                namespace_path = "/spec/data/0/sourceRef/namespace"
+                kind_path = "/spec/data/*/sourceRef/kind"
+                kinds = ["secretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
                 kind_path = "/spec/secretStoreRef/kind"
                 kinds = ["SecretStores", " "]
                 "#,
@@ -1620,11 +1644,31 @@ mod tests {
             .unwrap()
             .views,
         );
-        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert_eq!(warnings.len(), 7, "{warnings:?}");
         assert!(warnings[0].contains("ref 1") && warnings[0].contains("kinds"));
         assert!(warnings[1].contains("ref 2") && warnings[1].contains("kind_path"));
         assert!(warnings[2].contains("ref 3") && warnings[2].contains("JSON Pointer"));
+        assert!(
+            warnings[3].contains("ref 4") && warnings[3].contains("must be one of kinds"),
+            "{}",
+            warnings[3]
+        );
+        for (i, what) in [(4, "ref 5"), (5, "ref 6"), (6, "ref 7")] {
+            assert!(
+                warnings[i].contains(what) && warnings[i].contains("same arrays"),
+                "{}",
+                warnings[i]
+            );
+        }
+        assert!(warnings[4].contains("kind_path") && warnings[5].contains("kind_path"));
+        assert!(warnings[6].contains("namespace_path"));
         let rules = &views["externalsecrets"].refs;
+        assert_eq!(rules.len(), 2);
+        assert_eq!(
+            rules[0].namespace_path.as_deref(),
+            Some("/spec/data/0/sourceRef/namespace")
+        );
+        let rules = &rules[1..];
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].kinds, ["secretstores"]);
         assert_eq!(rules[0].kind, "");

--- a/src/adjacent.rs
+++ b/src/adjacent.rs
@@ -629,6 +629,9 @@ pub fn plan(
     // that isn't installed — simply contributes nothing.
     for rule in rules_for(views, &source.ar, row_ns) {
         let targets = Targets::resolve(kinds, &rule);
+        if let Some(why) = &targets.stray_default {
+            plan.warns.push(why.clone());
+        }
         if targets.all.is_empty() {
             continue;
         }
@@ -714,6 +717,7 @@ pub fn plan(
 struct Targets {
     all: Vec<KindRef>,
     default: Option<KindRef>,
+    stray_default: Option<String>,
 }
 
 impl Targets {
@@ -725,6 +729,7 @@ impl Targets {
             return Self {
                 all: default.clone().into_iter().collect(),
                 default,
+                stray_default: None,
             };
         }
         let mut all: Vec<KindRef> = Vec::new();
@@ -733,8 +738,24 @@ impl Targets {
                 all.push(candidate);
             }
         }
-        let default = default.filter(|d| all.iter().any(|t| same_kind(t, d)));
-        Self { all, default }
+        let (default, stray_default) = match default {
+            Some(d) if all.iter().any(|t| same_kind(t, &d)) => (Some(d), None),
+            Some(_) => (
+                None,
+                Some(format!(
+                    "ref {} → {}: kind {} is not one of kinds",
+                    rule.from,
+                    rule.target_label(),
+                    rule.kind
+                )),
+            ),
+            None => (None, None),
+        };
+        Self {
+            all,
+            default,
+            stray_default,
+        }
     }
 
     fn pick(&self, rule: &RefRule, named: Option<&str>) -> Option<&KindRef> {
@@ -1608,12 +1629,6 @@ mod tests {
                 kinds = ["secretstores"]
 
                 [[views.externalsecrets.refs]]
-                path = "/spec/secretStoreRef/name"
-                kind = "secretstores"
-                kind_path = "/spec/secretStoreRef/kind"
-                kinds = ["clustersecretstores"]
-
-                [[views.externalsecrets.refs]]
                 path = "/spec/data/*/sourceRef/name"
                 kind_path = "/spec/other/*/kind"
                 kinds = ["secretstores"]
@@ -1644,24 +1659,19 @@ mod tests {
             .unwrap()
             .views,
         );
-        assert_eq!(warnings.len(), 7, "{warnings:?}");
+        assert_eq!(warnings.len(), 6, "{warnings:?}");
         assert!(warnings[0].contains("ref 1") && warnings[0].contains("kinds"));
         assert!(warnings[1].contains("ref 2") && warnings[1].contains("kind_path"));
         assert!(warnings[2].contains("ref 3") && warnings[2].contains("JSON Pointer"));
-        assert!(
-            warnings[3].contains("ref 4") && warnings[3].contains("must be one of kinds"),
-            "{}",
-            warnings[3]
-        );
-        for (i, what) in [(4, "ref 5"), (5, "ref 6"), (6, "ref 7")] {
+        for (i, what) in [(3, "ref 4"), (4, "ref 5"), (5, "ref 6")] {
             assert!(
                 warnings[i].contains(what) && warnings[i].contains("same arrays"),
                 "{}",
                 warnings[i]
             );
         }
-        assert!(warnings[4].contains("kind_path") && warnings[5].contains("kind_path"));
-        assert!(warnings[6].contains("namespace_path"));
+        assert!(warnings[3].contains("kind_path") && warnings[4].contains("kind_path"));
+        assert!(warnings[5].contains("namespace_path"));
         let rules = &views["externalsecrets"].refs;
         assert_eq!(rules.len(), 2);
         assert_eq!(
@@ -1673,6 +1683,80 @@ mod tests {
         assert_eq!(rules[0].kinds, ["secretstores"]);
         assert_eq!(rules[0].kind, "");
         assert!(rules[0].is_dynamic());
+    }
+
+    #[test]
+    fn a_default_kind_is_matched_to_the_candidates_by_the_cluster() {
+        let (views, warnings) = crate::views::compile(
+            &toml::from_str::<crate::config::Config>(
+                r#"
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
+                kind = "SecretStore"
+                kind_path = "/spec/secretStoreRef/kind"
+                kinds = ["secretstores", "clustersecretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/data/*/sourceRef/name"
+                kind = "secretstores"
+                kind_path = "/spec/data/*/sourceRef/kind"
+                kinds = ["clustersecretstores"]
+                relation = "pulls"
+                "#,
+            )
+            .unwrap()
+            .views,
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+        let mut kinds = cluster();
+        kinds.0.extend([
+            kind(
+                "external-secrets.io",
+                "ExternalSecret",
+                "externalsecrets",
+                true,
+            ),
+            kind("external-secrets.io", "SecretStore", "secretstores", true),
+            kind(
+                "external-secrets.io",
+                "ClusterSecretStore",
+                "clustersecretstores",
+                false,
+            ),
+        ]);
+        let es = kind(
+            "external-secrets.io",
+            "ExternalSecret",
+            "externalsecrets",
+            true,
+        );
+        let es_obj = obj(
+            json!({"apiVersion": "external-secrets.io/v1", "kind": "ExternalSecret",
+            "metadata": {"name": "db", "namespace": "shop"},
+            "spec": {"secretStoreRef": {"name": "local"},
+                     "data": [{"sourceRef": {"name": "vault"}}]}}),
+        );
+        let plan = self::plan(&views, &kinds, &es, &es_obj, "shop");
+        assert_eq!(plan.forward.len(), 1);
+        assert_eq!(plan.forward[0].target.plural, "secretstores");
+        assert_eq!(
+            plan.forward[0].refs,
+            [("local".to_string(), "shop".to_string())]
+        );
+        assert_eq!(plan.warns.len(), 1, "{:?}", plan.warns);
+        assert!(
+            plan.warns[0].contains("kind secretstores is not one of kinds"),
+            "{}",
+            plan.warns[0]
+        );
+
+        let store = kind("external-secrets.io", "SecretStore", "secretstores", true);
+        let store_obj = obj(
+            json!({"apiVersion": "external-secrets.io/v1", "kind": "SecretStore",
+            "metadata": {"name": "vault", "namespace": "shop"}}),
+        );
+        let plan = self::plan(&views, &kinds, &store, &store_obj, "shop");
+        assert!(plan.backward.iter().all(|b| b.rule.relation != "pulls"));
     }
 
     #[test]

--- a/src/adjacent.rs
+++ b/src/adjacent.rs
@@ -78,9 +78,25 @@ pub struct RefRule {
     pub namespace_path: Option<String>,
     /// Target kind (alias, plural, or kind), resolved against the cluster.
     pub kind: String,
+    pub kind_path: Option<String>,
+    pub kinds: Vec<String>,
     /// Relation label shown on the row: "mounts", "runs on".
     pub relation: String,
     pub reverse: Reverse,
+}
+
+impl RefRule {
+    pub fn is_dynamic(&self) -> bool {
+        self.kind_path.is_some()
+    }
+
+    pub fn target_label(&self) -> String {
+        if self.kinds.is_empty() {
+            self.kind.clone()
+        } else {
+            self.kinds.join("|")
+        }
+    }
 }
 
 struct BuiltinRef {
@@ -99,6 +115,8 @@ impl BuiltinRef {
             path: self.path.to_string(),
             namespace_path: self.namespace_path.map(str::to_string),
             kind: self.kind.to_string(),
+            kind_path: None,
+            kinds: Vec::new(),
             relation: self.relation.to_string(),
             reverse: self.reverse,
         }
@@ -435,20 +453,52 @@ pub fn pointer_pairs(
     path: &str,
     namespace_path: Option<&str>,
 ) -> Vec<(String, Option<String>)> {
+    pointer_hits(obj, path, namespace_path, None)
+        .into_iter()
+        .map(|hit| (hit.name, hit.namespace))
+        .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Hit {
+    pub name: String,
+    pub namespace: Option<String>,
+    pub kind: Option<String>,
+}
+
+pub fn pointer_hits(
+    obj: &Value,
+    path: &str,
+    namespace_path: Option<&str>,
+    kind_path: Option<&str>,
+) -> Vec<Hit> {
     let Some(segs) = segments(path) else {
         return Vec::new();
     };
     let mut hits = Vec::new();
     expand(obj, &segs, &mut Vec::new(), &mut hits);
     let ns_segs = namespace_path.and_then(segments);
+    let kind_segs = kind_path.and_then(segments);
     hits.into_iter()
-        .map(|(taken, name)| {
-            let ns = ns_segs
+        .map(|(taken, name)| Hit {
+            name,
+            namespace: ns_segs
                 .as_deref()
-                .and_then(|segs| value_at(obj, segs, &taken));
-            (name, ns)
+                .and_then(|segs| value_at(obj, segs, &taken)),
+            kind: kind_segs
+                .as_deref()
+                .and_then(|segs| value_at(obj, segs, &taken)),
         })
         .collect()
+}
+
+fn rule_hits(obj: &Value, rule: &RefRule) -> Vec<Hit> {
+    pointer_hits(
+        obj,
+        &rule.path,
+        rule.namespace_path.as_deref(),
+        rule.kind_path.as_deref(),
+    )
 }
 
 /// The string at a pointer whose `*`s are filled from `indices`, in order.
@@ -578,43 +628,68 @@ pub fn plan(
     // A rule whose target kind isn't served here — a class from a CSI driver
     // that isn't installed — simply contributes nothing.
     for rule in rules_for(views, &source.ar, row_ns) {
-        let Some(target) = kinds.by_name(&rule.kind) else {
+        let targets = Targets::resolve(kinds, &rule);
+        if targets.all.is_empty() {
             continue;
-        };
-        if let Some(why) = unreachable_namespace(&rule, source.namespaced, target.namespaced) {
+        }
+        if !rule.is_dynamic()
+            && let Some(why) =
+                unreachable_namespace(&rule, source.namespaced, targets.all[0].namespaced)
+        {
             plan.warns.push(why);
             continue;
         }
-        let mut refs: Vec<(String, String)> = Vec::new();
-        for (name, target_ns) in pointer_pairs(&value, &rule.path, rule.namespace_path.as_deref()) {
-            match target_ns {
-                Some(target_ns) => refs.push((name, target_ns)),
+        let mut forwards: Vec<Forward> = Vec::new();
+        for hit in rule_hits(&value, &rule) {
+            let Some(target) = targets.pick(&rule, hit.kind.as_deref()) else {
+                continue;
+            };
+            if rule.is_dynamic()
+                && let Some(why) =
+                    unreachable_namespace(&rule, source.namespaced, target.namespaced)
+            {
+                if !plan.warns.contains(&why) {
+                    plan.warns.push(why);
+                }
+                continue;
+            }
+            let target_ns = match hit.namespace {
+                Some(target_ns) => target_ns,
                 // The row's own namespace covers a missing one — unless the
                 // row has none: then there is nowhere to read, and a GET in
                 // no namespace would quietly find nothing.
-                None if !target.namespaced || !ns.is_empty() => refs.push((name, ns.clone())),
+                None if !target.namespaced || !ns.is_empty() => ns.clone(),
                 None => {
                     plan.warns.push(format!(
-                        "ref {} → {}: {name} has no namespace at {}",
+                        "ref {} → {}: {} has no namespace at {}",
                         rule.from,
-                        rule.kind,
+                        rule.target_label(),
+                        hit.name,
                         rule.namespace_path.as_deref().unwrap_or_default()
                     ));
+                    continue;
                 }
+            };
+            match forwards.iter_mut().find(|f| f.target == *target) {
+                Some(forward) => forward.refs.push((hit.name, target_ns)),
+                None => forwards.push(Forward {
+                    rule: rule.clone(),
+                    target: target.clone(),
+                    refs: vec![(hit.name, target_ns)],
+                }),
             }
         }
-        if !refs.is_empty() {
-            plan.forward.push(Forward { rule, target, refs });
-        }
+        plan.forward.extend(forwards);
     }
     for rule in all_rules(views) {
         if rule.reverse == Reverse::None {
             continue;
         }
-        let Some(target) = kinds.by_name(&rule.kind) else {
-            continue;
-        };
-        if target.ar.plural != source.ar.plural || target.ar.group != source.ar.group {
+        if !Targets::resolve(kinds, &rule)
+            .all
+            .iter()
+            .any(|t| same_kind(t, source))
+        {
             continue;
         }
         let Some(from) = resolve_view_key(kinds, &rule.from) else {
@@ -636,6 +711,61 @@ pub fn plan(
     plan
 }
 
+struct Targets {
+    all: Vec<KindRef>,
+    default: Option<KindRef>,
+}
+
+impl Targets {
+    fn resolve(kinds: &impl Kinds, rule: &RefRule) -> Self {
+        let default = (!rule.kind.is_empty())
+            .then(|| kinds.by_name(&rule.kind))
+            .flatten();
+        if !rule.is_dynamic() {
+            return Self {
+                all: default.clone().into_iter().collect(),
+                default,
+            };
+        }
+        let mut all: Vec<KindRef> = Vec::new();
+        for candidate in rule.kinds.iter().filter_map(|k| kinds.by_name(k)) {
+            if !all.iter().any(|t| same_kind(t, &candidate)) {
+                all.push(candidate);
+            }
+        }
+        if let Some(d) = &default
+            && !all.iter().any(|t| same_kind(t, d))
+        {
+            all.push(d.clone());
+        }
+        Self { all, default }
+    }
+
+    fn pick(&self, rule: &RefRule, named: Option<&str>) -> Option<&KindRef> {
+        if !rule.is_dynamic() {
+            return self.all.first();
+        }
+        match named {
+            Some(named) => self.all.iter().find(|t| kind_is_named(t, named)),
+            None => self
+                .default
+                .as_ref()
+                .and_then(|d| self.all.iter().find(|t| same_kind(t, d))),
+        }
+    }
+}
+
+fn same_kind(a: &KindRef, b: &KindRef) -> bool {
+    a.ar.plural == b.ar.plural && a.ar.group == b.ar.group
+}
+
+fn kind_is_named(kind: &KindRef, name: &str) -> bool {
+    kind.ar.kind.eq_ignore_ascii_case(name)
+        || kind.plural.eq_ignore_ascii_case(name)
+        || (!kind.ar.group.is_empty()
+            && format!("{}.{}", kind.plural, kind.ar.group).eq_ignore_ascii_case(name))
+}
+
 /// Why a rule can't be followed: a cluster-scoped object naming a namespaced
 /// one says nothing about which namespace, unless `namespace_path` does.
 /// Better one warning than a GET in no namespace that quietly finds nothing.
@@ -647,7 +777,8 @@ fn unreachable_namespace(
     (!from_namespaced && to_namespaced && rule.namespace_path.is_none()).then(|| {
         format!(
             "ref {} → {}: a namespaced kind named from a cluster-scoped one needs namespace_path",
-            rule.from, rule.kind
+            rule.from,
+            rule.target_label()
         )
     })
 }
@@ -672,25 +803,34 @@ pub fn owned_by(o: &DynamicObject, uid: Option<&str>) -> bool {
 pub fn names_source(
     o: &DynamicObject,
     rule: &RefRule,
+    source: &KindRef,
     source_name: &str,
     source_ns: Option<&str>,
 ) -> bool {
     let value = serde_json::to_value(o).unwrap_or(Value::Null);
-    pointer_pairs(&value, &rule.path, rule.namespace_path.as_deref())
-        .into_iter()
-        .any(|(name, named_ns)| {
-            if name != source_name {
-                return false;
-            }
-            let Some(source_ns) = source_ns else {
-                return true;
-            };
-            let named_ns = match &rule.namespace_path {
-                Some(_) => named_ns,
-                None => o.metadata.namespace.clone(),
-            };
-            named_ns.as_deref() == Some(source_ns)
-        })
+    rule_hits(&value, rule).into_iter().any(|hit| {
+        if hit.name != source_name || !hit_names_kind(rule, hit.kind.as_deref(), source) {
+            return false;
+        }
+        let Some(source_ns) = source_ns else {
+            return true;
+        };
+        let named_ns = match &rule.namespace_path {
+            Some(_) => hit.namespace,
+            None => o.metadata.namespace.clone(),
+        };
+        named_ns.as_deref() == Some(source_ns)
+    })
+}
+
+fn hit_names_kind(rule: &RefRule, named: Option<&str>, source: &KindRef) -> bool {
+    if !rule.is_dynamic() {
+        return true;
+    }
+    match named {
+        Some(named) => kind_is_named(source, named),
+        None => !rule.kind.is_empty() && kind_is_named(source, &rule.kind),
+    }
 }
 
 /// Drop repeats — the same object reached the same way twice, as a ConfigMap
@@ -1220,12 +1360,19 @@ mod tests {
             .into_iter()
             .find(|r| r.path.contains("persistentVolumeClaim"))
             .unwrap();
+        let pvc = kind("", "PersistentVolumeClaim", "persistentvolumeclaims", true);
         // Same name in the same namespace: a match; same name elsewhere: not.
-        assert!(names_source(&pod, &mounts, "data-db-0", Some("db")));
-        assert!(!names_source(&pod, &mounts, "data-db-0", Some("other")));
-        assert!(!names_source(&pod, &mounts, "wal-db-0", Some("db")));
+        assert!(names_source(&pod, &mounts, &pvc, "data-db-0", Some("db")));
+        assert!(!names_source(
+            &pod,
+            &mounts,
+            &pvc,
+            "data-db-0",
+            Some("other")
+        ));
+        assert!(!names_source(&pod, &mounts, &pvc, "wal-db-0", Some("db")));
         // A cluster-scoped selection has no namespace to match.
-        assert!(names_source(&pod, &mounts, "data-db-0", None));
+        assert!(names_source(&pod, &mounts, &pvc, "data-db-0", None));
 
         // With a namespace path, the pointed-at namespace decides, not the
         // referencing object's own.
@@ -1240,8 +1387,248 @@ mod tests {
         .into_iter()
         .find(|r| r.namespace_path.is_some())
         .unwrap();
-        assert!(names_source(&pv, &bound, "data-db-0", Some("db")));
-        assert!(!names_source(&pv, &bound, "data-db-0", Some("other")));
+        assert!(names_source(&pv, &bound, &pvc, "data-db-0", Some("db")));
+        assert!(!names_source(&pv, &bound, &pvc, "data-db-0", Some("other")));
+    }
+
+    #[test]
+    fn a_dynamic_kind_is_read_from_the_object() {
+        let (views, warnings) = crate::views::compile(
+            &toml::from_str::<crate::config::Config>(
+                r#"
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
+                kind = "secretstores"
+                kind_path = "/spec/secretStoreRef/kind"
+                kinds = ["secretstores", "clustersecretstores"]
+                relation = "reads from"
+
+                [[views.clusterrolebindings.refs]]
+                path = "/subjects/*/name"
+                namespace_path = "/subjects/*/namespace"
+                kind_path = "/subjects/*/kind"
+                kinds = ["serviceaccounts"]
+                relation = "binds"
+                reverse = "cluster"
+                "#,
+            )
+            .unwrap()
+            .views,
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+        let mut kinds = cluster();
+        kinds.0.extend([
+            kind("", "ServiceAccount", "serviceaccounts", true),
+            kind(
+                "rbac.authorization.k8s.io",
+                "ClusterRoleBinding",
+                "clusterrolebindings",
+                false,
+            ),
+            kind(
+                "external-secrets.io",
+                "ExternalSecret",
+                "externalsecrets",
+                true,
+            ),
+            kind("external-secrets.io", "SecretStore", "secretstores", true),
+            kind(
+                "external-secrets.io",
+                "ClusterSecretStore",
+                "clustersecretstores",
+                false,
+            ),
+        ]);
+        let es = kind(
+            "external-secrets.io",
+            "ExternalSecret",
+            "externalsecrets",
+            true,
+        );
+        let forward_to = |value: Value| {
+            let plan = self::plan(&views, &kinds, &es, &obj(value), "shop");
+            assert!(plan.warns.is_empty(), "{:?}", plan.warns);
+            plan.forward
+                .into_iter()
+                .map(|f| (f.target.plural, f.refs))
+                .collect::<Vec<_>>()
+        };
+        let es_obj = |store_ref: Value| {
+            json!({"apiVersion": "external-secrets.io/v1", "kind": "ExternalSecret",
+                "metadata": {"name": "db", "namespace": "shop"},
+                "spec": {"secretStoreRef": store_ref}})
+        };
+        assert_eq!(
+            forward_to(es_obj(
+                json!({"name": "vault", "kind": "ClusterSecretStore"})
+            )),
+            [(
+                "clustersecretstores".to_string(),
+                vec![("vault".to_string(), "shop".to_string())]
+            )]
+        );
+        assert_eq!(
+            forward_to(es_obj(json!({"name": "local", "kind": "SecretStore"}))),
+            [(
+                "secretstores".to_string(),
+                vec![("local".to_string(), "shop".to_string())]
+            )]
+        );
+        assert_eq!(
+            forward_to(es_obj(json!({"name": "local"}))),
+            [(
+                "secretstores".to_string(),
+                vec![("local".to_string(), "shop".to_string())]
+            )]
+        );
+        assert!(forward_to(es_obj(json!({"name": "x", "kind": "Widget"}))).is_empty());
+
+        let crb = obj(
+            json!({"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "ClusterRoleBinding",
+            "metadata": {"name": "admins"},
+            "subjects": [
+                {"kind": "User", "name": "alice"},
+                {"kind": "ServiceAccount", "name": "deployer", "namespace": "ci"},
+                {"kind": "Group", "name": "ops"},
+                {"kind": "ServiceAccount", "name": "reader", "namespace": "audit"},
+            ]}),
+        );
+        let crb_kind = kind(
+            "rbac.authorization.k8s.io",
+            "ClusterRoleBinding",
+            "clusterrolebindings",
+            false,
+        );
+        let plan = self::plan(&views, &kinds, &crb_kind, &crb, "");
+        assert!(plan.warns.is_empty(), "{:?}", plan.warns);
+        assert_eq!(plan.forward.len(), 1);
+        assert_eq!(plan.forward[0].target.plural, "serviceaccounts");
+        assert_eq!(
+            plan.forward[0].refs,
+            [
+                ("deployer".to_string(), "ci".to_string()),
+                ("reader".to_string(), "audit".to_string()),
+            ]
+        );
+
+        let store = kind("external-secrets.io", "SecretStore", "secretstores", true);
+        let cluster_store = kind(
+            "external-secrets.io",
+            "ClusterSecretStore",
+            "clustersecretstores",
+            false,
+        );
+        let store_obj = obj(
+            json!({"apiVersion": "external-secrets.io/v1", "kind": "SecretStore",
+            "metadata": {"name": "local", "namespace": "shop"}}),
+        );
+        let plan = self::plan(&views, &kinds, &store, &store_obj, "shop");
+        let back = plan
+            .backward
+            .iter()
+            .find(|b| b.from.plural == "externalsecrets")
+            .expect("externalsecrets are listed for a store");
+        assert_eq!(back.scope, "shop");
+        let rule = &back.rule;
+        let names_local = obj(es_obj(json!({"name": "local", "kind": "SecretStore"})));
+        let names_default = obj(es_obj(json!({"name": "local"})));
+        let names_cluster = obj(es_obj(
+            json!({"name": "local", "kind": "ClusterSecretStore"}),
+        ));
+        assert!(names_source(
+            &names_local,
+            rule,
+            &store,
+            "local",
+            Some("shop")
+        ));
+        assert!(names_source(
+            &names_default,
+            rule,
+            &store,
+            "local",
+            Some("shop")
+        ));
+        assert!(!names_source(
+            &names_cluster,
+            rule,
+            &store,
+            "local",
+            Some("shop")
+        ));
+        assert!(names_source(
+            &names_cluster,
+            rule,
+            &cluster_store,
+            "local",
+            None
+        ));
+        assert!(!names_source(
+            &names_default,
+            rule,
+            &cluster_store,
+            "local",
+            None
+        ));
+        assert!(!names_source(
+            &names_local,
+            rule,
+            &cluster_store,
+            "local",
+            None
+        ));
+        let secret = obj(json!({"apiVersion": "v1", "kind": "Secret",
+            "metadata": {"name": "local", "namespace": "shop"}}));
+        let plan = self::plan(
+            &views,
+            &kinds,
+            &kind("", "Secret", "secrets", true),
+            &secret,
+            "shop",
+        );
+        assert!(
+            plan.backward
+                .iter()
+                .all(|b| b.from.plural != "externalsecrets")
+        );
+    }
+
+    #[test]
+    fn a_dynamic_kind_needs_its_candidates() {
+        let (views, warnings) = crate::views::compile(
+            &toml::from_str::<crate::config::Config>(
+                r#"
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
+                kind_path = "/spec/secretStoreRef/kind"
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
+                kinds = ["secretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
+                kind_path = "spec/secretStoreRef/kind"
+                kinds = ["secretstores"]
+
+                [[views.externalsecrets.refs]]
+                path = "/spec/secretStoreRef/name"
+                kind_path = "/spec/secretStoreRef/kind"
+                kinds = ["SecretStores", " "]
+                "#,
+            )
+            .unwrap()
+            .views,
+        );
+        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert!(warnings[0].contains("ref 1") && warnings[0].contains("kinds"));
+        assert!(warnings[1].contains("ref 2") && warnings[1].contains("kind_path"));
+        assert!(warnings[2].contains("ref 3") && warnings[2].contains("JSON Pointer"));
+        let rules = &views["externalsecrets"].refs;
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].kinds, ["secretstores"]);
+        assert_eq!(rules[0].kind, "");
+        assert!(rules[0].is_dynamic());
     }
 
     #[test]

--- a/src/app/adjacent.rs
+++ b/src/app/adjacent.rs
@@ -187,9 +187,15 @@ impl App {
                     }
                 }
             }
-            for Backward { rule, from, scope } in plan.backward {
+            for Backward {
+                rule,
+                from,
+                scope,
+                default,
+            } in plan.backward
+            {
                 for o in cached_list(&mut lists, &client, &from, &scope, &mut warn).await {
-                    if names_source(o, &rule, &source, &source_name, source_ns) {
+                    if names_source(o, &rule, default.as_ref(), &source, &source_name, source_ns) {
                         items.push(item(Direction::NamedBy, &rule.relation, &from, o.clone()));
                     }
                 }

--- a/src/app/adjacent.rs
+++ b/src/app/adjacent.rs
@@ -189,7 +189,7 @@ impl App {
             }
             for Backward { rule, from, scope } in plan.backward {
                 for o in cached_list(&mut lists, &client, &from, &scope, &mut warn).await {
-                    if names_source(o, &rule, &source_name, source_ns) {
+                    if names_source(o, &rule, &source, &source_name, source_ns) {
                         items.push(item(Direction::NamedBy, &rule.relation, &from, o.clone()));
                     }
                 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4063,6 +4063,131 @@ async fn adjacent_reverse_rules_resolve_a_qualified_source_group() {
     );
 }
 
+fn secret_store_views(app: &mut App) {
+    app.cluster
+        .register_kind("external-secrets.io", "SecretStore", "secretstores", true);
+    app.cluster.register_kind(
+        "external-secrets.io",
+        "ClusterSecretStore",
+        "clustersecretstores",
+        false,
+    );
+    let cfg: crate::config::Config = toml::from_str(
+        r#"
+        [[views.externalsecrets.refs]]
+        path = "/spec/secretStoreRef/name"
+        kind = "secretstores"
+        kind_path = "/spec/secretStoreRef/kind"
+        kinds = ["secretstores", "clustersecretstores"]
+        relation = "reads from"
+    "#,
+    )
+    .unwrap();
+    let (views, warnings) = crate::views::compile(&cfg.views);
+    assert!(warnings.is_empty(), "{warnings:?}");
+    app.user_views = views;
+}
+
+fn external_secret(name: &str, store_ref: serde_json::Value) -> serde_json::Value {
+    json!({"apiVersion":"external-secrets.io/v1","kind":"ExternalSecret",
+        "metadata":{"name":name,"namespace":"default","uid":format!("{name}-uid")},
+        "spec":{"secretStoreRef":store_ref}})
+}
+
+#[tokio::test]
+async fn adjacent_follows_the_kind_named_by_the_object() {
+    let root = external_secret("db", json!({"name":"vault","kind":"ClusterSecretStore"}));
+    let (mut app, mut rx, responses, requests) = health_report_app("externalsecrets", root.clone());
+    secret_store_views(&mut app);
+    {
+        let mut replies = responses.lock().unwrap();
+        replies.insert(
+            "/apis/external-secrets.io/v1/namespaces/default/externalsecrets/db".into(),
+            (200, root.clone()),
+        );
+        replies.insert(
+            "/apis/external-secrets.io/v1/clustersecretstores/vault".into(),
+            (200, json!({"apiVersion":"external-secrets.io/v1","kind":"ClusterSecretStore","metadata":{"name":"vault"}})),
+        );
+    }
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    assert_eq!(app.adjacent_items.len(), 1);
+    assert_eq!(app.adjacent_items[0].name, "vault");
+    assert_eq!(
+        app.adjacent_items[0].plural,
+        "clustersecretstores.external-secrets.io"
+    );
+    assert_eq!(app.adjacent_items[0].relation, "reads from");
+    assert!(
+        !requests
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|path| path.contains("/secretstores/"))
+    );
+
+    let mut defaulted = root;
+    defaulted["spec"]["secretStoreRef"] = json!({"name":"local"});
+    {
+        let mut replies = responses.lock().unwrap();
+        replies.insert(
+            "/apis/external-secrets.io/v1/namespaces/default/externalsecrets/db".into(),
+            (200, defaulted),
+        );
+        replies.insert(
+            "/apis/external-secrets.io/v1/namespaces/default/secretstores/local".into(),
+            (200, json!({"apiVersion":"external-secrets.io/v1","kind":"SecretStore","metadata":{"name":"local","namespace":"default"}})),
+        );
+    }
+    app.handle_key(press(KeyCode::Char('r'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    assert_eq!(app.adjacent_items.len(), 1);
+    assert_eq!(app.adjacent_items[0].name, "local");
+    assert_eq!(
+        app.adjacent_items[0].plural,
+        "secretstores.external-secrets.io"
+    );
+}
+
+#[tokio::test]
+async fn adjacent_reverse_lookup_matches_the_kind_named_by_the_object() {
+    let root = json!({"apiVersion":"external-secrets.io/v1","kind":"SecretStore",
+        "metadata":{"name":"local","namespace":"default","uid":"store-uid"}});
+    let (mut app, rx) = test_app();
+    secret_store_views(&mut app);
+    let (mut app, mut rx, responses, _) =
+        health_report_app_with(app, rx, "secretstores", root.clone());
+    {
+        let mut replies = responses.lock().unwrap();
+        replies.insert(
+            "/apis/external-secrets.io/v1/namespaces/default/secretstores/local".into(),
+            (200, root),
+        );
+        replies.insert(
+            "/apis/external-secrets.io/v1/namespaces/default/externalsecrets".into(),
+            (200, json!({"apiVersion":"external-secrets.io/v1","kind":"ExternalSecretList","metadata":{},"items":[
+                external_secret("same-kind", json!({"name":"local","kind":"SecretStore"})),
+                external_secret("defaulted", json!({"name":"local"})),
+                external_secret("other-kind", json!({"name":"local","kind":"ClusterSecretStore"})),
+                external_secret("other-name", json!({"name":"vault","kind":"SecretStore"})),
+            ]})),
+        );
+    }
+    app.handle_key(press(KeyCode::Char('u'))).unwrap();
+    receive_adjacent(&mut app, &mut rx).await;
+    let mut names: Vec<_> = app
+        .adjacent_items
+        .iter()
+        .map(|it| (it.name.as_str(), it.relation.as_str()))
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        [("defaulted", "reads from"), ("same-kind", "reads from")]
+    );
+}
+
 #[tokio::test]
 async fn adjacent_rules_share_pod_lists_and_refresh_reads_them_again() {
     let root = json!({"apiVersion":"v1","kind":"Secret","metadata":{"name":"credentials","namespace":"default","uid":"secret-uid"}});
@@ -20800,7 +20925,21 @@ fn health_report_app(
     HealthResponses,
     Arc<std::sync::Mutex<Vec<String>>>,
 ) {
-    let (mut app, rx) = test_app();
+    let (app, rx) = test_app();
+    health_report_app_with(app, rx, plural, resource)
+}
+
+fn health_report_app_with(
+    mut app: App,
+    rx: Receiver<Msg>,
+    plural: &str,
+    resource: serde_json::Value,
+) -> (
+    App,
+    Receiver<Msg>,
+    HealthResponses,
+    Arc<std::sync::Mutex<Vec<String>>>,
+) {
     app.switch_kind(plural);
     apply(&mut app, resource);
     app.table_state.select(Some(0));

--- a/src/config.rs
+++ b/src/config.rs
@@ -774,6 +774,8 @@ pub struct ViewConfig {
 pub struct RefConfig {
     pub path: String,
     pub kind: String,
+    pub kind_path: Option<String>,
+    pub kinds: Vec<String>,
     pub relation: Option<String>,
     pub reverse: Option<String>,
     /// Where the target's namespace lives when it isn't the row's own.

--- a/src/views.rs
+++ b/src/views.rs
@@ -495,12 +495,31 @@ pub fn compile(
         for (index, r) in cfg.refs.iter().enumerate() {
             let path = r.path.trim();
             let kind = r.kind.trim();
+            let kind_path = r
+                .kind_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|p| !p.is_empty());
+            let kinds: Vec<String> = r
+                .kinds
+                .iter()
+                .map(|k| k.trim().to_lowercase())
+                .filter(|k| !k.is_empty())
+                .collect();
             let mut problem = None;
             if !path.starts_with('/') {
                 problem = Some(format!(
                     "path '{path}' is not a JSON Pointer (must start with '/')"
                 ));
-            } else if kind.is_empty() {
+            } else if let Some(p) = kind_path
+                && !p.starts_with('/')
+            {
+                problem = Some(format!("kind_path '{p}' is not a JSON Pointer"));
+            } else if kind_path.is_some() && kinds.is_empty() {
+                problem = Some("kind_path needs kinds, the kinds it may name".to_string());
+            } else if kind_path.is_none() && !kinds.is_empty() {
+                problem = Some("kinds needs kind_path, where the kind is read from".to_string());
+            } else if kind_path.is_none() && kind.is_empty() {
                 problem = Some("kind is empty".to_string());
             } else if let Some(p) = r.namespace_path.as_deref().map(str::trim)
                 && !p.starts_with('/')
@@ -533,6 +552,8 @@ pub fn compile(
                     .map(str::trim)
                     .map(str::to_string),
                 kind: kind.to_string(),
+                kind_path: kind_path.map(str::to_string),
+                kinds,
                 relation: r
                     .relation
                     .as_deref()

--- a/src/views.rs
+++ b/src/views.rs
@@ -521,11 +521,6 @@ pub fn compile(
                 problem = Some("kinds needs kind_path, where the kind is read from".to_string());
             } else if kind_path.is_none() && kind.is_empty() {
                 problem = Some("kind is empty".to_string());
-            } else if kind_path.is_some()
-                && !kind.is_empty()
-                && !kinds.contains(&kind.to_lowercase())
-            {
-                problem = Some(format!("kind '{kind}' must be one of kinds"));
             } else if let Some(p) = kind_path
                 && !wildcards_align(path, p)
             {

--- a/src/views.rs
+++ b/src/views.rs
@@ -521,10 +521,27 @@ pub fn compile(
                 problem = Some("kinds needs kind_path, where the kind is read from".to_string());
             } else if kind_path.is_none() && kind.is_empty() {
                 problem = Some("kind is empty".to_string());
+            } else if kind_path.is_some()
+                && !kind.is_empty()
+                && !kinds.contains(&kind.to_lowercase())
+            {
+                problem = Some(format!("kind '{kind}' must be one of kinds"));
+            } else if let Some(p) = kind_path
+                && !wildcards_align(path, p)
+            {
+                problem = Some(format!(
+                    "kind_path '{p}' does not follow the same arrays as path '{path}'"
+                ));
             } else if let Some(p) = r.namespace_path.as_deref().map(str::trim)
                 && !p.starts_with('/')
             {
                 problem = Some(format!("namespace_path '{p}' is not a JSON Pointer"));
+            } else if let Some(p) = r.namespace_path.as_deref().map(str::trim)
+                && !wildcards_align(path, p)
+            {
+                problem = Some(format!(
+                    "namespace_path '{p}' does not follow the same arrays as path '{path}'"
+                ));
             }
             let reverse = match r.reverse.as_deref().map(str::trim) {
                 None | Some("") => Some(crate::adjacent::Reverse::Namespace),
@@ -584,6 +601,25 @@ pub fn compile(
         );
     }
     (views, warnings)
+}
+
+fn wildcards_align(path: &str, sibling: &str) -> bool {
+    let path_segs: Vec<&str> = path.split('/').collect();
+    let sibling_segs: Vec<&str> = sibling.split('/').collect();
+    let stars = |segs: &[&str]| -> Vec<usize> {
+        segs.iter()
+            .enumerate()
+            .filter(|(_, s)| **s == "*")
+            .map(|(i, _)| i)
+            .collect()
+    };
+    let path_stars = stars(&path_segs);
+    let sibling_stars = stars(&sibling_segs);
+    sibling_stars.len() <= path_stars.len()
+        && sibling_stars
+            .iter()
+            .zip(&path_stars)
+            .all(|(&s, &p)| sibling_segs[..=s] == path_segs[..=p])
 }
 
 /// Parse a view's `sort` value: `"READY"`, `"READY:asc"`, or `"READY:desc"`.


### PR DESCRIPTION
Closes #505. Discussion: #503.

## Why

Some kinds name objects whose kind is itself a field of the reference: an ExternalSecret's `secretStoreRef` points at a SecretStore or a ClusterSecretStore, a ClusterRoleBinding's subjects mix ServiceAccounts with users and groups. A ref took one fixed `kind`, so covering both meant one rule per kind on the same `path`, and every lookup then issued a GET for the kind the row did not reference.

## What

`[[views."…".refs]]` gains two fields:

```toml
[[views.externalsecrets.refs]]
path      = "/spec/secretStoreRef/name"
kind      = "secretstores"                # default when the element has no kind
kind_path = "/spec/secretStoreRef/kind"
kinds     = ["secretstores", "clustersecretstores"]
relation  = "reads from"
```

- `kind_path` is read alongside `path` the way `namespace_path` already is, so `*` segments pair element by element.
- `kinds` bounds the rule to a candidate list. Forward, each element picks its target from the candidates by kind, plural, or group-qualified plural; an element naming none of them (`User`, `Group`) contributes nothing, silently. Backward, the rule is planned only when a candidate is the selected kind, and an object matches only when its element names that kind. The candidate list is what keeps the reverse lookup from listing the source kind for every selection, and it lets the cluster-scoped-to-namespaced check still run per kind.
- `kind` is optional when `kind_path` is set and acts as the default for an element without a kind, which is how ExternalSecrets default to SecretStore.
- Config validation rejects `kind_path` without `kinds`, `kinds` without `kind_path`, and a non-pointer `kind_path`, each as a skipped-ref warning.

## Tests

- Unit tests in `src/adjacent.rs`: forward selection across SecretStore and ClusterSecretStore, the `kind` default, skipping non-candidates, mixed ClusterRoleBinding subjects with per-element namespaces, backward matching per kind, and the three validation errors.
- Two `handle_key`-driven tests in `src/app/tests.rs` press `u` on an ExternalSecret and on a SecretStore against a fake API server, checking the GET path used and that the reverse list filters by kind.

`just check` passes locally (fmt, clippy `-D warnings`, 1364 tests).
