### PR TITLE
feat: support multiple commands in plugin packages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -346,6 +346,8 @@ apply without a restart.
 
 sofka reads packages from the `plugins/` directory next to the base config.
 Each package directory contains a `plugin.toml` manifest.
+Schema 2 uses `[[commands]]` entries, each with separate inputs and safety settings.
+Sofka also reads schema 1 manifests with one `[plugin]` table.
 Enter `:reload` to read package changes.
 The `:config` view shows invalid packages and absent executables.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -775,6 +775,7 @@ pod is rejected; browse through a pod that already mounts the claim instead.
 - **Package discovery** reads `plugins/*/plugin.toml` from the sofka configuration directory.
   Packages reload with `:reload`.
 - **Named commands** and key chords start adapters without changes to sofka's source code.
+  A package can contain several commands with separate scopes, inputs, and safety settings.
 - **Validated inputs** supply named arguments with types, defaults, choices, and limits.
 - **JSON reports** show text sections and tables in a searchable document.
 - **Shared execution** limits output and concurrency.

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -93,9 +93,9 @@ Then enter `:reload`.
 ## Manifest
 
 ```toml
-schema_version = 1
+schema_version = 2
 
-[plugin]
+[[commands]]
 name = "Resource summary"
 palette = "resource-summary"
 command = "python3"
@@ -106,10 +106,53 @@ output = "report"
 mutating = false
 timeout = "10s"
 
-[plugin.inputs.detail]
+[commands.inputs.detail]
 type = "boolean"
 default = "false"
 ```
+
+Set the root `schema_version` to `2`. A package must contain at least one
+`[[commands]]` entry. Each entry has its own inputs, resource scopes, runtime
+requirements, timeout, and safety flags. Command names, palette names, and
+nonempty key chords must be unique within the package. If one entry is invalid,
+Sofka rejects the whole package.
+
+For example, one package can contain a read-only status command and a renewal
+command that changes resources and requires confirmation:
+
+```toml
+schema_version = 2
+
+[[commands]]
+name = "Certificate status"
+palette = "cert-manager-status"
+command = "./adapter"
+args = ["status"]
+scopes = ["certificates"]
+output = "report"
+mutating = false
+
+[[commands]]
+name = "Renew certificate"
+palette = "cert-manager-renew"
+command = "./adapter"
+args = ["renew"]
+scopes = ["certificates"]
+output = "report"
+mutating = true
+confirm = true
+```
+
+The adapter must accept the action argument. The request and report protocols
+still use schema version `1`. Status remains available in read-only mode.
+Guardrails can match `plugin:cert-manager-renew` separately. Installation,
+update, and removal apply to the whole package.
+
+Sofka still reads schema `1` packages with one `[plugin]` table. To migrate,
+change the root schema version to `2`, replace `[plugin]` with `[[commands]]`,
+and replace `[plugin.inputs.NAME]` with `[commands.inputs.NAME]`. Keep each input
+table below its command entry. Do not mix the two manifest formats. Inline
+`[[plugins]]` configuration keeps its existing format.
 
 ### `[package]`
 
@@ -127,7 +170,7 @@ license = "MIT OR Apache-2.0"
 description = "Scan the active context with Popeye and report findings by linter."
 repository = "https://github.com/nklmilojevic/sofka-plugins"
 readme = "README.md"
-sofka = ">=0.26.0"
+sofka = ">=0.27.0"
 platforms = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
 tags = ["diagnostics", "report"]
 ```
@@ -145,37 +188,37 @@ tags = ["diagnostics", "report"]
 | `tags`         | Search keywords.                                                                               |
 | `requirements` | Tools the adapter finds itself. `alternatives` names equivalent executables.                   |
 
-The package ID is its directory name. `[plugin]` keeps its meaning: `name` is
-the display name and `palette` is the command.
+The package ID is its directory name. Each `[[commands]]` entry defines one
+command. `name` is its display name. `palette` is its full command name, without
+an automatic package prefix. Use names such as `cert-manager-status` and
+`cert-manager-renew` to group related commands.
 
-A catalog install reconciles this manifest against the index entry it came
-from. The `[package]` version and the `[plugin]` command, target, output,
-`mutating`, `confirm`, `dangerous`, and `network_load` must match the published
-entry, and an omitted field is compared as the behaviour it produces — an
-absent `mutating` means `true`. A package that disagrees is refused.
+A catalog install checks the package version and Sofka requirement against the
+selected release. It also checks each command's name, palette, key, arguments,
+scopes, executable, target, output, and safety flags. A missing `mutating` flag
+means `true`. Sofka refuses a package if these values differ from the catalog.
 
-### `[plugin]`
+### `[[commands]]`
 
-| Field            | Function                                                                                   |
-| ---------------- | ------------------------------------------------------------------------------------------ |
-| `schema_version` | Required package format version. Use `1`.                                                  |
-| `name`           | Required display name.                                                                     |
-| `palette`        | Optional command name, without `:`. Use lowercase letters, digits, or hyphens.             |
-| `key`            | Optional key chord. Supply `key`, `palette`, or both.                                      |
-| `command`        | Required executable name or path.                                                          |
-| `args`           | Command arguments. Each item is one argument.                                              |
-| `requires`       | Executables that must be available. sofka also checks `command`.                           |
-| `install`        | Instructions that appear when an executable is absent.                                     |
-| `scopes`         | Resource plurals where the plugin can run. An empty list permits all resource kinds.       |
-| `target`         | `selection` by default. Use `context` to run once without a selected object.               |
-| `output`         | Required package output mode: `popup`, `background`, or `report`.                          |
-| `timeout`        | Maximum time for each target. Default: `30s`.                                              |
-| `mutating`       | `true` by default. Use `false` only when the plugin does not change cluster resources.     |
-| `network_load`   | Set to `true` when the plugin generates test traffic. Default: `false`.                    |
-| `confirm`        | Require confirmation before execution. Default: `false`.                                   |
-| `dangerous`      | Require confirmation and identify the action as dangerous. Default: `false`.               |
-| `port_forward`   | Optional remote port for the selected pod or service. See [Port-forwards](#port-forwards). |
-| `inputs`         | Input definitions. See [Inputs](#inputs).                                                  |
+| Field          | Function                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| `name`         | Required display name.                                                                     |
+| `palette`      | Optional command name, without `:`. Use lowercase letters, digits, or hyphens.             |
+| `key`          | Optional key chord. Supply `key`, `palette`, or both.                                      |
+| `command`      | Required executable name or path.                                                          |
+| `args`         | Command arguments. Each item is one argument.                                              |
+| `requires`     | Executables that must be available. sofka also checks `command`.                           |
+| `install`      | Instructions that appear when an executable is absent.                                     |
+| `scopes`       | Resource plurals where the plugin can run. An empty list permits all resource kinds.       |
+| `target`       | `selection` by default. Use `context` to run once without a selected object.               |
+| `output`       | Required package output mode: `popup`, `background`, or `report`.                          |
+| `timeout`      | Maximum time for each target. Default: `30s`.                                              |
+| `mutating`     | `true` by default. Use `false` only when the plugin does not change cluster resources.     |
+| `network_load` | Set to `true` when the plugin generates test traffic. Default: `false`.                    |
+| `confirm`      | Require confirmation before execution. Default: `false`.                                   |
+| `dangerous`    | Require confirmation and identify the action as dangerous. Default: `false`.               |
+| `port_forward` | Optional remote port for the selected pod or service. See [Port-forwards](#port-forwards). |
+| `inputs`       | Input definitions. See [Inputs](#inputs).                                                  |
 
 The adapter's working directory is the package directory.
 Use `command = "./adapter"` for an executable in that directory.
@@ -202,19 +245,19 @@ Input values cannot contain spaces in this version.
 ```
 
 ```toml
-[plugin.inputs.duration]
+[commands.inputs.duration]
 type = "duration"
 default = "10s"
 min = 1
 max = 300
 
-[plugin.inputs.connections]
+[commands.inputs.connections]
 type = "integer"
 default = "20"
 min = 1
 max = 1000
 
-[plugin.inputs.port]
+[commands.inputs.port]
 type = "integer"
 min = 1
 max = 65535
@@ -392,7 +435,7 @@ The remote port must be explicit.
 sofka does not select the HTTP port or test the application protocol.
 
 ```toml
