### PR TITLE
fix: fill selected contexts and fit palette key instructions

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -152,8 +152,9 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   navigation screen, then close back to the screen where they were opened.
 - **Cross-context resource navigation** - `:pods @production-cluster default`
   switches context, resource, and namespace together without changing kubeconfig's
-  `current-context`. Context names after `@` fuzzy-complete: Tab/Shift-Tab select
-  a suggestion and Enter opens it. Omit the namespace to use the target context's
+  `current-context`. Context names after `@` fuzzy-complete: Tab/Shift-Tab or
+  Down/Up fill the selected context in the command. Add a namespace if needed,
+  then press Enter to run the query. Omit the namespace to use the target context's
   remembered or default namespace. Namespace completion after `@context` is not
   provided.
 - **Help scrolling** (`?`) - browse all bindings, including plugins, bookmarks,

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -15,7 +15,8 @@ resource, or pods if none is set.
 
 Use `:resource -n namespace --context context /filter` to apply a complete query.
 Use `:resource @context [namespace]` for cross-context navigation. Context names
-fuzzy-complete after `@`; Tab/Shift-Tab select a suggestion and Enter opens it.
+fuzzy-complete after `@`; Tab/Shift-Tab or Down/Up fill the selected context in
+the command. Add a namespace if needed, then press Enter to run the query.
 Without a namespace, a context switch uses its remembered or default namespace.
 This does not change kubeconfig's `current-context`.
 Scope options precede the slash. Structured filter terms combine with spaces or

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -480,6 +480,7 @@ impl App {
         if key.action == Some(Action::Down) {
             if !self.cmd_suggestions.is_empty() {
                 self.cmd_sel = (self.cmd_sel + 1) % self.cmd_suggestions.len();
+                self.fill_resource_context();
             }
             return;
         }
@@ -489,6 +490,7 @@ impl App {
                     .cmd_sel
                     .checked_sub(1)
                     .unwrap_or(self.cmd_suggestions.len() - 1);
+                self.fill_resource_context();
             }
             return;
         }
@@ -511,6 +513,20 @@ impl App {
                 self.update_suggestions();
             }
             _ => {}
