### PR TITLE
fix: synchronize terminal screen updates

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10,6 +10,7 @@ mod label_filter;
 mod proxy;
 mod scale;
 mod server_table;
+mod synchronized_output;
 
 fn obj(v: serde_json::Value) -> DynamicObject {
     serde_json::from_value(v).unwrap()

--- a/src/app/tests/synchronized_output.rs
+++ b/src/app/tests/synchronized_output.rs
@@ -1,0 +1,104 @@
+use super::*;
+use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend, layout::Rect};
+use std::{cell::RefCell, io, rc::Rc};
+
+const BEGIN: &[u8] = b"\x1b[?2026h";
+const END: &[u8] = b"\x1b[?2026l";
+
+#[derive(Default)]
+struct Output {
+    bytes: Vec<u8>,
+    flushed: usize,
+    fail_flush: bool,
+}
+
+struct Writer(Rc<RefCell<Output>>);
+
+impl io::Write for Writer {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.borrow_mut().bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut output = self.0.borrow_mut();
+        if std::mem::take(&mut output.fail_flush) {
+            return Err(io::Error::other("draw flush failed"));
+        }
+        output.flushed = output.bytes.len();
+        Ok(())
+    }
+}
+
+fn terminal(output: &Rc<RefCell<Output>>) -> Terminal<CrosstermBackend<Writer>> {
+    Terminal::with_options(
+        CrosstermBackend::new(Writer(Rc::clone(output))),
+        TerminalOptions {
+            viewport: Viewport::Fixed(Rect::new(0, 0, 80, 16)),
+        },
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn held_down_keeps_each_viewport_update_inside_sync_markers() {
+    let (mut app, _rx) = test_app();
+    for i in 0..40 {
+        apply(
+            &mut app,
+            json!({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": format!("pod-{i:02}"), "namespace": "default"},
+                "status": {"phase": "Running"}
+            }),
+        );
+    }
+    let output = Rc::new(RefCell::new(Output::default()));
+    let mut terminal = terminal(&output);
+    crate::ui::present(&mut terminal, &mut app).unwrap();
+    for _ in 0..30 {
+        *output.borrow_mut() = Output::default();
+        app.handle_key(press(KeyCode::Down)).unwrap();
+        crate::ui::present(&mut terminal, &mut app).unwrap();
+        let output = output.borrow();
+        assert!(output.bytes.starts_with(BEGIN));
+        assert!(output.bytes.ends_with(END));
+        assert_eq!(output.flushed, output.bytes.len());
+        assert!(output.bytes.len() > BEGIN.len() + END.len());
+        assert_eq!(
+            output
+                .bytes
+                .windows(BEGIN.len())
+                .filter(|s| *s == BEGIN)
+                .count(),
+            1
+        );
+        assert_eq!(
+            output
+                .bytes
+                .windows(END.len())
+                .filter(|s| *s == END)
+                .count(),
+            1
+        );
+    }
+    assert!(app.table_state.offset() > 0);
+    assert!(app.table_state.selected().unwrap() >= app.table_page_rows);
+}
+
+#[tokio::test]
+async fn failed_draw_still_ends_and_flushes_sync_update() {
+    let (mut app, _rx) = test_app();
+    let output = Rc::new(RefCell::new(Output {
+        fail_flush: true,
+        ..Output::default()
+    }));
+    let mut terminal = terminal(&output);
+    app.handle_key(press(KeyCode::Down)).unwrap();
+    let error = crate::ui::present(&mut terminal, &mut app).unwrap_err();
+    assert_eq!(error.to_string(), "draw flush failed");
+    let output = output.borrow();
+    assert!(output.bytes.starts_with(BEGIN));
+    assert!(output.bytes.ends_with(END));
+    assert_eq!(output.flushed, output.bytes.len());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1026,7 +1026,7 @@ fn dispatch(
         app.handle_key(key)?;
         take_suspend(terminal, app, captured);
     }
-    terminal.draw(|f| ui::draw(f, app))?;
+    ui::present(terminal, app)?;
     Ok(true)
 }
 
@@ -1069,7 +1069,7 @@ async fn run(
     let mut repair = altscroll::Repair::default();
 
     let mut title = terminal_title::Title::default();
-    terminal.draw(|f| ui::draw(f, app))?;
+    ui::present(terminal, app)?;
     loop {
         if app.should_quit {
             return Ok(());
@@ -1118,7 +1118,7 @@ async fn run(
                     }
                     Some(Err(_)) | None => return Ok(()),
                     Some(Ok(Event::Resize(_, _))) => {
-                        ui::resize(terminal, app)?;
+                        ui::present(terminal, app)?;
                         dirty = false;
                     }
                     _ => dirty = true,
@@ -1140,7 +1140,7 @@ async fn run(
             _ = frame.tick(), if dirty || app.scrollbar_activity.is_some() => {
                 let expired = app.expire_scrollbars();
                 if dirty || expired {
-                    terminal.draw(|f| ui::draw(f, app))?;
+                    ui::present(terminal, app)?;
                     dirty = false;
                 }
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -88,6 +88,20 @@ fn cell_alignment(align: crate::views::Align) -> Alignment {
     }
 }
 
+/// Keep terminal output in one synchronized update per frame.
+pub fn present<W: std::io::Write>(
+    terminal: &mut ratatui::Terminal<ratatui::backend::CrosstermBackend<W>>,
+    app: &mut App,
+) -> std::io::Result<()> {
+    use crossterm::terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
+
+    crossterm::queue!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
+    let drawn = terminal.draw(|frame| draw(frame, app)).map(|_| ());
+    // Attempt to release the screen even if the draw failed.
+    let ended = crossterm::execute!(terminal.backend_mut(), EndSynchronizedUpdate);
+    drawn.and(ended)
+}
+
 /// Refresh layout after a resize before another input event can use its dimensions.
 pub fn resize<B: ratatui::backend::Backend>(
     terminal: &mut ratatui::Terminal<B>,


### PR DESCRIPTION
Holding Down past the bottom of the resource table shifts all visible rows. These draws had no synchronized output markers, so terminals such as Ghostty could display an incomplete frame. Wrap keyboard, startup, resize, and background draws in DEC mode 2026. Attempt to end and flush the update after a draw error, and preserve the draw error.

This change addresses partial screen updates. It does not change keyboard repeat timing or whole-row scrolling.

Validation:
- `just check` passed: formatting, Clippy, and 1,562 tests.
- Added tests for repeated Down input past the viewport and cleanup after a draw error.
- Local testing in Ghostty indicated some improvement; it did not establish that all visible stepping was removed.

Protocol: https://github.com/contour-terminal/vt-extensions/blob/1a9fde53d80c4a60b1be44c5a4492d86ec9f9cce/synchronized-output.md