-[plugin]
+[[commands]]
 name = "Endpoint benchmark"
 palette = "benchmark"
 command = "python3"
@@ -404,7 +447,7 @@ network_load = true
 port_forward = "${input.port}"
 timeout = "2m"
 
-[plugin.inputs.port]
+[commands.inputs.port]
 type = "integer"
 min = 1
 max = 65535

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -59,7 +59,7 @@ The installer verifies BLAKE3 before extraction, rejects links and unsafe
 paths, validates the existing `plugin.toml` format, and activates a complete
 staged directory. It also reconciles the staged `plugin.toml` against the
 catalog entry the package was selected from and refuses a package whose
-version, command, target, output, or safety flags disagree, so what `describe`
+version or command settings disagree, so what `describe`
 reports is what the session runs. It reports missing external tools and their installation
 instructions, but does not install them. Metadata and package downloads have
 separate budgets: a download that makes no progress for 30 seconds is dropped,
@@ -72,12 +72,20 @@ Search returns an array with `id`, `display_name`, `description`, `tags`,
 `latest_version`, `compatible`, `installed`, `installed_version`, and
 `withdrawal_reason`. Describe returns `id`, `display_name`, `description`,
 `tags`, `publisher`, `repository`, `version`, `status`, `withdrawal_reason`,
-`license`, `readme`, `sofka`, `platforms`, `requirements`, `command`, `target`,
-`output`, `mutating`, `confirm`, `confirmation`, `dangerous`, `network_load`,
+`license`, `readme`, `sofka`, `platforms`, `requirements`, `confirmation`,
 `installed`, `installed_version`, and `installed_withdrawal_reason`.
-`confirmation` is true whenever sofka will prompt: `confirm`, `dangerous`, or
-`network_load` is true. List returns an array with `id`, `version`, `path`,
-`managed`, `modified`, and `withdrawal_reason`.
+For a schema 2 package, `commands` lists each command's `name`, optional `palette`
+and `key`, `args`, `scopes`, `command`, `target`, `output`, `mutating`, `confirm`,
+`dangerous`, and `network_load`. For an old release, the execution fields remain
+at the top level. `confirmation` is true if any command has `confirm`,
+`dangerous`, or `network_load` set to true. List returns an array with `id`,
+`version`, `path`, `managed`, `modified`, and `withdrawal_reason`.
+
+A package can contain several commands. Each command has separate scopes,
+inputs, and safety settings. Installation, update, and removal apply to all
+commands in the package. Catalog schema 2 can contain both old release records
+and new releases with command arrays. Sofka still accepts catalog schema 1 and
+old installed packages. Older Sofka clients cannot read catalog schema 2.
 
 Home Manager users can continue to place immutable package sources in the same
 directory. Sofka reports those as manual packages and does not take ownership

--- a/examples/plugins/resource-summary/plugin.toml
+++ b/examples/plugins/resource-summary/plugin.toml
@@ -1,6 +1,6 @@
-schema_version = 1
+schema_version = 2
 
-[plugin]
+[[commands]]
 name = "Resource summary"
 palette = "resource-summary"
 command = "python3"
@@ -11,6 +11,6 @@ output = "report"
 mutating = false
 timeout = "10s"
 
-[plugin.inputs.detail]
+[commands.inputs.detail]
 type = "boolean"
 default = "false"

--- a/plugins/sanitize/plugin.toml
+++ b/plugins/sanitize/plugin.toml
@@ -1,6 +1,6 @@
-schema_version = 1
+schema_version = 2
 
-[plugin]
+[[commands]]
 name = "Sanitize pods"
 palette = "sanitize"
 # Rewritten to the running executable when sofka registers this package, so a
@@ -14,11 +14,11 @@ mutating = true
 dangerous = true
 timeout = "2m"
 
-[plugin.inputs.states]
+[commands.inputs.states]
 type = "string"
 default = "terminal"
 choices = ["terminal", "stuck", "all"]
 
-[plugin.inputs.dry_run]
+[commands.inputs.dry_run]
 type = "boolean"
 default = "false"

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -18137,6 +18137,90 @@ async fn context_switch_and_quit_cancel_plugin_tasks() {
 }
 
 #[tokio::test]
