### PR TITLE
feat: keep the resource type when switching context

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -203,6 +203,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
 - **RBAC-aware palette browse** - the empty `:` list hides kinds you cannot
   `list`. An explicit search checks the full discovery catalog, because some
   delegated authorizers return incomplete rule reviews.
+- **Resource type on context switch** - `:ctx` keeps the current resource type
+  when the target cluster supports it. If unavailable, sofka opens that context's
+  configured default resource, or Pods, and shows a fallback message. Filters and
+  object ownership scope are cleared. Namespace selection follows the existing
+  per-context rules. Explicit resource queries, bookmarks, and workspaces keep
+  their specified destination.
 - **Context picker at launch** - `sofka ctx` and `sofka contexts` open the picker
   before connecting to a cluster. Enter connects to the selected context and
   opens its configured default resource, or pods. `--context NAME` selects the

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -19,10 +19,16 @@ fuzzy-complete after `@`; Tab/Shift-Tab or Down/Up fill the selected context in
 the command. Add a namespace if needed, then press Enter to run the query.
 Without a namespace, a context switch uses its remembered or default namespace.
 This does not change kubeconfig's `current-context`.
+
 Scope options precede the slash. Structured filter terms combine with spaces or
 `&&`, with `||` for OR and `!(...)` for group negation. `/` edits the active filter
 and Esc clears it. See [filtering](filtering.md)
 for the grammar and selector persistence rules.
