### PR TITLE
fix: reference the local Nix setup action in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Nix
-        uses: $/.github/actions/setup-nix
+        uses: ./.github/actions/setup-nix # zizmor: ignore[self-repository]
 
       - name: Check flake outputs on all supported systems
         run: nix flake check --no-build --all-systems


### PR DESCRIPTION
## Problem

`ci.yaml` points the home-manager job at `$/.github/actions/setup-nix`, which is not a valid `uses` value. GitHub rejects the workflow before scheduling anything, so the run ends as:

> This run likely failed because of a workflow file issue.

with **zero jobs** — the `rust` (fmt/clippy/test) and `coverage` jobs never get the chance to run either. Every pull request whose head contains this file reports a red CI with no results. Current examples: runs for #522, #521 and #518 all failed this way with `total_count: 0` jobs.

Introduced in 51541ea ("feat: add a complete Home Manager module"). `.github/actions/setup-nix/` exists, and `release.yaml:212` already refers to it correctly.

## Change

Use the repository-relative path, with the same `zizmor` pragma `release.yaml` carries:

```yaml
uses: ./.github/actions/setup-nix # zizmor: ignore[self-repository]
```

CI on this pull request is itself the check — the workflow file under test is the one on this branch, so a run that actually schedules its jobs confirms the fix.

Bug fix, so no discussion per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)