### PR TITLE
fix: support stable package display names

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -199,6 +199,9 @@ are added or reordered. The official catalog requires this title for packages
 with several commands. A package with one command can use that command's name
 as its title. If the manifest declares `display_name`, set `[package].sofka` to
 `>=0.27.1` or a later supported version. Older manifest readers reject this field.
+Sofka rejects a missing requirement or a range that permits versions before
+0.27.1 when `display_name` is present. Valid ranges include `^0.27.1`,
+`>0.27.0`, and `>=0.27.1, <1`.
 
 A catalog install checks the package version and Sofka requirement against the
 selected release. It also checks each command's name, palette, key, arguments,

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -178,6 +178,7 @@ tags = ["diagnostics", "report"]
 | Field          | Function                                                                                       |
 | -------------- | ---------------------------------------------------------------------------------------------- |
 | `version`      | Required semantic version of this package release. Separate from `schema_version`.             |
+| `display_name` | Optional package title for the catalog. Requires Sofka 0.27.1 or later.                        |
 | `description`  | Required one-line summary, shown by `sofka plugin search`.                                     |
 | `license`      | Required SPDX expression.                                                                      |
 | `authors`      | Who is responsible for the package.                                                            |
@@ -192,6 +193,12 @@ The package ID is its directory name. Each `[[commands]]` entry defines one
 command. `name` is its display name. `palette` is its full command name, without
 an automatic package prefix. Use names such as `cert-manager-status` and
 `cert-manager-renew` to group related commands.
