### PR TITLE
fix: size the confirm dialog to its own text

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5592,6 +5592,65 @@ async fn delete_confirm_cascade_can_cycle() {
     ));
 }
 
+/// A label longer than the dialog's minimum width has to stay readable: the
+/// drain question on a node with an ordinary name is 67 characters, which the
+/// fixed 56-column popup truncated mid-word.
+#[tokio::test]
+async fn confirm_dialog_fits_its_label_at_any_terminal_size() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    for (width, height) in [(80u16, 24u16), (120, 32), (200, 40)] {
+        let (mut app, _rx) = test_app();
+        app.switch_kind("nodes");
+        apply(
+            &mut app,
+            json!({"apiVersion": "v1", "kind": "Node",
+                   "metadata": {"name": "bastion-expert-lizard-1"}}),
+        );
+        app.table_state.select(Some(0));
+        app.handle_key(press(KeyCode::Char('D'))).unwrap();
+        assert_eq!(app.mode, Mode::Confirm);
+
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let screen: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(usize::from(width))
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Every word of the label and of the key hints is on screen.
+        for expected in ["bastion-expert-lizard-1", "eligible pods.", "esc:cancel"] {
+            assert!(
+                screen.contains(expected),
+                "{width}x{height} lost {expected:?}:\n{screen}"
+            );
+        }
+
+        // And the dialog is no wider than the text needs, so a large terminal
+        // does not get a mostly empty box.
+        let title = screen
+            .lines()
+            .find(|line| line.contains("Confirm"))
+            .expect("the dialog is on screen");
+        let chars: Vec<char> = title.chars().collect();
+        let at = title.chars().count() - title.rsplit("Confirm").next().unwrap().chars().count();
+        let start = chars[..at].iter().rposition(|&c| c == '╭').unwrap();
+        let end = at + chars[at..].iter().position(|&c| c == '╮').unwrap();
+        let dialog_width = end - start + 1;
+        let label_width = app.confirm_label.chars().count();
+        assert!(
+            dialog_width <= label_width + 4,
+            "{width}x{height}: dialog is {dialog_width} columns for a \
+{label_width}-character label:\n{screen}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn node_drain_key_opens_confirm_for_marked_nodes() {
     let (mut app, _rx) = test_app();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3999,29 +3999,64 @@ fn draw_set_image(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+/// Floor for the confirm dialog, so a short question still reads as a dialog.
+const MIN_CONFIRM_WIDTH: u16 = 56;
+const MIN_CONFIRM_HEIGHT: u16 = 7;
+
 fn draw_confirm(frame: &mut Frame, app: &App, area: Rect) {
-    let popup = centered_rect_with_min(50, 20, 56, 7, area);
+    // Sized from its own text: a share of the frame is too narrow for a long
+    // label on a small terminal, which truncated it mid-word, and mostly empty
+    // on a large one.
+    let hint = confirm_action_hint(app, app.confirm_allows_force_toggle());
+    // Two border columns plus the block's one column of padding on each side.
+    const CHROME: usize = 4;
+    let longest = app
+        .confirm_label
+        .split('\n')
+        .chain(std::iter::once(&*hint))
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0);
+    let width = u16::try_from(longest + CHROME)
+        .unwrap_or(u16::MAX)
+        .clamp(MIN_CONFIRM_WIDTH.min(area.width), area.width);
+    let inner = usize::from(width).saturating_sub(CHROME).max(1);
+    // Whatever still does not fit wraps, and the dialog grows by those rows.
+    let rows: usize = app
+        .confirm_label
+        .split('\n')
+        .chain(std::iter::once(&*hint))
+        .map(|line| line.chars().count().div_ceil(inner).max(1))
+        .sum();
+    // Two borders, a leading blank row, and the blank between label and hint.
+    let height = u16::try_from(rows + 4)
+        .unwrap_or(u16::MAX)
+        .clamp(MIN_CONFIRM_HEIGHT.min(area.height), area.height);
+    let popup = centered_rect_with_min(0, 0, width, height, area);
     clear_region(frame, popup);
-    let lines = vec![
-        Line::from(""),
+    let mut lines = vec![Line::from("")];
+    lines.extend(app.confirm_label.split('\n').map(|line| {
         Line::from(Span::styled(
-            format!("  {}", app.confirm_label),
+            line.to_string(),
             Style::default().fg(theme::text()),
-        )),
-        Line::from(""),
-        Line::from(Span::styled(
-            confirm_action_hint(app, app.confirm_allows_force_toggle()),
-            Style::default().fg(theme::yellow()),
-        )),
-    ];
+        ))
+    }));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        hint,
+        Style::default().fg(theme::yellow()),
+    )));
     frame.render_widget(
-        Paragraph::new(lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(theme::red()))
-                .title(Span::styled(" Confirm ", Style::default().fg(theme::red()))),
-        ),
+        Paragraph::new(lines)
+            .wrap(ratatui::widgets::Wrap { trim: true })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(theme::red()))
+                    .padding(ratatui::widgets::Padding::horizontal(1))
+                    .title(Span::styled(" Confirm ", Style::default().fg(theme::red()))),
+            ),
         popup,
     );
 }


### PR DESCRIPTION
## Problem

`draw_confirm` sizes the popup as a fixed share of the frame — 50% of the width with a 56-column floor — and renders `confirm_label` on one unwrapped line. A label longer than the inner width is truncated mid-word.

The drain prompt reaches 67 characters on a node with an ordinary name, so on `main` today, pressing `D` on a node called `bastion-expert-lizard-1` shows:

```
╭ Confirm ─────────────────────────────────────────────────╮
│  Drain node bastion-expert-lizard-1? Cordon and evict eli│
│y:confirm  esc:cancel                                     │
╰──────────────────────────────────────────────────────────╯
```

"eligible pods." is gone, and the hint line sits flush against the border. The same percentage leaves most of the box empty on a wide terminal.

## Change

Measure the label and the key hints, size the popup to the longest of them (keeping the 56-column floor so a short question still reads as a dialog), and grow it by however many rows the text needs. Anything still too long wraps rather than being cut. The block carries its own horizontal padding, which survives wrapping — the label's leading spaces did not.

Same prompt after:

```
╭ Confirm ─────────────────────────────────────────────────────────────╮
│                                                                      │
│ Drain node bastion-expert-lizard-1? Cordon and evict eligible pods.  │
│                                                                      │
│ y:confirm  esc:cancel                                                │
╰──────────────────────────────────────────────────────────────────────╯
```

A multi-line label is supported too: `confirm_label` is split on newlines, so an action that wants a second line gets one.

## Tests

`confirm_dialog_fits_its_label_at_any_terminal_size` drives `D` through `handle_key` at 80x24, 120x32 and 200x40 and asserts both directions — every word of the label and the hints is on screen, and the dialog is no wider than the label needs. It fails on `main` with `80x24 lost "eligible pods."`.

`cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings` and `cargo test --locked` all pass (1381 tests).

Bug fix, so no discussion per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)