### PR TITLE
feat: load drop-in config files from conf.d/

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,28 @@ converted settings in memory. See [palette migration](keybindings.md#legacy-pale
 
 Everything below is optional. An empty config behaves like no config.
 
+## Drop-in files
+
+To split the configuration, put extra files in `conf.d/` next to the base
+config. Every `*.toml`, `*.yaml`, and `*.yml` file in that directory is merged
+over the base config, in file name order. This lets a team share one file and
+keep personal settings in another:
+
+```
+~/.config/sofka/
+├── config.toml
+└── conf.d/
+    ├── 10-team.yaml       # shared, for example CRD view settings
+    └── 20-personal.toml   # applied after 10-team.yaml
+```
+
+TOML and YAML files can be mixed in `conf.d/`. Drop-in files merge before the
+cluster and context overrides, so those keep the last word. The merge rules are
+the same as for [overrides](#per-cluster-and-per-context-overrides): tables
+merge key by key, and arrays like `[[plugins]]` replace the base value. An
+invalid drop-in file is skipped with a warning. `:config` lists the drop-in
+files and `:reload` reads them again.
+
 The [Home Manager module](home-manager.md) can manage generated TOML settings
 or existing TOML and YAML files, including cluster and context overrides.
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1590,6 +1590,13 @@ impl App {
         {
             lines.push(format!("  {} (previous config kept)", path.display()));
         }
+        for path in self.config.dropin_paths() {
+            lines.push(format!(
+                "  {} ({})",
+                path.display(),
+                crate::config::dropin_state(&path)
+            ));
+        }
         for path in self
             .config
             .override_paths(&self.cluster.context, &self.cluster.cluster_name)

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -208,6 +208,7 @@ impl App {
             .config
             .base_path()
             .into_iter()
+            .chain(self.config.dropin_paths())
             .chain(
                 self.config
                     .override_paths(&self.cluster.context, &self.cluster.cluster_name),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -16195,6 +16195,54 @@ async fn config_view_lists_sources_active_skin_and_warnings() {
     std::fs::remove_dir_all(&dir).unwrap();
 }
 
+#[tokio::test]
+async fn reload_applies_dropin_files_and_config_view_lists_them() {
+    let dir = std::env::temp_dir().join(format!("sofka-app-dropin-{}", std::process::id()));
+    write_config(&dir, "[aliases]\npo = \"pods\"\n");
+    let dropin_dir = dir.join("conf.d");
+    std::fs::create_dir_all(&dropin_dir).unwrap();
+    std::fs::write(
+        dropin_dir.join("10-team.yaml"),
+        "aliases:\n  dep: deployments\n",
+    )
+    .unwrap();
+    std::fs::write(dropin_dir.join("20-broken.toml"), "not valid toml [[[").unwrap();
+    let (mut app, _rx) = test_app();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    app.reload_config();
+
+    assert_eq!(
+        app.user_aliases.get("dep").map(String::as_str),
+        Some("deployments")
+    );
+    assert_eq!(app.user_aliases.get("po").map(String::as_str), Some("pods"));
+    assert!(
+        app.config_warnings
+            .iter()
+            .any(|w| w.contains("20-broken.toml")),
+        "{:?}",
+        app.config_warnings
+    );
+
+    assert!(app.run_palette_command("config"));
+    let text = app
+        .detail
+        .lines
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    let team = dropin_dir.join("10-team.yaml").display().to_string();
+    let broken = dropin_dir.join("20-broken.toml").display().to_string();
+    assert!(text.contains(&format!("{team} (loaded)")), "{text}");
+    assert!(
+        text.contains(&format!("{broken} (invalid - skipped)")),
+        "{text}"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
 // ----- provider logs (VictoriaLogs) ------------------------------------
 
 fn install_provider(app: &mut App) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1401,7 +1401,7 @@ impl ConfigLoader {
         let base = merged.clone();
 
         for path in self.dropin_paths() {
-            match read_file(&path) {
+            match read_dropin(&path) {
                 Ok(Some(mut v)) => {
                     if let Some(migration) = key_migration::prepare(&mut v, &path, &mut warnings) {
                         migrations.push(migration);
@@ -1508,7 +1508,7 @@ pub fn file_state(path: &Path) -> &'static str {
 }
 
 pub fn dropin_state(path: &Path) -> &'static str {
-    state_of(read_file(path))
+    state_of(read_dropin(path))
 }
 
 fn state_of(result: Result<Option<toml::Value>, String>) -> &'static str {
@@ -1525,6 +1525,14 @@ fn read_value(path: &Path) -> Result<Option<toml::Value>, String> {
         document::select(dir)?;
     }
     read_file(path)
+}
+
+fn read_dropin(path: &Path) -> Result<Option<toml::Value>, String> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => validate_file(path, &text).map(Some),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
 }
 
 fn read_file(path: &Path) -> Result<Option<toml::Value>, String> {
@@ -2211,6 +2219,7 @@ mod tests {
         )
         .unwrap();
         std::fs::write(dropin_dir.join("30-broken.yml"), "aliases: [unclosed\n").unwrap();
+        std::fs::write(dropin_dir.join("40-typed.toml"), "readonly = \"yes\"\n").unwrap();
         std::fs::write(dropin_dir.join("README.md"), "ignored\n").unwrap();
         std::fs::write(cluster_dir.join("config.toml"), "readonly = false\n").unwrap();
 
@@ -2221,7 +2230,12 @@ mod tests {
                 dropin_dir.join("10-team.yaml"),
                 dropin_dir.join("20-personal.toml"),
                 dropin_dir.join("30-broken.yml"),
+                dropin_dir.join("40-typed.toml"),
             ]
+        );
+        assert_eq!(
+            dropin_state(&dropin_dir.join("40-typed.toml")),
+            "invalid - skipped"
         );
 
         let r = loader.resolve("", "");
@@ -2230,8 +2244,10 @@ mod tests {
         for (alias, kind) in [("po", "pods"), ("svc", "services"), ("dep", "deployments")] {
             assert_eq!(r.config.aliases.get(alias).map(String::as_str), Some(kind));
         }
-        assert_eq!(r.warnings.len(), 1, "{:?}", r.warnings);
+        assert_eq!(r.warnings.len(), 2, "{:?}", r.warnings);
         assert!(r.warnings[0].contains("30-broken.yml"), "{}", r.warnings[0]);
+        assert!(r.warnings[1].contains("40-typed.toml"), "{}", r.warnings[1]);
+        assert!(r.warnings[1].contains("readonly"), "{}", r.warnings[1]);
 
         let r = loader.resolve("ctx", "c1");
         assert!(!r.config.readonly, "cluster override wins over drop-ins");

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@
 //! ```text
 //! sofka/
 //! ├── config.toml                  # base, applies everywhere
+//! ├── conf.d/
+//! │   └── *.toml, *.yaml, *.yml    # drop-ins merged over the base, in name order
 //! └── clusters/
 //!     └── <cluster>/               # kubeconfig *cluster* name
 //!         ├── config.toml          # every context on this cluster
@@ -1344,6 +1346,26 @@ impl ConfigLoader {
         self.base.is_some()
     }
 
+    pub fn dropin_paths(&self) -> Vec<PathBuf> {
+        let Some(dir) = &self.dir else {
+            return Vec::new();
+        };
+        let Ok(entries) = std::fs::read_dir(dir.join("conf.d")) else {
+            return Vec::new();
+        };
+        let mut paths: Vec<PathBuf> = entries
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|path| {
+                matches!(
+                    path.extension().and_then(|s| s.to_str()),
+                    Some("toml" | "yaml" | "yml")
+                ) && path.is_file()
+            })
+            .collect();
+        paths.sort();
+        paths
+    }
+
     /// Override files consulted for the given kubeconfig cluster/context, in
     /// merge order (cluster level first, then context level). The files need
     /// not exist — this is the search path, for [`resolve`](Self::resolve)
@@ -1378,6 +1400,19 @@ impl ConfigLoader {
         }
         let base = merged.clone();
 
+        for path in self.dropin_paths() {
+            match read_file(&path) {
+                Ok(Some(mut v)) => {
+                    if let Some(migration) = key_migration::prepare(&mut v, &path, &mut warnings) {
+                        migrations.push(migration);
+                    }
+                    merge(&mut merged, v);
+                }
+                Ok(None) => {}
+                Err(e) => warnings.push(format!("ignoring invalid {}: {e}", path.display())),
+            }
+        }
+
         for path in self.override_paths(context, cluster) {
             match read_value(&path) {
                 Ok(Some(mut v)) => {
@@ -1397,7 +1432,7 @@ impl ConfigLoader {
         let mut valid_config = true;
         let mut config: Config = merged.try_into().unwrap_or_else(|e| {
             valid_config = false;
-            warnings.push(format!("ignoring cluster overrides: {e}"));
+            warnings.push(format!("ignoring drop-in and cluster overrides: {e}"));
             base.try_into().unwrap_or_default()
         });
         if !migrations.is_empty() {
@@ -1469,7 +1504,15 @@ fn validate(text: &str) -> Result<toml::Value, toml::de::Error> {
 /// `loaded` (present and parseable), `absent`, or `invalid` (present but
 /// malformed config).
 pub fn file_state(path: &Path) -> &'static str {
-    match read_value(path) {
+    state_of(read_value(path))
+}
+
+pub fn dropin_state(path: &Path) -> &'static str {
+    state_of(read_file(path))
+}
+
+fn state_of(result: Result<Option<toml::Value>, String>) -> &'static str {
+    match result {
         Ok(Some(_)) => "loaded",
         Ok(None) => "absent",
         Err(_) => "invalid - skipped",
@@ -1481,6 +1524,10 @@ fn read_value(path: &Path) -> Result<Option<toml::Value>, String> {
     if let Some(dir) = path.parent() {
         document::select(dir)?;
     }
+    read_file(path)
+}
+
+fn read_file(path: &Path) -> Result<Option<toml::Value>, String> {
     match std::fs::read_to_string(path) {
         Ok(text) => document::parse(path, &text).map(Some),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -2136,6 +2183,59 @@ mod tests {
         let r = loader.resolve("ctx", "c1");
         assert_eq!(r.warnings.len(), 1);
         assert_eq!(r.config.default_namespace.as_deref(), Some("base"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn dropins_merge_in_name_order_before_cluster_overrides() {
+        let dir =
+            std::env::temp_dir().join(format!("sofka-cfg-dropin-test-{}", std::process::id()));
+        let dropin_dir = dir.join("conf.d");
+        let cluster_dir = dir.join("clusters").join("c1");
+        std::fs::create_dir_all(&dropin_dir).unwrap();
+        std::fs::create_dir_all(&cluster_dir).unwrap();
+        std::fs::write(
+            dir.join("config.toml"),
+            "default_namespace = \"base\"\nreadonly = false\n[aliases]\npo = \"pods\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dropin_dir.join("20-personal.toml"),
+            "default_namespace = \"personal\"\n[aliases]\ndep = \"deployments\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dropin_dir.join("10-team.yaml"),
+            "default_namespace: team\nreadonly: true\naliases:\n  svc: services\n",
+        )
+        .unwrap();
+        std::fs::write(dropin_dir.join("30-broken.yml"), "aliases: [unclosed\n").unwrap();
+        std::fs::write(dropin_dir.join("README.md"), "ignored\n").unwrap();
+        std::fs::write(cluster_dir.join("config.toml"), "readonly = false\n").unwrap();
+
+        let loader = ConfigLoader::from_dir(Some(dir.clone()));
+        assert_eq!(
+            loader.dropin_paths(),
+            vec![
+                dropin_dir.join("10-team.yaml"),
+                dropin_dir.join("20-personal.toml"),
+                dropin_dir.join("30-broken.yml"),
+            ]
+        );
+
+        let r = loader.resolve("", "");
+        assert_eq!(r.config.default_namespace.as_deref(), Some("personal"));
+        assert!(r.config.readonly);
+        for (alias, kind) in [("po", "pods"), ("svc", "services"), ("dep", "deployments")] {
+            assert_eq!(r.config.aliases.get(alias).map(String::as_str), Some(kind));
+        }
+        assert_eq!(r.warnings.len(), 1, "{:?}", r.warnings);
+        assert!(r.warnings[0].contains("30-broken.yml"), "{}", r.warnings[0]);
+
+        let r = loader.resolve("ctx", "c1");
+        assert!(!r.config.readonly, "cluster override wins over drop-ins");
+        assert_eq!(r.config.default_namespace.as_deref(), Some("personal"));
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -351,6 +351,13 @@ pub fn config_source_lines(
         }
         None => lines.push("  no config directory — using defaults".into()),
     }
+    for path in loader.dropin_paths() {
+        lines.push(format!(
+            "  {} ({})",
+            path.display(),
+            crate::config::dropin_state(&path)
+        ));
+    }
     for path in loader.override_paths(context, cluster) {
         lines.push(format!(
             "  {} ({})",


### PR DESCRIPTION
Closes #507. Agreed in discussion #504.

## Why

Teams want to share some settings, such as view settings for their CRDs, and still keep personal settings. The base config was a single file, so the only way to share was to copy sections around by hand.

## What

- Every `*.toml`, `*.yaml`, and `*.yml` file under `conf.d/` next to the base config is merged over the base in file name order.
- Drop-ins merge before the cluster and context overrides, so those keep the last word. The merge rules are the same ones the overrides use.
- TOML and YAML can be mixed in `conf.d/`.
- An invalid drop-in is skipped with a warning. `:config` and `--check` list each drop-in with its state, and `:reload` reads them again.
- `docs/configuration.md` gets a "Drop-in files" section.

## Tests

- `config::tests::dropins_merge_in_name_order_before_cluster_overrides` covers ordering, mixed formats, skipping a broken file, and that cluster overrides still win.
- `app::tests::reload_applies_dropin_files_and_config_view_lists_them` drives `:reload` and `:config` through the app.

`just check` passes.