+
+Use `[package].display_name` for a package title that stays the same when commands
+are added or reordered. The official catalog requires this title for packages
+with several commands. A package with one command can use that command's name
+as its title. If the manifest declares `display_name`, set `[package].sofka` to
+`>=0.27.1` or a later supported version. Older manifest readers reject this field.
 
 A catalog install checks the package version and Sofka requirement against the
 selected release. It also checks each command's name, palette, key, arguments,

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -213,12 +213,20 @@ pub fn validate_package(package: &Package) -> Result<(), String> {
     {
         return Err("package authors must not contain an empty entry".into());
     }
-    if let Some(sofka) = &package.sofka
-        && semver::VersionReq::parse(sofka).is_err()
+    let requirement = package
+        .sofka
+        .as_ref()
+        .map(|sofka| {
+            semver::VersionReq::parse(sofka)
+                .map_err(|_| format!("package sofka {sofka:?} is not a version requirement"))
+        })
+        .transpose()?;
+    if package.display_name.is_some()
+        && !requirement.as_ref().is_some_and(|requirement| {
+            requires_version(requirement, &semver::Version::new(0, 27, 1))
+        })
     {
-        return Err(format!(
-            "package sofka {sofka:?} is not a version requirement"
-        ));
+        return Err("package display_name requires a sofka requirement that excludes versions before 0.27.1".into());
     }
     for field in [&package.repository, &package.readme] {
         if field.as_ref().is_some_and(|value| value.trim().is_empty()) {
@@ -266,6 +274,45 @@ pub fn validate_package(package: &Package) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+fn requires_version(requirement: &semver::VersionReq, minimum: &semver::Version) -> bool {
+    use semver::{Op, Prerelease, Version};
+    requirement.comparators.iter().any(|comparator| {
+        let mut lower = Version::new(
+            comparator.major,
+            comparator.minor.unwrap_or(0),
+            comparator.patch.unwrap_or(0),
+        );
+        lower.pre = comparator.pre.clone();
+        match comparator.op {
+            Op::Exact | Op::GreaterEq | Op::Caret | Op::Tilde | Op::Wildcard => lower >= *minimum,
+            Op::Greater if lower >= *minimum => true,
+            Op::Greater if comparator.pre.is_empty() => {
+                let component = if comparator.patch.is_some() {
+                    &mut lower.patch
+                } else if comparator.minor.is_some() {
+                    &mut lower.minor
+                } else {
+                    &mut lower.major
+                };
+                let Some(next) = component.checked_add(1) else {
+                    return false;
+                };
+                *component = next;
+                if requirement.comparators.iter().any(|other| {
+                    !other.pre.is_empty()
+                        && other.major == lower.major
+                        && other.minor == Some(lower.minor)
+                        && other.patch == Some(lower.patch)
+                }) {
+                    lower.pre = Prerelease::new("0").expect("valid prerelease");
+                }
+                lower >= *minimum
+            }
+            _ => false,
+        }
+    })
 }
 
 /// The manifest exactly as the package declares it, before `read_package`
@@ -910,10 +957,12 @@ default = "false"
 
     #[test]
     fn package_display_name_is_independent_of_command_names() {
-        let manifest = PACKAGED.replace(
-            "[package]",
-            "[package]\ndisplay_name = \"Certificate tools\"",
-        );
+        let manifest = PACKAGED
+            .replace(
+                "[package]",
+                "[package]\ndisplay_name = \"Certificate tools\"",
+            )
+            .replace(">=0.26.0", ">=0.27.1");
         let (commands, package) = read_manifest(&manifest).unwrap();
         assert_eq!(
             package.unwrap().display_name.as_deref(),
@@ -925,6 +974,51 @@ default = "false"
                 PACKAGED.replace("[package]", &format!("[package]\ndisplay_name = {invalid}"));
             assert!(read_manifest(&manifest).is_err(), "accepted {invalid}");
         }
+    }
+
+    #[test]
+    fn package_titles_require_compatible_sofka_ranges() {
+        let named = PACKAGED.replace(
+            "[package]",
+            "[package]\ndisplay_name = \"Certificate tools\"",
+        );
+        for range in [
+            ">=0.27.1",
+            "=0.27.1",
+            "^0.27.1",
+            "~0.27.1",
+            ">0.27.0",
+            ">0.27",
+            ">=0.28",
+            "1.*",
+            ">=1",
+            ">=0.27.1, <1",
+            ">=0.27.1-alpha, >=0.27.1",
+        ] {
+            read_manifest(&named.replace(">=0.26.0", range))
+                .unwrap_or_else(|error| panic!("{range}: {error}"));
+        }
+        for range in [
+            "*",
+            ">=0.27.0",
+            "=0.26.0",
+            "^0.27",
+            "0.27.*",
+            "~0.27.0",
+            "<1",
+            "<=0.27.1",
+            ">0.26",
+            ">=0.27.1-alpha",
+            ">0.27.0, <0.27.1-beta",
+            "latest",
+        ] {
+            assert!(
+                read_manifest(&named.replace(">=0.26.0", range)).is_err(),
+                "accepted {range}"
+            );
+        }
+        assert!(read_manifest(&named.replace("sofka = \">=0.26.0\"\n", "")).is_err());
+        read_manifest(&PACKAGED.replace("sofka = \">=0.26.0\"\n", "")).unwrap();
     }
 
     #[test]

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -160,6 +160,7 @@ struct Manifest {
 #[serde(deny_unknown_fields)]
 pub struct Package {
     pub version: String,
+    pub display_name: Option<String>,
     pub description: String,
     pub license: String,
     #[serde(default)]
@@ -189,6 +190,13 @@ pub struct PackageRequirement {
 }
 
 pub fn validate_package(package: &Package) -> Result<(), String> {
+    if package
+        .display_name
+        .as_ref()
+        .is_some_and(|name| name.trim().is_empty())
+    {
+        return Err("package display_name must not be empty".into());
+    }
     if semver::Version::parse(&package.version).is_err() {
         return Err(format!(
             "package version {:?} is not a semantic version",
@@ -901,6 +909,25 @@ default = "false"
     }
 
     #[test]
+    fn package_display_name_is_independent_of_command_names() {
+        let manifest = PACKAGED.replace(
+            "[package]",
+            "[package]\ndisplay_name = \"Certificate tools\"",
+        );
+        let (commands, package) = read_manifest(&manifest).unwrap();
+        assert_eq!(
+            package.unwrap().display_name.as_deref(),
+            Some("Certificate tools")
+        );
+        assert_eq!(commands[0].name, "Popeye scan");
+        for invalid in ["\"\"", "\"   \"", "false", "42"] {
+            let manifest =
+                PACKAGED.replace("[package]", &format!("[package]\ndisplay_name = {invalid}"));
+            assert!(read_manifest(&manifest).is_err(), "accepted {invalid}");
+        }
+    }
+
+    #[test]
     fn a_package_table_is_read_beside_the_execution_fields() {
         let (commands, package) = read_manifest(PACKAGED).unwrap();
         let plugin = &commands[0];
@@ -909,6 +936,7 @@ default = "false"
         assert_eq!(plugin.palette.as_deref(), Some("popeye"));
         assert_eq!(plugin.command, "./adapter");
         let package = package.unwrap();
+        assert!(package.display_name.is_none());
         assert_eq!(package.version, "0.1.0");
         assert_eq!(package.authors, ["sofka maintainers"]);
         assert_eq!(package.license, "MIT OR Apache-2.0");


### PR DESCRIPTION
Packages with several commands need a stable catalog title. The manifest reader currently rejects a package-level `display_name` field, so the catalog cannot use an explicit title.

Add optional `[package].display_name` support and reject empty or invalid values. A manifest with this field must declare a Sofka requirement that excludes versions before 0.27.1. The standalone validator enforces this rule, including strict bounds and prerelease ranges. Existing manifests without the field remain valid.

This supports the metadata fixes in https://github.com/nklmilojevic/sofka-plugins/pull/17. Release this support in Sofka 0.27.1 before merging that package migration.

Validation: `just check` passed, including 1,579 tests. Tests cover independent package titles, absent titles, invalid values, and compatible and incompatible Sofka ranges. The earlier title-support build also accepted all five staged packages and report fixtures from PR #17. Executable checks used stubs for the unavailable oha, popeye, and trivy tools. No live cluster actions ran.