+
+A normal context switch through `:ctx` keeps the current resource type if the
+target cluster supports it. Otherwise, sofka opens that context's configured
+default resource, or Pods, and shows a fallback message. Filters and object
+ownership scope are cleared. Startup still uses the configured default resource.
 
 | Key                                           | Action                                                                                                                                                              |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -99,7 +99,7 @@ impl App {
     /// selectors, and reset filter/sort/cursor. A stale selection from the
     /// previous kind (e.g. row 5 on pods) would otherwise carry over — the new
     /// view always starts with its first row selected.
-    fn set_root_view(&mut self, kind: Kind) {
+    pub(super) fn set_root_view(&mut self, kind: Kind) {
         self.stack.clear();
         self.kind_plural = kind.ar.plural.to_lowercase();
         self.kind = Some(kind);

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -852,6 +852,7 @@ impl App {
     /// re-resolved so per-cluster/per-context overrides (aliases, plugins,
     /// skin, defaults) follow the new context.
     pub(super) fn apply_context_switch(&mut self, name: String, mut cluster: Box<Cluster>) {
+        let previous_kind = self.kind.clone().filter(|_| self.cluster.connected);
         self.stop_notifications();
         let resolved = self.config.resolve(&name, &cluster.cluster_name);
         self.user_aliases = resolved.config.aliases;
@@ -943,8 +944,7 @@ impl App {
         self.config_warnings = resolved.warnings;
         self.config_warnings.extend(plugin_warnings);
         self.config_warnings.extend(threshold_warnings);
-        // A bookmark/workspace that requested this context lands on its own
-        // view(s); a plain switch lands on the context's default resource.
+        // Explicit destinations take priority over the previous resource type.
         if let Some(mut query) = self.pending_resource_query.take() {
             query.context = None;
             self.apply_resource_query(query);
@@ -953,11 +953,37 @@ impl App {
         } else if self.pending_bookmark.is_some() {
             self.apply_pending_bookmark();
         } else {
-            let kind = resolved
+            let retained = previous_kind.as_ref().and_then(|previous| {
+                self.cluster.resolve(&previous.title()).filter(|kind| {
+                    kind.ar.group == previous.ar.group && kind.ar.plural == previous.ar.plural
+                })
+            });
+            let fallback = retained.is_none();
+            let default = resolved
                 .config
                 .default_resource
-                .unwrap_or_else(|| "pods".into());
-            self.switch_kind(&kind);
+                .as_deref()
+                .unwrap_or("pods");
+            let kind = retained
+                .or_else(|| self.cluster.resolve(default))
+                .or_else(|| self.cluster.resolve("pods"));
+            if let Some(kind) = kind {
+                let title = kind.title();
+                self.set_root_view(kind);
+                self.record_history();
+                self.start_watch();
+                self.set_flash(format!("Viewing {title}"));
+                if fallback && let Some(previous) = previous_kind {
+                    self.flash_warn(&format!(
+                        "{} is unavailable in {name}; viewing {title}",
+                        previous.title()
+                    ));
+                }
+            } else {
+                self.flash_warn(&format!(
+                    "No resource matches '{default}' or 'pods' in {name}"
+                ));
+            }
         }
         if let Some(w) = &first_warning {
             self.flash_warn(w);

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -986,7 +986,11 @@ impl App {
             }
         }
         if let Some(w) = &first_warning {
-            self.flash_warn(w);
+            if self.flash_err {
+                self.flash_warn(&format!("{}; {w}", self.flash));
+            } else {
+                self.flash_warn(w);
+            }
         }
         self.flash_discovery_warnings();
         // Saved forwards for the new context. Running ones from the previous

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12886,6 +12886,40 @@ async fn context_switch_missing_resource_uses_default_then_pods() {
 }
 
 #[tokio::test]
+async fn context_switch_keeps_fallback_message_with_config_warning() {
+    let (mut app, _rx) = test_app();
+    app.all_contexts = vec!["test".into(), "west".into()];
+    let dir = std::env::temp_dir().join(format!(
+        "sofka-context-fallback-warning-{}",
+        std::process::id()
+    ));
+    let context_dir = dir.join("clusters/test-cluster/west");
+    std::fs::create_dir_all(&context_dir).unwrap();
+    std::fs::write(context_dir.join("config.toml"), "readonly = \n").unwrap();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    app.cluster
+        .register_kind("example.com", "Widget", "widgets", true);
+    type_resource_query(&mut app, "widgets.example.com");
+    palette(&mut app, "ctx west");
+    assert_eq!(
+        app.context_switch_target,
+        Some((app.generation, "west".into()))
+    );
+    land_context(&mut app, "west");
+    assert_eq!(app.kind_plural, "pods");
+    assert!(app.flash_err);
+    assert!(
+        app.flash
+            .contains("widgets.example.com is unavailable in west; viewing pods"),
+        "{}",
+        app.flash
+    );
+    assert_eq!(app.config_warnings.len(), 1);
+    assert!(app.flash.contains(&app.config_warnings[0]), "{}", app.flash);
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[tokio::test]
 async fn context_picker_launch_connects_on_enter_and_opens_default_resource() {
     for default in [None, Some("deployments")] {
         let (mut app, _rx) = test_app();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12761,6 +12761,131 @@ async fn context_switch_resolves_readonly_and_cli_pin_wins() {
 }
 
 #[tokio::test]
+async fn context_switch_keeps_resource_type_and_clears_filter_scope() {
+    for resource in ["deployments", "statefulsets", "nodes"] {
+        for picker in [false, true] {
+            let (mut app, _rx) = test_app();
+            app.all_contexts = vec!["test".into(), "west".into()];
+            app.cluster
+                .register_kind("apps", "StatefulSet", "statefulsets", true);
+            type_resource_query(&mut app, &format!("{resource} /-l app=api"));
+            app.namespace_memory.set("west", "remembered");
+            if picker {
+                palette(&mut app, "ctx");
+                pick_context(&mut app, "west");
+            } else {
+                palette(&mut app, "ctx west");
+            }
+            assert_eq!(
+                app.context_switch_target,
+                Some((app.generation, "west".into())),
+                "resource={resource}, picker={picker}, mode={:?}, flash={}, context filter={}",
+                app.mode,
+                app.flash,
+                app.ctx_filter
+            );
+            let mut target = Cluster::fake();
+            target.context = "west".into();
+            target.register_kind("apps", "StatefulSet", "statefulsets", true);
+            app.handle_msg(Msg::ContextSwitched {
+                generation: app.generation,
+                name: "west".into(),
+                result: Ok(Box::new(target)),
+            });
+            assert_eq!(app.kind_plural, resource);
+            assert_eq!(app.namespace, "remembered");
+            assert!(app.filter.is_empty());
+            assert!(app.labels.is_none());
+            assert!(app.fields.is_none());
+            assert!(app.owner.is_none());
+            assert!(app.applied_filter_labels.is_none());
+            assert!(app.applied_filter_fields.is_none());
+            assert!(app.stack.is_empty());
+            assert_eq!(app.history.len(), 1);
+            assert!(!app.flash_err, "{}", app.flash);
+        }
+    }
+}
+
+#[tokio::test]
+async fn context_switch_resolves_custom_resource_in_target_group() {
+    let (mut app, _rx) = test_app();
+    app.all_contexts = vec!["test".into(), "west".into()];
+    app.cluster
+        .register_kind("example.com", "Widget", "widgets", true);
+    type_resource_query(&mut app, "widgets.example.com");
+    palette(&mut app, "ctx west");
+    assert_eq!(
+        app.context_switch_target,
+        Some((app.generation, "west".into()))
+    );
+    let mut target = Cluster::fake();
+    target.context = "west".into();
+    target.register_kind("example.com", "Widget", "widgets", false);
+    target.register_kind("other.example.com", "Widget", "widgets", true);
+    app.handle_msg(Msg::ContextSwitched {
+        generation: app.generation,
+        name: "west".into(),
+        result: Ok(Box::new(target)),
+    });
+    let kind = app.kind.as_ref().unwrap();
+    assert_eq!(kind.title(), "widgets.example.com");
+    assert!(
+        !kind.namespaced,
+        "resource metadata must come from the target cluster"
+    );
+}
+
+#[tokio::test]
+async fn context_switch_missing_resource_uses_default_then_pods() {
+    for (default, expected) in [("services", "services"), ("missing", "pods")] {
+        let (mut app, _rx) = test_app();
+        app.all_contexts = vec!["test".into(), "west".into()];
+        let dir = std::env::temp_dir().join(format!(
+            "sofka-context-fallback-{}-{default}",
+            std::process::id()
+        ));
+        let context_dir = dir.join("clusters/test-cluster/west");
+        std::fs::create_dir_all(&context_dir).unwrap();
+        std::fs::write(
+            context_dir.join("config.toml"),
+            format!("default_resource = \"{default}\"\n"),
+        )
+        .unwrap();
+        app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+        app.cluster
+            .register_kind("example.com", "Widget", "widgets", true);
+        type_resource_query(&mut app, "widgets.example.com");
+        palette(&mut app, "ctx west");
+        assert_eq!(
+            app.context_switch_target,
+            Some((app.generation, "west".into()))
+        );
+        let mut target = Cluster::fake();
+        target.context = "west".into();
+        target.register_kind("other.example.com", "Widget", "widgets", true);
+        app.handle_msg(Msg::ContextSwitched {
+            generation: app.generation,
+            name: "west".into(),
+            result: Ok(Box::new(target)),
+        });
+        assert_eq!(app.kind_plural, expected);
+        assert!(
+            app.flash
+                .contains("widgets.example.com is unavailable in west"),
+            "{}",
+            app.flash
+        );
+        assert!(
+            app.flash.contains(&format!("viewing {expected}")),
+            "{}",
+            app.flash
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}
+
+#[tokio::test]
 async fn context_picker_launch_connects_on_enter_and_opens_default_resource() {
     for default in [None, Some("deployments")] {
         let (mut app, _rx) = test_app();


### PR DESCRIPTION
A context switch opened the configured default resource, so a user viewing Deployments had to select Deployments again in the next cluster. The switch now keeps the current resource type when the target cluster supports it, using that cluster's resource metadata and API group.

If the resource is unavailable, sofka opens the target context's configured default resource, then Pods if needed, and shows a fallback message. Startup defaults, namespace selection, and explicit destinations from queries, bookmarks, and workspaces keep their current behavior. Filters and object ownership scope are cleared.

Added keyboard-driven tests for the context picker, direct context commands, custom resource groups, target metadata, and fallback selection. Updated the key reference and feature documentation.

Validation: `just check` and `git diff --check` passed.

Closes #534

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/515