+        }
+    }
+
+    fn fill_resource_context(&mut self) {
+        if let Some(suggestion) = self
+            .cmd_suggestions
+            .get(self.cmd_sel)
+            .filter(|s| s.kind == SuggestKind::Context)
+            && let Some((head, argument)) = self.command.split_once(char::is_whitespace)
+            && !is_ctx_command(head)
+            && argument.trim_start().starts_with('@')
+        {
+            self.command = format!("{head} @{}", suggestion.label);
+            // Keep the matching list so the next key can select another context.
         }
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15202,6 +15202,63 @@ async fn resource_context_shortcut_preserves_explicit_namespace() {
 }
 
 #[tokio::test]
+async fn resource_context_selection_fills_and_cycles_before_adding_namespace() {
+    for (next, previous) in [
+        (KeyCode::Down, KeyCode::Up),
+        (KeyCode::Tab, KeyCode::BackTab),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.all_contexts = vec!["gke-east".into(), "gke-west".into()];
+        let generation = app.generation;
+        app.handle_key(press(KeyCode::Char(':'))).unwrap();
+        for c in "pods @gke".chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        for (key, expected) in [
+            (next, "pods @gke-west"),
+            (next, "pods @gke-east"),
+            (previous, "pods @gke-west"),
+            (previous, "pods @gke-east"),
+            (next, "pods @gke-west"),
+        ] {
+            app.handle_key(press(key)).unwrap();
+            assert_eq!(app.command, expected);
+            assert_eq!(app.mode, Mode::Command);
+            assert_eq!(app.generation, generation);
+            assert!(app.pending_resource_query.is_none());
+        }
+        for c in " production".chars() {
+            app.handle_key(press(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        land_context(&mut app, "gke-west");
+        assert_eq!(app.kind_plural, "pods");
+        assert_eq!(app.namespace, "production");
+        assert_eq!(app.cluster.context, "gke-west");
+    }
+}
+
+#[tokio::test]
+async fn resource_context_completion_stays_editable_and_can_be_cancelled() {
+    let (mut app, _rx) = test_app();
+    app.all_contexts = vec!["gke-west".into()];
+    let generation = app.generation;
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    for c in "services @gke".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    app.handle_key(press(KeyCode::Tab)).unwrap();
+    assert_eq!(app.command, "services @gke-west");
+    app.handle_key(press(KeyCode::Backspace)).unwrap();
+    assert_eq!(app.command, "services @gke-wes");
+    app.handle_key(press(KeyCode::Char('t'))).unwrap();
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, Mode::Table);
+    assert_eq!(app.generation, generation);
+    assert!(app.pending_resource_query.is_none());
+}
+
+#[tokio::test]
 async fn resource_context_shortcut_completes_long_names_and_uses_target_default() {
     let (mut app, _rx) = test_app();
     let context = "gke_project_europe-west1_production-cluster";
@@ -26945,9 +27002,9 @@ async fn document_fullscreen_layout_and_prompts_follow_keys() {
         assert!(command[0].contains("document title"));
         assert!(command[19].contains(':'));
         assert!(
-            command
-                .iter()
-                .any(|row| row.contains("commands & resources"))
+            command.iter().any(|row| row.contains(":next")
+                && row.contains(":previous")
+                && row.contains(":run"))
         );
         app.handle_key(press(KeyCode::Esc)).unwrap();
         assert_eq!(app.mode, mode);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2730,7 +2730,7 @@ fn build_help(app: &App, width: usize) -> (Vec<Line<'static>>, String) {
     ));
     lines.push(bind(
         ":resource @context [namespace]",
-        "switch context and resource (context fuzzy-completes; kubeconfig unchanged)",
+        "switch context and resource (select to fill context, then add namespace)",
     ));
     lines.push(bind(":rightsize", "historical right-sizing: P50/P95/P99 usage → suggested requests + patch (needs [providers.metrics])"));
     lines.push(bind(
@@ -4034,7 +4034,29 @@ fn draw_palette(frame: &mut Frame, app: &mut App, area: Rect) {
     }
     let shown = app.cmd_suggestions.len().min(12) as u16;
     let h = shown + 2;
-    let w = area.width.saturating_sub(4).min(46);
+    let keys = key_hint(
+        app,
+        "command",
+        &[
+            (Action::Down, "next"),
+            (Action::Up, "previous"),
+            (Action::Accept, "run"),
+        ],
+    );
+    let full_title = format!(" commands & resources ({keys}) ");
+    let w = area
+        .width
+        .saturating_sub(4)
+        .min(full_title.width().saturating_add(2).max(46) as u16);
+    let title_width = usize::from(w.saturating_sub(2));
+    let hint = [
+        full_title,
+        format!(" {keys} "),
+        format!(" {} ", key_hint(app, "command", &[(Action::Accept, "run")])),
+    ]
+    .into_iter()
+    .find(|title| title.width() <= title_width)
+    .unwrap_or_else(|| clip_to_width(" commands ", title_width));
     let rect = Rect {
         x: area.x + 1,
         y: area.y + area.height.saturating_sub(h + 1),
@@ -4082,18 +4104,6 @@ fn draw_palette(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     let mut state = ListState::default();
     state.select(Some(app.cmd_sel));
-    let hint = format!(
-        " commands & resources ({}) ",
-        key_hint(
-            app,
-            "command",
-            &[
-                (Action::Down, "next"),
-                (Action::Up, "previous"),
-                (Action::Accept, "run")
-            ]
-        )
-    );
     render_framed_list(
         frame,
         show_scrollbars,
@@ -5158,6 +5168,60 @@ mod tests {
         assert!(clipped.ends_with('…'));
         // No room even for the ellipsis.
         assert_eq!(clip_to_width("abc", 0), "");
+    }
+
+    #[tokio::test]
+    async fn palette_title_fits_wide_and_narrow_terminals() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let mut app = App::new(crate::k8s::Cluster::fake(), tx);
+        app.all_contexts = vec!["gke-west".into()];
+        for c in ":pods @gke".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+                .unwrap();
+        }
+        for custom_keys in [false, true] {
+            if custom_keys {
+                let cfg: crate::config::Config = toml::from_str(
+                    "[keys.command]\ndown = 'ctrl-n'\nup = 'ctrl-p'\naccept = 'ctrl-y'",
+                )
+                .unwrap();
+                app.keymap = crate::keymap::Keymap::compile(&cfg.keys).unwrap();
+            }
+            let keys = key_hint(
+                &app,
+                "command",
+                &[
+                    (Action::Down, "next"),
+                    (Action::Up, "previous"),
+                    (Action::Accept, "run"),
+                ],
+            );
+            for (width, expected) in [
+                (100, format!(" commands & resources ({keys}) ")),
+                (60, format!(" {keys} ")),
+                (
+                    30,
+                    format!(
+                        " {} ",
+                        key_hint(&app, "command", &[(Action::Accept, "run")])
+                    ),
+                ),
+            ] {
+                let mut terminal = Terminal::new(TestBackend::new(width, 12)).unwrap();
+                terminal
+                    .draw(|f| draw_palette(f, &mut app, f.area()))
+                    .unwrap();
+                let buffer = terminal.backend().buffer();
+                let title = (0..width)
+                    .map(|x| buffer[(x, 8)].symbol())
+                    .collect::<String>();
+                assert!(title.contains(&expected), "width {width}: {title:?}");
+                assert!(title.contains('╮'), "missing right border: {title:?}");
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Selecting a context in `:pods @gke` now fills the command without running it. Users can keep cycling through matching contexts, add a namespace, and press Enter to run the query. Previously, selection changed only the highlighted row and Enter completed and ran the command in one step.

The palette now adjusts its width and title to show complete key instructions where space permits, with shorter text for narrow terminals. Help and docs describe the completion steps.

Validation: `just check` passed, including regression tests for context cycling, namespace execution, editing, cancellation, and title rendering with default and custom keys. `git diff --check` passed. No live cluster test was run.

Closes #511.

Reported in [discussion #390](https://github.com/nklmilojevic/sofka/discussions/390#discussioncomment-18398404).