+async fn package_commands_keep_scope_inputs_readonly_and_guardrails_separate() {
+    let dir = std::env::temp_dir().join(format!("sofka-command-package-ui-{}", std::process::id()));
+    let package = dir.join("plugins/example");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(
+        package.join("plugin.toml"),
+        r#"
+schema_version = 2
+[[commands]]
+name = "Read status"
+palette = "example-status"
+command = "/bin/cat"
+scopes = ["pods"]
+output = "popup"
+mutating = false
+[commands.inputs.detail]
+type = "boolean"
+default = "false"
+[[commands]]
+name = "Renew"
+palette = "example-renew"
+command = "/bin/cat"
+scopes = ["services"]
+output = "popup"
+mutating = true
+confirm = true
+"#,
+    )
+    .unwrap();
+    let (mut app, mut rx) = app_with_pod();
+    app.config = crate::config::ConfigLoader::from_dir(Some(dir.clone()));
+    plugin_command(&mut app, "reload");
+    assert_eq!(app.plugins.iter().filter(|p| !p.bundled).count(), 2);
+    app.readonly = true;
+    plugin_command(&mut app, "example-status detail=true");
+    let Msg::PluginOutput { lines, .. } = plugin_result(&mut rx).await else {
+        panic!("missing status output")
+    };
+    assert!(lines.join("\n").contains("\"detail\":\"true\""));
+    // Finish the captured run before invoking another command.
+    app.plugin_task = None;
+    plugin_command(&mut app, "example-renew");
+    assert!(app.plugin_task.is_none());
+    assert_ne!(app.mode, Mode::Confirm);
+    app.readonly = false;
+    plugin_command(&mut app, "example-renew");
+    assert!(app.plugin_task.is_none(), "the renewal scope excludes pods");
+    assert_ne!(app.mode, Mode::Confirm);
+    let renew = app
+        .plugins
+        .iter_mut()
+        .find(|p| p.palette.as_deref() == Some("example-renew"))
+        .unwrap();
+    assert!(renew.inputs.is_empty());
+    renew.scopes = vec!["pods".into()];
+    app.readonly = true;
+    plugin_command(&mut app, "example-renew");
+    assert!(app.plugin_task.is_none());
+    assert!(app.flash.contains("read-only"), "{}", app.flash);
+    app.readonly = false;
+    plugin_command(&mut app, "example-renew");
+    assert_eq!(app.mode, Mode::Confirm);
+    app.handle_key(press(KeyCode::Char('n'))).unwrap();
+    app.guardrails = vec![crate::config::Guardrail {
+        actions: vec!["plugin:example-renew".into()],
+        deny: true,
+        ..Default::default()
+    }];
+    plugin_command(&mut app, "example-renew");
+    assert!(app.flash.contains("blocked by guardrail"));
+    assert!(app.plugin_task.is_none());
+    plugin_command(&mut app, "example-status");
+    let Msg::PluginOutput { lines, .. } = plugin_result(&mut rx).await else {
+        panic!("missing status output")
+    };
+    assert!(lines.join("\n").contains("\"detail\":\"false\""));
+    app.plugin_task = None;
+    std::fs::remove_dir_all(&package).unwrap();
+    plugin_command(&mut app, "reload");
+    assert!(!app.plugins.iter().any(|p| !p.bundled));
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[tokio::test]
 async fn plugin_package_reload_loads_valid_packages_and_isolates_invalid_ones() {
     let dir = std::env::temp_dir().join(format!("sofka-plugin-reload-{}", std::process::id()));
     let package = dir.join("plugins/example");

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,9 +209,11 @@ async fn run_main(args: Args) -> Result<()> {
         };
     }
     if let Some(dir) = &args.validate_plugin {
-        let plugin = sofka::plugins::read_package(dir).map_err(anyhow::Error::msg)?;
-        sofka::plugins::available(&plugin).map_err(anyhow::Error::msg)?;
-        println!("valid plugin: {}", plugin.name);
+        let commands = sofka::plugins::read_package(dir).map_err(anyhow::Error::msg)?;
+        for command in commands {
+            sofka::plugins::available(&command).map_err(anyhow::Error::msg)?;
+            println!("valid plugin: {}", command.name);
+        }
         return Ok(());
     }
     if let Some(path) = &args.validate_plugin_report {

--- a/src/plugin_catalog.rs
+++ b/src/plugin_catalog.rs
@@ -69,6 +69,23 @@ pub struct CatalogVersion {
     pub readme: String,
     #[serde(default)]
     pub requirements: Vec<RuntimeRequirement>,
+    #[serde(flatten)]
+    pub execution: CatalogExecution,
+    pub status: VersionStatus,
+    #[serde(default)]
+    pub withdrawal_reason: Option<String>,
+    pub artifacts: Vec<Artifact>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+pub enum CatalogExecution {
+    Commands { commands: Vec<CatalogCommand> },
+    Legacy(Execution),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Execution {
     pub command: String,
     #[serde(default = "default_target")]
     pub target: String,
@@ -80,10 +97,85 @@ pub struct CatalogVersion {
     pub dangerous: bool,
     #[serde(default)]
     pub network_load: bool,
-    pub status: VersionStatus,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct CatalogCommand {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub palette: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
     #[serde(default)]
-    pub withdrawal_reason: Option<String>,
-    pub artifacts: Vec<Artifact>,
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    #[serde(flatten)]
+    pub execution: Execution,
+}
+
+impl From<&crate::config::Plugin> for CatalogCommand {
+    fn from(command: &crate::config::Plugin) -> Self {
+        Self {
+            name: command.name.clone(),
+            palette: command.palette.clone(),
+            key: (!command.key.is_empty()).then(|| command.key.clone()),
+            args: command.args.clone(),
+            scopes: command.scopes.clone(),
+            execution: Execution {
+                command: command.command.clone(),
+                target: command.target.clone().unwrap_or_else(default_target),
+                output: command.output.clone().unwrap_or_else(|| "terminal".into()),
+                mutating: command.mutating.unwrap_or(true),
+                confirm: command.confirm,
+                dangerous: command.dangerous,
+                network_load: command.network_load,
+            },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CatalogExecution {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error;
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if let Some(commands) = value.get("commands") {
+            if [
+                "command",
+                "target",
+                "output",
+                "mutating",
+                "confirm",
+                "dangerous",
+                "network_load",
+            ]
+            .iter()
+            .any(|field| value.get(field).is_some())
+            {
+                return Err(D::Error::custom(
+                    "catalog release mixes commands and legacy execution fields",
+                ));
+            }
+            Ok(Self::Commands {
+                commands: serde_json::from_value(commands.clone()).map_err(D::Error::custom)?,
+            })
+        } else {
+            Ok(Self::Legacy(
+                serde_json::from_value(value).map_err(D::Error::custom)?,
+            ))
+        }
+    }
+}
+
+impl CatalogExecution {
+    pub fn entries(&self) -> Vec<&Execution> {
+        match self {
+            Self::Legacy(execution) => vec![execution],
+            Self::Commands { commands } => {
+                commands.iter().map(|command| &command.execution).collect()
+            }
+        }
+    }
 }
 
 fn default_target() -> String {
@@ -148,9 +240,9 @@ impl Catalog {
         }
         let schema: Schema =
             serde_json::from_slice(bytes).map_err(|e| format!("invalid catalog JSON: {e}"))?;
-        if schema.schema_version != 1 {
+        if !matches!(schema.schema_version, 1 | 2) {
             return Err(format!(
-                "unsupported catalog schema_version {} (expected 1)",
+                "unsupported catalog schema_version {} (expected 1 or 2)",
                 schema.schema_version
             ));
         }
@@ -161,9 +253,9 @@ impl Catalog {
     }
 
     pub fn validate(&self) -> Result<(), String> {
-        if self.schema_version != 1 {
+        if !matches!(self.schema_version, 1 | 2) {
             return Err(format!(
-                "unsupported catalog schema_version {} (expected 1)",
+                "unsupported catalog schema_version {} (expected 1 or 2)",
                 self.schema_version
             ));
         }
@@ -210,10 +302,41 @@ impl Catalog {
                         plugin.id, release.version
                     ));
                 }
-                if release.command.trim().is_empty()
-                    || !matches!(release.target.as_str(), "selection" | "context")
-                    || !matches!(release.output.as_str(), "popup" | "background" | "report")
-                {
+                if let CatalogExecution::Commands { commands } = &release.execution {
+                    if self.schema_version != 2 || commands.is_empty() {
+                        return Err("command entries require catalog schema 2 and a nonempty commands array".into());
+                    }
+                    let mut names = HashSet::new();
+                    let mut palettes = HashSet::new();
+                    let mut keys = HashSet::new();
+                    for command in commands {
+                        if command.name.trim().is_empty()
+                            || !names.insert(&command.name)
+                            || (command.palette.is_none() && command.key.is_none())
+                            || command.palette.as_ref().is_some_and(|palette| {
+                                palette.is_empty()
+                                    || !palette.bytes().all(|b| {
+                                        b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'
+                                    })
+                                    || crate::app::plugin_command_reserved(palette)
+                                    || !palettes.insert(palette)
+                            })
+                            || command
+                                .key
+                                .as_ref()
+                                .is_some_and(|key| key.trim().is_empty() || !keys.insert(key))
+                        {
+                            return Err(
+                                "invalid or duplicate catalog command name, palette, or key".into(),
+                            );
+                        }
+                    }
+                }
+                if release.execution.entries().iter().any(|execution| {
+                    execution.command.trim().is_empty()
+                        || !matches!(execution.target.as_str(), "selection" | "context")
+                        || !matches!(execution.output.as_str(), "popup" | "background" | "report")
+                }) {
                     return Err(format!(
                         "plugin {} version {} has invalid execution metadata",
                         plugin.id, release.version
@@ -1058,13 +1181,15 @@ mod tests {
                     license: "MIT OR Apache-2.0".into(),
                     readme: "https://example.com/readme".into(),
                     requirements: vec![],
-                    command: "./resource-summary".into(),
-                    target: "selection".into(),
-                    output: "report".into(),
-                    mutating: false,
-                    confirm: false,
-                    dangerous: false,
-                    network_load: false,
+                    execution: CatalogExecution::Legacy(Execution {
+                        command: "./resource-summary".into(),
+                        target: "selection".into(),
+                        output: "report".into(),
+                        mutating: false,
+                        confirm: false,
+                        dangerous: false,
+                        network_load: false,
+                    }),
                     status: VersionStatus::Active,
                     withdrawal_reason: None,
                     artifacts: vec![Artifact {
@@ -1078,6 +1203,70 @@ mod tests {
                 }],
             }],
         }
+    }
+
+    #[test]
+    fn command_catalogs_reject_mixed_empty_and_duplicate_definitions() {
+        let mut value = serde_json::to_value(catalog()).unwrap();
+        value["schema_version"] = 2.into();
+        let release = value["plugins"][0]["versions"][0].as_object_mut().unwrap();
+        let mut command = serde_json::Map::new();
+        for field in [
+            "command",
+            "target",
+            "output",
+            "mutating",
+            "confirm",
+            "dangerous",
+            "network_load",
+        ] {
+            command.insert(field.into(), release.remove(field).unwrap());
+        }
+        command.insert("name".into(), "Status".into());
+        command.insert("palette".into(), "cert-manager-status".into());
+        command.insert("args".into(), serde_json::json!(["status"]));
+        command.insert("scopes".into(), serde_json::json!(["certificates"]));
+        release.insert("commands".into(), serde_json::json!([command]));
+        Catalog::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
+        for case in [
+            "schema",
+            "mixed",
+            "empty",
+            "duplicate",
+            "mutation",
+            "missing_mutation",
+            "palette",
+        ] {
+            let mut invalid = value.clone();
+            let release = &mut invalid["plugins"][0]["versions"][0];
+            match case {
+                "schema" => invalid["schema_version"] = 1.into(),
+                "mixed" => release["mutating"] = false.into(),
+                "empty" => release["commands"] = serde_json::json!([]),
+                "duplicate" => {
+                    let command = release["commands"][0].clone();
+                    release["commands"].as_array_mut().unwrap().push(command);
+                }
+                "mutation" => release["commands"][0]["mutating"] = "false".into(),
+                "missing_mutation" => {
+                    release["commands"][0]
+                        .as_object_mut()
+                        .unwrap()
+                        .remove("mutating");
+                }
+                _ => release["commands"][0]["palette"] = "xray".into(),
+            }
+            assert!(
+                Catalog::parse(&serde_json::to_vec(&invalid).unwrap()).is_err(),
+                "accepted {case}"
+            );
+        }
+        let mut mixed = value.clone();
+        mixed["plugins"][0]["versions"][0]["mutating"] = false.into();
+        assert!(
+            serde_json::from_value::<Catalog>(mixed).is_err(),
+            "cached catalogs must reject mixed forms too"
+        );
     }
 
     #[test]
@@ -1106,12 +1295,12 @@ mod tests {
         Catalog::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
 
         let future = serde_json::json!({
-            "schema_version": 2,
+            "schema_version": 3,
             "future_layout": {},
         });
         let error = Catalog::parse(&serde_json::to_vec(&future).unwrap()).unwrap_err();
         assert!(
-            error.contains("unsupported catalog schema_version 2"),
+            error.contains("unsupported catalog schema_version 3"),
             "{error}"
         );
     }
@@ -1269,7 +1458,7 @@ mod tests {
     #[test]
     fn validation_rejects_every_malformed_release_field() {
         let mutate: Vec<Mutation> = vec![
-            ("schema", Box::new(|c: &mut Catalog| c.schema_version = 2)),
+            ("schema", Box::new(|c: &mut Catalog| c.schema_version = 3)),
             (
                 "display name",
                 Box::new(|c: &mut Catalog| c.plugins[0].display_name = "  ".into()),
@@ -1300,15 +1489,33 @@ mod tests {
             ),
             (
                 "command",
-                Box::new(|c: &mut Catalog| c.plugins[0].versions[0].command = " ".into()),
+                Box::new(|c: &mut Catalog| {
+                    if let CatalogExecution::Legacy(execution) =
+                        &mut c.plugins[0].versions[0].execution
+                    {
+                        execution.command = " ".into()
+                    }
+                }),
             ),
             (
                 "target",
-                Box::new(|c: &mut Catalog| c.plugins[0].versions[0].target = "cluster".into()),
+                Box::new(|c: &mut Catalog| {
+                    if let CatalogExecution::Legacy(execution) =
+                        &mut c.plugins[0].versions[0].execution
+                    {
+                        execution.target = "cluster".into()
+                    }
+                }),
             ),
             (
                 "output",
-                Box::new(|c: &mut Catalog| c.plugins[0].versions[0].output = "terminal".into()),
+                Box::new(|c: &mut Catalog| {
+                    if let CatalogExecution::Legacy(execution) =
+                        &mut c.plugins[0].versions[0].execution
+                    {
+                        execution.output = "terminal".into()
+                    }
+                }),
             ),
             (
                 "requirement",
@@ -1505,7 +1712,7 @@ mod tests {
         };
 
         let mut future = cached.clone();
-        future.schema_version = 2;
+        future.schema_version = 3;
         std::fs::write(&path, serde_json::to_vec(&future).unwrap()).unwrap();
         assert!(
             load_cached(&path)

--- a/src/plugin_cli.rs
+++ b/src/plugin_cli.rs
@@ -112,14 +112,9 @@ struct Description<'a> {
     sofka: &'a str,
     platforms: Vec<&'a str>,
     requirements: &'a [crate::plugin_catalog::RuntimeRequirement],
-    command: &'a str,
-    target: &'a str,
-    output: &'a str,
-    mutating: bool,
-    confirm: bool,
+    #[serde(flatten)]
+    execution: &'a crate::plugin_catalog::CatalogExecution,
     confirmation: bool,
-    dangerous: bool,
-    network_load: bool,
     installed: bool,
     installed_version: Option<&'a str>,
     installed_withdrawal_reason: Option<&'a str>,
@@ -129,7 +124,11 @@ struct Description<'a> {
 /// `App::run_plugin`: confirmation, danger, and traffic generation each
 /// require it.
 fn confirms(release: &CatalogVersion) -> bool {
-    release.confirm || release.dangerous || release.network_load
+    release
+        .execution
+        .entries()
+        .iter()
+        .any(|command| command.confirm || command.dangerous || command.network_load)
 }
 
 pub async fn run(args: &PluginArgs) -> Result<(), String> {
@@ -291,14 +290,8 @@ fn description<'a>(
             .map(|artifact| artifact.platform.as_str())
             .collect(),
         requirements: &release.requirements,
-        command: &release.command,
-        target: &release.target,
-        output: &release.output,
-        mutating: release.mutating,
-        confirm: release.confirm,
+        execution: &release.execution,
         confirmation: confirms(release),
-        dangerous: release.dangerous,
-        network_load: release.network_load,
         installed: installed.is_some(),
         installed_version: installed,
         installed_withdrawal_reason,
@@ -335,12 +328,22 @@ async fn describe(request: &str, offline: bool, json: bool) -> Result<(), String
         println!("license: {}", description.license);
         println!("requires sofka: {}", description.sofka);
         println!("platforms: {}", description.platforms.join(", "));
-        println!("command: {}", description.command);
-        println!("target: {}", description.target);
-        println!("output: {}", description.output);
-        println!("mutating: {}", description.mutating);
-        println!("confirmation: {}", description.confirmation);
-        println!("network load: {}", description.network_load);
+        match description.execution {
+            crate::plugin_catalog::CatalogExecution::Legacy(execution) => {
+                print_execution(execution)
+            }
+            crate::plugin_catalog::CatalogExecution::Commands { commands } => {
+                for command in commands {
+                    println!(
+                        "{} ({}):",
+                        command.name,
+                        command.palette.as_deref().unwrap_or("key only")
+                    );
+                    println!("scopes: {}", command.scopes.join(", "));
+                    print_execution(&command.execution);
+                }
+            }
+        }
         println!(
             "installed: {}",
             description.installed_version.unwrap_or("no")
@@ -354,6 +357,18 @@ async fn describe(request: &str, offline: bool, json: bool) -> Result<(), String
         }
     }
     Ok(())
+}
+
+fn print_execution(command: &crate::plugin_catalog::Execution) {
+    println!("command: {}", command.command);
+    println!("target: {}", command.target);
+    println!("output: {}", command.output);
+    println!("mutating: {}", command.mutating);
+    println!(
+        "confirmation: {}",
+        command.confirm || command.dangerous || command.network_load
+    );
+    println!("network load: {}", command.network_load);
 }
 
 async fn install(requests: &[String], offline: bool) -> Result<(), String> {
@@ -853,6 +868,43 @@ mod tests {
     }
 
     #[test]
+    fn description_lists_each_command_with_its_own_safety_flags() {
+        let catalog = catalog(serde_json::json!([{
+            "version": "1.0.0", "sofka": ">=0.0.1", "source_commit": "0".repeat(40),
+            "license": "MIT", "readme": "https://example.invalid/readme", "requirements": [],
+            "command": "adapter", "target": "selection", "output": "report", "mutating": false,
+            "status": "active", "artifacts": [{"platform": "any", "url": format!("{}x/x.tar.zst", crate::plugin_catalog::RELEASE_ROOT), "blake3": "0".repeat(64), "size": 1}]
+        }]));
+        let plugin = &catalog.plugins[0];
+        let mut release = plugin.versions[0].clone();
+        let command = |name: &str, mutating: bool| crate::plugin_catalog::CatalogCommand {
+            name: name.into(),
+            palette: Some(format!("cert-manager-{name}")),
+            key: None,
+            args: vec![name.into()],
+            scopes: vec!["certificates".into()],
+            execution: crate::plugin_catalog::Execution {
+                command: "./adapter".into(),
+                target: "selection".into(),
+                output: "report".into(),
+                mutating,
+                confirm: mutating,
+                dangerous: false,
+                network_load: false,
+            },
+        };
+        release.execution = crate::plugin_catalog::CatalogExecution::Commands {
+            commands: vec![command("status", false), command("renew", true)],
+        };
+        let described = serde_json::to_value(description(plugin, &release, None)).unwrap();
+        assert_eq!(described["commands"][0]["mutating"], false);
+        assert_eq!(described["commands"][1]["mutating"], true);
+        assert_eq!(described["commands"][1]["confirm"], true);
+        assert_eq!(described["confirmation"], true);
+        assert!(described.get("mutating").is_none());
+    }
+
+    #[test]
     fn describe_selects_exact_versions_and_errors_on_anything_unknown() {
         let snapshot = snapshot(serde_json::json!([
             release("1.0.0", "active", None),
@@ -948,8 +1000,8 @@ mod tests {
         assert_eq!(described.installed_withdrawal_reason, None);
         assert_eq!(described.platforms, ["any"]);
         assert_eq!(described.sofka, ">=0.0.1");
-        assert_eq!(described.target, "selection");
-        assert_eq!(described.output, "report");
+        assert_eq!(described.execution.entries()[0].target, "selection");
+        assert_eq!(described.execution.entries()[0].output, "report");
 
         let value = serde_json::to_value(&described).unwrap();
         assert_eq!(

--- a/src/plugin_install.rs
+++ b/src/plugin_install.rs
@@ -285,7 +285,7 @@ async fn prepare_below(
 
     let mut prepared = Vec::new();
     // Manifests prepared so far in this batch, by package ID.
-    let mut batch: Vec<(String, crate::config::Plugin)> = Vec::new();
+    let mut batch: Vec<(String, Vec<crate::config::Plugin>)> = Vec::new();
     for (id, release, artifact) in selections {
         let version = release.version.clone();
         let destination = plugins.join(&id);
@@ -341,10 +341,7 @@ async fn prepare_below(
         conflicts.extend(
             batch
                 .iter()
-                .filter(|(_, manifest)| {
-                    manifest.name == package.name
-                        || (package.palette.is_some() && manifest.palette == package.palette)
-                })
+                .filter(|(_, manifest)| packages_conflict(manifest, &package))
                 .map(|(other, _)| plugins.join(other)),
         );
         batch.push((id.clone(), package.clone()));
@@ -384,7 +381,7 @@ async fn prepare_below(
 fn reconcile(
     id: &str,
     release: &plugin_catalog::CatalogVersion,
-    declared: &crate::config::Plugin,
+    declared: &[crate::config::Plugin],
     published: Option<&crate::plugins::Package>,
 ) -> Result<(), String> {
     let published = published
@@ -401,31 +398,19 @@ fn reconcile(
         published.sofka.as_deref().unwrap_or(""),
         &release.sofka,
     );
-    compare("command", &declared.command, &release.command);
-    // Resolved the way the loader resolves them, so an omitted field is
-    // compared as the behaviour it actually produces.
-    compare(
-        "target",
-        declared.target.as_deref().unwrap_or("selection"),
-        &release.target,
-    );
-    compare(
-        "output",
-        declared.output.as_deref().unwrap_or("terminal"),
-        &release.output,
-    );
-    for (field, manifest, catalog) in [
-        (
-            "mutating",
-            declared.mutating.unwrap_or(true),
-            release.mutating,
-        ),
-        ("confirm", declared.confirm, release.confirm),
-        ("dangerous", declared.dangerous, release.dangerous),
-        ("network_load", declared.network_load, release.network_load),
-    ] {
-        if manifest != catalog {
-            differences.push(format!("{field} {manifest}, catalog says {catalog}"));
+    let actual: Vec<plugin_catalog::CatalogCommand> = declared.iter().map(Into::into).collect();
+    match &release.execution {
+        plugin_catalog::CatalogExecution::Commands { commands } => {
+            if &actual != commands {
+                differences.push(
+                    "commands differ in identity, arguments, scopes, or execution settings".into(),
+                );
+            }
+        }
+        plugin_catalog::CatalogExecution::Legacy(execution) => {
+            if actual.len() != 1 || actual[0].execution != *execution {
+                differences.push("command, target, output, mutating, confirm, dangerous, or network_load differs".into());
+            }
         }
     }
     if differences.is_empty() {
@@ -441,7 +426,11 @@ fn reconcile(
 /// The installed packages a freshly staged one would collide with. Package
 /// directories load in sorted order and the first plugin name or palette
 /// command wins, so either side of a collision can end up unreachable.
-fn conflicts(plugins: &Path, destination: &Path, package: &crate::config::Plugin) -> Vec<PathBuf> {
+fn conflicts(
+    plugins: &Path,
+    destination: &Path,
+    package: &[crate::config::Plugin],
+) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(plugins) else {
         return Vec::new();
     };
@@ -452,12 +441,17 @@ fn conflicts(plugins: &Path, destination: &Path, package: &crate::config::Plugin
         .collect();
     paths.sort();
     paths.retain(|path| {
-        crate::plugins::read_package(path).is_ok_and(|other| {
-            other.name == package.name
-                || (package.palette.is_some() && other.palette == package.palette)
-        })
+        crate::plugins::read_package(path).is_ok_and(|other| packages_conflict(&other, package))
     });
     paths
+}
+
+fn packages_conflict(left: &[crate::config::Plugin], right: &[crate::config::Plugin]) -> bool {
+    left.iter().any(|a| {
+        right
+            .iter()
+            .any(|b| crate::plugins::command_conflicts(a, b))
+    })
 }
 
 fn inspect_destination(path: &Path, id: &str) -> Result<Option<InstallationRecord>, String> {
@@ -1253,6 +1247,150 @@ mod tests {
             fetched_at: 0,
             offline: true,
         }
+    }
+
+    fn multi_manifest() -> String {
+        format!(
+            "{}{}",
+            MANIFEST
+                .replace("schema_version = 1", "schema_version = 2")
+                .replace("[plugin]", "[[commands]]"),
+            r#"
+[[commands]]
+name = "Renew"
+palette = "cert-manager-renew"
+command = "/bin/echo"
+args = ["renew"]
+scopes = ["certificates"]
+output = "report"
+mutating = true
+confirm = true
+"#
+        )
+    }
+
+    fn published_commands(cache: &Path, version: &str, manifest: &str) -> CatalogSnapshot {
+        let mut snapshot = published(cache, "cert-manager", version, manifest);
+        snapshot.catalog.schema_version = 2;
+        let (commands, _) = crate::plugins::read_manifest(manifest).unwrap();
+        snapshot.catalog.plugins[0].versions[0].execution =
+            plugin_catalog::CatalogExecution::Commands {
+                commands: commands.iter().map(Into::into).collect(),
+            };
+        snapshot.catalog =
+            plugin_catalog::Catalog::parse(&serde_json::to_vec(&snapshot.catalog).unwrap())
+                .unwrap();
+        snapshot
+    }
+
+    #[tokio::test]
+    async fn command_package_installs_updates_and_removes_as_one_unit() {
+        let config = scratch("command-lifecycle");
+        let cache = config.join("cache");
+        std::fs::create_dir_all(&cache).unwrap();
+        let manifest = multi_manifest();
+        let snapshot = published_commands(&cache, "1.0.0", &manifest);
+        let requests = ["cert-manager".to_string()];
+        let prepared = prepare_below(&config, &cache, &snapshot, &requests, true)
+            .await
+            .unwrap();
+        assert_eq!(prepared.len(), 1);
+        prepared.into_iter().next().unwrap().activate().unwrap();
+        let destination = config.join("plugins/cert-manager");
+        let commands = crate::plugins::read_package(&destination).unwrap();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[1].args, ["renew"]);
+        let next = manifest
+            .replace("version = \"1.0.0\"", "version = \"2.0.0\"")
+            .replace("cert-manager-renew", "cert-manager-renew-v2");
+        let snapshot = published_commands(&cache, "2.0.0", &next);
+        let prepared = prepare_below(&config, &cache, &snapshot, &requests, true)
+            .await
+            .unwrap();
+        assert_eq!(prepared[0].previous_version.as_deref(), Some("1.0.0"));
+        assert_eq!(
+            prepared.into_iter().next().unwrap().activate().unwrap(),
+            Activation::Updated
+        );
+        let commands = crate::plugins::read_package(&destination).unwrap();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(
+            commands[1].palette.as_deref(),
+            Some("cert-manager-renew-v2")
+        );
+        remove_below(&config, &requests).unwrap();
+        assert!(!destination.exists());
+        std::fs::remove_dir_all(config).unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_second_command_cannot_disagree_with_catalog_safety_or_identity() {
+        let config = scratch("command-reconcile");
+        let cache = config.join("cache");
+        std::fs::create_dir_all(&cache).unwrap();
+        let snapshot = published_commands(&cache, "1.0.0", &multi_manifest());
+        for field in [
+            "mutating", "confirm", "args", "scopes", "palette", "missing",
+        ] {
+            let mut modified = snapshot.clone();
+            let plugin_catalog::CatalogExecution::Commands { commands } =
+                &mut modified.catalog.plugins[0].versions[0].execution
+            else {
+                unreachable!()
+            };
+            match field {
+                "mutating" => commands[1].execution.mutating = false,
+                "confirm" => commands[1].execution.confirm = false,
+                "args" => commands[1].args.clear(),
+                "scopes" => commands[1].scopes.clear(),
+                "palette" => commands[1].palette = Some("different".into()),
+                _ => {
+                    commands.pop();
+                }
+            }
+            let error = prepare_below(&config, &cache, &modified, &["cert-manager".into()], true)
+                .await
+                .err()
+                .unwrap();
+            assert!(
+                error.contains("contradicts the catalog"),
+                "{field}: {error}"
+            );
+            assert!(!config.join("plugins/cert-manager").exists());
+        }
+        std::fs::remove_dir_all(config).unwrap();
+    }
+
+    #[tokio::test]
+    async fn conflicts_include_later_commands_in_installed_and_staged_packages() {
+        let config = scratch("command-conflicts");
+        let cache = config.join("cache");
+        std::fs::create_dir_all(&cache).unwrap();
+        let mut snapshot = published_commands(&cache, "1.0.0", &multi_manifest());
+        let other_manifest = MANIFEST
+            .replace("Resource summary", "Other")
+            .replace("resource-summary", "cert-manager-renew");
+        let other = published(&cache, "other", "1.0.0", &other_manifest);
+        snapshot.catalog.plugins.extend(other.catalog.plugins);
+        let prepared = prepare_below(
+            &config,
+            &cache,
+            &snapshot,
+            &["cert-manager".into(), "other".into()],
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(prepared[1].conflicts, [config.join("plugins/cert-manager")]);
+        let mut prepared = prepared.into_iter();
+        prepared.next().unwrap().activate().unwrap();
+        drop(prepared);
+        let prepared = prepare_below(&config, &cache, &snapshot, &["other".into()], true)
+            .await
+            .unwrap();
+        assert_eq!(prepared[0].conflicts, [config.join("plugins/cert-manager")]);
+        drop(prepared);
+        std::fs::remove_dir_all(config).unwrap();
     }
 
     fn record_for(id: &str, version: &str) -> InstallationRecord {

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -149,7 +149,8 @@ struct Manifest {
     /// index entry from it.
     #[serde(default)]
     package: Option<Package>,
-    plugin: Plugin,
+    plugin: Option<Plugin>,
+    commands: Option<Vec<Plugin>>,
 }
 
 /// The `[package]` table: who publishes this package, under what licence, and
@@ -263,7 +264,7 @@ pub fn validate_package(package: &Package) -> Result<(), String> {
 /// resolves a relative command against the package directory. Checking a
 /// package against the catalog entry it was selected from has to compare what
 /// the author wrote, not the absolute path this process resolved it to.
-pub fn read_package_manifest(dir: &Path) -> Result<(Plugin, Option<Package>), String> {
+pub fn read_package_manifest(dir: &Path) -> Result<(Vec<Plugin>, Option<Package>), String> {
     let path = dir.join("plugin.toml");
     use std::io::Read;
     let mut bytes = Vec::new();
@@ -278,48 +279,64 @@ pub fn read_package_manifest(dir: &Path) -> Result<(Plugin, Option<Package>), St
     read_manifest(std::str::from_utf8(&bytes).map_err(|e| e.to_string())?)
 }
 
-pub fn read_package(dir: &Path) -> Result<Plugin, String> {
+pub fn read_package(dir: &Path) -> Result<Vec<Plugin>, String> {
     let dir = dir.canonicalize().map_err(|e| e.to_string())?;
-    let mut plugin = read_package_manifest(&dir)?.0;
-    if plugin.command.starts_with("./") {
-        let command = dir
-            .join(&plugin.command)
-            .canonicalize()
-            .map_err(|e| e.to_string())?;
-        if !command.starts_with(&dir) {
-            return Err("relative command escapes package directory".into());
+    let mut commands = read_package_manifest(&dir)?.0;
+    for plugin in &mut commands {
+        if plugin.command.starts_with("./") {
+            let command = dir
+                .join(&plugin.command)
+                .canonicalize()
+                .map_err(|e| e.to_string())?;
+            if !command.starts_with(&dir) {
+                return Err("relative command escapes package directory".into());
+            }
+            plugin.command = command.to_string_lossy().into_owned();
         }
-        plugin.command = command.to_string_lossy().into_owned();
-    }
-    for requirement in &mut plugin.requires {
-        if requirement.starts_with("./") {
-            *requirement = dir.join(&*requirement).to_string_lossy().into_owned();
+        for requirement in &mut plugin.requires {
+            if requirement.starts_with("./") {
+                *requirement = dir.join(&*requirement).to_string_lossy().into_owned();
+            }
         }
+        if !plugin.requires.contains(&plugin.command) {
+            plugin.requires.push(plugin.command.clone());
+        }
+        plugin.package_dir = Some(dir.clone());
     }
-    if !plugin.requires.contains(&plugin.command) {
-        plugin.requires.push(plugin.command.clone());
-    }
-    plugin.package_dir = Some(dir);
-    Ok(plugin)
+    Ok(commands)
 }
 
 /// Parse and validate a `plugin.toml`, wherever it came from.
-pub fn parse_manifest(text: &str) -> Result<Plugin, String> {
+pub fn parse_manifest(text: &str) -> Result<Vec<Plugin>, String> {
     Ok(read_manifest(text)?.0)
 }
 
 /// The whole manifest: how the plugin runs, and the publication metadata when
 /// the package declares any.
-pub fn read_manifest(text: &str) -> Result<(Plugin, Option<Package>), String> {
+pub fn read_manifest(text: &str) -> Result<(Vec<Plugin>, Option<Package>), String> {
     let manifest: Manifest = toml::from_str(text).map_err(|e| e.to_string())?;
-    if manifest.schema_version != 1 {
-        return Err("unsupported schema_version (expected 1)".into());
-    }
+    let commands = match (manifest.schema_version, manifest.plugin, manifest.commands) {
+        (1, Some(plugin), None) => vec![plugin],
+        (2, None, Some(commands)) if !commands.is_empty() => commands,
+        (1 | 2, _, _) => return Err("schema 1 requires [plugin]; schema 2 requires nonempty [[commands]]; do not mix the formats".into()),
+        _ => return Err("unsupported schema_version (expected 1 or 2)".into()),
+    };
     if let Some(package) = &manifest.package {
         validate_package(package)?;
     }
-    validate_plugin(&manifest.plugin)?;
-    Ok((manifest.plugin, manifest.package))
+    for (index, command) in commands.iter().enumerate() {
+        validate_plugin(command)?;
+        if commands[..index]
+            .iter()
+            .any(|other| command_conflicts(command, other))
+        {
+            return Err(format!(
+                "duplicate command name, palette, or key: {}",
+                command.name
+            ));
+        }
+    }
+    Ok((commands, manifest.package))
 }
 
 /// The manifest of every package sofka ships. Kept as real files under
@@ -333,17 +350,30 @@ pub fn bundled() -> Vec<Result<Plugin, String>> {
     let exe = std::env::current_exe();
     BUNDLED
         .iter()
-        .map(|(name, text)| {
-            let mut plugin = parse_manifest(text).map_err(|e| format!("bundled {name}: {e}"))?;
-            let exe = exe
-                .as_ref()
-                .map_err(|e| format!("bundled {name}: locating the sofka binary: {e}"))?;
-            plugin.command = exe.to_string_lossy().into_owned();
-            plugin.requires = vec![plugin.command.clone()];
-            plugin.bundled = true;
-            Ok(plugin)
+        .flat_map(|(name, text)| {
+            let commands = parse_manifest(text).and_then(|mut commands| {
+                let exe = exe
+                    .as_ref()
+                    .map_err(|e| format!("locating the sofka binary: {e}"))?;
+                for command in &mut commands {
+                    command.command = exe.to_string_lossy().into_owned();
+                    command.requires = vec![command.command.clone()];
+                    command.bundled = true;
+                }
+                Ok(commands)
+            });
+            match commands {
+                Ok(commands) => commands.into_iter().map(Ok).collect(),
+                Err(error) => vec![Err(format!("bundled {name}: {error}"))],
+            }
         })
         .collect()
+}
+
+pub(crate) fn command_conflicts(left: &Plugin, right: &Plugin) -> bool {
+    left.name == right.name
+        || (left.palette.is_some() && left.palette == right.palette)
+        || (!left.key.is_empty() && left.key == right.key)
 }
 
 pub fn validate_plugin(plugin: &Plugin) -> Result<(), String> {
@@ -455,19 +485,19 @@ pub fn load_packages(dir: &Path, plugins: &mut Vec<Plugin>, warnings: &mut Vec<S
     paths.sort();
     for path in paths {
         match read_package(&path) {
-            Ok(p) => {
-                if plugins.iter().any(|old| {
-                    old.name == p.name || (p.palette.is_some() && old.palette == p.palette)
-                }) {
-                    warnings.push(format!(
-                        "{}: duplicate plugin name/command; earlier configuration wins",
-                        path.display()
-                    ));
-                } else {
-                    if let Err(e) = available(&p) {
-                        warnings.push(format!("plugin {}: {e}", p.name));
+            Ok(commands) => {
+                for p in commands {
+                    if plugins.iter().any(|old| command_conflicts(old, &p)) {
+                        warnings.push(format!(
+                            "{}: duplicate plugin name/command; earlier configuration wins",
+                            path.display()
+                        ));
+                    } else {
+                        if let Err(e) = available(&p) {
+                            warnings.push(format!("plugin {}: {e}", p.name));
+                        }
+                        plugins.push(p);
                     }
-                    plugins.push(p);
                 }
             }
             Err(e) => warnings.push(format!("ignoring {}: {e}", path.display())),
@@ -795,7 +825,7 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("plugin.toml"), text).unwrap();
-        let result = read_package(&dir);
+        let result = read_package(&dir).map(|mut commands| commands.remove(0));
         std::fs::remove_dir_all(dir).unwrap();
         result
     }
@@ -825,8 +855,55 @@ mod tests {
     );
 
     #[test]
+    fn command_manifests_validate_all_entries_and_reject_ambiguous_formats() {
+        let first = PACKAGED
+            .replace("schema_version = 1", "schema_version = 2")
+            .replace("[plugin]", "[[commands]]");
+        let second = r#"
+[[commands]]
+name = "Renew"
+palette = "cert-manager-renew"
+key = "ctrl-r"
+command = "/bin/echo"
+args = ["renew"]
+scopes = ["certificates"]
+output = "report"
+mutating = true
+confirm = true
+[commands.inputs.force]
+type = "boolean"
+default = "false"
+"#;
+        let text = format!("{first}{second}");
+        let (commands, _) = read_manifest(&text).unwrap();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].mutating, Some(false));
+        assert_eq!(commands[1].mutating, Some(true));
+        assert!(commands[1].confirm);
+        assert!(commands[0].inputs.is_empty());
+        assert!(commands[1].inputs.contains_key("force"));
+        for invalid in [
+            text.replace("cert-manager-renew", "popeye"),
+            text.replace("name = \"Renew\"", "name = \"Popeye scan\""),
+            text.replace("output = \"report\"", "output = \"terminal\""),
+            text.replace("schema_version = 2", "schema_version = 1"),
+            format!("{first}\n[plugin]\nname = \"Legacy\"\ncommand = \"echo\""),
+            "schema_version = 2\ncommands = []".into(),
+            "schema_version = 2".into(),
+        ] {
+            assert!(read_manifest(&invalid).is_err(), "accepted {invalid}");
+        }
+        let duplicated_key = text.replace(
+            "palette = \"popeye\"",
+            "palette = \"popeye\"\nkey = \"ctrl-r\"",
+        );
+        assert!(read_manifest(&duplicated_key).is_err());
+    }
+
+    #[test]
     fn a_package_table_is_read_beside_the_execution_fields() {
-        let (plugin, package) = read_manifest(PACKAGED).unwrap();
+        let (commands, package) = read_manifest(PACKAGED).unwrap();
+        let plugin = &commands[0];
         // The execution half is untouched by the new table.
         assert_eq!(plugin.name, "Popeye scan");
         assert_eq!(plugin.palette.as_deref(), Some("popeye"));
@@ -848,7 +925,7 @@ mod tests {
             "schema_version = 1\n[plugin]\nname = \"Local\"\npalette = \"local\"\ncommand = \"/bin/echo\"\noutput = \"popup\"\n",
         )
         .unwrap();
-        assert_eq!(plugin.name, "Local");
+        assert_eq!(plugin[0].name, "Local");
         assert!(package.is_none());
     }
 
@@ -942,7 +1019,7 @@ mod tests {
         let valid = "schema_version = 1\n[plugin]\nname = 'Demo'\npalette = 'demo'\ncommand = '/bin/cat'\noutput = 'report'\n";
         assert!(package(valid).is_ok());
         assert!(
-            package(&valid.replace("schema_version = 1", "schema_version = 2"))
+            package(&valid.replace("schema_version = 1", "schema_version = 3"))
                 .unwrap_err()
                 .contains("unsupported")
         );


### PR DESCRIPTION
A package currently exposes one command with one set of safety flags. An adapter with both status and renewal actions must therefore use separate packages or share a mutation flag.

Add manifest schema 2 with `[[commands]]` entries. Each command has its own palette name, key, arguments, scopes, inputs, timeout, and safety flags. Sofka validates every entry before it loads the package. Installation, update, and removal apply to the whole package.

Catalog schema 2 records command settings separately. The installer checks every command against its catalog record and reports conflicts in both installed and staged packages. `plugin describe` shows each command. Sofka still reads schema 1 manifests and catalogs. The bundled and example manifests now use schema 2.

Validation:

- `just check`: formatting, Clippy, and 1,577 passing tests; two existing tests ignored.
- Required Git hooks passed.
- Tests cover mixed-format rejection, command conflicts, catalog mismatches, package installation/update/removal, and command-specific scopes, inputs, read-only checks, confirmation, and guardrails through the TUI key path.
- All five migrated catalog packages and report fixtures were accepted by the new binary. Catalog fields matched `plugin describe --offline --json`. Executable checks used stubs for the unavailable oha, popeye, and trivy tools. No live cluster actions ran.

Release Sofka 0.27.0 with this support before publishing the migrated packages. Older clients cannot read catalog schema 2.

Package migration: https://github.com/nklmilojevic/sofka-plugins/pull/17

Related: https://github.com/nklmilojevic/sofka-plugins/pull/16
