### PR TITLE
feat: show active and context default namespaces

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -72,6 +72,12 @@ The full list. For how sofka compares to k9s, see [vs k9s](vs-k9s.md).
   extension API server is down, or it sends an `apiVersion` that is not `v1`.
   Sofka does not load that group. It shows a warning at startup and a flash
   on the first screen. `:info` shows the group and the reason.
+- **Namespace switcher** (`n`) opens with the cursor on the active namespace.
+  `current` marks the active namespace, including `<all>`. `context default`
+  marks the kubeconfig namespace. Both labels can apply to one row and stay
+  visible when you filter the list. The active and context default namespaces
+  are available even if namespace listing is restricted. Favourites, recent
+  namespaces, and shortcuts keep their existing order. Startup rules do not change.
 - **Namespace commands**: `:ns <name>` changes namespace and keeps the current
   resource view, as the namespace switcher does. `:namespace` and `:namespaces`
   accept the same argument; `all` and `*` select all namespaces. From the

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1637,9 +1637,6 @@ impl App {
                 let keep = self.ns_state.selected().unwrap_or(0);
                 let selected = names.get(keep);
                 self.ns_list = list;
-                if self.mode == Mode::Namespaces {
-                    self.ensure_known_namespaces();
-                }
                 let names = self.filtered_namespaces();
                 let index = selected
                     .and_then(|selected| names.iter().position(|n| n == selected))

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1633,11 +1633,18 @@ impl App {
                 }
             }
             Msg::Namespaces { generation, list } if generation == self.generation => {
-                // Keep the picker open and preserve the selection if possible.
+                let names = self.filtered_namespaces();
                 let keep = self.ns_state.selected().unwrap_or(0);
+                let selected = names.get(keep);
                 self.ns_list = list;
-                self.ns_state
-                    .select(Some(keep.min(self.ns_list.len().saturating_sub(1))));
+                if self.mode == Mode::Namespaces {
+                    self.ensure_known_namespaces();
+                }
+                let names = self.filtered_namespaces();
+                let index = selected
+                    .and_then(|selected| names.iter().position(|n| n == selected))
+                    .unwrap_or_else(|| keep.min(names.len().saturating_sub(1)));
+                self.ns_state.select(Some(index));
             }
             Msg::Contexts { generation, list } if generation == self.generation => {
                 if list.is_empty() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1545,6 +1545,7 @@ struct NamespaceMemo {
     filter: String,
     context: String,
     ns_list: Vec<String>,
+    known_namespaces: [String; 2],
     favorites: Vec<String>,
     recents: Vec<String>,
     value: Rc<Vec<String>>,

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -10,7 +10,7 @@ pub const DEFAULT_SORT_LABEL: &str = "default (ns/name)";
 impl App {
     /// Open the switcher on the active namespace, then fetch the namespace list.
     pub(super) fn open_namespaces(&mut self) {
-        self.ensure_known_namespaces();
+        self.mode = Mode::Namespaces;
         self.ns_filter.clear();
         let current = if self.namespace.is_empty() {
             "<all>"
@@ -19,17 +19,7 @@ impl App {
         };
         let selected = self.filtered_namespaces().iter().position(|n| n == current);
         self.ns_state.select(selected);
-        self.mode = Mode::Namespaces;
         self.spawn_namespace_fetch();
-    }
-
-    pub(super) fn ensure_known_namespaces(&mut self) {
-        for ns in ["<all>", &self.namespace, &self.cluster.default_namespace] {
-            if !ns.is_empty() && !self.ns_list.iter().any(|n| n == ns) {
-                self.ns_list.push(ns.to_string());
-            }
-        }
-        self.ns_list.sort();
     }
 
     /// Fetch the namespace list off-thread; it arrives as `Msg::Namespaces` and
@@ -77,10 +67,19 @@ impl App {
     /// everything is fuzzy-matched (favourites/recents lose their pinning so
     /// the best textual match wins).
     pub fn filtered_namespaces(&self) -> Rc<Vec<String>> {
+        let known_namespaces = if self.mode == Mode::Namespaces {
+            [
+                self.namespace.as_str(),
+                self.cluster.default_namespace.as_str(),
+            ]
+        } else {
+            ["", ""]
+        };
         if let Some(m) = self.picker_memos.borrow().namespaces.as_ref()
             && m.filter == self.ns_filter
             && m.context == self.cluster.context
             && m.ns_list == self.ns_list
+            && m.known_namespaces.each_ref().map(String::as_str) == known_namespaces
             && m.favorites == self.namespace_favorites
             && m.recents
                 .iter()
@@ -91,14 +90,21 @@ impl App {
         }
 
         let mut out = vec!["<all>".to_string()];
-        let rest = self.ns_list.iter().filter(|n| n.as_str() != "<all>");
+        let mut candidates = self.ns_list.clone();
+        for ns in known_namespaces {
+            if !ns.is_empty() && !candidates.iter().any(|n| n == ns) {
+                candidates.push(ns.to_string());
+            }
+        }
+        candidates.sort();
+        let rest = candidates.iter().filter(|n| n.as_str() != "<all>");
         if !self.ns_filter.is_empty() {
             let mut scored: Vec<(i64, &String)> = rest
                 .filter_map(|n| self.matcher.score(n, &self.ns_filter).map(|s| (s, n)))
                 .collect();
             scored.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(b.1)));
             out.extend(scored.into_iter().map(|(_, n)| n.clone()));
-            return self.remember_namespaces(out);
+            return self.remember_namespaces(out, known_namespaces);
         }
 
         let available: std::collections::HashSet<&str> = rest.map(String::as_str).collect();
@@ -116,21 +122,26 @@ impl App {
                 out.push(r.to_string());
             }
         }
-        // Then everything else (ns_list is already sorted).
-        for n in self.ns_list.iter().filter(|n| n.as_str() != "<all>") {
+        // Then the remaining names in alphabetical order.
+        for n in candidates.iter().filter(|n| n.as_str() != "<all>") {
             if seen.insert(n.clone()) {
                 out.push(n.clone());
             }
         }
-        self.remember_namespaces(out)
+        self.remember_namespaces(out, known_namespaces)
     }
 
-    fn remember_namespaces(&self, out: Vec<String>) -> Rc<Vec<String>> {
+    fn remember_namespaces(
+        &self,
+        out: Vec<String>,
+        known_namespaces: [&str; 2],
+    ) -> Rc<Vec<String>> {
         let value = Rc::new(out);
         self.picker_memos.borrow_mut().namespaces = Some(NamespaceMemo {
             filter: self.ns_filter.clone(),
             context: self.cluster.context.clone(),
             ns_list: self.ns_list.clone(),
+            known_namespaces: known_namespaces.map(str::to_string),
             favorites: self.namespace_favorites.clone(),
             recents: self
                 .recent_namespaces_for_context()

--- a/src/app/pickers.rs
+++ b/src/app/pickers.rs
@@ -8,19 +8,28 @@ const MAX_RECENT_NAMESPACES: usize = 8;
 pub const DEFAULT_SORT_LABEL: &str = "default (ns/name)";
 
 impl App {
-    /// Open the namespace switcher immediately with a loading placeholder, then
-    /// fetch the list off-thread (it arrives as `Msg::Namespaces`).
+    /// Open the switcher on the active namespace, then fetch the namespace list.
     pub(super) fn open_namespaces(&mut self) {
-        // Show whatever is cached immediately (instant reopen); a fresh fetch
-        // refreshes it. Only fall back to the bare `<all>` placeholder when the
-        // cache is empty.
-        if self.ns_list.is_empty() {
-            self.ns_list = vec!["<all>".into()];
-        }
-        self.ns_state.select(Some(0));
+        self.ensure_known_namespaces();
         self.ns_filter.clear();
+        let current = if self.namespace.is_empty() {
+            "<all>"
+        } else {
+            &self.namespace
+        };
+        let selected = self.filtered_namespaces().iter().position(|n| n == current);
+        self.ns_state.select(selected);
         self.mode = Mode::Namespaces;
         self.spawn_namespace_fetch();
+    }
+
+    pub(super) fn ensure_known_namespaces(&mut self) {
+        for ns in ["<all>", &self.namespace, &self.cluster.default_namespace] {
+            if !ns.is_empty() && !self.ns_list.iter().any(|n| n == ns) {
+                self.ns_list.push(ns.to_string());
+            }
+        }
+        self.ns_list.sort();
     }
 
     /// Fetch the namespace list off-thread; it arrives as `Msg::Namespaces` and

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10238,6 +10238,84 @@ async fn logs_keep_view_and_restore_selection() {
 }
 
 #[tokio::test]
+async fn namespace_switcher_known_rows_do_not_block_palette_fetch_retry() {
+    let (mut app, mut rx) = test_app();
+    let (requests, mut request_rx) = mpsc::unbounded_channel();
+    let mut attempts = 0;
+    app.cluster.client = kube::Client::new(
+        tower::service_fn(move |request: http::Request<kube::client::Body>| {
+            assert_eq!(request.uri().path(), "/api/v1/namespaces");
+            attempts += 1;
+            requests.send(attempts).unwrap();
+            let (status, body) = if attempts == 1 {
+                (
+                    503,
+                    json!({
+                        "kind": "Status", "apiVersion": "v1", "status": "Failure",
+                        "reason": "ServiceUnavailable", "message": "try again", "code": 503
+                    }),
+                )
+            } else {
+                (
+                    200,
+                    json!({
+                        "kind": "NamespaceList", "apiVersion": "v1", "metadata": {},
+                        "items": [{"metadata": {"name": "staging"}}]
+                    }),
+                )
+            };
+            async move {
+                Ok::<_, std::convert::Infallible>(
+                    http::Response::builder()
+                        .status(status)
+                        .body(http_body_util::Full::new(hyper::body::Bytes::from(
+                            body.to_string(),
+                        )))
+                        .unwrap(),
+                )
+            }
+        }),
+        "default",
+    );
+    app.namespace = "prod".into();
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(
+        app.filtered_namespaces().as_ref(),
+        &["<all>", "default", "prod"]
+    );
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), request_rx.recv())
+            .await
+            .unwrap(),
+        Some(1)
+    );
+    assert!(app.ns_list.is_empty());
+
+    app.handle_key(press(KeyCode::Esc)).unwrap();
+    app.handle_key(press(KeyCode::Char(':'))).unwrap();
+    assert_eq!(app.filtered_namespaces().as_ref(), &["<all>"]);
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), request_rx.recv())
+            .await
+            .unwrap(),
+        Some(2)
+    );
+    let message = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(&message, Msg::Namespaces { .. }));
+    app.handle_msg(message);
+    for c in "pods sta".chars() {
+        app.handle_key(press(KeyCode::Char(c))).unwrap();
+    }
+    let suggestion = app.cmd_suggestions.first().expect("namespace suggestion");
+    assert_eq!(suggestion.kind, SuggestKind::Namespace);
+    assert_eq!(suggestion.label, "staging");
+    assert_eq!(app.ns_list, ["<all>", "staging"]);
+}
+
+#[tokio::test]
 async fn namespace_switcher_selects_current_and_preserves_cursor_on_refresh() {
     let (mut app, _rx) = test_app();
     app.namespace = "prod".into();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10238,6 +10238,108 @@ async fn logs_keep_view_and_restore_selection() {
 }
 
 #[tokio::test]
+async fn namespace_switcher_selects_current_and_preserves_cursor_on_refresh() {
+    let (mut app, _rx) = test_app();
+    app.namespace = "prod".into();
+    app.namespace_favorites = vec!["staging".into()];
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    assert_eq!(app.mode, Mode::Namespaces);
+    assert_eq!(
+        app.filtered_namespaces()[app.ns_state.selected().unwrap()],
+        "prod"
+    );
+    assert!(app.filtered_namespaces().iter().any(|n| n == "default"));
+
+    app.handle_msg(Msg::Namespaces {
+        generation: app.generation,
+        list: vec!["<all>".into(), "alpha".into(), "prod".into()],
+    });
+    assert_eq!(
+        app.filtered_namespaces().as_ref(),
+        &["<all>", "staging", "alpha", "default", "prod"]
+    );
+    assert_eq!(
+        app.filtered_namespaces()[app.ns_state.selected().unwrap()],
+        "prod"
+    );
+
+    app.handle_key(press(KeyCode::Up)).unwrap();
+    app.handle_msg(Msg::Namespaces {
+        generation: app.generation,
+        list: vec!["<all>".into(), "beta".into(), "gamma".into(), "prod".into()],
+    });
+    assert_eq!(
+        app.filtered_namespaces()[app.ns_state.selected().unwrap()],
+        "default"
+    );
+
+    app.handle_key(press(KeyCode::Char('p'))).unwrap();
+    app.handle_msg(Msg::Namespaces {
+        generation: app.generation,
+        list: vec!["<all>".into(), "alpha".into(), "prod".into()],
+    });
+    assert_eq!(
+        app.filtered_namespaces()[app.ns_state.selected().unwrap()],
+        "prod"
+    );
+    app.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(app.namespace, "prod");
+    assert_eq!(app.mode, Mode::Table);
+}
+
+#[tokio::test]
+async fn namespace_switcher_labels_current_and_context_default() {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    for (namespace, expected) in [
+        ("default", "default (current, context default)"),
+        ("prod", "prod (current)"),
+        ("", "<all> (current)"),
+    ] {
+        let (mut app, _rx) = test_app();
+        app.namespace = namespace.into();
+        app.handle_key(press(KeyCode::Char('n'))).unwrap();
+        assert_eq!(
+            app.filtered_namespaces()[app.ns_state.selected().unwrap()],
+            if namespace.is_empty() {
+                "<all>"
+            } else {
+                namespace
+            }
+        );
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains(expected), "{text}");
+        if namespace != "default" {
+            assert!(text.contains("default (context default)"), "{text}");
+        }
+
+        app.handle_key(press(KeyCode::Char('d'))).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &mut app)).unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains(expected), "{text}");
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        app.handle_key(press(KeyCode::Esc)).unwrap();
+        app.handle_key(press(KeyCode::Char('n'))).unwrap();
+        app.handle_key(press(KeyCode::Enter)).unwrap();
+        assert_eq!(app.namespace, namespace);
+    }
+}
+
+#[tokio::test]
 async fn namespace_switcher_pins_all_and_fuzzy_filters() {
     let (mut app, _rx) = test_app();
     app.ns_list = vec![

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3056,21 +3056,34 @@ fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
             }
             if n == "<all>" {
                 spans.push(Span::styled(n.clone(), Style::default().fg(theme::teal())));
-                return ListItem::new(Line::from(spans));
-            }
-            // Only tag favourites/recents while browsing (the pinned ordering);
-            // a filtered list is ranked by match, so a tag there would mislead.
-            let (tag, color) = if !browsing {
-                ("", theme::text())
-            } else if app.is_favorite_namespace(n) {
-                ("★ ", theme::yellow())
-            } else if app.is_recent_namespace(n) {
-                ("· ", theme::sky())
             } else {
-                ("  ", theme::text())
+                // Only tag favourites/recents while browsing (the pinned ordering);
+                // a filtered list is ranked by match, so a tag there would mislead.
+                let (tag, color) = if !browsing {
+                    ("", theme::text())
+                } else if app.is_favorite_namespace(n) {
+                    ("★ ", theme::yellow())
+                } else if app.is_recent_namespace(n) {
+                    ("· ", theme::sky())
+                } else {
+                    ("  ", theme::text())
+                };
+                spans.push(Span::styled(tag.to_string(), theme::dim()));
+                spans.push(Span::styled(n.clone(), Style::default().fg(color)));
+            }
+            let current = if app.namespace.is_empty() {
+                n == "<all>"
+            } else {
+                n == &app.namespace
             };
-            spans.push(Span::styled(tag.to_string(), theme::dim()));
-            spans.push(Span::styled(n.clone(), Style::default().fg(color)));
+            let context_default = n == &app.cluster.default_namespace;
+            let label = match (current, context_default) {
+                (true, true) => " (current, context default)",
+                (true, false) => " (current)",
+                (false, true) => " (context default)",
+                (false, false) => "",
+            };
+            spans.push(Span::styled(label, theme::dim()));
             ListItem::new(Line::from(spans))
         })
         .collect();
@@ -3084,7 +3097,7 @@ fn draw_namespaces(frame: &mut Frame, app: &mut App, area: Rect) {
         frame,
         show_scrollbars,
         area,
-        (40, 60),
+        (70, 60),
         items,
         Span::styled(title, theme::title()),
         &mut app.ns_state,


### PR DESCRIPTION
The namespace switcher opened on `<all>` and did not identify the active namespace or the kubeconfig default. It now opens on the active namespace and shows `current` and `context default` labels, including both labels when they apply to the same row.

The labels remain visible in filtered results. The switcher keeps the selected namespace when the list loads and includes the active and context default namespaces when listing is restricted. The popup is wider to fit the labels. Known namespace rows are added only to the switcher display, so a failed list request does not block later command palette retries.

Validation: formatting, Clippy with warnings denied, and 1,387 tests passed through the required commit hooks. Tests cover labels at an 80-column terminal width, filtering, selection after list refreshes, and a failed namespace request followed by a successful command palette retry.

Agreed discussion: https://github.com/nklmilojevic/sofka/discussions/484#discussioncomment-18411371

Closes #536
